### PR TITLE
fix(sysinfo): detect Linux GPU VRAM via sysfs instead of hardcoding 0

### DIFF
--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -3,6 +3,7 @@
 // selection (ADR-025: vendor → fastest backend).
 import { execFileSync } from 'node:child_process'
 import os from 'node:os'
+import fs from 'node:fs'
 
 export type GpuVendor = 'nvidia' | 'amd' | 'intel' | 'apple' | 'unknown'
 
@@ -119,7 +120,8 @@ function enumWindowsGpus(): GpuInfo[] {
 }
 
 function enumLinuxGpus(): GpuInfo[] {
-  // lspci lists display controllers; we only need the vendor from the description.
+  // lspci gives vendor + name but no VRAM size; read VRAM per-adapter from
+  // sysfs (linuxVramMb), matched by the adapter's PCI slot.
   const out = execFileSync('sh', ['-c', "lspci -mm 2>/dev/null | grep -iE 'VGA|3D|Display'"], {
     timeout: 8000,
   }).toString()
@@ -129,7 +131,28 @@ function enumLinuxGpus(): GpuInfo[] {
     .filter(Boolean)
     .map((line) => {
       const vendor = classifyVendor(line)
-      return { name: line.replace(/"/g, '').trim().slice(0, 80), vramMb: 0, vendor }
+      const slot = line.trim().split(/\s+/)[0] ?? ''
+      return { name: line.replace(/"/g, '').trim().slice(0, 80), vramMb: linuxVramMb(slot), vendor }
     })
     .filter((g) => g.vendor !== 'unknown')
+}
+
+// amdgpu exposes total VRAM in bytes via sysfs (incl. the BIOS carveout on
+// APUs like Ryzen AI / Strix Halo); lspci carries no size. Each lspci -mm line
+// begins with the PCI slot (e.g. "c3:00.0"), whose sysfs node lives at
+// /sys/bus/pci/devices/<domain>:<slot> — lspci omits the "0000:" domain by
+// default, so try both forms. Intel iGPUs / nouveau lack the attribute → 0 (no
+// dedicated VRAM), preserving prior behaviour. Byte→MB uses the same /1e6 as
+// the nvidia/windows/apple branches.
+function linuxVramMb(pciSlot: string): number {
+  if (!pciSlot) return 0
+  for (const dev of [`/sys/bus/pci/devices/0000:${pciSlot}`, `/sys/bus/pci/devices/${pciSlot}`]) {
+    try {
+      const bytes = parseInt(fs.readFileSync(`${dev}/mem_info_vram_total`, 'utf8').trim(), 10)
+      if (Number.isFinite(bytes) && bytes > 0) return Math.round(bytes / 1e6)
+    } catch {
+      /* no such device, or adapter exposes no VRAM (Intel iGPU, nouveau) */
+    }
+  }
+  return 0
 }


### PR DESCRIPTION
## Problem
`enumLinuxGpus()` in `src/sysinfo/sysinfo.ts` only parsed vendor/name from `lspci` and left `vramMb` hardcoded to `0`. `detectGpus()` has real VRAM sources only for NVIDIA (`nvidia-smi`) and Apple (`system_profiler`), so **every non-NVIDIA Linux GPU reported 0 VRAM** — including AMD APUs (Radeon 8060S / Strix Halo). That cascades into `gpuBudgetMb()`/`estimateVram()` returning a CPU verdict, so the UI shows no GPU memory and default profiles avoid GPU offload.

## Fix
Read the real per-adapter total from sysfs: `/sys/bus/pci/devices/<domain>:<slot>/mem_info_vram_total`, keyed by the PCI slot from each `lspci` line (stays correct on multi-GPU boxes). Dependency-free; adapters without the attribute (Intel iGPU, nouveau) fall back to `0` as before. Byte→MB uses the same `/1e6` as the nvidia/windows/apple branches.

## Verification
- `tsc --noEmit` passes.
- Live on an AMD Ryzen AI MAX+ 395 / Radeon 8060S: `/api/v1/sysinfo` now reports `vramMb: 34360` (was `0`); Settings → Hardware shows "34.4 GB VRAM".