### PR TITLE
test(ci): fix flaky cli-launch test (stdout corrupts test-runner IPC)

### DIFF
--- a/turbollm/src/cli-launch.timeout.test.ts
+++ b/turbollm/src/cli-launch.timeout.test.ts
@@ -37,14 +37,33 @@ function stubFetch(model = 'qwen3-8b'): () => void {
   return () => { globalThis.fetch = original }
 }
 
+/** Silence process stdout/stderr for the duration of a launchCli call. launchCli writes
+ *  a "▸ Launching…" banner to stdout; under the full `node --test` suite each file runs in
+ *  a subprocess whose stdout IS the V8-serialized result channel the parent runner parses,
+ *  so raw writes corrupt that stream ("Unable to deserialize cloned data"). Capturing the
+ *  writes keeps the channel clean and the test deterministic. */
+function silenceOutput(): () => void {
+  const outW = process.stdout.write.bind(process.stdout)
+  const errW = process.stderr.write.bind(process.stderr)
+  const noop = (() => true) as typeof process.stdout.write
+  process.stdout.write = noop
+  process.stderr.write = noop
+  return () => {
+    process.stdout.write = outW
+    process.stderr.write = errW
+  }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 test('launchCli passes ANTHROPIC_TIMEOUT=300000 to Claude Code spawn', async () => {
   const { calls, fn } = makeSpawn()
   const restore = stubFetch()
+  const unsilence = silenceOutput()
   try {
     await launchCli('claude', 6996, [], fn)
   } finally {
+    unsilence()
     restore()
   }
   assert.equal(calls.length, 1, 'spawn should be called once')
@@ -58,9 +77,11 @@ test('launchCli passes ANTHROPIC_TIMEOUT=300000 to Claude Code spawn', async () 
 test('launchCli passes ANTHROPIC_MAX_RETRIES=0 to Claude Code spawn', async () => {
   const { calls, fn } = makeSpawn()
   const restore = stubFetch()
+  const unsilence = silenceOutput()
   try {
     await launchCli('claude', 6996, [], fn)
   } finally {
+    unsilence()
     restore()
   }
   assert.equal(calls.length, 1, 'spawn should be called once')


### PR DESCRIPTION
## What

Fixes the intermittent CI failure in `src/cli-launch.timeout.test.ts`:

```
not ok 6 - src/cli-launch.timeout.test.ts
  failureType: 'uncaughtException'
  error: 'Unable to deserialize cloned data due to invalid or unsupported version.'
```

## Root cause

`launchCli` writes a `▸ Launching…` banner to `process.stdout`. Under the full
`node --test` suite, each test file runs in its own subprocess whose **stdout is the
V8-serialized result channel** the parent runner parses (`#processRawBuffer`). The raw
banner write interleaves with that serialized stream and intermittently corrupts it —
so the *file* fails as an uncaughtException even though every subtest passes. It's
timing-dependent, which is why it passed on the `main` merge run but failed on the PR run,
and passes when the file is run in isolation (the single-file runner executes inline, no
serialized channel).

## Fix

Capture `stdout`/`stderr` for the duration of each `launchCli` call in the test, so its
output never reaches the runner's IPC channel. Test-only change — shipped code and the
published v0.8.0 tarball (which excludes tests) are unaffected.

## Verification

Full suite run 3× consecutively: **237 pass / 0 fail, exit 0** each time; zero
`cli-launch` failure markers.
