### PR TITLE
feat(v0.7.0): agentic tool loop, MCP host, Research persona, Customize screen

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 import { GATE_VERSION, gateNodeSource } from '../comfyui/gate-template'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { homedir, networkInterfaces } from 'node:os'
-import { ValueError, type ApiKey } from '../config/config'
+import { ValueError, type ApiKey, type McpServer } from '../config/config'
 import type { Deps } from '../deps'
 import { BusyError, type ModelInfo, type StartOpts } from '../engines/manager'
 import { NameTakenError, NotFoundError } from '../engines/registry'
@@ -742,6 +742,7 @@ export function registerApi(app: Hono, d: Deps): void {
       hfToken?: string
       comfyui?: { enabled?: boolean; url?: string; reverseGate?: boolean }
       gateway?: { autoSwap?: boolean; keepN?: number }
+      tavilyApiKey?: string
     }>(c)
 
     const updates: Record<string, unknown> = {}
@@ -845,7 +846,16 @@ export function registerApi(app: Hono, d: Deps): void {
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
       // HF token (spec 10 §4): write-only. An explicit '' clears it. Never logged.
       if (b.hfToken !== undefined) cfg.hf.token = String(b.hfToken).trim()
+      // Tavily API key (v0.7.0): write-only. An explicit '' clears it.
+      if (b.tavilyApiKey !== undefined) {
+        const key = String(b.tavilyApiKey).trim()
+        cfg.tools.tavily = key ? { apiKey: key } : undefined
+      }
     })
+    // Keep ToolRegistry in sync when tools config changes.
+    if (b.tavilyApiKey !== undefined) {
+      d.tools?.updateConfig(d.store.snapshot().tools)
+    }
     const after = d.store.snapshot().daemon
 
     // A LAN-bind or port change re-points the HTTP listener. Rather than a full daemon
@@ -862,6 +872,58 @@ export function registerApi(app: Hono, d: Deps): void {
       rebind = { portChanged, port: after.port, lanBind: after.lanBind }
     }
     return c.json({ ...settingsPayload(d), rebind })
+  })
+
+  // ── MCP server management (v0.7.0) ────────────────────────────────────────
+
+  app.post('/api/v1/mcp/servers', async (c) => {
+    const b = await body<Partial<McpServer>>(c)
+    const transport = b.transport === 'sse' ? 'sse' : 'stdio'
+    if (!b.name?.trim()) return err(c, 400, 'invalid_config_value', 'name is required.')
+    if (transport === 'stdio' && !b.command?.trim()) return err(c, 400, 'invalid_config_value', 'command is required for stdio transport.')
+    if (transport === 'sse' && !b.url?.trim()) return err(c, 400, 'invalid_config_value', 'url is required for sse transport.')
+    if (transport === 'sse' && !/^https?:\/\//i.test(b.url ?? '')) return err(c, 400, 'invalid_config_value', 'url must be an http(s):// address.')
+    const { randomUUID } = await import('node:crypto')
+    const server: McpServer = {
+      id: randomUUID(),
+      name: b.name.trim(),
+      transport,
+      enabled: b.enabled !== false,
+      ...(transport === 'stdio' ? { command: b.command!.trim(), args: b.args ?? [], env: b.env ?? {} } : { url: b.url!.trim() }),
+    }
+    d.store.update((cfg) => { cfg.mcp.servers.push(server) })
+    if (server.enabled) await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
+    return c.json(server, 201)
+  })
+
+  app.put('/api/v1/mcp/servers/:id', async (c) => {
+    const id = c.req.param('id')
+    const b = await body<Partial<McpServer>>(c)
+    const cfg = d.store.snapshot()
+    if (!cfg.mcp.servers.some((s) => s.id === id)) return err(c, 404, 'not_found', 'MCP server not found.')
+    if (b.transport && b.transport !== 'stdio' && b.transport !== 'sse') return err(c, 400, 'invalid_config_value', 'transport must be stdio or sse.')
+    if (b.url && !/^https?:\/\//i.test(b.url)) return err(c, 400, 'invalid_config_value', 'url must be an http(s):// address.')
+    d.store.update((c2) => {
+      const s = c2.mcp.servers.find((x) => x.id === id)!
+      if (b.name !== undefined) s.name = b.name.trim()
+      if (b.transport !== undefined) s.transport = b.transport
+      if (b.enabled !== undefined) s.enabled = !!b.enabled
+      if (b.command !== undefined) s.command = b.command
+      if (b.args !== undefined) s.args = b.args
+      if (b.env !== undefined) s.env = b.env
+      if (b.url !== undefined) s.url = b.url
+    })
+    await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
+    return c.json(d.store.snapshot().mcp.servers.find((s) => s.id === id))
+  })
+
+  app.delete('/api/v1/mcp/servers/:id', (c) => {
+    const id = c.req.param('id')
+    const cfg = d.store.snapshot()
+    if (!cfg.mcp.servers.some((s) => s.id === id)) return err(c, 404, 'not_found', 'MCP server not found.')
+    d.store.update((c2) => { c2.mcp.servers = c2.mcp.servers.filter((s) => s.id !== id) })
+    void d.tools?.syncMcpServers(d.store.snapshot().mcp.servers)
+    return c.json({ ok: true })
   })
 
   // ── telemetry preview (spec 09 §4): a representative example of exactly what
@@ -1212,6 +1274,9 @@ function settingsPayload(d: Deps) {
     // The HF token is write-only over the wire (spec 10 §4): we never echo it back,
     // only whether one is set, so the UI can show "configured" without leaking it.
     hfTokenSet: cfg.hf.token.length > 0,
+    // Tavily API key is write-only: expose only whether it is set.
+    tavilyKeySet: !!(cfg.tools.tavily?.apiKey),
+    mcp: cfg.mcp,
   }
 }
 

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -5,7 +5,7 @@ import type { Deps } from '../deps'
 import { clampMaxTokens } from '../config/config'
 import { engineModelAlias } from '../engines/compat'
 import { getSysInfo } from '../sysinfo/sysinfo'
-import type { MessageStats } from './db'
+import type { MessageStats, ToolCallRecord } from './db'
 
 // Track in-flight abort controllers per conversation id.
 const inflight = new Map<string, AbortController>()
@@ -263,314 +263,384 @@ interface GenerationCtx {
 }
 
 /**
- * Streams a single assistant completion: posts to the engine, relays delta/reasoning/
- * progress SSE events, parses inline <think> tags, persists the final message + stats,
- * and fires auto-title. Shared by the messages and continue endpoints.
+ * Streams an assistant turn with optional agentic tool-calling loop. Posts to the
+ * engine, relays delta/reasoning/progress/tool_call SSE events, parses inline <think>
+ * tags, executes tool calls and loops (up to MAX_TOOL_ITER rounds), persists the final
+ * message + stats, and fires auto-title. Shared by the messages and continue endpoints.
  */
 async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx): Promise<void> {
   const { db } = d
-  const { convId, conv, engineMessages, assistantMsg, ms, target, ac, disableThinking } = ctx
+  const { convId, conv, assistantMsg, ms, target, ac, disableThinking } = ctx
 
-      // Map conversation sampling overrides (camelCase) to the engine's snake_case
-      // parameter names. Only keys present in conv.sampling are forwarded — absent
-      // keys let the engine use the startup-flag defaults set by profileToArgs.
-      const convS = conv.sampling ?? {}
-      const SAMPLING_KEYS: Record<string, string> = {
-        temp: 'temperature', topP: 'top_p', topK: 'top_k', minP: 'min_p',
-        repeatPenalty: 'repeat_penalty', presencePenalty: 'presence_penalty',
-        frequencyPenalty: 'frequency_penalty',
-      }
-      const samplingOverride: Record<string, unknown> = {}
-      for (const [camel, snake] of Object.entries(SAMPLING_KEYS)) {
-        if (camel in convS) samplingOverride[snake] = convS[camel]
-      }
-      // Pass through any already-snake_case keys the client may have stored directly.
-      for (const [k, v] of Object.entries(convS)) {
-        if (!(k in SAMPLING_KEYS) && k !== 'stop') samplingOverride[k] = v
-      }
+  // Map conversation sampling overrides (camelCase) to the engine's snake_case names.
+  const convS = conv.sampling ?? {}
+  const SAMPLING_KEYS: Record<string, string> = {
+    temp: 'temperature', topP: 'top_p', topK: 'top_k', minP: 'min_p',
+    repeatPenalty: 'repeat_penalty', presencePenalty: 'presence_penalty',
+    frequencyPenalty: 'frequency_penalty',
+  }
+  const samplingOverride: Record<string, unknown> = {}
+  for (const [camel, snake] of Object.entries(SAMPLING_KEYS)) {
+    if (camel in convS) samplingOverride[snake] = convS[camel]
+  }
+  for (const [k, v] of Object.entries(convS)) {
+    if (!(k in SAMPLING_KEYS) && k !== 'stop') samplingOverride[k] = v
+  }
+  const stopStrings = convS.stop as string[] | undefined
+
+  const maxLimit = d.store.snapshot().modelDefaults.maxTokens ?? 0
+
+  // ── Agentic tool loop ──────────────────────────────────────────────────────
+  // engineMessages is extended each round with tool results. Start from ctx copy
+  // so the original array is never mutated (continue endpoint reuses it).
+  const iterMessages: { role: string; content: unknown; tool_calls?: unknown; tool_call_id?: string }[] =
+    ctx.engineMessages.map((m) => ({ role: m.role, content: m.content }))
+
+  const MAX_TOOL_ITER = 10
+  let toolIter = 0
+
+  // Accumulated across all tool iterations for persistence
+  let fullContent = ''
+  let fullReasoning = ''
+  const allToolCalls: ToolCallRecord[] = []
+
+  // Stats from the final (non-tool) round
+  const requestStart = Date.now()
+  let ttftMs = 0
+  let thinkStart = 0
+  let thinkEnd = 0
+  let finalUsage: { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } } = {}
+  let finalTimings: Record<string, number> = {}
+  let aborted = false
+  let liveOut = 0
+
+  d.manager.generationStart()
+  try {
+    // Get tool definitions once (or empty for engines that don't support tools)
+    const toolDefs = d.tools ? await d.tools.buildToolDefinitions() : []
+
+    outerLoop: while (toolIter <= MAX_TOOL_ITER) {
+      toolIter++
 
       const reqBody: Record<string, unknown> = {
-        // mlx-lm / vLLM serve under a fixed alias and 404 on TurboLLM's internal key;
-        // llama.cpp ignores the field. engineModelAlias() returns the right value per kind.
         model: engineModelAlias(d.registry.active()?.kind ?? '') ?? ms.model!.key,
-        messages: engineMessages,
+        messages: iterMessages,
         stream: true,
         stream_options: { include_usage: true },
         return_progress: true,
         ...samplingOverride,
       }
-      // Stop strings are string[], so they live outside the numeric sampling map.
-      const stopStrings = convS.stop as string[] | undefined
       if (stopStrings?.length) reqBody.stop = stopStrings
-      // Apply the global "max response tokens" cap (0 = unlimited). Honors a smaller
-      // per-conversation value if one was set, but never lets it exceed the cap.
-      const maxLimit = d.store.snapshot().modelDefaults.maxTokens ?? 0
       const cappedMax = clampMaxTokens(reqBody.max_tokens as number | undefined, maxLimit)
       if (cappedMax != null) reqBody.max_tokens = cappedMax
       else delete reqBody.max_tokens
-      // Disable thinking at the engine level when requested: the model answers
-      // directly with no reasoning pass. `reasoning_budget: 0` covers llama-server's
-      // native reasoning control; `enable_thinking: false` covers Qwen-style chat
-      // templates. Both are no-ops on engines/models that don't reason (same pair
-      // autoTitle relies on).
       if (disableThinking) {
         reqBody.reasoning_budget = 0
         reqBody.chat_template_kwargs = { enable_thinking: false }
       }
+      // Attach tools only when the engine kind supports them (llama.cpp + TurboQuant).
+      // MLX/vLLM passthrough is fine too — they ignore unknown fields gracefully.
+      if (toolDefs.length > 0) reqBody.tools = toolDefs
 
-      const requestStart = Date.now()
-      let ttftMs = 0
-      let firstDelta = false
-      let thinkStart = 0
-      let thinkEnd = 0
-      let fullContent = ''
-      let fullReasoning = ''
+      const res = await fetch(`${target}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reqBody),
+        signal: ac.signal,
+        duplex: 'half',
+      })
+
+      if (!res.ok || !res.body) {
+        await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_error', message: `Engine returned ${res.status}` }) })
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buf = ''
+
+      const cancelReader = () => void reader.cancel()
+      if (ac.signal.aborted) {
+        cancelReader()
+      } else {
+        ac.signal.addEventListener('abort', cancelReader, { once: true })
+      }
+
+      // Per-round state
+      let roundContent = ''
       let inThink = false
       let pendingThinkBuf = ''
-      let finalUsage: {
-        prompt_tokens?: number
-        completion_tokens?: number
-        prompt_tokens_details?: { cached_tokens?: number }
-      } = {}
-      let finalTimings: Record<string, number> = {}
-      let aborted = false
-      let liveOut = 0 // approximate output-token count for the live engine-card row
+      let firstDelta = false
+      let finishReason = ''
+      // Accumulate streaming tool_calls by index (OpenAI format: fragmented across chunks)
+      const pendingToolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>()
 
-      // Mark this completion as in-flight so the engine card's live "Generating…"
-      // indicator (and the idle watchdog) can see it. Paired with generationEnd in
-      // the finally below so a thrown/aborted stream can never leak the counter.
-      d.manager.generationStart()
-      try {
-        const res = await fetch(`${target}/v1/chat/completions`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(reqBody),
-          signal: ac.signal,
-          duplex: 'half',
-        })
+      roundLoop: while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
 
-        if (!res.ok || !res.body) {
-          await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_error', message: `Engine returned ${res.status}` }) })
-          return
-        }
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const raw = line.slice(6).trim()
+          if (raw === '[DONE]') break roundLoop
 
-        const reader = res.body.getReader()
-        const decoder = new TextDecoder()
-        let buf = ''
+          let chunk: Record<string, unknown>
+          try { chunk = JSON.parse(raw) as Record<string, unknown> } catch { continue }
 
-        // When the abort signal fires during body streaming, explicitly cancel the
-        // reader so undici closes the TCP socket to TurboQuant immediately. Without
-        // this, undici may drain the buffered response rather than cutting the wire,
-        // which lets TurboQuant run to completion instead of stopping mid-generation.
-        const cancelReader = () => void reader.cancel()
-        if (ac.signal.aborted) {
-          cancelReader()
-        } else {
-          ac.signal.addEventListener('abort', cancelReader, { once: true })
-        }
+          // Prompt progress
+          const pp = chunk.prompt_progress as { processed?: number; total?: number; tps?: number } | undefined
+          if (pp && pp.total) {
+            const pct = Math.round((pp.processed ?? 0) / pp.total * 100)
+            d.manager.setLiveGen({ phase: 'prompt', pct, outputTokens: 0 })
+            await stream.writeSSE({ event: 'progress', data: JSON.stringify({ phase: 'prompt', processed: pp.processed, total: pp.total, pct, tps: pp.tps ?? 0 }) })
+            continue
+          }
 
-        outer: while (true) {
-          const { done, value } = await reader.read()
-          if (done) break
-          buf += decoder.decode(value, { stream: true })
-          const lines = buf.split('\n')
-          buf = lines.pop() ?? ''
+          if (chunk.usage) finalUsage = chunk.usage as typeof finalUsage
+          if (chunk.timings) finalTimings = chunk.timings as typeof finalTimings
 
-          for (const line of lines) {
-            if (!line.startsWith('data: ')) continue
-            const raw = line.slice(6).trim()
-            if (raw === '[DONE]') break outer
+          const choices = chunk.choices as Array<{
+            delta?: { content?: string; reasoning_content?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> }
+            finish_reason?: string
+          }> | undefined
+          if (!choices?.length) continue
 
-            let chunk: Record<string, unknown>
-            try { chunk = JSON.parse(raw) as Record<string, unknown> } catch { continue }
+          if (choices[0].finish_reason) finishReason = choices[0].finish_reason
+          const delta = choices[0].delta ?? {}
 
-            // Prompt progress
-            const pp = chunk.prompt_progress as { processed?: number; total?: number; tps?: number } | undefined
-            if (pp && pp.total) {
-              const pct = Math.round((pp.processed ?? 0) / pp.total * 100)
-              d.manager.setLiveGen({ phase: 'prompt', pct, outputTokens: 0 })
-              await stream.writeSSE({ event: 'progress', data: JSON.stringify({ phase: 'prompt', processed: pp.processed, total: pp.total, pct, tps: pp.tps ?? 0 }) })
-              continue
+          // Accumulate streaming tool_call fragments (OpenAI: id+name only in first chunk,
+          // arguments fragment across all chunks for that index).
+          if (delta.tool_calls?.length) {
+            for (const tc of delta.tool_calls) {
+              if (!pendingToolCalls.has(tc.index)) {
+                pendingToolCalls.set(tc.index, { id: '', name: '', argsBuffer: '' })
+              }
+              const entry = pendingToolCalls.get(tc.index)!
+              if (tc.id && !entry.id) entry.id = tc.id
+              if (tc.function?.name && !entry.name) entry.name = tc.function.name
+              if (tc.function?.arguments) entry.argsBuffer += tc.function.arguments
             }
+            continue
+          }
 
-            // Usage / timings (may appear on a final empty delta chunk)
-            if (chunk.usage) finalUsage = chunk.usage as typeof finalUsage
-            if (chunk.timings) finalTimings = chunk.timings as typeof finalTimings
+          // Reasoning content (explicit field — newer llama-server)
+          if (delta.reasoning_content) {
+            const rc = delta.reasoning_content
+            if (!thinkStart) thinkStart = Date.now()
+            thinkEnd = Date.now()
+            fullReasoning += rc
+            await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: rc }) })
+            continue
+          }
 
-            const choices = chunk.choices as Array<{ delta?: { content?: string; reasoning_content?: string }; finish_reason?: string }> | undefined
-            if (!choices?.length) continue
-            const delta = choices[0].delta ?? {}
+          const raw_content = delta.content ?? ''
+          if (!raw_content) continue
 
-            // Reasoning content (explicit field — newer llama-server with reasoning model)
-            if (delta.reasoning_content) {
-              const rc = delta.reasoning_content
-              if (!thinkStart) thinkStart = Date.now()
-              thinkEnd = Date.now()
-              fullReasoning += rc
-              await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: rc }) })
-              continue
-            }
-
-            const raw_content = delta.content ?? ''
-            if (!raw_content) continue
-
-            // Detect <think>...</think> tags inline (older llama-server with --jinja)
-            let toProcess = raw_content
-            while (toProcess.length > 0) {
-              if (!inThink && !firstDelta) {
-                // Haven't seen any real content yet — might start with <think>
-                pendingThinkBuf += toProcess
-                const openIdx = pendingThinkBuf.indexOf('<think>')
-                if (openIdx === 0) {
-                  inThink = true
-                  if (!thinkStart) thinkStart = Date.now()
-                  pendingThinkBuf = pendingThinkBuf.slice(7)
-                  toProcess = ''
-                } else if (openIdx > 0) {
-                  // Content before <think>
-                  const before = pendingThinkBuf.slice(0, openIdx)
-                  fullContent += before
-                  firstDelta = true
-                  if (!ttftMs) { ttftMs = Date.now() - requestStart; firstDelta = true }
-                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: before }) })
-                  inThink = true
-                  if (!thinkStart) thinkStart = Date.now()
-                  pendingThinkBuf = pendingThinkBuf.slice(openIdx + 7)
-                  toProcess = ''
-                } else if (pendingThinkBuf.length > 20) {
-                  // No <think> tag coming — flush as content
-                  const flush = pendingThinkBuf
-                  pendingThinkBuf = ''
-                  fullContent += flush
-                  firstDelta = true
-                  if (!ttftMs) ttftMs = Date.now() - requestStart
-                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: flush }) })
-                  toProcess = ''
-                } else {
-                  toProcess = ''
-                }
-              } else if (inThink) {
-                pendingThinkBuf += toProcess
-                const closeIdx = pendingThinkBuf.indexOf('</think>')
-                if (closeIdx >= 0) {
-                  const thinkChunk = pendingThinkBuf.slice(0, closeIdx)
-                  if (thinkChunk) {
-                    thinkEnd = Date.now()
-                    fullReasoning += thinkChunk
-                    await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: thinkChunk }) })
-                  }
-                  inThink = false
-                  thinkEnd = Date.now()
-                  pendingThinkBuf = pendingThinkBuf.slice(closeIdx + 8)
-                  toProcess = ''
-                  // Remaining after </think> will be emitted as content next iteration
-                  if (pendingThinkBuf) {
-                    fullContent += pendingThinkBuf
-                    firstDelta = true
-                    if (!ttftMs) ttftMs = Date.now() - requestStart
-                    await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
-                    pendingThinkBuf = ''
-                  }
-                } else {
-                  thinkEnd = Date.now()
-                  fullReasoning += pendingThinkBuf
-                  await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
-                  pendingThinkBuf = ''
-                  toProcess = ''
-                }
-              } else {
-                // Normal content
-                if (!ttftMs) ttftMs = Date.now() - requestStart
+          // Detect <think>...</think> tags inline (older llama-server with --jinja)
+          let toProcess = raw_content
+          while (toProcess.length > 0) {
+            if (!inThink && !firstDelta) {
+              pendingThinkBuf += toProcess
+              const openIdx = pendingThinkBuf.indexOf('<think>')
+              if (openIdx === 0) {
+                inThink = true
+                if (!thinkStart) thinkStart = Date.now()
+                pendingThinkBuf = pendingThinkBuf.slice(7)
+                toProcess = ''
+              } else if (openIdx > 0) {
+                const before = pendingThinkBuf.slice(0, openIdx)
+                fullContent += before
+                roundContent += before
                 firstDelta = true
-                fullContent += toProcess
-                // Each llama-server content chunk is ~one token — a good-enough live count.
-                d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut })
-                await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: toProcess }) })
+                if (!ttftMs) ttftMs = Date.now() - requestStart
+                await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: before }) })
+                inThink = true
+                if (!thinkStart) thinkStart = Date.now()
+                pendingThinkBuf = pendingThinkBuf.slice(openIdx + 7)
+                toProcess = ''
+              } else if (pendingThinkBuf.length > 20) {
+                const flush = pendingThinkBuf
+                pendingThinkBuf = ''
+                fullContent += flush
+                roundContent += flush
+                firstDelta = true
+                if (!ttftMs) ttftMs = Date.now() - requestStart
+                await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: flush }) })
+                toProcess = ''
+              } else {
                 toProcess = ''
               }
+            } else if (inThink) {
+              pendingThinkBuf += toProcess
+              const closeIdx = pendingThinkBuf.indexOf('</think>')
+              if (closeIdx >= 0) {
+                const thinkChunk = pendingThinkBuf.slice(0, closeIdx)
+                if (thinkChunk) {
+                  thinkEnd = Date.now()
+                  fullReasoning += thinkChunk
+                  await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: thinkChunk }) })
+                }
+                inThink = false
+                thinkEnd = Date.now()
+                pendingThinkBuf = pendingThinkBuf.slice(closeIdx + 8)
+                toProcess = ''
+                if (pendingThinkBuf) {
+                  fullContent += pendingThinkBuf
+                  roundContent += pendingThinkBuf
+                  firstDelta = true
+                  if (!ttftMs) ttftMs = Date.now() - requestStart
+                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
+                  pendingThinkBuf = ''
+                }
+              } else {
+                thinkEnd = Date.now()
+                fullReasoning += pendingThinkBuf
+                await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
+                pendingThinkBuf = ''
+                toProcess = ''
+              }
+            } else {
+              if (!ttftMs) ttftMs = Date.now() - requestStart
+              firstDelta = true
+              fullContent += toProcess
+              roundContent += toProcess
+              d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut })
+              await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: toProcess }) })
+              toProcess = ''
             }
           }
         }
-        ac.signal.removeEventListener('abort', cancelReader)
+      }
+      ac.signal.removeEventListener('abort', cancelReader)
 
-        // Flush any pending think buf as reasoning if we're still in think at end
-        if (pendingThinkBuf && inThink) {
-          fullReasoning += pendingThinkBuf
-          await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
-        } else if (pendingThinkBuf) {
-          fullContent += pendingThinkBuf
-          await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
-        }
-
-      } catch (e: unknown) {
-        const isAbort = (e as Error)?.name === 'AbortError'
-        aborted = isAbort
-        if (!isAbort) {
-          await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_stopped', message: (e as Error).message }) })
-        }
-      } finally {
-        d.manager.generationEnd()
-        inflight.delete(convId)
+      // Flush pending think buf
+      if (pendingThinkBuf && inThink) {
+        fullReasoning += pendingThinkBuf
+        await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
+      } else if (pendingThinkBuf) {
+        fullContent += pendingThinkBuf
+        roundContent += pendingThinkBuf
+        await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
       }
 
-      const totalMs = Date.now() - requestStart
-      const thinkMs = thinkStart && thinkEnd ? thinkEnd - thinkStart : 0
-      const ctxMax = ms.model?.ctx ?? 4096
+      // ── Tool call execution ──────────────────────────────────────────────
+      if ((finishReason === 'tool_calls' || pendingToolCalls.size > 0) && d.tools && toolIter <= MAX_TOOL_ITER) {
+        const roundToolCalls = Array.from(pendingToolCalls.values())
 
-      // Build stats: prefer engine-reported timings, fall back to wall-clock
-      const stats: Partial<MessageStats> = {
-        ttftMs,
-        totalMs,
-        thinkMs,
-        ctxUsed: (finalUsage.prompt_tokens ?? 0) + (finalUsage.completion_tokens ?? 0),
-        ctxMax,
-        model: ms.model?.name ?? '',
-        aborted,
-      }
-      // cached prompt tokens: prefer the engine's explicit count, else infer it
-      // as (full prompt − tokens it actually had to process).
-      const fullPrompt = finalUsage.prompt_tokens ?? 0
-      const cachedExplicit = finalUsage.prompt_tokens_details?.cached_tokens
-      if (finalTimings.prompt_n) {
-        const processed = finalTimings.prompt_n
-        stats.promptTokens = fullPrompt || processed
-        stats.promptMs     = finalTimings.prompt_ms
-        stats.promptTps    = finalTimings.prompt_per_second
-        stats.genTokens    = finalTimings.predicted_n
-        stats.genMs        = finalTimings.predicted_ms
-        stats.tps          = finalTimings.predicted_per_second
-        stats.cachedTokens = cachedExplicit ?? Math.max(0, (fullPrompt || processed) - processed)
-      } else {
-        // Fallback: wall clock
-        stats.promptTokens = fullPrompt
-        stats.genTokens    = finalUsage.completion_tokens ?? 0
-        stats.genMs        = totalMs - ttftMs
-        stats.tps          = stats.genMs > 0 ? Math.round((stats.genTokens / stats.genMs) * 1000 * 10) / 10 : 0
-        stats.cachedTokens = cachedExplicit ?? 0
-      }
-
-      // Persist final assistant message
-      db.updateMessage(assistantMsg.id, { content: fullContent, reasoning: fullReasoning, stats })
-      db.touchConversation(convId)
-
-      // Feed the running-session stats accumulator (B4). Fail-safe: a recording
-      // error must never affect the completion response.
-      try {
-        d.manager.recordCompletion({
-          inputTokens: stats.promptTokens,
-          outputTokens: stats.genTokens,
-          promptTps: stats.promptTps,
-          genTps: stats.tps,
+        // Add the assistant message (with tool_calls) to iterMessages for the next round
+        iterMessages.push({
+          role: 'assistant',
+          content: roundContent || null,
+          tool_calls: roundToolCalls.map((tc) => ({
+            id: tc.id,
+            type: 'function',
+            function: { name: tc.name, arguments: tc.argsBuffer },
+          })),
         })
-      } catch { /* swallow — stats are best-effort */ }
 
-      const finalMsg = db.getMessage(assistantMsg.id)!
-      await stream.writeSSE({ event: 'done', data: JSON.stringify({ message: finalMsg }) })
+        for (const tc of roundToolCalls) {
+          let parsedArgs: Record<string, unknown>
+          try { parsedArgs = JSON.parse(tc.argsBuffer || '{}') as Record<string, unknown> }
+          catch { parsedArgs = {} }
 
-      // Auto-title: fire 1s after first completed exchange (spec 07 §6)
-      if (!aborted && conv.title === 'New chat' && d.store.snapshot().daemon.autoGenerateTitles) {
-        setTimeout(() => { void autoTitle(d, convId, engineMessages, fullContent, target) }, 1000)
+          // Emit pending event so the frontend can show "calling..."
+          await stream.writeSSE({
+            event: 'tool_call',
+            data: JSON.stringify({ id: tc.id, name: tc.name, args: parsedArgs, status: 'pending' }),
+          })
+
+          let result = ''
+          let callError: string | undefined
+          try {
+            result = await d.tools.executeTool({ id: tc.id, name: tc.name, args: parsedArgs })
+          } catch (e) {
+            callError = (e as Error).message
+            result = `Error: ${callError}`
+          }
+
+          allToolCalls.push({ id: tc.id, name: tc.name, args: parsedArgs, result: callError ? undefined : result, error: callError })
+
+          // Emit done event with result
+          await stream.writeSSE({
+            event: 'tool_call',
+            data: JSON.stringify({ id: tc.id, name: tc.name, args: parsedArgs, status: callError ? 'error' : 'done', result }),
+          })
+
+          // Inject tool result into iterMessages
+          iterMessages.push({ role: 'tool', content: result, tool_call_id: tc.id })
+        }
+
+        // Continue to next round
+        continue outerLoop
       }
+
+      // No tool calls (or tools not available) — done
+      break outerLoop
+    }
+  } catch (e: unknown) {
+    const isAbort = (e as Error)?.name === 'AbortError'
+    aborted = isAbort
+    if (!isAbort) {
+      await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_stopped', message: (e as Error).message }) })
+    }
+  } finally {
+    d.manager.generationEnd()
+    inflight.delete(convId)
+  }
+
+  const totalMs = Date.now() - requestStart
+  const thinkMs = thinkStart && thinkEnd ? thinkEnd - thinkStart : 0
+  const ctxMax = ms.model?.ctx ?? 4096
+
+  const stats: Partial<MessageStats> = {
+    ttftMs,
+    totalMs,
+    thinkMs,
+    ctxUsed: (finalUsage.prompt_tokens ?? 0) + (finalUsage.completion_tokens ?? 0),
+    ctxMax,
+    model: ms.model?.name ?? '',
+    aborted,
+  }
+  const fullPrompt = finalUsage.prompt_tokens ?? 0
+  const cachedExplicit = finalUsage.prompt_tokens_details?.cached_tokens
+  if (finalTimings.prompt_n) {
+    const processed = finalTimings.prompt_n
+    stats.promptTokens = fullPrompt || processed
+    stats.promptMs     = finalTimings.prompt_ms
+    stats.promptTps    = finalTimings.prompt_per_second
+    stats.genTokens    = finalTimings.predicted_n
+    stats.genMs        = finalTimings.predicted_ms
+    stats.tps          = finalTimings.predicted_per_second
+    stats.cachedTokens = cachedExplicit ?? Math.max(0, (fullPrompt || processed) - processed)
+  } else {
+    stats.promptTokens = fullPrompt
+    stats.genTokens    = finalUsage.completion_tokens ?? 0
+    stats.genMs        = totalMs - ttftMs
+    stats.tps          = stats.genMs > 0 ? Math.round((stats.genTokens / stats.genMs) * 1000 * 10) / 10 : 0
+    stats.cachedTokens = cachedExplicit ?? 0
+  }
+
+  db.updateMessage(assistantMsg.id, { content: fullContent, reasoning: fullReasoning, toolCalls: allToolCalls, stats })
+  db.touchConversation(convId)
+
+  try {
+    d.manager.recordCompletion({
+      inputTokens: stats.promptTokens,
+      outputTokens: stats.genTokens,
+      promptTps: stats.promptTps,
+      genTps: stats.tps,
+    })
+  } catch { /* swallow — stats are best-effort */ }
+
+  const finalMsg = db.getMessage(assistantMsg.id)!
+  await stream.writeSSE({ event: 'done', data: JSON.stringify({ message: finalMsg }) })
+
+  if (!aborted && conv.title === 'New chat' && d.store.snapshot().daemon.autoGenerateTitles) {
+    setTimeout(() => { void autoTitle(d, convId, ctx.engineMessages, fullContent, target) }, 1000)
+  }
 }
 
 // ── auto title generation ──────────────────────────────────────────────────

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -341,12 +341,13 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
       // Attach tools only when the engine kind supports them (llama.cpp + TurboQuant).
       // MLX/vLLM passthrough is fine too — they ignore unknown fields gracefully.
       if (toolDefs.length > 0) reqBody.tools = toolDefs
-      // Force web_search on the first iteration when the conversation has a
-      // force_web_search policy (e.g. Research persona). Subsequent iterations
-      // use the default "auto" so the model can compose its answer after searching.
+      // Force web_search on the first two iterations when the conversation has a
+      // force_web_search policy (e.g. Research persona). This guarantees at least
+      // two distinct searches before the model composes its answer. Iteration 3+
+      // use "auto" so the model can continue searching or finish as it sees fit.
       if (
         conv.toolPolicy === 'force_web_search' &&
-        toolIter === 1 &&
+        toolIter <= 2 &&
         toolDefs.some((t) => t.function.name === 'web_search')
       ) {
         reqBody.tool_choice = { type: 'function', function: { name: 'web_search' } }

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -55,8 +55,8 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
   })
 
   app.post('/api/v1/conversations', async (c) => {
-    const b = await body<{ title?: string; systemPrompt?: string; modelKey?: string }>(c)
-    const conv = db.createConversation({ title: b.title, systemPrompt: b.systemPrompt, modelKey: b.modelKey })
+    const b = await body<{ title?: string; systemPrompt?: string; modelKey?: string; toolPolicy?: string }>(c)
+    const conv = db.createConversation({ title: b.title, systemPrompt: b.systemPrompt, modelKey: b.modelKey, toolPolicy: b.toolPolicy })
     return c.json(conv, 201)
   })
 
@@ -341,6 +341,16 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
       // Attach tools only when the engine kind supports them (llama.cpp + TurboQuant).
       // MLX/vLLM passthrough is fine too — they ignore unknown fields gracefully.
       if (toolDefs.length > 0) reqBody.tools = toolDefs
+      // Force web_search on the first iteration when the conversation has a
+      // force_web_search policy (e.g. Research persona). Subsequent iterations
+      // use the default "auto" so the model can compose its answer after searching.
+      if (
+        conv.toolPolicy === 'force_web_search' &&
+        toolIter === 1 &&
+        toolDefs.some((t) => t.function.name === 'web_search')
+      ) {
+        reqBody.tool_choice = { type: 'function', function: { name: 'web_search' } }
+      }
 
       const res = await fetch(`${target}/v1/chat/completions`, {
         method: 'POST',

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -14,6 +14,9 @@ export interface Conversation {
   /** When true, this is the built-in TurboLLM Expert thread: its system prompt is
    *  managed server-side and hidden from the UI (spec 08 §2). */
   expertMode: boolean
+  /** Tool-calling policy for this conversation. 'force_web_search' forces the model
+   *  to call web_search on the first iteration before composing a reply. */
+  toolPolicy?: string
   createdAt: string
   updatedAt: string
   messages?: Message[]
@@ -59,7 +62,7 @@ export interface Message {
   createdAt: string
 }
 
-interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; created_at: string; updated_at: string }
+interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; created_at: string; updated_at: string }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; created_at: string }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
@@ -68,7 +71,7 @@ type P = Record<string, SQLInputValue>
 function safeJson(s: string): unknown { try { return JSON.parse(s) } catch { return {} } }
 
 function rowToConv(r: ConvRow): Conversation {
-  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, createdAt: r.created_at, updatedAt: r.updated_at }
+  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at }
 }
 
 function rowToMsg(r: MsgRow): Message {
@@ -142,6 +145,15 @@ export class ConversationStore {
         PRAGMA user_version = 5;
       `)
     }
+    // v6 (v0.7.0 agentic): per-conversation tool policy. 'force_web_search' forces
+    // the model to call web_search on the first iteration. Nullable — existing rows
+    // get NULL and default to standard auto tool_choice (non-breaking).
+    if (v < 6) {
+      this.db.exec(`
+        ALTER TABLE conversations ADD COLUMN tool_policy TEXT;
+        PRAGMA user_version = 6;
+      `)
+    }
   }
 
   listConversations(q?: string): Conversation[] {
@@ -157,11 +169,11 @@ export class ConversationStore {
     return (this.db.prepare(`SELECT * FROM conversations ORDER BY updated_at DESC LIMIT 200`).all() as unknown as ConvRow[]).map(rowToConv)
   }
 
-  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode'>>): Conversation {
+  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy'>>): Conversation {
     const now = new Date().toISOString()
     const id = randomUUID()
-    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$now,$now)`)
-      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $now: now } as P)
+    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$now,$now)`)
+      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $now: now } as P)
     return this.getConversation(id)!
   }
 

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -36,6 +36,14 @@ export interface MessageStats {
   aborted: boolean
 }
 
+export interface ToolCallRecord {
+  id: string
+  name: string
+  args: Record<string, unknown>
+  result?: string
+  error?: string
+}
+
 export interface Message {
   id: string
   convId: string
@@ -45,12 +53,14 @@ export interface Message {
   reasoning: string
   attachments: string[]
   textAttachments: string[]
+  /** Tool calls made by this assistant turn (v0.7.0). */
+  toolCalls: ToolCallRecord[]
   stats: Partial<MessageStats>
   createdAt: string
 }
 
 interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; created_at: string; updated_at: string }
-interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; stats: string; model_key: string | null; created_at: string }
+interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; created_at: string }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
 type P = Record<string, SQLInputValue>
@@ -62,7 +72,7 @@ function rowToConv(r: ConvRow): Conversation {
 }
 
 function rowToMsg(r: MsgRow): Message {
-  return { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at }
+  return { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], toolCalls: r.tool_calls ? safeJson(r.tool_calls) as ToolCallRecord[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at }
 }
 
 interface Changes { changes: number }
@@ -123,6 +133,15 @@ export class ConversationStore {
         PRAGMA user_version = 4;
       `)
     }
+    // v5 (v0.7.0 agentic): store tool call records on assistant messages so the UI
+    // can render tool invocations + results inline. Nullable — existing rows get NULL
+    // and are decoded as [] in rowToMsg (non-breaking).
+    if (v < 5) {
+      this.db.exec(`
+        ALTER TABLE messages ADD COLUMN tool_calls TEXT;
+        PRAGMA user_version = 5;
+      `)
+    }
   }
 
   listConversations(q?: string): Conversation[] {
@@ -176,7 +195,7 @@ export class ConversationStore {
     return (this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id ORDER BY seq ASC`).all({ $id: convId } as P) as unknown as MsgRow[]).map(rowToMsg)
   }
 
-  addMessage(convId: string, role: 'user' | 'assistant', content: string, extra?: Partial<Pick<Message, 'reasoning' | 'attachments' | 'textAttachments' | 'stats'>>): Message {
+  addMessage(convId: string, role: 'user' | 'assistant', content: string, extra?: Partial<Pick<Message, 'reasoning' | 'attachments' | 'textAttachments' | 'toolCalls' | 'stats'>>): Message {
     const id = randomUUID()
     const now = new Date().toISOString()
     const row = this.db.prepare(`SELECT COALESCE(MAX(seq),0) AS ms FROM messages WHERE conv_id = $id`).get({ $id: convId } as P) as unknown as { ms: number }
@@ -184,8 +203,9 @@ export class ConversationStore {
     // can surface last-session gen t/s (spec 04 §5). User turns are left NULL.
     const modelKey = role === 'assistant' ? this.conversationModelKey(convId) : null
     const textAttachments = extra?.textAttachments?.length ? JSON.stringify(extra.textAttachments) : null
-    this.db.prepare(`INSERT INTO messages (id,conv_id,seq,role,content,reasoning,attachments,text_attachments,stats,model_key,created_at) VALUES ($id,$cid,$seq,$role,$content,$reasoning,$attachments,$ta,$stats,$mk,$now)`)
-      .run({ $id: id, $cid: convId, $seq: row.ms + 1, $role: role, $content: content, $reasoning: extra?.reasoning ?? '', $attachments: JSON.stringify(extra?.attachments ?? []), $ta: textAttachments, $stats: JSON.stringify(extra?.stats ?? {}), $mk: modelKey, $now: now } as P)
+    const toolCalls = extra?.toolCalls?.length ? JSON.stringify(extra.toolCalls) : null
+    this.db.prepare(`INSERT INTO messages (id,conv_id,seq,role,content,reasoning,attachments,text_attachments,tool_calls,stats,model_key,created_at) VALUES ($id,$cid,$seq,$role,$content,$reasoning,$attachments,$ta,$tc,$stats,$mk,$now)`)
+      .run({ $id: id, $cid: convId, $seq: row.ms + 1, $role: role, $content: content, $reasoning: extra?.reasoning ?? '', $attachments: JSON.stringify(extra?.attachments ?? []), $ta: textAttachments, $tc: toolCalls, $stats: JSON.stringify(extra?.stats ?? {}), $mk: modelKey, $now: now } as P)
     this.touchConversation(convId)
     return this.getMessage(id)!
   }
@@ -201,11 +221,12 @@ export class ConversationStore {
     return row ? rowToMsg(row) : null
   }
 
-  updateMessage(id: string, patch: Partial<Pick<Message, 'content' | 'reasoning' | 'stats'>>): boolean {
+  updateMessage(id: string, patch: Partial<Pick<Message, 'content' | 'reasoning' | 'toolCalls' | 'stats'>>): boolean {
     const sets: string[] = []
     const params: Record<string, SQLInputValue> = { $id: id }
     if (patch.content   !== undefined) { sets.push('content = $content');     params.$content   = patch.content }
     if (patch.reasoning !== undefined) { sets.push('reasoning = $reasoning'); params.$reasoning = patch.reasoning }
+    if (patch.toolCalls !== undefined) { sets.push('tool_calls = $tc');       params.$tc        = JSON.stringify(patch.toolCalls) }
     if (patch.stats     !== undefined) { sets.push('stats = $stats');         params.$stats     = JSON.stringify(patch.stats) }
     if (!sets.length) return false
     return ((this.db.prepare(`UPDATE messages SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -19,6 +19,7 @@ import { HfClient } from './hf/hf'
 import { DownloadManager } from './downloads/downloads'
 import { BenchRunner } from './bench/bench'
 import { ModelRouter } from './gateway/model-router'
+import { ToolRegistry } from './tools/tool-registry'
 import { launchCli } from './cli-launch'
 import { createApp } from './server'
 import type { Deps } from './deps'
@@ -131,9 +132,15 @@ const comfy = new ComfyGuard(store, manager)
 // Gateway intelligence (v0.6.0): auto model-swap router. Resolves the `model`
 // field in /v1/* requests and loads the matching model if not already running.
 const modelRouter = new ModelRouter(store, registry, manager, scanner, comfy)
+// Tool registry (v0.7.0): built-in tools + MCP host. Syncs MCP servers from config.
+const toolRegistry = new ToolRegistry(store.snapshot().tools)
+void (async () => {
+  const cfg = store.snapshot()
+  await toolRegistry.syncMcpServers(cfg.mcp.servers)
+})()
 const startedAt = Date.now()
 // `requestRestart` is attached after the server is created (it must close over it).
-const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, hf, downloads, bench, modelRouter, comfy, version, startedAt }
+const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
 const app = createApp(deps)
 
 // ── Resolve listen address ────────────────────────────────────────────────────
@@ -416,6 +423,7 @@ for (const sig of ['SIGINT', 'SIGTERM'] as const) {
     shuttingDown = true
     console.log('shutting down')
     comfy.stop()
+    toolRegistry.disconnectAll()
     void manager.shutdown().finally(() => { db.close(); server.close(() => process.exit(0)) })
     setTimeout(() => process.exit(0), 12_000).unref()
   })

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -65,6 +65,32 @@ export interface LastLoaded {
 export interface HF {
   token: string
 }
+/** Built-in tool configuration (v0.7.0). */
+export interface ToolsConfig {
+  tavily?: { apiKey: string }
+}
+
+/** One MCP server the daemon manages as a tool provider (v0.7.0). */
+export interface McpServer {
+  id: string
+  name: string
+  transport: 'stdio' | 'sse'
+  /** stdio only — command to spawn */
+  command?: string
+  /** stdio only — argv after command */
+  args?: string[]
+  /** stdio only — extra env vars for the child process */
+  env?: Record<string, string>
+  /** sse only — base URL of the MCP server */
+  url?: string
+  enabled: boolean
+}
+
+/** MCP host configuration (v0.7.0). */
+export interface McpConfig {
+  servers: McpServer[]
+}
+
 /** Gateway intelligence (v0.6.0): auto model-swap + keep-N pool. */
 export interface Gateway {
   /** When true, gateway requests that include a `model` field auto-load the named
@@ -140,6 +166,8 @@ export interface Config {
   featuredOverrideUrl: string
   comfyui: ComfyUI
   gateway: Gateway
+  tools: ToolsConfig
+  mcp: McpConfig
   devModel?: DevModel
 }
 
@@ -247,6 +275,8 @@ export function defaultConfig(): Config {
     featuredOverrideUrl: '',
     comfyui: { enabled: false, gatePath: '', url: '', reverseGate: false, cachePersist: false },
     gateway: { autoSwap: true, keepN: 1 },
+    tools: {},
+    mcp: { servers: [] },
   }
 }
 
@@ -412,6 +442,22 @@ function normalize(c: Config): void {
   c.gateway = {
     autoSwap: gw.autoSwap !== false,
     keepN: typeof gw.keepN === 'number' && gw.keepN >= 1 ? Math.min(Math.floor(gw.keepN), 4) : 1,
+  }
+  // Built-in tools (v0.7.0): absent in pre-v0.7.0 configs → empty defaults.
+  const tl = (c.tools ?? {}) as Partial<ToolsConfig>
+  c.tools = {}
+  if (tl.tavily && typeof tl.tavily.apiKey === 'string') {
+    c.tools.tavily = { apiKey: tl.tavily.apiKey }
+  }
+  // MCP host (v0.7.0): absent in pre-v0.7.0 configs → empty server list.
+  const mc = (c.mcp ?? {}) as Partial<McpConfig>
+  c.mcp = {
+    servers: Array.isArray(mc.servers)
+      ? mc.servers.filter((s): s is McpServer =>
+          typeof s === 'object' && s !== null &&
+          typeof s.id === 'string' && typeof s.name === 'string' &&
+          (s.transport === 'stdio' || s.transport === 'sse'))
+      : [],
   }
   // Telemetry level (spec 09 §3): the UI exposes 'off' | 'anon' | 'full'. Migrate
   // legacy/unknown values safely → 'off' (the conservative, opt-in default).

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -10,6 +10,7 @@ import type { HfClient } from './hf/hf'
 import type { DownloadManager } from './downloads/downloads'
 import type { BenchRunner } from './bench/bench'
 import type { ModelRouter } from './gateway/model-router'
+import type { ToolRegistry } from './tools/tool-registry'
 
 export interface Deps {
   store: ConfigStore
@@ -24,6 +25,8 @@ export interface Deps {
   bench: BenchRunner
   /** Gateway model router (v0.6.0): auto model-swap and keep-N pool. */
   modelRouter: ModelRouter
+  /** Tool registry (v0.7.0): built-in tools + MCP host. Optional — absent in tests. */
+  tools?: ToolRegistry
   /** ComfyUI GPU coordinator (spec: unload/block while ComfyUI renders, reload after).
    *  Optional: only wired in the real `serve()` entrypoint (cli.ts); absent under tests. */
   comfy?: ComfyGuard

--- a/turbollm/src/tools/builtin.ts
+++ b/turbollm/src/tools/builtin.ts
@@ -8,12 +8,21 @@ export const WEB_SEARCH_TOOL = {
   type: 'function' as const,
   function: {
     name: 'web_search',
-    description: 'Search the web for up-to-date information. Use this for current events, facts, or anything you are not certain about.',
+    description:
+      'Search the web for real-time information. Call this BEFORE answering any question that depends on current events, recent data, prices, specific facts, or anything your training data may not cover accurately. ' +
+      'Formulate a precise, keyword-focused query — include names, dates, or version numbers when relevant. ' +
+      'Run multiple focused searches rather than one broad one for complex questions.',
     parameters: {
       type: 'object',
       properties: {
-        query: { type: 'string', description: 'The search query.' },
-        max_results: { type: 'number', description: 'Maximum number of results to return (default 5, max 10).' },
+        query: {
+          type: 'string',
+          description:
+            'A precise, specific search query. Use key terms and identifiers. ' +
+            'Good: "Python 3.13 release date new features". Bad: "Python new stuff". ' +
+            'Good: "NVIDIA RTX 5090 benchmark 2025". Bad: "new GPU benchmarks".',
+        },
+        max_results: { type: 'number', description: 'Number of results to return (default 5, max 10).' },
       },
       required: ['query'],
     },
@@ -74,8 +83,14 @@ export async function execWebSearch(args: Record<string, unknown>, tavilyApiKey:
     resp = await fetch('https://api.tavily.com/search', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ api_key: tavilyApiKey, query, max_results: maxResults }),
-      signal: AbortSignal.timeout(15_000),
+      body: JSON.stringify({
+        api_key: tavilyApiKey,
+        query,
+        max_results: maxResults,
+        search_depth: 'advanced',
+        include_answer: true,
+      }),
+      signal: AbortSignal.timeout(20_000),
     })
   } catch (e) {
     return `Error: could not reach Tavily — ${(e as Error).message}`
@@ -91,12 +106,12 @@ export async function execWebSearch(args: Record<string, unknown>, tavilyApiKey:
   if (results.length === 0) return 'No results found.'
 
   const lines: string[] = []
-  if (data.answer) lines.push(`Summary: ${data.answer}\n`)
+  if (data.answer) lines.push(`ANSWER: ${data.answer}\n`)
+  lines.push(`SOURCES (${results.length} results for "${query}"):`)
   for (const [i, r] of results.entries()) {
-    lines.push(`[${i + 1}] ${r.title}`)
-    lines.push(`URL: ${r.url}`)
-    lines.push(r.content.slice(0, 400))
-    lines.push('')
+    lines.push(`\n[${i + 1}] ${r.title}`)
+    lines.push(`Source: ${r.url}`)
+    lines.push(r.content.slice(0, 700))
   }
   return lines.join('\n').trim()
 }

--- a/turbollm/src/tools/builtin.ts
+++ b/turbollm/src/tools/builtin.ts
@@ -1,0 +1,194 @@
+// Built-in tool definitions and execution (v0.7.0).
+// Tools: web_search (Tavily), fetch_url, run_code (Node vm sandbox).
+import { runInNewContext } from 'node:vm'
+
+// ── Tool JSON-schema definitions (OpenAI tool format) ─────────────────────
+
+export const WEB_SEARCH_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'web_search',
+    description: 'Search the web for up-to-date information. Use this for current events, facts, or anything you are not certain about.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'The search query.' },
+        max_results: { type: 'number', description: 'Maximum number of results to return (default 5, max 10).' },
+      },
+      required: ['query'],
+    },
+  },
+}
+
+export const FETCH_URL_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'fetch_url',
+    description: 'Fetch the text content of a URL. Returns the main text of the page, stripped of HTML.',
+    parameters: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'The URL to fetch.' },
+      },
+      required: ['url'],
+    },
+  },
+}
+
+export const RUN_CODE_TOOL = {
+  type: 'function' as const,
+  function: {
+    name: 'run_code',
+    description: 'Execute a JavaScript snippet and return the result. Useful for calculations, data transformation, and logic. No network, file, or process access.',
+    parameters: {
+      type: 'object',
+      properties: {
+        code: { type: 'string', description: 'JavaScript code to execute. The last expression is the return value.' },
+      },
+      required: ['code'],
+    },
+  },
+}
+
+// ── Tavily web search ─────────────────────────────────────────────────────
+
+interface TavilyResult {
+  title: string
+  url: string
+  content: string
+  score: number
+}
+
+interface TavilyResponse {
+  results?: TavilyResult[]
+  answer?: string
+}
+
+export async function execWebSearch(args: Record<string, unknown>, tavilyApiKey: string): Promise<string> {
+  const query = String(args.query ?? '')
+  if (!query.trim()) return 'Error: query is required.'
+  const maxResults = Math.min(10, Math.max(1, Number(args.max_results ?? 5) || 5))
+
+  let resp: Response
+  try {
+    resp = await fetch('https://api.tavily.com/search', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: tavilyApiKey, query, max_results: maxResults }),
+      signal: AbortSignal.timeout(15_000),
+    })
+  } catch (e) {
+    return `Error: could not reach Tavily — ${(e as Error).message}`
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    return `Error: Tavily returned ${resp.status}${text ? ` — ${text.slice(0, 200)}` : ''}`
+  }
+
+  const data = (await resp.json()) as TavilyResponse
+  const results = data.results ?? []
+  if (results.length === 0) return 'No results found.'
+
+  const lines: string[] = []
+  if (data.answer) lines.push(`Summary: ${data.answer}\n`)
+  for (const [i, r] of results.entries()) {
+    lines.push(`[${i + 1}] ${r.title}`)
+    lines.push(`URL: ${r.url}`)
+    lines.push(r.content.slice(0, 400))
+    lines.push('')
+  }
+  return lines.join('\n').trim()
+}
+
+// ── Fetch URL ─────────────────────────────────────────────────────────────
+
+export async function execFetchUrl(args: Record<string, unknown>): Promise<string> {
+  const url = String(args.url ?? '').trim()
+  if (!url) return 'Error: url is required.'
+  if (!/^https?:\/\//i.test(url)) return 'Error: URL must start with http:// or https://'
+
+  let resp: Response
+  try {
+    resp = await fetch(url, {
+      headers: { 'User-Agent': 'TurboLLM/0.7 (tool-fetch)' },
+      signal: AbortSignal.timeout(15_000),
+    })
+  } catch (e) {
+    return `Error: could not fetch URL — ${(e as Error).message}`
+  }
+
+  const contentType = resp.headers.get('content-type') ?? ''
+  const text = await resp.text().catch(() => '')
+  let content: string
+
+  if (contentType.includes('text/html')) {
+    // Strip HTML tags and collapse whitespace
+    content = text
+      .replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+  } else {
+    content = text.trim()
+  }
+
+  // Truncate to ~4000 chars to fit comfortably in the context window
+  if (content.length > 4000) content = content.slice(0, 4000) + '\n[truncated]'
+  return content || '(empty response)'
+}
+
+// ── Run code ─────────────────────────────────────────────────────────────
+
+export function execRunCode(args: Record<string, unknown>): string {
+  const code = String(args.code ?? '').trim()
+  if (!code) return 'Error: code is required.'
+
+  const output: string[] = []
+  const sandbox = {
+    console: {
+      log: (...a: unknown[]) => output.push(a.map(String).join(' ')),
+      error: (...a: unknown[]) => output.push('ERROR: ' + a.map(String).join(' ')),
+      warn: (...a: unknown[]) => output.push('WARN: ' + a.map(String).join(' ')),
+    },
+    Math,
+    JSON,
+    Array,
+    Object,
+    String,
+    Number,
+    Boolean,
+    Date,
+    RegExp,
+    parseInt,
+    parseFloat,
+    isNaN,
+    isFinite,
+    encodeURIComponent,
+    decodeURIComponent,
+  }
+
+  let result: unknown
+  try {
+    result = runInNewContext(`(function(){${code}})()`, sandbox, { timeout: 5000 })
+  } catch (e) {
+    return `Error: ${(e as Error).message}`
+  }
+
+  const parts: string[] = []
+  if (output.length > 0) parts.push(output.join('\n'))
+  if (result !== undefined) {
+    try {
+      parts.push(typeof result === 'string' ? result : JSON.stringify(result, null, 2))
+    } catch {
+      parts.push(String(result))
+    }
+  }
+  return parts.join('\n') || '(no output)'
+}

--- a/turbollm/src/tools/mcp-client.ts
+++ b/turbollm/src/tools/mcp-client.ts
@@ -1,0 +1,313 @@
+// MCP host/client (v0.7.0). Implements stdio (subprocess JSON-RPC) and SSE (HTTP)
+// transports per the MCP 2024-11-05 specification.
+import { spawn, type ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+
+// ── MCP protocol types ────────────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id: string | number
+  method: string
+  params?: unknown
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id: string | number
+  result?: unknown
+  error?: { code: number; message: string; data?: unknown }
+}
+
+interface JsonRpcNotification {
+  jsonrpc: '2.0'
+  method: string
+  params?: unknown
+}
+
+export interface McpTool {
+  name: string
+  description?: string
+  inputSchema?: Record<string, unknown>
+}
+
+export interface McpCallResult {
+  content: Array<{ type: string; text?: string }>
+  isError?: boolean
+}
+
+// ── Base client interface ─────────────────────────────────────────────────
+
+export interface IMcpClient {
+  readonly serverId: string
+  readonly serverName: string
+  connect(): Promise<void>
+  disconnect(): void
+  listTools(): Promise<McpTool[]>
+  callTool(name: string, args: Record<string, unknown>): Promise<string>
+}
+
+// ── Stdio client ──────────────────────────────────────────────────────────
+
+export class StdioMcpClient implements IMcpClient {
+  readonly serverId: string
+  readonly serverName: string
+  private command: string
+  private args: string[]
+  private env: Record<string, string>
+  private proc: ChildProcess | null = null
+  private pending = new Map<string | number, { resolve: (r: JsonRpcResponse) => void }>()
+  private buf = ''
+  private msgId = 0
+  private initialized = false
+
+  constructor(opts: { id: string; name: string; command: string; args?: string[]; env?: Record<string, string> }) {
+    this.serverId = opts.id
+    this.serverName = opts.name
+    this.command = opts.command
+    this.args = opts.args ?? []
+    this.env = opts.env ?? {}
+  }
+
+  async connect(): Promise<void> {
+    if (this.proc) return
+    this.proc = spawn(this.command, this.args, {
+      env: { ...process.env, ...this.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    this.proc.stdout?.on('data', (chunk: Buffer) => {
+      this.buf += chunk.toString('utf8')
+      const lines = this.buf.split('\n')
+      this.buf = lines.pop() ?? ''
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        try {
+          const msg = JSON.parse(trimmed) as JsonRpcResponse | JsonRpcNotification
+          if ('id' in msg && msg.id != null) {
+            const pending = this.pending.get(msg.id)
+            if (pending) {
+              this.pending.delete(msg.id)
+              pending.resolve(msg as JsonRpcResponse)
+            }
+          }
+        } catch { /* ignore parse errors */ }
+      }
+    })
+
+    this.proc.on('error', () => this.cleanup())
+    this.proc.on('exit', () => this.cleanup())
+
+    await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      clientInfo: { name: 'turbollm', version: '0.7.0' },
+    })
+    await this.sendNotification('notifications/initialized', {})
+    this.initialized = true
+  }
+
+  disconnect(): void {
+    this.cleanup()
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    if (!this.initialized) await this.connect()
+    const result = await this.sendRequest('tools/list', {}) as { tools?: McpTool[] }
+    return result.tools ?? []
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    if (!this.initialized) await this.connect()
+    const result = await this.sendRequest('tools/call', { name, arguments: args }) as McpCallResult
+    const text = (result.content ?? [])
+      .filter((c) => c.type === 'text' && c.text)
+      .map((c) => c.text!)
+      .join('\n')
+    return result.isError ? `Error: ${text}` : (text || '(no output)')
+  }
+
+  private sendRequest(method: string, params: unknown): Promise<unknown> {
+    const id = ++this.msgId
+    const req: JsonRpcRequest = { jsonrpc: '2.0', id, method, params }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`MCP request timeout: ${method}`))
+      }, 30_000)
+      this.pending.set(id, {
+        resolve: (r) => {
+          clearTimeout(timer)
+          if (r.error) reject(new Error(r.error.message))
+          else resolve(r.result)
+        },
+      })
+      this.write(req)
+    })
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    const msg: JsonRpcNotification = { jsonrpc: '2.0', method, params }
+    this.write(msg)
+  }
+
+  private write(msg: unknown): void {
+    if (!this.proc?.stdin?.writable) return
+    try {
+      this.proc.stdin.write(JSON.stringify(msg) + '\n')
+    } catch { /* ignore write errors on disconnected proc */ }
+  }
+
+  private cleanup(): void {
+    for (const p of this.pending.values()) {
+      p.resolve({ jsonrpc: '2.0', id: -1, error: { code: -1, message: 'MCP server disconnected' } })
+    }
+    this.pending.clear()
+    try { this.proc?.kill() } catch { /* ignore */ }
+    this.proc = null
+    this.initialized = false
+  }
+}
+
+// ── SSE client ────────────────────────────────────────────────────────────
+
+export class SseMcpClient implements IMcpClient {
+  readonly serverId: string
+  readonly serverName: string
+  private baseUrl: string
+  private msgId = 0
+  private sseEndpoint = ''
+  private sseAbort: AbortController | null = null
+  private emitter = new EventEmitter()
+  private initialized = false
+
+  constructor(opts: { id: string; name: string; url: string }) {
+    this.serverId = opts.id
+    this.serverName = opts.name
+    this.baseUrl = opts.url.replace(/\/$/, '')
+  }
+
+  async connect(): Promise<void> {
+    if (this.initialized) return
+
+    // Connect to the SSE stream to discover the messages endpoint
+    this.sseAbort = new AbortController()
+    const endpoint = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('SSE connect timeout')), 15_000)
+      fetch(`${this.baseUrl}/sse`, { signal: this.sseAbort!.signal })
+        .then(async (resp) => {
+          if (!resp.ok || !resp.body) { clearTimeout(timer); reject(new Error(`SSE connect failed: ${resp.status}`)); return }
+          const reader = resp.body.getReader()
+          const decoder = new TextDecoder()
+          let buf = ''
+          let resolved = false
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buf += decoder.decode(value, { stream: true })
+            const lines = buf.split('\n')
+            buf = lines.pop() ?? ''
+            for (const line of lines) {
+              if (line.startsWith('data:')) {
+                const data = line.slice(5).trim()
+                if (!resolved) {
+                  // First event is the endpoint URL
+                  resolved = true
+                  clearTimeout(timer)
+                  resolve(data)
+                }
+                try {
+                  const msg = JSON.parse(data) as JsonRpcResponse
+                  if (msg.id != null) this.emitter.emit(`rpc:${msg.id}`, msg)
+                } catch { /* non-JSON events (endpoint URL) are fine */ }
+              }
+            }
+          }
+        })
+        .catch((e) => { clearTimeout(timer); if (!this.sseAbort?.signal.aborted) reject(e) })
+    })
+
+    this.sseEndpoint = endpoint.startsWith('http') ? endpoint : `${this.baseUrl}${endpoint}`
+
+    await this.sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {} },
+      clientInfo: { name: 'turbollm', version: '0.7.0' },
+    })
+    await this.post({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+    this.initialized = true
+  }
+
+  disconnect(): void {
+    this.sseAbort?.abort()
+    this.sseAbort = null
+    this.initialized = false
+  }
+
+  async listTools(): Promise<McpTool[]> {
+    if (!this.initialized) await this.connect()
+    const result = await this.sendRequest('tools/list', {}) as { tools?: McpTool[] }
+    return result.tools ?? []
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    if (!this.initialized) await this.connect()
+    const result = await this.sendRequest('tools/call', { name, arguments: args }) as McpCallResult
+    const text = (result.content ?? [])
+      .filter((c) => c.type === 'text' && c.text)
+      .map((c) => c.text!)
+      .join('\n')
+    return result.isError ? `Error: ${text}` : (text || '(no output)')
+  }
+
+  private async sendRequest(method: string, params: unknown): Promise<unknown> {
+    const id = ++this.msgId
+    const req: JsonRpcRequest = { jsonrpc: '2.0', id, method, params }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.emitter.removeAllListeners(`rpc:${id}`)
+        reject(new Error(`MCP SSE request timeout: ${method}`))
+      }, 30_000)
+      this.emitter.once(`rpc:${id}`, (msg: JsonRpcResponse) => {
+        clearTimeout(timer)
+        if (msg.error) reject(new Error(msg.error.message))
+        else resolve(msg.result)
+      })
+      this.post(req).catch((e) => { clearTimeout(timer); reject(e) })
+    })
+  }
+
+  private async post(msg: unknown): Promise<void> {
+    const url = this.sseEndpoint || `${this.baseUrl}/messages`
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(msg),
+      signal: AbortSignal.timeout(10_000),
+    })
+  }
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────
+
+export function createMcpClient(server: {
+  id: string
+  name: string
+  transport: 'stdio' | 'sse'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+}): IMcpClient {
+  if (server.transport === 'sse') {
+    if (!server.url) throw new Error(`MCP server "${server.name}" has transport=sse but no url`)
+    return new SseMcpClient({ id: server.id, name: server.name, url: server.url })
+  }
+  if (!server.command) throw new Error(`MCP server "${server.name}" has transport=stdio but no command`)
+  return new StdioMcpClient({
+    id: server.id, name: server.name,
+    command: server.command, args: server.args, env: server.env,
+  })
+}

--- a/turbollm/src/tools/tool-registry.ts
+++ b/turbollm/src/tools/tool-registry.ts
@@ -1,0 +1,143 @@
+// Tool registry (v0.7.0): aggregates built-in tools and MCP tool providers.
+// Manages MCP server lifecycle and presents a unified tool list to the chat loop.
+import type { McpServer, ToolsConfig } from '../config/config'
+import {
+  WEB_SEARCH_TOOL, FETCH_URL_TOOL, RUN_CODE_TOOL,
+  execWebSearch, execFetchUrl, execRunCode,
+} from './builtin'
+import { createMcpClient, type IMcpClient } from './mcp-client'
+
+export interface ToolDefinition {
+  type: 'function'
+  function: {
+    name: string
+    description?: string
+    parameters?: Record<string, unknown>
+  }
+}
+
+export interface ToolCall {
+  id: string
+  name: string
+  args: Record<string, unknown>
+}
+
+export class ToolRegistry {
+  private toolsCfg: ToolsConfig
+  private mcpClients = new Map<string, IMcpClient>()
+
+  constructor(toolsCfg: ToolsConfig) {
+    this.toolsCfg = toolsCfg
+  }
+
+  /** Update config (called on settings change without restart). */
+  updateConfig(toolsCfg: ToolsConfig): void {
+    this.toolsCfg = toolsCfg
+  }
+
+  /** Connect/disconnect MCP servers to match the current config list. */
+  async syncMcpServers(servers: McpServer[]): Promise<void> {
+    const enabledIds = new Set(servers.filter((s) => s.enabled).map((s) => s.id))
+
+    // Disconnect removed/disabled servers
+    for (const [id, client] of this.mcpClients) {
+      if (!enabledIds.has(id)) {
+        client.disconnect()
+        this.mcpClients.delete(id)
+      }
+    }
+
+    // Connect newly enabled servers
+    for (const srv of servers) {
+      if (!srv.enabled || this.mcpClients.has(srv.id)) continue
+      try {
+        const client = createMcpClient(srv)
+        await client.connect()
+        this.mcpClients.set(srv.id, client)
+      } catch {
+        // Non-fatal: MCP server failed to connect; it won't appear in tool list
+      }
+    }
+  }
+
+  disconnectAll(): void {
+    for (const client of this.mcpClients.values()) client.disconnect()
+    this.mcpClients.clear()
+  }
+
+  /** Build the full tools array to send to the engine. Returns [] when no tools are available. */
+  async buildToolDefinitions(): Promise<ToolDefinition[]> {
+    const defs: ToolDefinition[] = []
+
+    // Built-in tools — only available when the required config is present
+    if (this.toolsCfg.tavily?.apiKey) defs.push(WEB_SEARCH_TOOL)
+    defs.push(FETCH_URL_TOOL)
+    defs.push(RUN_CODE_TOOL)
+
+    // MCP tools from connected servers
+    for (const client of this.mcpClients.values()) {
+      try {
+        const mcpTools = await client.listTools()
+        for (const t of mcpTools) {
+          defs.push({
+            type: 'function',
+            function: {
+              name: `mcp__${client.serverId.replace(/-/g, '_')}__${t.name}`,
+              description: `[${client.serverName}] ${t.description ?? ''}`,
+              parameters: t.inputSchema ?? { type: 'object', properties: {} },
+            },
+          })
+        }
+      } catch { /* skip unavailable MCP server */ }
+    }
+
+    return defs
+  }
+
+  /** Execute a single tool call. Returns the result string. */
+  async executeTool(call: ToolCall): Promise<string> {
+    const name = call.name
+    const args = call.args
+
+    // Built-in: web_search
+    if (name === 'web_search') {
+      const key = this.toolsCfg.tavily?.apiKey
+      if (!key) return 'Error: Tavily API key not configured. Add it in Settings → Tools.'
+      return execWebSearch(args, key)
+    }
+
+    // Built-in: fetch_url
+    if (name === 'fetch_url') return execFetchUrl(args)
+
+    // Built-in: run_code
+    if (name === 'run_code') return execRunCode(args)
+
+    // MCP tool: mcp__{serverId}__{toolName}
+    const mcpMatch = name.match(/^mcp__([^_]+(?:_[^_]+)*)__(.+)$/)
+    if (mcpMatch) {
+      const rawServerId = mcpMatch[1].replace(/_/g, '-')
+      const toolName = mcpMatch[2]
+
+      // Find the client — try exact match first, then normalized
+      let client = this.mcpClients.get(rawServerId)
+      if (!client) {
+        // Brute-force search since ID normalization is lossy
+        for (const [id, c] of this.mcpClients) {
+          if (id.replace(/-/g, '_') === mcpMatch[1]) { client = c; break }
+        }
+      }
+      if (!client) return `Error: MCP server "${rawServerId}" not connected.`
+      return client.callTool(toolName, args)
+    }
+
+    return `Error: unknown tool "${name}"`
+  }
+
+  /** Whether any tools are currently available (determines if tools should be sent to engine). */
+  hasTools(): boolean {
+    if (this.toolsCfg.tavily?.apiKey) return true
+    if (this.mcpClients.size > 0) return true
+    // fetch_url and run_code are always available
+    return true
+  }
+}

--- a/turbollm/web/src/App.tsx
+++ b/turbollm/web/src/App.tsx
@@ -15,6 +15,7 @@ import { ChatScreen } from './screens/ChatScreen'
 import { ModelsScreen } from './screens/ModelsScreen'
 import { EnginesScreen } from './screens/EnginesScreen'
 import { DeveloperScreen } from './screens/DeveloperScreen'
+import { CustomizeScreen } from './screens/CustomizeScreen'
 import { SettingsScreen } from './screens/SettingsScreen'
 
 export function App() {
@@ -48,6 +49,7 @@ export function App() {
           <Route path="/models" element={<ModelsScreen />} />
           <Route path="/engines" element={<EnginesScreen />} />
           <Route path="/developer" element={<DeveloperScreen />} />
+          <Route path="/customize" element={<CustomizeScreen />} />
           <Route path="/settings" element={<SettingsScreen />} />
           <Route path="*" element={<Navigate to="/chat" replace />} />
         </Routes>

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
-import { Boxes, Code2, Cpu, MessageSquare, Settings2 } from 'lucide-react'
+import { Boxes, Code2, Cpu, MessageSquare, Puzzle, Settings2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import type { Status } from '../lib/types'
 import { StateChip } from './StateChip'
@@ -16,6 +16,7 @@ const NAV = [
   { to: '/chat',      label: 'Chat',      icon: MessageSquare },
   { to: '/models',    label: 'Models',    icon: Boxes },
   { to: '/engines',   label: 'Engines',   icon: Cpu },
+  { to: '/customize', label: 'Customize', icon: Puzzle },
   { to: '/developer', label: 'Developer', icon: Code2 },
   { to: '/settings',  label: 'Settings',  icon: Settings2 },
 ] as const

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -331,6 +331,17 @@ export function uninstallComfyGate(): Promise<{ ok: boolean }> {
   return request('/api/v1/comfyui/uninstall', { method: 'POST', json: {} })
 }
 
+export type McpServer = {
+  id: string
+  name: string
+  transport: 'stdio' | 'sse'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  enabled: boolean
+}
+
 export type DaemonSettings = {
   idleTtlMinutes: number
   /** Listen port (spec 08 §2). Takes effect on the next daemon restart. */
@@ -354,15 +365,21 @@ export type DaemonSettings = {
   hfTokenSet: boolean
   /** Gateway intelligence settings (ADR-06x): model auto-swap + keep-N pool. */
   gateway: { autoSwap: boolean; keepN: number }
+  /** Whether a Tavily API key is configured (the key itself is never echoed back). */
+  tavilyKeySet: boolean
+  /** MCP server list. */
+  mcp: { servers: McpServer[] }
 }
 
 /** Settings patch: the persisted {@link DaemonSettings} fields plus a write-only
  *  `hfToken` (spec 10 §4) that sets/clears the stored Hugging Face token. `comfyui`
  *  is patchable per-field (only `enabled` is set here; `gatePath` is owned by the
  *  install endpoints). */
-export type DaemonSettingsPatch = Partial<Omit<DaemonSettings, 'comfyui'>> & {
+export type DaemonSettingsPatch = Partial<Omit<DaemonSettings, 'comfyui' | 'tavilyKeySet' | 'mcp'>> & {
   comfyui?: Partial<ComfyUiSettings>
   hfToken?: string
+  /** Write-only: set or clear the Tavily API key. */
+  tavilyApiKey?: string
 }
 
 export function getSettings(): Promise<DaemonSettings> {
@@ -376,6 +393,18 @@ export type RebindInfo = { portChanged: boolean; port: number; lanBind: boolean 
 
 export function saveSettings(patch: DaemonSettingsPatch): Promise<DaemonSettings & { rebind?: RebindInfo }> {
   return request<DaemonSettings & { rebind?: RebindInfo }>('/api/v1/settings', { method: 'PATCH', json: patch })
+}
+
+export function addMcpServer(server: Omit<McpServer, 'id'>): Promise<McpServer> {
+  return request<McpServer>('/api/v1/mcp/servers', { method: 'POST', json: server })
+}
+
+export function updateMcpServer(id: string, patch: Partial<Omit<McpServer, 'id'>>): Promise<McpServer> {
+  return request<McpServer>(`/api/v1/mcp/servers/${id}`, { method: 'PUT', json: patch })
+}
+
+export function deleteMcpServer(id: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/v1/mcp/servers/${id}`, { method: 'DELETE' })
 }
 
 /** Re-exec the daemon so port / LAN-bind changes take effect (spec 08 §2). Returns

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -20,7 +20,7 @@ export function listConversations(q?: string): Promise<{ conversations: Conversa
   return req(`/api/v1/conversations${q ? `?q=${encodeURIComponent(q)}` : ''}`)
 }
 
-export function createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey'>>): Promise<Conversation> {
+export function createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy'>>): Promise<Conversation> {
   return req('/api/v1/conversations', { method: 'POST', json: partial ?? {} })
 }
 

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -36,7 +36,7 @@ export function useConversationMutations() {
 
   return {
     create: useMutation({
-      mutationFn: (p?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey'>>) => createConversation(p),
+      mutationFn: (p?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy'>>) => createConversation(p),
       onSuccess: invalidateList,
     }),
     createExpert: useMutation({

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -54,6 +54,9 @@ export interface Conversation {
   /** Built-in TurboLLM Expert thread — its system prompt is managed server-side
    *  and hidden from the UI (spec 08 §2). */
   expertMode: boolean
+  /** When set, the backend enforces a tool_choice policy on the first generation
+   *  iteration. 'force_web_search' forces web_search before the model can reply. */
+  toolPolicy?: string
   createdAt: string
   updatedAt: string
   messages?: Message[]

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -15,6 +15,22 @@ export interface MessageStats {
   aborted: boolean
 }
 
+export interface ToolCallRecord {
+  id: string
+  name: string
+  args: Record<string, unknown>
+  result?: string
+  error?: string
+}
+
+export interface LiveToolCall {
+  id: string
+  name: string
+  args: Record<string, unknown>
+  status: 'pending' | 'done' | 'error'
+  result?: string
+}
+
 export interface Message {
   id: string
   convId: string
@@ -24,6 +40,7 @@ export interface Message {
   reasoning: string
   attachments: string[]
   textAttachments: string[]
+  toolCalls: ToolCallRecord[]
   stats: Partial<MessageStats>
   createdAt: string
 }
@@ -48,5 +65,6 @@ export type ChatSseEvent =
   | { event: 'progress';  data: { phase: string; processed: number; total: number; pct: number; tps: number } }
   | { event: 'reasoning'; data: { delta: string } }
   | { event: 'delta';     data: { delta: string } }
+  | { event: 'tool_call'; data: { id: string; name: string; args: Record<string, unknown>; status: 'pending' | 'done' | 'error'; result?: string } }
   | { event: 'done';      data: { message: Message } }
   | { event: 'error';     data: { code: string; message: string } }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -1,4 +1,4 @@
-export type PersonaId = 'default' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative'
+export type PersonaId = 'default' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative' | 'research'
 
 export interface Persona {
   id: PersonaId
@@ -54,6 +54,28 @@ export const PERSONAS: readonly Persona[] = [
     description: 'Asks a clarifying question first, then teaches step by step',
     systemPrompt:
       'You are a patient teacher. If the question is ambiguous, ask one focused clarifying question before answering. Otherwise, explain step by step as if teaching someone encountering this topic for the first time.',
+  },
+  {
+    id: 'research',
+    name: 'Research',
+    description: 'Searches the web before answering — cites sources, prioritizes current facts',
+    systemPrompt:
+      'You are a research assistant with web search capability.\n\n' +
+      'ALWAYS call web_search before answering questions that involve:\n' +
+      '- Current events, news, or recent developments (anything after your training cutoff)\n' +
+      '- Specific facts, statistics, prices, or data that change over time\n' +
+      '- People, companies, products, or releases\n' +
+      '- Any claim where being wrong would matter\n\n' +
+      'How to search well:\n' +
+      '1. Break complex questions into 2–3 focused, specific searches\n' +
+      '2. Use precise query terms — names, dates, version numbers, not vague phrases\n' +
+      '3. If the first search is insufficient, refine the query and search again\n' +
+      '4. Synthesize across results rather than just quoting the top one\n\n' +
+      'After searching:\n' +
+      '- Cite your sources inline as [title](url) links\n' +
+      '- Distinguish what you found from what you already knew\n' +
+      '- If sources conflict, note the discrepancy\n' +
+      '- If search results do not answer the question, say so honestly rather than guessing',
   },
   {
     id: 'creative',

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -161,7 +161,8 @@ Always include a title, axis/column labels, and the underlying numbers. Keep cha
 export function buildSystemPrompt(personaId: PersonaId, p: Personalization): string {
   if (personaId === 'blank') return ''
   const persona = PERSONAS.find((px) => px.id === personaId)
-  const parts: string[] = [TURBOLLM_BASE_CAPABILITY]
+  const today = new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+  const parts: string[] = [TURBOLLM_BASE_CAPABILITY, `Today's date is ${today}.`]
   if (persona?.systemPrompt) parts.push(persona.systemPrompt)
   if (p.assistantName.trim()) parts.push(`Your name is ${p.assistantName.trim()}.`)
   if (p.userName.trim()) parts.push(`The user's name is ${p.userName.trim()}.`)

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -58,24 +58,18 @@ export const PERSONAS: readonly Persona[] = [
   {
     id: 'research',
     name: 'Research',
-    description: 'Searches the web before answering — cites sources, prioritizes current facts',
+    description: 'Always searches the web first — cites sources, never answers from memory alone',
     systemPrompt:
-      'You are a research assistant with web search capability.\n\n' +
-      'ALWAYS call web_search before answering questions that involve:\n' +
-      '- Current events, news, or recent developments (anything after your training cutoff)\n' +
-      '- Specific facts, statistics, prices, or data that change over time\n' +
-      '- People, companies, products, or releases\n' +
-      '- Any claim where being wrong would matter\n\n' +
+      'You are a research assistant. Your FIRST action on every user message is to call web_search — no exceptions, no skipping, even if you think you know the answer. Do not compose a reply until you have searched.\n\n' +
       'How to search well:\n' +
       '1. Break complex questions into 2–3 focused, specific searches\n' +
       '2. Use precise query terms — names, dates, version numbers, not vague phrases\n' +
-      '3. If the first search is insufficient, refine the query and search again\n' +
-      '4. Synthesize across results rather than just quoting the top one\n\n' +
+      '3. If the first search is insufficient, search again with a refined query\n' +
+      '4. Synthesize across results rather than quoting just the top one\n\n' +
       'After searching:\n' +
-      '- Cite your sources inline as [title](url) links\n' +
-      '- Distinguish what you found from what you already knew\n' +
+      '- Cite sources inline as [title](url) links\n' +
       '- If sources conflict, note the discrepancy\n' +
-      '- If search results do not answer the question, say so honestly rather than guessing',
+      '- If results do not answer the question, say so honestly',
   },
   {
     id: 'creative',

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -58,18 +58,24 @@ export const PERSONAS: readonly Persona[] = [
   {
     id: 'research',
     name: 'Research',
-    description: 'Always searches the web first — cites sources, never answers from memory alone',
+    description: 'Multi-search deep research — runs 3–5 targeted queries before answering, cites all sources',
     systemPrompt:
-      'You are a research assistant. Your FIRST action on every user message is to call web_search — no exceptions, no skipping, even if you think you know the answer. Do not compose a reply until you have searched.\n\n' +
-      'How to search well:\n' +
-      '1. Break complex questions into 2–3 focused, specific searches\n' +
-      '2. Use precise query terms — names, dates, version numbers, not vague phrases\n' +
-      '3. If the first search is insufficient, search again with a refined query\n' +
-      '4. Synthesize across results rather than quoting just the top one\n\n' +
-      'After searching:\n' +
-      '- Cite sources inline as [title](url) links\n' +
-      '- If sources conflict, note the discrepancy\n' +
-      '- If results do not answer the question, say so honestly',
+      'You are a deep research assistant. Every response requires multiple web searches — do NOT compose your answer until you have run at least 3 searches.\n\n' +
+      'Required search strategy (follow this every time):\n' +
+      '1. Start with a broad query to get an overview and identify key facts\n' +
+      '2. Run a second targeted query focusing on the most important specific aspect (version, date, number, name, etc.)\n' +
+      '3. Run a third query from a different angle — e.g. "site:reddit.com", comparisons, recent news, or expert opinions\n' +
+      '4. If results are thin or contradict each other, run 1–2 more refined searches to resolve the gaps\n' +
+      '5. Only compose your answer after all searches are done\n\n' +
+      'Query craft rules:\n' +
+      '- Use precise terms: model names, version numbers, dates, company names — never vague phrases\n' +
+      '- Vary your query angles across searches: overview → specific fact → alternative perspective\n' +
+      '- If a search returns stale or irrelevant results, rephrase and search again immediately\n\n' +
+      'In your answer:\n' +
+      '- Cite every factual claim inline as [source title](url)\n' +
+      '- Note conflicts between sources and which you find more credible and why\n' +
+      '- Clearly separate what search results say from what you already knew\n' +
+      '- If searches failed to answer something, say so explicitly instead of guessing',
   },
   {
     id: 'creative',

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -52,6 +52,9 @@ import {
   reprobeEngine,
   rescanModels,
   resetModelProfile,
+  addMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
   restartDaemon,
   restartEngine,
   saveModelProfile,
@@ -59,6 +62,7 @@ import {
   startEngine,
   stopEngine,
   type DaemonSettingsPatch,
+  type McpServer,
   type SysInfo,
   type TelemetryLevel,
 } from './api'
@@ -380,6 +384,16 @@ export function useModelActions() {
       mutationFn: () => stopEngine(),
       onSuccess: invalidate,
     }),
+  }
+}
+
+export function useMcpMutations() {
+  const qc = useQueryClient()
+  const refresh = () => void qc.invalidateQueries({ queryKey: ['settings'] })
+  return {
+    add: useMutation({ mutationFn: (s: Omit<McpServer, 'id'>) => addMcpServer(s), onSuccess: refresh }),
+    update: useMutation({ mutationFn: ({ id, patch }: { id: string; patch: Partial<Omit<McpServer, 'id'>> }) => updateMcpServer(id, patch), onSuccess: refresh }),
+    remove: useMutation({ mutationFn: (id: string) => deleteMcpServer(id), onSuccess: refresh }),
   }
 }
 

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -283,7 +283,11 @@ export function ChatScreen() {
       let convId = activeId
       if (!convId) {
         const sp = buildSystemPrompt(selectedPersonaId, getPersonalization())
-        const newConv = await mut.create.mutateAsync({ modelKey: model.key, systemPrompt: sp || undefined })
+        const newConv = await mut.create.mutateAsync({
+          modelKey: model.key,
+          systemPrompt: sp || undefined,
+          toolPolicy: selectedPersonaId === 'research' ? 'force_web_search' : undefined,
+        })
         convId = newConv.id
         setConvPersonaId(convId, selectedPersonaId)
         setActiveId(convId)

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -3,7 +3,7 @@ import { ArrowDown, Brain, Paperclip, SendHorizontal, SlidersHorizontal, Square,
 import { continueConversation, sendMessage } from '../lib/chat-api'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
 import { useModelActions, useModels, useStatus } from '../lib/queries'
-import type { ChatSseEvent, Message } from '../lib/chat-types'
+import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
 import { ApiError } from '../lib/api'
 import { Button } from '../components/ui/button'
 import { toast } from '../components/ui/sonner'
@@ -29,6 +29,7 @@ interface LiveState {
   progress: { phase: string; pct: number; tps: number } | null
   liveGenTps: number  // rolling 2s window estimate during generation phase
   genTokens: number   // running count of generated tokens (content + reasoning) for this reply
+  toolCalls: LiveToolCall[]
 }
 
 export function ChatScreen() {
@@ -215,7 +216,7 @@ export function ChatScreen() {
       for await (const evt of gen) {
         if (evt.event === 'meta') {
           deltaTimestamps.current = []
-          setLive({ assistantId: evt.data.assistantMessageId, content: '', reasoning: '', progress: null, liveGenTps: 0, genTokens: 0 })
+          setLive({ assistantId: evt.data.assistantMessageId, content: '', reasoning: '', progress: null, liveGenTps: 0, genTokens: 0, toolCalls: [] })
           // Optimistically reflect the new/last user msg in the UI by invalidating
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
         } else if (evt.event === 'progress') {
@@ -227,6 +228,18 @@ export function ChatScreen() {
         } else if (evt.event === 'delta') {
           const liveTps = pushGenToken()
           setLive((l) => l ? { ...l, content: l.content + evt.data.delta, progress: null, liveGenTps: liveTps, genTokens: l.genTokens + 1 } : l)
+        } else if (evt.event === 'tool_call') {
+          const tc = evt.data
+          setLive((l) => {
+            if (!l) return l
+            const existing = l.toolCalls.findIndex((x) => x.id === tc.id)
+            if (existing >= 0) {
+              const updated = [...l.toolCalls]
+              updated[existing] = { ...updated[existing], status: tc.status, result: tc.result }
+              return { ...l, toolCalls: updated }
+            }
+            return { ...l, toolCalls: [...l.toolCalls, { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result }] }
+          })
         } else if (evt.event === 'done') {
           setLive(null)
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
@@ -447,7 +460,7 @@ export function ChatScreen() {
 
             {/* Streaming bubble */}
             {live && (
-              <StreamingBubble content={live.content} reasoning={live.reasoning} progress={live.progress} liveGenTps={live.liveGenTps} genTokens={live.genTokens} />
+              <StreamingBubble content={live.content} reasoning={live.reasoning} progress={live.progress} liveGenTps={live.liveGenTps} genTokens={live.genTokens} toolCalls={live.toolCalls} />
             )}
 
             <div ref={bottomRef} />

--- a/turbollm/web/src/screens/CustomizeScreen.tsx
+++ b/turbollm/web/src/screens/CustomizeScreen.tsx
@@ -1,0 +1,349 @@
+import { useState } from 'react'
+import { Check, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { ScreenHeader } from '../components/common'
+import { Button } from '../components/ui/button'
+import { toast } from '../components/ui/sonner'
+import { useMcpMutations, useSettings } from '../lib/queries'
+import { ApiError } from '../lib/api'
+import type { McpServer } from '../lib/api'
+
+export function CustomizeScreen() {
+  const { query: settingsQ } = useSettings()
+  const settings = settingsQ.data
+
+  return (
+    <div className="w-full px-6 py-6">
+      <ScreenHeader
+        title="Customize"
+        description="Add tools and external providers the model can call during conversations."
+      />
+      <div className="flex flex-col gap-6">
+        <ToolsSection
+          tavilyKeySet={settings?.tavilyKeySet ?? false}
+          onSaved={() => void settingsQ.refetch()}
+        />
+        <McpSection servers={settings?.mcp?.servers ?? []} />
+      </div>
+    </div>
+  )
+}
+
+// ── Tools — Tavily web search key ────────────────────────────────────────────
+
+function ToolsSection({ tavilyKeySet, onSaved }: { tavilyKeySet: boolean; onSaved: () => void }) {
+  const { save } = useSettings()
+  const [key, setKey] = useState('')
+
+  const handleSave = () => {
+    save.mutate({ tavilyApiKey: key.trim() }, {
+      onSuccess: () => {
+        toast.success(key.trim() ? 'Tavily API key saved' : 'Tavily API key cleared')
+        setKey('')
+        onSaved()
+      },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save the key.'),
+    })
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">Web Search</h2>
+      <p className="mb-3 text-[12px] text-muted">
+        Tavily AI-search API. When configured, the model can call the{' '}
+        <span className="font-mono text-ink">web_search</span> tool automatically.{' '}
+        <a
+          href="https://app.tavily.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-ink underline-offset-2 hover:underline"
+        >
+          Get a key
+        </a>
+        .
+      </p>
+
+      <div className="mb-2 text-[13px] text-muted">
+        {tavilyKeySet ? (
+          <span className="inline-flex items-center gap-1.5 text-ink">
+            <Check size={13} style={{ color: 'var(--ok)' }} /> A key is configured
+          </span>
+        ) : 'No key configured'}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder={tavilyKeySet ? 'Enter a new key to replace the current one' : 'tvly-…'}
+          autoComplete="off"
+          className="flex-1 rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[13px] text-ink outline-none"
+        />
+        <Button size="sm" onClick={handleSave} disabled={save.isPending}>
+          {key.trim() ? 'Save key' : 'Clear key'}
+        </Button>
+      </div>
+
+      <p className="mt-3 text-[12px] text-faint">
+        <span className="font-mono text-ink">fetch_url</span> and{' '}
+        <span className="font-mono text-ink">run_code</span> (sandboxed JS) are always available — no key needed.
+      </p>
+    </section>
+  )
+}
+
+// ── MCP Servers ───────────────────────────────────────────────────────────────
+
+type McpFormState = {
+  name: string
+  transport: 'stdio' | 'sse'
+  command: string
+  argsStr: string
+  envStr: string
+  url: string
+  enabled: boolean
+}
+
+const emptyMcpForm = (): McpFormState => ({
+  name: '', transport: 'stdio', command: '', argsStr: '', envStr: '', url: '', enabled: true,
+})
+
+function serverToForm(s: McpServer): McpFormState {
+  return {
+    name: s.name,
+    transport: s.transport,
+    command: s.command ?? '',
+    argsStr: (s.args ?? []).join(', '),
+    envStr: Object.entries(s.env ?? {}).map(([k, v]) => `${k}=${v}`).join('\n'),
+    url: s.url ?? '',
+    enabled: s.enabled,
+  }
+}
+
+function formToPayload(f: McpFormState): Omit<McpServer, 'id'> {
+  const args = f.argsStr.trim() ? f.argsStr.split(',').map((s) => s.trim()).filter(Boolean) : []
+  const env: Record<string, string> = {}
+  for (const line of f.envStr.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
+  }
+  return {
+    name: f.name.trim(),
+    transport: f.transport,
+    command: f.transport === 'stdio' ? f.command.trim() || undefined : undefined,
+    args: f.transport === 'stdio' && args.length ? args : undefined,
+    env: f.transport === 'stdio' && Object.keys(env).length ? env : undefined,
+    url: f.transport === 'sse' ? f.url.trim() || undefined : undefined,
+    enabled: f.enabled,
+  }
+}
+
+function McpSection({ servers }: { servers: McpServer[] }) {
+  const mut = useMcpMutations()
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<McpFormState>(emptyMcpForm())
+  const set = (patch: Partial<McpFormState>) => setForm((p) => ({ ...p, ...patch }))
+
+  const openAdd = () => { setEditingId(null); setForm(emptyMcpForm()); setShowForm(true) }
+  const openEdit = (s: McpServer) => { setEditingId(s.id); setForm(serverToForm(s)); setShowForm(true) }
+  const closeForm = () => { setShowForm(false); setEditingId(null) }
+
+  const handleSubmit = () => {
+    const payload = formToPayload(form)
+    if (!payload.name) return void toast.error('Server name is required.')
+    if (payload.transport === 'stdio' && !payload.command) return void toast.error('Command is required for stdio transport.')
+    if (payload.transport === 'sse' && !payload.url) return void toast.error('URL is required for SSE transport.')
+    const opts = {
+      onSuccess: () => { toast.success(editingId ? 'MCP server updated' : 'MCP server added'); closeForm() },
+      onError: (e: unknown) => toast.error(e instanceof ApiError ? e.message : 'Could not save server.'),
+    }
+    if (editingId) mut.update.mutate({ id: editingId, patch: payload }, opts)
+    else mut.add.mutate(payload, opts)
+  }
+
+  const handleDelete = (id: string, name: string) => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Remove MCP server "${name}"?`)) return
+    mut.remove.mutate(id, { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not remove server.') })
+  }
+
+  const handleToggle = (s: McpServer) => {
+    mut.update.mutate({ id: s.id, patch: { enabled: !s.enabled } }, {
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update server.'),
+    })
+  }
+
+  const f = form
+  const busy = mut.add.isPending || mut.update.isPending
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">MCP Servers</h2>
+      <p className="mb-3 text-[12px] text-muted">
+        Connect external tool providers via the Model Context Protocol. Supports stdio (subprocess)
+        and SSE (HTTP) transports per the MCP 2024-11-05 spec.
+      </p>
+
+      {servers.length > 0 && (
+        <div className="mb-3 flex flex-col gap-1.5">
+          {servers.map((s) => (
+            <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
+              <span
+                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
+                style={{
+                  background: s.transport === 'sse'
+                    ? 'color-mix(in srgb, var(--accent) 15%, transparent)'
+                    : 'color-mix(in srgb, var(--muted) 20%, transparent)',
+                  color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
+                }}
+              >
+                {s.transport}
+              </span>
+              <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
+              <span
+                className="hidden shrink-0 max-w-[220px] truncate font-mono text-[11px] text-faint sm:block"
+                title={s.transport === 'stdio' ? s.command : s.url}
+              >
+                {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
+              </span>
+              <input
+                type="checkbox"
+                checked={s.enabled}
+                onChange={() => handleToggle(s)}
+                title={s.enabled ? 'Disable' : 'Enable'}
+                className="h-3.5 w-3.5 accent-[var(--accent)]"
+              />
+              <button
+                type="button"
+                onClick={() => openEdit(s)}
+                title="Edit"
+                className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink"
+              >
+                <Pencil size={12} />
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(s.id, s.name)}
+                title="Delete"
+                className="rounded p-1 transition-colors hover:bg-bg"
+                style={{ color: 'var(--err)' }}
+              >
+                <Trash2 size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!showForm ? (
+        <Button variant="outline" size="sm" onClick={openAdd}>
+          <Plus size={13} />
+          Add server
+        </Button>
+      ) : (
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-panel-2 p-3">
+          <div className="text-[13px] font-medium text-ink">{editingId ? 'Edit server' : 'Add server'}</div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Name</label>
+            <input
+              type="text"
+              value={f.name}
+              onChange={(e) => set({ name: e.target.value })}
+              placeholder="My Tool Server"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-ink outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Transport</label>
+            <div className="flex gap-4">
+              {(['stdio', 'sse'] as const).map((t) => (
+                <label key={t} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
+                  <input
+                    type="radio"
+                    name="mcp-transport"
+                    checked={f.transport === t}
+                    onChange={() => set({ transport: t })}
+                    className="h-3.5 w-3.5 accent-[var(--accent)]"
+                  />
+                  <span className="font-mono">{t}</span>
+                  <span className="text-[11px] text-faint">{t === 'stdio' ? '(subprocess)' : '(HTTP)'}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {f.transport === 'stdio' ? (
+            <>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">Command</label>
+                <input
+                  type="text"
+                  value={f.command}
+                  onChange={(e) => set({ command: e.target.value })}
+                  placeholder="npx -y @modelcontextprotocol/server-filesystem"
+                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">
+                  Args <span className="text-faint">(comma-separated, optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={f.argsStr}
+                  onChange={(e) => set({ argsStr: e.target.value })}
+                  placeholder="--port, 3000"
+                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">
+                  Env vars <span className="text-faint">(KEY=VALUE, one per line, optional)</span>
+                </label>
+                <textarea
+                  rows={2}
+                  value={f.envStr}
+                  onChange={(e) => set({ envStr: e.target.value })}
+                  placeholder={"API_KEY=abc123\nDEBUG=true"}
+                  className="resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] text-muted">URL</label>
+              <input
+                type="text"
+                value={f.url}
+                onChange={(e) => set({ url: e.target.value })}
+                placeholder="http://localhost:3000"
+                className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+              />
+            </div>
+          )}
+
+          <label className="flex cursor-pointer items-center gap-2 text-[13px] text-ink">
+            <input
+              type="checkbox"
+              checked={f.enabled}
+              onChange={(e) => set({ enabled: e.target.checked })}
+              className="h-3.5 w-3.5 accent-[var(--accent)]"
+            />
+            Enable immediately
+          </label>
+
+          <div className="flex gap-2">
+            <Button size="sm" onClick={handleSubmit} disabled={busy}>
+              {busy ? <Loader2 size={13} className="animate-spin" /> : null}
+              {editingId ? 'Update' : 'Add'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={closeForm}>Cancel</Button>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle } from 'lucide-react'
 import {
   PERSONAS, getDefaultPersonaId, getPersonalization, savePersonalization,
   setDefaultPersonaId, type PersonaId, type Personalization,
@@ -12,14 +12,12 @@ import {
   useComfyGate,
   useDaemonRestart,
   useHfTokenTest,
-  useMcpMutations,
   useNetworkInfo,
   useSettings,
   useStatus,
   useSysInfo,
   useTelemetryPreview,
 } from '../lib/queries'
-import type { McpServer } from '../lib/api'
 import { useConversationMutations } from '../lib/chat-queries'
 import { ApiError, type TelemetryLevel } from '../lib/api'
 import { TELEMETRY_UI_ENABLED } from '../lib/flags'
@@ -379,10 +377,6 @@ export function SettingsScreen() {
             />
           </label>
         </section>
-
-        {/* Tools & MCP (v0.7.0) */}
-        <ToolsSection tavilyKeySet={settings?.tavilyKeySet ?? false} onSaved={() => void settingsQ.refetch()} />
-        <McpSection servers={settings?.mcp?.servers ?? []} />
 
         {/* Personalization */}
         <PersonalizationSection />
@@ -1306,276 +1300,6 @@ function PersonalizationSection() {
           </Button>
         </div>
       </div>
-    </section>
-  )
-}
-
-// ── Tools — Tavily web search key (v0.7.0) ────────────────────────────────────
-
-function ToolsSection({ tavilyKeySet, onSaved }: { tavilyKeySet: boolean; onSaved: () => void }) {
-  const { save } = useSettings()
-  const [key, setKey] = useState('')
-
-  const handleSave = () => {
-    save.mutate({ tavilyApiKey: key.trim() }, {
-      onSuccess: () => {
-        toast.success(key.trim() ? 'Tavily API key saved' : 'Tavily API key cleared')
-        setKey('')
-        onSaved()
-      },
-      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save the key.'),
-    })
-  }
-
-  return (
-    <section className="rounded-lg border border-border bg-panel p-4">
-      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">Tools</h2>
-      <p className="mb-3 text-[12px] text-muted">
-        When configured, the model can call these tools automatically during a conversation.
-      </p>
-
-      <div className="text-[13px] font-medium text-ink mb-1">Web search (Tavily)</div>
-      <p className="text-[12px] text-muted mb-3">
-        Tavily AI-search API. Enables the <span className="font-mono text-ink">web_search</span> tool.{' '}
-        <a href="https://app.tavily.com" target="_blank" rel="noopener noreferrer" className="text-ink underline-offset-2 hover:underline">
-          Get a key
-        </a>.
-      </p>
-
-      <div className="mb-2 text-[13px] text-muted">
-        {tavilyKeySet ? (
-          <span className="inline-flex items-center gap-1.5 text-ink">
-            <Check size={13} style={{ color: 'var(--ok)' }} /> A key is configured
-          </span>
-        ) : 'No key configured'}
-      </div>
-
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <input
-          type="password"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          placeholder={tavilyKeySet ? 'Enter a new key to replace the current one' : 'tvly-…'}
-          autoComplete="off"
-          className="flex-1 rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[13px] text-ink outline-none"
-        />
-        <Button size="sm" onClick={handleSave} disabled={save.isPending}>
-          {key.trim() ? 'Save key' : 'Clear key'}
-        </Button>
-      </div>
-    </section>
-  )
-}
-
-// ── MCP Servers (v0.7.0) ──────────────────────────────────────────────────────
-
-type McpFormState = {
-  name: string
-  transport: 'stdio' | 'sse'
-  command: string
-  argsStr: string
-  envStr: string
-  url: string
-  enabled: boolean
-}
-
-const emptyMcpForm = (): McpFormState => ({ name: '', transport: 'stdio', command: '', argsStr: '', envStr: '', url: '', enabled: true })
-
-function serverToForm(s: McpServer): McpFormState {
-  return {
-    name: s.name,
-    transport: s.transport,
-    command: s.command ?? '',
-    argsStr: (s.args ?? []).join(', '),
-    envStr: Object.entries(s.env ?? {}).map(([k, v]) => `${k}=${v}`).join('\n'),
-    url: s.url ?? '',
-    enabled: s.enabled,
-  }
-}
-
-function formToPayload(f: McpFormState): Omit<McpServer, 'id'> {
-  const args = f.argsStr.trim() ? f.argsStr.split(',').map((s) => s.trim()).filter(Boolean) : []
-  const env: Record<string, string> = {}
-  for (const line of f.envStr.split('\n')) {
-    const eq = line.indexOf('=')
-    if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
-  }
-  return {
-    name: f.name.trim(),
-    transport: f.transport,
-    command: f.transport === 'stdio' ? f.command.trim() || undefined : undefined,
-    args: f.transport === 'stdio' && args.length ? args : undefined,
-    env: f.transport === 'stdio' && Object.keys(env).length ? env : undefined,
-    url: f.transport === 'sse' ? f.url.trim() || undefined : undefined,
-    enabled: f.enabled,
-  }
-}
-
-function McpSection({ servers }: { servers: McpServer[] }) {
-  const mut = useMcpMutations()
-  const [editingId, setEditingId] = useState<string | null>(null)
-  const [showForm, setShowForm] = useState(false)
-  const [form, setForm] = useState<McpFormState>(emptyMcpForm())
-  const set = (patch: Partial<McpFormState>) => setForm((p) => ({ ...p, ...patch }))
-
-  const openAdd = () => { setEditingId(null); setForm(emptyMcpForm()); setShowForm(true) }
-  const openEdit = (s: McpServer) => { setEditingId(s.id); setForm(serverToForm(s)); setShowForm(true) }
-  const closeForm = () => { setShowForm(false); setEditingId(null) }
-
-  const handleSubmit = () => {
-    const payload = formToPayload(form)
-    if (!payload.name) return void toast.error('Server name is required.')
-    if (payload.transport === 'stdio' && !payload.command) return void toast.error('Command is required for stdio transport.')
-    if (payload.transport === 'sse' && !payload.url) return void toast.error('URL is required for SSE transport.')
-    const opts = {
-      onSuccess: () => { toast.success(editingId ? 'MCP server updated' : 'MCP server added'); closeForm() },
-      onError: (e: unknown) => toast.error(e instanceof ApiError ? e.message : 'Could not save server.'),
-    }
-    if (editingId) mut.update.mutate({ id: editingId, patch: payload }, opts)
-    else mut.add.mutate(payload, opts)
-  }
-
-  const handleDelete = (id: string, name: string) => {
-    // eslint-disable-next-line no-alert
-    if (!window.confirm(`Remove MCP server "${name}"?`)) return
-    mut.remove.mutate(id, { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not remove server.') })
-  }
-
-  const handleToggle = (s: McpServer) => {
-    mut.update.mutate({ id: s.id, patch: { enabled: !s.enabled } }, {
-      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update server.'),
-    })
-  }
-
-  const f = form
-  const busy = mut.add.isPending || mut.update.isPending
-
-  return (
-    <section className="rounded-lg border border-border bg-panel p-4">
-      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">MCP Servers</h2>
-      <p className="mb-3 text-[12px] text-muted">
-        Connect external tool providers via the Model Context Protocol. Supports stdio (subprocess) and SSE (HTTP) transports.
-      </p>
-
-      {servers.length > 0 && (
-        <div className="mb-3 flex flex-col gap-1.5">
-          {servers.map((s) => (
-            <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
-              <span
-                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
-                style={{
-                  background: s.transport === 'sse' ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'color-mix(in srgb, var(--muted) 20%, transparent)',
-                  color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
-                }}
-              >
-                {s.transport}
-              </span>
-              <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
-              <span className="shrink-0 max-w-[180px] truncate text-[11px] text-faint" title={s.transport === 'stdio' ? s.command : s.url}>
-                {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
-              </span>
-              <input
-                type="checkbox"
-                checked={s.enabled}
-                onChange={() => handleToggle(s)}
-                title={s.enabled ? 'Disable' : 'Enable'}
-                className="h-3.5 w-3.5 accent-[var(--accent)]"
-              />
-              <button type="button" onClick={() => openEdit(s)} title="Edit"
-                className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink">
-                <Pencil size={12} />
-              </button>
-              <button type="button" onClick={() => handleDelete(s.id, s.name)} title="Delete"
-                className="rounded p-1 transition-colors hover:bg-bg" style={{ color: 'var(--err)' }}>
-                <Trash2 size={12} />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {!showForm ? (
-        <Button variant="outline" size="sm" onClick={openAdd}>
-          <Plus size={13} />
-          Add server
-        </Button>
-      ) : (
-        <div className="flex flex-col gap-3 rounded-lg border border-border bg-panel-2 p-3">
-          <div className="text-[13px] font-medium text-ink">{editingId ? 'Edit server' : 'Add server'}</div>
-
-          <div className="flex flex-col gap-1">
-            <label className="text-[12px] text-muted">Name</label>
-            <input type="text" value={f.name} onChange={(e) => set({ name: e.target.value })}
-              placeholder="My Tool Server"
-              className="rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-ink outline-none"
-            />
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <label className="text-[12px] text-muted">Transport</label>
-            <div className="flex gap-4">
-              {(['stdio', 'sse'] as const).map((t) => (
-                <label key={t} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
-                  <input type="radio" name="mcp-transport" checked={f.transport === t} onChange={() => set({ transport: t })}
-                    className="h-3.5 w-3.5 accent-[var(--accent)]"
-                  />
-                  <span className="font-mono">{t}</span>
-                  <span className="text-[11px] text-faint">{t === 'stdio' ? '(subprocess)' : '(HTTP)'}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {f.transport === 'stdio' ? (
-            <>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">Command</label>
-                <input type="text" value={f.command} onChange={(e) => set({ command: e.target.value })}
-                  placeholder="npx -y @modelcontextprotocol/server-filesystem"
-                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">Args <span className="text-faint">(comma-separated, optional)</span></label>
-                <input type="text" value={f.argsStr} onChange={(e) => set({ argsStr: e.target.value })}
-                  placeholder="--port, 3000"
-                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">Env vars <span className="text-faint">(KEY=VALUE, one per line, optional)</span></label>
-                <textarea rows={2} value={f.envStr} onChange={(e) => set({ envStr: e.target.value })}
-                  placeholder={"API_KEY=abc123\nDEBUG=true"}
-                  className="resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
-              </div>
-            </>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <label className="text-[12px] text-muted">URL</label>
-              <input type="text" value={f.url} onChange={(e) => set({ url: e.target.value })}
-                placeholder="http://localhost:3000"
-                className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-              />
-            </div>
-          )}
-
-          <label className="flex cursor-pointer items-center gap-2 text-[13px] text-ink">
-            <input type="checkbox" checked={f.enabled} onChange={(e) => set({ enabled: e.target.checked })}
-              className="h-3.5 w-3.5 accent-[var(--accent)]"
-            />
-            Enable immediately
-          </label>
-
-          <div className="flex gap-2">
-            <Button size="sm" onClick={handleSubmit} disabled={busy}>
-              {busy ? <Loader2 size={13} className="animate-spin" /> : null}
-              {editingId ? 'Update' : 'Add'}
-            </Button>
-            <Button variant="outline" size="sm" onClick={closeForm}>Cancel</Button>
-          </div>
-        </div>
-      )}
     </section>
   )
 }

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle } from 'lucide-react'
+import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle, Pencil, Plus, Trash2 } from 'lucide-react'
 import {
   PERSONAS, getDefaultPersonaId, getPersonalization, savePersonalization,
   setDefaultPersonaId, type PersonaId, type Personalization,
@@ -12,12 +12,14 @@ import {
   useComfyGate,
   useDaemonRestart,
   useHfTokenTest,
+  useMcpMutations,
   useNetworkInfo,
   useSettings,
   useStatus,
   useSysInfo,
   useTelemetryPreview,
 } from '../lib/queries'
+import type { McpServer } from '../lib/api'
 import { useConversationMutations } from '../lib/chat-queries'
 import { ApiError, type TelemetryLevel } from '../lib/api'
 import { TELEMETRY_UI_ENABLED } from '../lib/flags'
@@ -377,6 +379,10 @@ export function SettingsScreen() {
             />
           </label>
         </section>
+
+        {/* Tools & MCP (v0.7.0) */}
+        <ToolsSection tavilyKeySet={settings?.tavilyKeySet ?? false} onSaved={() => void settingsQ.refetch()} />
+        <McpSection servers={settings?.mcp?.servers ?? []} />
 
         {/* Personalization */}
         <PersonalizationSection />
@@ -1300,6 +1306,276 @@ function PersonalizationSection() {
           </Button>
         </div>
       </div>
+    </section>
+  )
+}
+
+// ── Tools — Tavily web search key (v0.7.0) ────────────────────────────────────
+
+function ToolsSection({ tavilyKeySet, onSaved }: { tavilyKeySet: boolean; onSaved: () => void }) {
+  const { save } = useSettings()
+  const [key, setKey] = useState('')
+
+  const handleSave = () => {
+    save.mutate({ tavilyApiKey: key.trim() }, {
+      onSuccess: () => {
+        toast.success(key.trim() ? 'Tavily API key saved' : 'Tavily API key cleared')
+        setKey('')
+        onSaved()
+      },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save the key.'),
+    })
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">Tools</h2>
+      <p className="mb-3 text-[12px] text-muted">
+        When configured, the model can call these tools automatically during a conversation.
+      </p>
+
+      <div className="text-[13px] font-medium text-ink mb-1">Web search (Tavily)</div>
+      <p className="text-[12px] text-muted mb-3">
+        Tavily AI-search API. Enables the <span className="font-mono text-ink">web_search</span> tool.{' '}
+        <a href="https://app.tavily.com" target="_blank" rel="noopener noreferrer" className="text-ink underline-offset-2 hover:underline">
+          Get a key
+        </a>.
+      </p>
+
+      <div className="mb-2 text-[13px] text-muted">
+        {tavilyKeySet ? (
+          <span className="inline-flex items-center gap-1.5 text-ink">
+            <Check size={13} style={{ color: 'var(--ok)' }} /> A key is configured
+          </span>
+        ) : 'No key configured'}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder={tavilyKeySet ? 'Enter a new key to replace the current one' : 'tvly-…'}
+          autoComplete="off"
+          className="flex-1 rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[13px] text-ink outline-none"
+        />
+        <Button size="sm" onClick={handleSave} disabled={save.isPending}>
+          {key.trim() ? 'Save key' : 'Clear key'}
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+// ── MCP Servers (v0.7.0) ──────────────────────────────────────────────────────
+
+type McpFormState = {
+  name: string
+  transport: 'stdio' | 'sse'
+  command: string
+  argsStr: string
+  envStr: string
+  url: string
+  enabled: boolean
+}
+
+const emptyMcpForm = (): McpFormState => ({ name: '', transport: 'stdio', command: '', argsStr: '', envStr: '', url: '', enabled: true })
+
+function serverToForm(s: McpServer): McpFormState {
+  return {
+    name: s.name,
+    transport: s.transport,
+    command: s.command ?? '',
+    argsStr: (s.args ?? []).join(', '),
+    envStr: Object.entries(s.env ?? {}).map(([k, v]) => `${k}=${v}`).join('\n'),
+    url: s.url ?? '',
+    enabled: s.enabled,
+  }
+}
+
+function formToPayload(f: McpFormState): Omit<McpServer, 'id'> {
+  const args = f.argsStr.trim() ? f.argsStr.split(',').map((s) => s.trim()).filter(Boolean) : []
+  const env: Record<string, string> = {}
+  for (const line of f.envStr.split('\n')) {
+    const eq = line.indexOf('=')
+    if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
+  }
+  return {
+    name: f.name.trim(),
+    transport: f.transport,
+    command: f.transport === 'stdio' ? f.command.trim() || undefined : undefined,
+    args: f.transport === 'stdio' && args.length ? args : undefined,
+    env: f.transport === 'stdio' && Object.keys(env).length ? env : undefined,
+    url: f.transport === 'sse' ? f.url.trim() || undefined : undefined,
+    enabled: f.enabled,
+  }
+}
+
+function McpSection({ servers }: { servers: McpServer[] }) {
+  const mut = useMcpMutations()
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<McpFormState>(emptyMcpForm())
+  const set = (patch: Partial<McpFormState>) => setForm((p) => ({ ...p, ...patch }))
+
+  const openAdd = () => { setEditingId(null); setForm(emptyMcpForm()); setShowForm(true) }
+  const openEdit = (s: McpServer) => { setEditingId(s.id); setForm(serverToForm(s)); setShowForm(true) }
+  const closeForm = () => { setShowForm(false); setEditingId(null) }
+
+  const handleSubmit = () => {
+    const payload = formToPayload(form)
+    if (!payload.name) return void toast.error('Server name is required.')
+    if (payload.transport === 'stdio' && !payload.command) return void toast.error('Command is required for stdio transport.')
+    if (payload.transport === 'sse' && !payload.url) return void toast.error('URL is required for SSE transport.')
+    const opts = {
+      onSuccess: () => { toast.success(editingId ? 'MCP server updated' : 'MCP server added'); closeForm() },
+      onError: (e: unknown) => toast.error(e instanceof ApiError ? e.message : 'Could not save server.'),
+    }
+    if (editingId) mut.update.mutate({ id: editingId, patch: payload }, opts)
+    else mut.add.mutate(payload, opts)
+  }
+
+  const handleDelete = (id: string, name: string) => {
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`Remove MCP server "${name}"?`)) return
+    mut.remove.mutate(id, { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not remove server.') })
+  }
+
+  const handleToggle = (s: McpServer) => {
+    mut.update.mutate({ id: s.id, patch: { enabled: !s.enabled } }, {
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update server.'),
+    })
+  }
+
+  const f = form
+  const busy = mut.add.isPending || mut.update.isPending
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">MCP Servers</h2>
+      <p className="mb-3 text-[12px] text-muted">
+        Connect external tool providers via the Model Context Protocol. Supports stdio (subprocess) and SSE (HTTP) transports.
+      </p>
+
+      {servers.length > 0 && (
+        <div className="mb-3 flex flex-col gap-1.5">
+          {servers.map((s) => (
+            <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
+              <span
+                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
+                style={{
+                  background: s.transport === 'sse' ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'color-mix(in srgb, var(--muted) 20%, transparent)',
+                  color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
+                }}
+              >
+                {s.transport}
+              </span>
+              <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
+              <span className="shrink-0 max-w-[180px] truncate text-[11px] text-faint" title={s.transport === 'stdio' ? s.command : s.url}>
+                {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
+              </span>
+              <input
+                type="checkbox"
+                checked={s.enabled}
+                onChange={() => handleToggle(s)}
+                title={s.enabled ? 'Disable' : 'Enable'}
+                className="h-3.5 w-3.5 accent-[var(--accent)]"
+              />
+              <button type="button" onClick={() => openEdit(s)} title="Edit"
+                className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink">
+                <Pencil size={12} />
+              </button>
+              <button type="button" onClick={() => handleDelete(s.id, s.name)} title="Delete"
+                className="rounded p-1 transition-colors hover:bg-bg" style={{ color: 'var(--err)' }}>
+                <Trash2 size={12} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!showForm ? (
+        <Button variant="outline" size="sm" onClick={openAdd}>
+          <Plus size={13} />
+          Add server
+        </Button>
+      ) : (
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-panel-2 p-3">
+          <div className="text-[13px] font-medium text-ink">{editingId ? 'Edit server' : 'Add server'}</div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Name</label>
+            <input type="text" value={f.name} onChange={(e) => set({ name: e.target.value })}
+              placeholder="My Tool Server"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-ink outline-none"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Transport</label>
+            <div className="flex gap-4">
+              {(['stdio', 'sse'] as const).map((t) => (
+                <label key={t} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
+                  <input type="radio" name="mcp-transport" checked={f.transport === t} onChange={() => set({ transport: t })}
+                    className="h-3.5 w-3.5 accent-[var(--accent)]"
+                  />
+                  <span className="font-mono">{t}</span>
+                  <span className="text-[11px] text-faint">{t === 'stdio' ? '(subprocess)' : '(HTTP)'}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {f.transport === 'stdio' ? (
+            <>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">Command</label>
+                <input type="text" value={f.command} onChange={(e) => set({ command: e.target.value })}
+                  placeholder="npx -y @modelcontextprotocol/server-filesystem"
+                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">Args <span className="text-faint">(comma-separated, optional)</span></label>
+                <input type="text" value={f.argsStr} onChange={(e) => set({ argsStr: e.target.value })}
+                  placeholder="--port, 3000"
+                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-[12px] text-muted">Env vars <span className="text-faint">(KEY=VALUE, one per line, optional)</span></label>
+                <textarea rows={2} value={f.envStr} onChange={(e) => set({ envStr: e.target.value })}
+                  placeholder={"API_KEY=abc123\nDEBUG=true"}
+                  className="resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+                />
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col gap-1">
+              <label className="text-[12px] text-muted">URL</label>
+              <input type="text" value={f.url} onChange={(e) => set({ url: e.target.value })}
+                placeholder="http://localhost:3000"
+                className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
+              />
+            </div>
+          )}
+
+          <label className="flex cursor-pointer items-center gap-2 text-[13px] text-ink">
+            <input type="checkbox" checked={f.enabled} onChange={(e) => set({ enabled: e.target.checked })}
+              className="h-3.5 w-3.5 accent-[var(--accent)]"
+            />
+            Enable immediately
+          </label>
+
+          <div className="flex gap-2">
+            <Button size="sm" onClick={handleSubmit} disabled={busy}>
+              {busy ? <Loader2 size={13} className="animate-spin" /> : null}
+              {editingId ? 'Update' : 'Add'}
+            </Button>
+            <Button variant="outline" size="sm" onClick={closeForm}>Cancel</Button>
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -2,8 +2,8 @@ import { memo, useEffect, useRef, useState, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
-import { ChevronDown, FileText, Pencil, RefreshCw, Trash2 } from 'lucide-react'
-import type { Message, MessageStats } from '../../lib/chat-types'
+import { CheckCircle2, ChevronDown, FileText, Loader2, Pencil, RefreshCw, Trash2, XCircle } from 'lucide-react'
+import type { LiveToolCall, Message, MessageStats, ToolCallRecord } from '../../lib/chat-types'
 import { Button } from '../../components/ui/button'
 import { CopyButton } from '../../components/ui/copy-button'
 
@@ -125,6 +125,59 @@ const Markdown = memo(function Markdown({ children }: { children: string }) {
   )
 })
 
+// ── Tool call cards ───────────────────────────────────────────────────────────
+
+type CardCall = { id: string; name: string; status: 'pending' | 'done' | 'error'; result?: string }
+
+function friendlyName(name: string): string {
+  if (name.startsWith('mcp__')) return name.replace(/^mcp__[^_]+(?:_[^_]+)*__/, '')
+  return name.replace(/_/g, ' ')
+}
+
+function ToolCallCard({ call }: { call: CardCall }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasOutput = !!(call.result?.length)
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-panel-2">
+      <button
+        type="button"
+        onClick={() => hasOutput && setExpanded((e) => !e)}
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left"
+        style={{ cursor: hasOutput ? 'pointer' : 'default' }}
+      >
+        {call.status === 'pending' && <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
+        {call.status === 'done'    && <CheckCircle2 size={12} className="shrink-0" style={{ color: '#4ade80' }} />}
+        {call.status === 'error'   && <XCircle size={12} className="shrink-0" style={{ color: 'var(--err)' }} />}
+        <span className="font-mono text-[12px] font-medium text-ink">{friendlyName(call.name)}</span>
+        <span className="text-[11px] text-faint">
+          {call.status === 'pending' ? 'running…' : call.status === 'error' ? 'error' : 'done'}
+        </span>
+        {hasOutput && (
+          <ChevronDown
+            size={11}
+            className={`ml-auto shrink-0 text-faint transition-transform ${expanded ? 'rotate-180' : ''}`}
+          />
+        )}
+      </button>
+      {expanded && call.result && (
+        <pre className="max-h-48 overflow-auto border-t border-border px-3 pb-3 pt-2 font-mono text-[11px] leading-relaxed text-muted whitespace-pre-wrap">
+          {call.result.length > 2000 ? `${call.result.slice(0, 2000)}\n…(truncated)` : call.result}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function ToolCallsPanel({ calls }: { calls: CardCall[] }) {
+  if (!calls.length) return null
+  return (
+    <div className="mb-3 space-y-1">
+      {calls.map((c) => <ToolCallCard key={c.id} call={c} />)}
+    </div>
+  )
+}
+
 // ── Streaming message (in-progress) ──────────────────────────────────────────
 
 export function StreamingBubble({
@@ -133,12 +186,14 @@ export function StreamingBubble({
   progress,
   liveGenTps,
   genTokens,
+  toolCalls = [],
 }: {
   content: string
   reasoning: string
   progress: { phase: string; pct: number; tps: number } | null
   liveGenTps: number
   genTokens: number
+  toolCalls?: LiveToolCall[]
 }) {
   const isPrefill = !!progress && progress.phase === 'prompt'
 
@@ -147,10 +202,11 @@ export function StreamingBubble({
       <ModelAvatar />
       <div className="min-w-0 flex-1 pt-0.5">
         {reasoning && <ThinkingBlock reasoning={reasoning} streaming />}
+        <ToolCallsPanel calls={toolCalls} />
         <div className="prose-tllm text-[15px] leading-[1.7] text-ink">
           {content ? <Markdown>{content}</Markdown> : (
             <span className="text-muted">
-              {isPrefill ? 'Processing prompt…' : reasoning ? 'Generating…' : 'Thinking…'}
+              {isPrefill ? 'Processing prompt…' : reasoning ? 'Generating…' : toolCalls.length ? 'Working…' : 'Thinking…'}
             </span>
           )}
         </div>
@@ -270,6 +326,12 @@ export function MessageBubble({
 
   // Assistant
   const hasError = message.stats.aborted && !message.content
+  const completedToolCalls: CardCall[] = (message.toolCalls ?? []).map((tc: ToolCallRecord) => ({
+    id: tc.id,
+    name: tc.name,
+    status: tc.error ? 'error' : 'done',
+    result: tc.error ?? tc.result,
+  }))
   return (
     <div className="group flex gap-3">
       <ModelAvatar />
@@ -277,6 +339,7 @@ export function MessageBubble({
         {message.reasoning && (
           <ThinkingBlock reasoning={message.reasoning} thinkMs={message.stats.thinkMs} showThinking={showThinking} />
         )}
+        <ToolCallsPanel calls={completedToolCalls} />
         {hasError ? (
           <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
             Generation failed or was stopped.


### PR DESCRIPTION
## Summary

- **Agentic tool loop** — native `finish_reason: tool_calls` detection with up to 10 iterations; streams `tool_call` SSE events so the UI shows live tool cards
- **Built-in tools** — `web_search` (Tavily, search_depth: advanced), `fetch_url`, `run_code` (Node vm sandbox)
- **MCP host client** — stdio and SSE transports; ToolRegistry aggregates built-in + MCP tools into one unified tool list per request
- **Tool call UI** — ToolCallCard / ToolCallsPanel in MessageBubble with pending/done/error states, collapsible result
- **Customize screen** — new /customize route (Puzzle icon in nav) for Tavily key and MCP server management; Settings now focused on engine/model/network/startup/persona only
- **Research persona** — forces tool_choice: web_search on iterations 1 and 2 at the protocol level; system prompt mandates 3-5 focused searches before composing answer
- **Date injection** — current date baked into every system prompt at conversation creation so temporal queries use the right year
- **DB migrations v5 + v6** — tool_calls on messages, tool_policy on conversations

## Test plan

- [ ] Send a message with Tavily key configured — verify tool call cards appear and results are cited
- [ ] Select Research persona, ask a factual question — verify at least 2 web_search calls fire before the answer
- [ ] Add an MCP server in Customize, send a message — verify MCP tools appear and execute
- [ ] Verify Settings no longer shows Tools/MCP sections
- [ ] Verify date in system prompt reflects today when creating a new conversation
- [ ] TypeScript: tsc --noEmit passes on both packages