### PR TITLE
fix(mlx): incomplete shard detection, GPT-OSS channel filter, re-download button

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1216,8 +1216,8 @@ function inferRepoFromPath(filePath: string, modelDirs: string[]): string | null
     const root = norm(dir)
     if (!fp.toLowerCase().startsWith(root.toLowerCase() + '/')) continue
     const parts = fp.slice(root.length + 1).split('/')
-    // Need at least owner/repo/file. owner+repo are the first two segments under root.
-    if (parts.length >= 3 && seg.test(parts[0]) && seg.test(parts[1])) {
+    // Need at least owner/repo (MLX dirs) or owner/repo/file (GGUF files).
+    if (parts.length >= 2 && seg.test(parts[0]) && seg.test(parts[1])) {
       return `${parts[0]}/${parts[1]}`
     }
     return null

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -421,7 +421,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
           if (chunk.timings) finalTimings = chunk.timings as typeof finalTimings
 
           const choices = chunk.choices as Array<{
-            delta?: { content?: string; reasoning_content?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> }
+            delta?: { content?: string; reasoning_content?: string; reasoning?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> }
             finish_reason?: string
           }> | undefined
           if (!choices?.length) continue
@@ -444,9 +444,9 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
             continue
           }
 
-          // Reasoning content (explicit field — newer llama-server)
-          if (delta.reasoning_content) {
-            const rc = delta.reasoning_content
+          // Reasoning content — llama-server uses `reasoning_content`, mlx-lm uses `reasoning`.
+          const rc = (delta.reasoning_content ?? delta.reasoning) as string | undefined
+          if (rc) {
             if (!thinkStart) thinkStart = Date.now()
             thinkEnd = Date.now()
             fullReasoning += rc
@@ -487,6 +487,9 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
                 if (!thinkStart) thinkStart = Date.now()
                 parseBuf = parseBuf.slice(openIdx + openTag.length)
               } else {
+                // 29-char lookahead: safe threshold to detect the 30-char CHAN_ANALYSIS_OPEN
+                // tag before flushing. Tradeoff: non-reasoning responses buffer ~1 extra
+                // cycle before first delta (TTFT impact ≈ 30 chars / tok/s).
                 const safeLen = parseBuf.length - (CHAN_ANALYSIS_OPEN.length - 1)
                 if (safeLen > 0) {
                   const flush = parseBuf.slice(0, safeLen)
@@ -507,7 +510,6 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
               if (closeIdx >= 0) {
                 if (closeIdx > 0) {
                   const chunk = parseBuf.slice(0, closeIdx)
-                  thinkEnd = Date.now()
                   fullReasoning += chunk
                   await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: chunk }) })
                 }
@@ -539,6 +541,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
               } else if (CHAN_FINAL_SKIP.startsWith(parseBuf) && parseBuf.length < CHAN_FINAL_SKIP.length) {
                 break
               } else {
+                parseBuf = ''
                 parsePhase = 'content'
               }
             } else {
@@ -560,7 +563,8 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
         if (parsePhase === 'reasoning') {
           fullReasoning += parseBuf
           await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: parseBuf }) })
-        } else if (parsePhase !== 'skipFinal') {
+        } else {
+          // Emit whatever's buffered, even if we're in skipFinal (truncated stream).
           fullContent += parseBuf
           roundContent += parseBuf
           await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: parseBuf }) })

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -10,6 +10,12 @@ import type { MessageStats, ToolCallRecord } from './db'
 // Track in-flight abort controllers per conversation id.
 const inflight = new Map<string, AbortController>()
 
+const THINK_OPEN = '<think>'
+const THINK_CLOSE = '</think>'
+const CHAN_ANALYSIS_OPEN = '<|channel|>analysis<|message|>'
+const CHAN_CLOSE = '<|end|>'
+const CHAN_FINAL_SKIP = '<|start|>assistant<|channel|>final<|message|>'
+
 // Built-in system prompt for the TurboLLM Expert thread (spec 08 §2). Kept
 // server-side and never sent to the client, so it stays hidden from the UI.
 const EXPERT_SYSTEM_PROMPT = `You are the TurboLLM in-app expert assistant — a knowledgeable, friendly guide built into TurboLLM, a local-first desktop app for running large language models on the user's own machine.
@@ -379,9 +385,10 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
 
       // Per-round state
       let roundContent = ''
-      let inThink = false
-      let pendingThinkBuf = ''
-      let firstDelta = false
+      type ParsePhase = 'initial' | 'reasoning' | 'skipFinal' | 'content'
+      let parsePhase: ParsePhase = 'initial'
+      let parseIsChannel = false
+      let parseBuf = ''
       let finishReason = ''
       // Accumulate streaming tool_calls by index (OpenAI format: fragmented across chunks)
       const pendingToolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>()
@@ -450,91 +457,114 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
           const raw_content = delta.content ?? ''
           if (!raw_content) continue
 
-          // Detect <think>...</think> tags inline (older llama-server with --jinja)
-          let toProcess = raw_content
-          while (toProcess.length > 0) {
-            if (!inThink && !firstDelta) {
-              pendingThinkBuf += toProcess
-              const openIdx = pendingThinkBuf.indexOf('<think>')
+          parseBuf += raw_content
+
+          // State machine handles <think>...</think> (llama.cpp) and
+          // <|channel|>analysis<|message|>...<|end|> (GPT-OSS channel format).
+          while (parseBuf.length > 0) {
+            if (parsePhase === 'initial') {
+              const thinkIdx = parseBuf.indexOf(THINK_OPEN)
+              const chanIdx  = parseBuf.indexOf(CHAN_ANALYSIS_OPEN)
+              const hasThink = thinkIdx >= 0
+              const hasChan  = chanIdx >= 0
+              const useThink = hasThink && (!hasChan || thinkIdx <= chanIdx)
+              const openIdx  = useThink ? thinkIdx : hasChan ? chanIdx : -1
+              const openTag  = useThink ? THINK_OPEN : CHAN_ANALYSIS_OPEN
+
               if (openIdx === 0) {
-                inThink = true
+                parseIsChannel = !useThink
+                parsePhase = 'reasoning'
                 if (!thinkStart) thinkStart = Date.now()
-                pendingThinkBuf = pendingThinkBuf.slice(7)
-                toProcess = ''
+                parseBuf = parseBuf.slice(openTag.length)
               } else if (openIdx > 0) {
-                const before = pendingThinkBuf.slice(0, openIdx)
+                const before = parseBuf.slice(0, openIdx)
                 fullContent += before
                 roundContent += before
-                firstDelta = true
                 if (!ttftMs) ttftMs = Date.now() - requestStart
                 await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: before }) })
-                inThink = true
+                parseIsChannel = !useThink
+                parsePhase = 'reasoning'
                 if (!thinkStart) thinkStart = Date.now()
-                pendingThinkBuf = pendingThinkBuf.slice(openIdx + 7)
-                toProcess = ''
-              } else if (pendingThinkBuf.length > 20) {
-                const flush = pendingThinkBuf
-                pendingThinkBuf = ''
-                fullContent += flush
-                roundContent += flush
-                firstDelta = true
-                if (!ttftMs) ttftMs = Date.now() - requestStart
-                await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: flush }) })
-                toProcess = ''
+                parseBuf = parseBuf.slice(openIdx + openTag.length)
               } else {
-                toProcess = ''
-              }
-            } else if (inThink) {
-              pendingThinkBuf += toProcess
-              const closeIdx = pendingThinkBuf.indexOf('</think>')
-              if (closeIdx >= 0) {
-                const thinkChunk = pendingThinkBuf.slice(0, closeIdx)
-                if (thinkChunk) {
-                  thinkEnd = Date.now()
-                  fullReasoning += thinkChunk
-                  await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: thinkChunk }) })
-                }
-                inThink = false
-                thinkEnd = Date.now()
-                pendingThinkBuf = pendingThinkBuf.slice(closeIdx + 8)
-                toProcess = ''
-                if (pendingThinkBuf) {
-                  fullContent += pendingThinkBuf
-                  roundContent += pendingThinkBuf
-                  firstDelta = true
+                const safeLen = parseBuf.length - (CHAN_ANALYSIS_OPEN.length - 1)
+                if (safeLen > 0) {
+                  const flush = parseBuf.slice(0, safeLen)
+                  parseBuf = parseBuf.slice(safeLen)
+                  fullContent += flush
+                  roundContent += flush
                   if (!ttftMs) ttftMs = Date.now() - requestStart
-                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
-                  pendingThinkBuf = ''
+                  d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut })
+                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: flush }) })
+                  parsePhase = 'content'
+                } else {
+                  break
                 }
-              } else {
+              }
+            } else if (parsePhase === 'reasoning') {
+              const closeTag = parseIsChannel ? CHAN_CLOSE : THINK_CLOSE
+              const closeIdx = parseBuf.indexOf(closeTag)
+              if (closeIdx >= 0) {
+                if (closeIdx > 0) {
+                  const chunk = parseBuf.slice(0, closeIdx)
+                  thinkEnd = Date.now()
+                  fullReasoning += chunk
+                  await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: chunk }) })
+                }
                 thinkEnd = Date.now()
-                fullReasoning += pendingThinkBuf
-                await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
-                pendingThinkBuf = ''
-                toProcess = ''
+                const wasChannel = parseIsChannel
+                parseBuf = parseBuf.slice(closeIdx + closeTag.length)
+                parsePhase = wasChannel ? 'skipFinal' : 'content'
+                if (!wasChannel && parseBuf) {
+                  fullContent += parseBuf
+                  roundContent += parseBuf
+                  if (!ttftMs) ttftMs = Date.now() - requestStart
+                  await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: parseBuf }) })
+                  parseBuf = ''
+                }
+              } else if (parseBuf.length >= closeTag.length) {
+                const safe = parseBuf.length - (closeTag.length - 1)
+                const chunk = parseBuf.slice(0, safe)
+                parseBuf = parseBuf.slice(safe)
+                thinkEnd = Date.now()
+                fullReasoning += chunk
+                await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: chunk }) })
+              } else {
+                break
+              }
+            } else if (parsePhase === 'skipFinal') {
+              if (parseBuf.startsWith(CHAN_FINAL_SKIP)) {
+                parseBuf = parseBuf.slice(CHAN_FINAL_SKIP.length)
+                parsePhase = 'content'
+              } else if (CHAN_FINAL_SKIP.startsWith(parseBuf) && parseBuf.length < CHAN_FINAL_SKIP.length) {
+                break
+              } else {
+                parsePhase = 'content'
               }
             } else {
               if (!ttftMs) ttftMs = Date.now() - requestStart
-              firstDelta = true
-              fullContent += toProcess
-              roundContent += toProcess
+              fullContent += parseBuf
+              roundContent += parseBuf
               d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut })
-              await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: toProcess }) })
-              toProcess = ''
+              await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: parseBuf }) })
+              parseBuf = ''
+              break
             }
           }
         }
       }
       ac.signal.removeEventListener('abort', cancelReader)
 
-      // Flush pending think buf
-      if (pendingThinkBuf && inThink) {
-        fullReasoning += pendingThinkBuf
-        await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: pendingThinkBuf }) })
-      } else if (pendingThinkBuf) {
-        fullContent += pendingThinkBuf
-        roundContent += pendingThinkBuf
-        await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: pendingThinkBuf }) })
+      // Flush lookahead buffer at end-of-stream.
+      if (parseBuf) {
+        if (parsePhase === 'reasoning') {
+          fullReasoning += parseBuf
+          await stream.writeSSE({ event: 'reasoning', data: JSON.stringify({ delta: parseBuf }) })
+        } else if (parsePhase !== 'skipFinal') {
+          fullContent += parseBuf
+          roundContent += parseBuf
+          await stream.writeSSE({ event: 'delta', data: JSON.stringify({ delta: parseBuf }) })
+        }
       }
 
       // ── Tool call execution ──────────────────────────────────────────────

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -541,7 +541,11 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
               } else if (CHAN_FINAL_SKIP.startsWith(parseBuf) && parseBuf.length < CHAN_FINAL_SKIP.length) {
                 break
               } else {
-                parseBuf = ''
+                // Unexpected prefix before skip token (e.g. whitespace between <|end|> and
+                // <|start|>assistant…). Find the token anywhere in the buffer so content
+                // after it isn't discarded along with the framing bytes.
+                const skipIdx = parseBuf.indexOf(CHAN_FINAL_SKIP)
+                parseBuf = skipIdx >= 0 ? parseBuf.slice(skipIdx + CHAN_FINAL_SKIP.length) : ''
                 parsePhase = 'content'
               }
             } else {

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -377,6 +377,21 @@ function mlxEntryFor(dir: string): ModelEntry {
     /* best effort */
   }
 
+  let incomplete = false
+  try {
+    const indexPath = join(dir, 'model.safetensors.index.json')
+    if (existsSync(indexPath)) {
+      const index = JSON.parse(readFileSync(indexPath, 'utf8')) as { weight_map?: Record<string, string> }
+      const shards = new Set(Object.values(index.weight_map ?? {}))
+      for (const shard of shards) {
+        if (!existsSync(join(dir, shard))) {
+          incomplete = true
+          break
+        }
+      }
+    }
+  } catch { /* best effort */ }
+
   const expertCount = cfg.num_local_experts ?? cfg.num_experts ?? 0
   const bits = cfg.quantization?.bits
   const quant = bits ? `${bits}bit` : 'fp16'
@@ -403,7 +418,7 @@ function mlxEntryFor(dir: string): ModelEntry {
     mmprojPath: null,
     hasChatTemplate,
     embedding: isEmbeddingModel(arch, basename(dir)),
-    incomplete: false,
+    incomplete,
     parseError,
     loaded: false,
     hasProfile: false,

--- a/turbollm/web/src/screens/ModelsScreen.tsx
+++ b/turbollm/web/src/screens/ModelsScreen.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState, type ReactNode } from 'react'
-import { Boxes, ChevronRight, CircleSlash, FolderPlus, Loader2, MoreHorizontal, PackageSearch, RefreshCw, SlidersHorizontal, Star, Trash2, X, Zap } from 'lucide-react'
+import { Boxes, ChevronRight, CircleSlash, Download, FolderPlus, Loader2, MoreHorizontal, PackageSearch, RefreshCw, SlidersHorizontal, Star, Trash2, X, Zap } from 'lucide-react'
 import { ApiError, deleteModel } from '../lib/api'
 import { queryKeys, useModelActions, useModelDirs, useModelMutations, useModels, useStatus } from '../lib/queries'
 import type { ModelEntry } from '../lib/types'
@@ -487,6 +487,12 @@ function ModelRow({
             {loadingThis ? <Loader2 size={14} className="animate-spin" /> : <Zap size={14} />}
             {loadingThis ? 'Loading…' : m.loaded ? 'Reload' : 'Load'}
           </Button>
+          {m.incomplete && (
+            <Button size="sm" variant="outline" onClick={onDiscover} title="Download the missing shard files">
+              <Download size={14} />
+              Re-download
+            </Button>
+          )}
           {m.loaded && (
             <Button size="sm" variant="outline" onClick={onEject} disabled={ejecting} title="Eject model (stop the engine)">
               <CircleSlash size={14} />


### PR DESCRIPTION
## Summary

- **Gemma MLX (incomplete download)**: `scanner.ts` now reads `model.safetensors.index.json` and checks every referenced shard exists on disk. A `.part` file (partial download) causes `incomplete: true`, blocking the model from loading instead of letting mlx-lm crash with `ValueError: Missing N parameters`.
- **GPT-OSS channel format**: `chat-routes.ts` streaming state machine extended from `<think>`-only to a 4-phase parser (`initial → reasoning → skipFinal → content`) that also handles `<|channel|>analysis<|message|>…<|end|>…<|channel|>final<|message|>…`. Analysis content is routed to `reasoning` SSE events; the final answer arrives as `delta` events. `roundContent` kept in sync for the tool-call round loop (v0.7.0 compat).
- **Re-download button**: `ModelsScreen.tsx` shows a Re-download button alongside the disabled Load button for any incomplete model, opening the HF repo dialog (if source repo is known) or the Discover tab pre-searched by model name.

## Test plan

- [x] Gemma 4 MLX with partial shard: API returns `incomplete: true`, Load button disabled, Re-download button visible
- [x] Gemma 4 MLX after full download: `incomplete: false`, loads successfully (required mlx-lm upgrade from GitHub HEAD for Gemma 4 `sanitize()` fix)
- [x] GPT-OSS 20B: `reasoning` SSE events carry analysis content, `delta` events carry the answer — verified live via API and UI
- [x] Non-reasoning models (GGUF, plain MLX): unaffected, content flows directly to `delta` events as before
- [x] TypeScript typecheck passes clean (`npm run typecheck`)