### PR TITLE
feat: v1.1.0 — app self-update check (F-006) + model config side panel

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -664,6 +664,21 @@ export function registerApi(app: Hono, d: Deps): void {
     return c.json({ updates, policies })
   })
 
+  // ---- app self-update check (F-006, ADR-031) ----
+  // Is a newer TurboLLM published on npm than the running version? Informational only —
+  // npm does the upgrade (`npm i -g turbollm`); we never auto-update the app. Offline-first:
+  // serves the cached answer and NEVER fabricates a "latest" it didn't fetch. Non-blocking —
+  // a stale (or `?refresh=1`) cache kicks a background re-check and returns the cache now.
+  app.get('/api/v1/app/update', (c) => {
+    const fallback = { installed: d.version, latest: null, hasUpdate: false, checkedAt: new Date().toISOString(), comparable: false }
+    if (!d.appUpdates) return c.json(fallback)
+    const refresh = c.req.query('refresh') === '1'
+    if (refresh || d.appUpdates.isStale()) {
+      void d.appUpdates.check(AbortSignal.timeout(10_000)).catch(() => {})
+    }
+    return c.json(d.appUpdates.get() ?? fallback)
+  })
+
   // Set an engine's per-engine auto-update policy (off | notify | auto). Default notify.
   app.put('/api/v1/engines/:id/update-policy', async (c) => {
     const b = await body<{ policy?: string }>(c)

--- a/turbollm/src/app-update.test.ts
+++ b/turbollm/src/app-update.test.ts
@@ -1,0 +1,109 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  compareAppVersions,
+  computeAppUpdateStatus,
+  AppUpdateChecker,
+  APP_UPDATE_CHECK_INTERVAL_MS,
+} from './app-update'
+
+// ─── version comparison ──────────────────────────────────────────────────────
+
+test('compareAppVersions: newer / equal / older (latest perspective)', () => {
+  assert.equal(compareAppVersions('1.0.0', '1.1.0'), 'newer') // npm ahead → update available
+  assert.equal(compareAppVersions('1.0.0', '1.0.0'), 'equal')
+  assert.equal(compareAppVersions('1.1.0', '1.0.0'), 'older') // running a dev build ahead of npm
+  assert.equal(compareAppVersions('1.0.0', '1.0.1'), 'newer')
+  assert.equal(compareAppVersions('0.9.0', '1.0.0'), 'newer')
+})
+
+test('compareAppVersions: tolerates leading v and ignores pre-release suffixes', () => {
+  assert.equal(compareAppVersions('v1.0.0', 'v1.1.0'), 'newer')
+  // pre-release suffix ignored: 1.1.0-rc1 reads as 1.1.0
+  assert.equal(compareAppVersions('1.0.0', '1.1.0-rc1'), 'newer')
+})
+
+// ─── computeAppUpdateStatus ──────────────────────────────────────────────────
+
+test('computeAppUpdateStatus: latest ahead → hasUpdate true', async () => {
+  const s = await computeAppUpdateStatus('1.0.0', async () => '1.1.0')
+  assert.equal(s.installed, '1.0.0')
+  assert.equal(s.latest, '1.1.0')
+  assert.equal(s.hasUpdate, true)
+  assert.equal(s.comparable, true)
+  assert.equal(s.error, undefined)
+  assert.ok(s.checkedAt)
+})
+
+test('computeAppUpdateStatus: equal version → no update', async () => {
+  const s = await computeAppUpdateStatus('1.0.0', async () => '1.0.0')
+  assert.equal(s.hasUpdate, false)
+  assert.equal(s.comparable, true)
+})
+
+test('computeAppUpdateStatus: running ahead of npm (local dev) → no update', async () => {
+  const s = await computeAppUpdateStatus('1.2.0', async () => '1.1.0')
+  assert.equal(s.hasUpdate, false)
+  assert.equal(s.comparable, true)
+})
+
+test('computeAppUpdateStatus: fetch throws → offline, never a fabricated latest', async () => {
+  const s = await computeAppUpdateStatus('1.0.0', async () => {
+    throw new Error('network down')
+  })
+  assert.equal(s.latest, null)
+  assert.equal(s.hasUpdate, false)
+  assert.equal(s.error, 'offline')
+  assert.equal(s.comparable, false)
+  assert.equal(s.installed, '1.0.0')
+})
+
+test('computeAppUpdateStatus: empty latest → offline (no false up-to-date)', async () => {
+  const s = await computeAppUpdateStatus('1.0.0', async () => '')
+  assert.equal(s.latest, null)
+  assert.equal(s.error, 'offline')
+  assert.equal(s.hasUpdate, false)
+})
+
+// ─── AppUpdateChecker (cache + TTL + offline-keeps-prior) ─────────────────────
+
+test('AppUpdateChecker: caches the last status', async () => {
+  const checker = new AppUpdateChecker('1.0.0', async () => '1.1.0')
+  assert.equal(checker.get(), null)
+  const s = await checker.check()
+  assert.equal(s.hasUpdate, true)
+  assert.equal(checker.get()?.latest, '1.1.0')
+})
+
+test('AppUpdateChecker: an offline re-check keeps a prior successful answer', async () => {
+  let online = true
+  const checker = new AppUpdateChecker('1.0.0', async () => {
+    if (!online) throw new Error('offline')
+    return '1.1.0'
+  })
+  await checker.check()
+  online = false
+  const s = await checker.check()
+  // Still the real latest, not a flap to "couldn't check".
+  assert.equal(s.latest, '1.1.0')
+  assert.equal(s.hasUpdate, true)
+  assert.equal(s.error, undefined)
+})
+
+test('AppUpdateChecker: with no prior success, an offline result is cached as offline', async () => {
+  const checker = new AppUpdateChecker('1.0.0', async () => {
+    throw new Error('offline')
+  })
+  const s = await checker.check()
+  assert.equal(s.error, 'offline')
+  assert.equal(checker.get()?.error, 'offline')
+})
+
+test('AppUpdateChecker.isStale: stale before any check, fresh right after, stale past TTL', async () => {
+  const checker = new AppUpdateChecker('1.0.0', async () => '1.0.0')
+  assert.equal(checker.isStale(), true) // never checked
+  await checker.check()
+  const at = Date.parse(checker.get()!.checkedAt)
+  assert.equal(checker.isStale(at + 1000), false) // 1s later → fresh
+  assert.equal(checker.isStale(at + APP_UPDATE_CHECK_INTERVAL_MS), true) // 24h later → stale
+})

--- a/turbollm/src/app-update.ts
+++ b/turbollm/src/app-update.ts
@@ -1,0 +1,123 @@
+// App self-update check (F-006, ADR-031). The *app* analog of the per-engine update
+// checker (ADR-085, src/engines/update.ts): is a newer TurboLLM published on npm than
+// the version we're running? Informational only — npm does the actual upgrade
+// (`npm i -g turbollm`); we never auto-update or restart ourselves.
+//
+// Same shape as the engine checker: the DECISION (compare installed vs latest) is the
+// pure, unit-tested semver comparator reused from engines/update.ts, and the I/O (the
+// npm registry fetch) is a thin shell that NEVER fabricates a "latest" on a network
+// failure — offline reports a "couldn't check" state instead of a false answer.
+
+import { type CompareResult, comparePipVersions } from './engines/update'
+
+/** Compare two app versions (semver `1.0.0` shape). Reuses the engine checker's
+ *  numeric dotted-release comparator (pre-release/build suffixes ignored — npm's
+ *  `latest` dist-tag is always a stable release, which is all this check compares).
+ *  Result is stated from the latest's perspective: `newer` = an update is available. */
+export function compareAppVersions(installed: string, latest: string): CompareResult {
+  return comparePipVersions(installed, latest)
+}
+
+/** Result of an app update check. On success `latest`/`hasUpdate` carry the compared
+ *  answer; on a network failure `error: 'offline'` is set and `latest`/`hasUpdate`
+ *  stay null/false — we never claim a "latest" we couldn't actually fetch (offline-
+ *  first, ADR-009). `checkedAt` is always set (drives the 24h cache TTL). */
+export interface AppUpdateStatus {
+  /** The running version we compared against (from package.json via the daemon). */
+  installed: string
+  /** The real npm `latest`, or null when the check failed. */
+  latest: string | null
+  hasUpdate: boolean
+  /** ISO timestamp of when this status was produced. */
+  checkedAt: string
+  /** Set when the check could not complete (network unreachable). Mutually exclusive
+   *  with a non-null latest. */
+  error?: 'offline'
+  /** False when latest couldn't be parsed/compared against installed (`unknown`) — the
+   *  UI then stays silent rather than showing a false "up to date". */
+  comparable: boolean
+}
+
+/** The npm package the app is published as (F-006). */
+export const APP_PACKAGE = 'turbollm'
+
+/** Resolve the real latest published version from the npm registry. Hits the cheap
+ *  per-package `latest` endpoint (no full metadata download). Throws on network
+ *  failure — the caller maps that to an `offline` status, never a fabricated latest. */
+export async function fetchNpmLatest(signal?: AbortSignal): Promise<string> {
+  const res = await fetch(`https://registry.npmjs.org/${APP_PACKAGE}/latest`, {
+    headers: { Accept: 'application/json', 'User-Agent': 'turbollm' },
+    signal,
+  })
+  if (!res.ok) throw new Error(`npm query failed: HTTP ${res.status}`)
+  const data = (await res.json()) as { version?: string }
+  return data.version ?? ''
+}
+
+/** Produce an {@link AppUpdateStatus} for the running version. Fetches npm's latest and
+ *  compares — never inventing a latest on failure. `fetcher` is injectable so tests can
+ *  drive the comparison + offline behavior without network. */
+export async function computeAppUpdateStatus(
+  installed: string,
+  fetcher: (signal?: AbortSignal) => Promise<string> = fetchNpmLatest,
+  signal?: AbortSignal,
+): Promise<AppUpdateStatus> {
+  const checkedAt = new Date().toISOString()
+  let latest: string
+  try {
+    latest = await fetcher(signal)
+  } catch {
+    return { installed, latest: null, hasUpdate: false, checkedAt, error: 'offline', comparable: false }
+  }
+  if (!latest) {
+    return { installed, latest: null, hasUpdate: false, checkedAt, error: 'offline', comparable: false }
+  }
+  const cmp = compareAppVersions(installed, latest)
+  return {
+    installed,
+    latest,
+    hasUpdate: cmp === 'newer',
+    checkedAt,
+    comparable: cmp !== 'unknown',
+  }
+}
+
+/** How long a successful check is trusted before a re-check is warranted (ADR-031:
+ *  "cache result for 24h"). */
+export const APP_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000 // 24h
+
+/** Process-lifetime cache of the last app-update check, with its timestamp. Offline-
+ *  first: a cached successful status survives a later network failure so the UI keeps
+ *  showing the last real answer instead of flapping to "couldn't check". Singleton (the
+ *  app checks exactly one version), unlike the per-engine {@link UpdateChecker}. */
+export class AppUpdateChecker {
+  private cache: AppUpdateStatus | null = null
+
+  constructor(
+    private installed: string,
+    private fetcher: (signal?: AbortSignal) => Promise<string> = fetchNpmLatest,
+  ) {}
+
+  /** The last cached status, or null when never checked. */
+  get(): AppUpdateStatus | null {
+    return this.cache
+  }
+
+  /** True when there's no cached status or it's older than the 24h TTL — i.e. a
+   *  re-check is warranted. `now` is injectable for tests. */
+  isStale(now: number = Date.now()): boolean {
+    if (!this.cache) return true
+    const at = Date.parse(this.cache.checkedAt)
+    return !Number.isFinite(at) || now - at >= APP_UPDATE_CHECK_INTERVAL_MS
+  }
+
+  /** Re-check and cache the result. On an offline result we KEEP a prior successful
+   *  status (don't overwrite a real latest with "couldn't check"); the UI's relative
+   *  time naturally ages. Returns the status used. */
+  async check(signal?: AbortSignal): Promise<AppUpdateStatus> {
+    const fresh = await computeAppUpdateStatus(this.installed, this.fetcher, signal)
+    if (fresh.error === 'offline' && this.cache && this.cache.latest !== null) return this.cache
+    this.cache = fresh
+    return fresh
+  }
+}

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -10,6 +10,7 @@ import { Registry } from './engines/registry'
 import { ProvisionState } from './engines/provision-state'
 import { UpdateChecker } from './engines/update'
 import { UpdateScheduler } from './engines/update-scheduler'
+import { AppUpdateChecker } from './app-update'
 import { applyEngineUpdate } from './engines/update-apply'
 import { seedDefaultEngines } from './engines/seed'
 import { engineAcceptsFormat } from './engines/compat'
@@ -168,9 +169,18 @@ void (async () => {
   await toolRegistry.syncMcpServers(cfg.mcp.servers)
 })()
 const startedAt = Date.now()
+// App self-update checker (F-006, ADR-031): is a newer TurboLLM published on npm than
+// the version we're running? Informational only — npm does the upgrade. The route serves
+// this cache offline-first; the startup check below warms it so the chip is ready.
+const appUpdates = new AppUpdateChecker(version)
 // `requestRestart` is attached after the server is created (it must close over it).
-const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, updates, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
+const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, updates, appUpdates, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
 const app = createApp(deps)
+
+// Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the
+// Settings chip is ready without the user clicking refresh. Offline-silent; unref'd so it
+// never holds the process open. The 24h re-check is on-demand when the cache goes stale.
+setTimeout(() => void appUpdates.check(AbortSignal.timeout(10_000)).catch(() => {}), 5_000).unref()
 
 // Background auto-update checker (ADR-085, Phase 6): runs shortly after boot + every
 // ~24h. Refreshes per-engine update status; for 'auto' engines with an available update

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -4,6 +4,7 @@ import type { ComfyGuard } from './engines/comfy-guard'
 import type { Registry } from './engines/registry'
 import type { ProvisionState } from './engines/provision-state'
 import type { UpdateChecker } from './engines/update'
+import type { AppUpdateChecker } from './app-update'
 import type { Scanner } from './models/scanner'
 import type { HashStore } from './models/hashes'
 import type { ConversationStore } from './chat/db'
@@ -24,6 +25,10 @@ export interface Deps {
   /** Honest engine update checker (ADR-085): per-engine installed/latest/hasUpdate with
    *  an in-memory cache. Optional — absent in tests that don't exercise the update routes. */
   updates?: UpdateChecker
+  /** App self-update checker (F-006, ADR-031): is a newer TurboLLM published on npm than
+   *  the running version? Informational only (npm does the upgrade). Optional — absent in
+   *  tests that don't exercise the app-update route. */
+  appUpdates?: AppUpdateChecker
   hf: HfClient
   downloads: DownloadManager
   bench: BenchRunner

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -33,7 +33,7 @@ export function Shell({
   children: ReactNode
 }) {
   return (
-    <div className="flex h-full">
+    <div className="app-shell flex h-full">
       <NavRail status={status} online={online} version={version} className="hidden md:flex" />
       <div className="flex min-w-0 flex-1 flex-col">
         <EngineProvisionBanner status={status} />

--- a/turbollm/web/src/components/ui/sheet.tsx
+++ b/turbollm/web/src/components/ui/sheet.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+/**
+ * Side sheet — the model config panel. Built on the Radix dialog primitive (for
+ * Esc-to-close, focus management, and the data-state the slide animation keys
+ * off), but it is NOT a modal: there is no backdrop overlay. Instead it docks to
+ * the right and the app shell shrinks to make room (see `.tllm-sheet` /
+ * `.app-shell` in index.css):
+ *   · mobile  — full-screen, slides in from the right
+ *   · desktop — right-docked push panel, slides in from the right
+ * Callers pass `modal={false}` on <Sheet> and keep the panel open while the user
+ * interacts with the resized content behind it.
+ */
+export const Sheet = DialogPrimitive.Root
+export const SheetTrigger = DialogPrimitive.Trigger
+export const SheetClose = DialogPrimitive.Close
+
+export const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        // Layout/position/width/border are responsive — handled by `.tllm-sheet`.
+        'tllm-sheet fixed z-50 flex flex-col border-border bg-panel shadow-[var(--shadow-2)] focus:outline-none',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className="absolute right-4 top-4 rounded-sm text-muted hover:text-ink"
+        aria-label="Close"
+      >
+        <X size={16} />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+))
+SheetContent.displayName = 'SheetContent'
+
+export function SheetHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mb-4 flex flex-col gap-1', className)} {...props} />
+}
+
+export const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-[16px] font-semibold tracking-[-0.01em] text-ink', className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = 'SheetTitle'
+
+export const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-[13px] text-muted', className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = 'SheetDescription'

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -84,6 +84,9 @@ html,
 body,
 #root {
   height: 100%;
+  /* Full-height SPA shell — page itself never scrolls (inner panes do), and this
+     clips the config panel while it sits off-screen during its slide animation. */
+  overflow: hidden;
 }
 
 body {
@@ -121,6 +124,100 @@ body {
 }
 .tllm-pulse {
   animation: tllm-pulse 1.2s ease-in-out infinite;
+}
+
+/* Model config panel. Slides in from the RIGHT at every width (Radix data-state).
+     · mobile  — full-screen takeover
+     · desktop — right-docked PUSH panel: no overlay, the app shell shrinks by the
+                 panel's width so content resizes instead of being covered.
+   The panel width lives in one variable so the panel and the shell padding stay
+   in lock-step. */
+:root {
+  --tllm-config-w: min(560px, 45vw);
+}
+
+@keyframes tllm-sheet-in-right {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+@keyframes tllm-sheet-out-right {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+
+/* Mobile (default): full-screen takeover. */
+.tllm-sheet {
+  inset: 0;
+  width: 100%;
+  max-width: none;
+}
+.tllm-sheet[data-state='open'] {
+  animation: tllm-sheet-in-right 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+}
+.tllm-sheet[data-state='closed'] {
+  animation: tllm-sheet-out-right 0.24s ease-in;
+}
+
+/* Desktop (≥768px, matches the app's nav breakpoint): right-docked panel and a
+   matching right-pad on the shell so the rest of the UI resizes (no overlap). */
+.app-shell {
+  transition: padding-right 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+}
+@media (min-width: 768px) {
+  .tllm-sheet {
+    inset: 0 0 0 auto;
+    width: var(--tllm-config-w);
+    max-width: var(--tllm-config-w);
+    border-left-width: 1px;
+  }
+  html.tllm-config-open .app-shell {
+    padding-right: var(--tllm-config-w);
+  }
+}
+
+/* Drag-to-resize handle on the panel's left seam (desktop only — on mobile the
+   panel is full-screen). Pinned to the viewport at the seam (right offset = panel
+   width) so it never scrolls with the panel content. */
+.tllm-config-resizer {
+  display: none;
+}
+@media (min-width: 768px) {
+  .tllm-config-resizer {
+    display: block;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    right: var(--tllm-config-w);
+    width: 10px;
+    margin-right: -5px;
+    z-index: 51;
+    cursor: col-resize;
+    touch-action: none;
+  }
+  /* Thin seam line that brightens on hover/drag. */
+  .tllm-config-resizer::after {
+    content: '';
+    position: absolute;
+    inset: 0 4px;
+    background: transparent;
+    transition: background-color 0.15s;
+  }
+  .tllm-config-resizer:hover::after,
+  html.tllm-config-resizing .tllm-config-resizer::after {
+    background: var(--accent);
+  }
+}
+/* While dragging: kill the open/push animations so the panel tracks the pointer
+   1:1, and stop text selection / cursor flicker across the whole window. */
+html.tllm-config-resizing {
+  cursor: col-resize;
+  user-select: none;
+}
+html.tllm-config-resizing .app-shell {
+  transition: none;
+}
+html.tllm-config-resizing .tllm-sheet {
+  animation: none;
 }
 
 /* Slim scrollbar — used on panels that need a non-intrusive scroll indicator.

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   ModelDirs,
   ModelsList,
   Status,
+  AppUpdate,
 } from './types'
 
 const AUTH_KEY = 'tllm.authToken'
@@ -205,6 +206,13 @@ export function updateBackend(
  *  `?refresh=1` forces a live re-check; otherwise the cache is served (offline-first). */
 export function getEngineUpdates(refresh = false): Promise<EngineUpdates> {
   return request<EngineUpdates>(`/api/v1/engines/updates${refresh ? '?refresh=1' : ''}`)
+}
+
+/** App self-update check (F-006, ADR-031): is a newer TurboLLM published on npm than the
+ *  running version? Offline-first — serves the daemon's 24h cache; `?refresh=1` forces a
+ *  live re-check. Informational only; npm performs the upgrade. */
+export function getAppUpdate(refresh = false): Promise<AppUpdate> {
+  return request<AppUpdate>(`/api/v1/app/update${refresh ? '?refresh=1' : ''}`)
 }
 
 /** Set an engine's auto-update policy (off | notify | auto). */

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -38,6 +38,7 @@ import {
   updateKoboldcpp,
   updateLlamafile,
   getEngineUpdates,
+  getAppUpdate,
   setEngineUpdatePolicy,
   getStatus,
   startBench,
@@ -91,6 +92,7 @@ import type {
   EngineRecommendationResult,
   EngineStats,
   EngineUpdates,
+  AppUpdate,
   EnginesList,
   UpdatePolicy,
   HfRepoDetail,
@@ -111,6 +113,7 @@ export const queryKeys = {
   engineCatalog: ['engine-catalog'] as const,
   engineRecommendation: ['engine-recommendation'] as const,
   engineUpdates: ['engine-updates'] as const,
+  appUpdate: ['app-update'] as const,
   models: ['models'] as const,
   modelDirs: ['modeldirs'] as const,
   downloads: ['downloads'] as const,
@@ -271,6 +274,21 @@ export function useEngineUpdates(provisioning = false): UseQueryResult<EngineUpd
     queryKey: queryKeys.engineUpdates,
     queryFn: () => getEngineUpdates(false),
     refetchInterval: provisioning ? 3000 : false,
+    retry: false,
+  })
+}
+
+/** App self-update check (F-006, ADR-031). Offline-first: serves the daemon's 24h cache,
+ *  never a fabricated "latest". The daemon warms the cache at startup; this polls gently
+ *  while the answer is still unknown (null) so the startup-warmed result lands without a
+ *  manual refresh, then stops once a real answer (or an offline state) is cached. */
+export function useAppUpdate(): UseQueryResult<AppUpdate> {
+  return useQuery({
+    queryKey: queryKeys.appUpdate,
+    queryFn: () => getAppUpdate(false),
+    refetchInterval: (q) => (q.state.data && q.state.data.latest === null && !q.state.data.error ? 20000 : false),
+    refetchIntervalInBackground: false,
+    staleTime: 60_000,
     retry: false,
   })
 }

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -112,6 +112,20 @@ export type Status = {
   uptimeSec: number
 }
 
+/** App self-update check (F-006, GET /api/v1/app/update). Is a newer TurboLLM published
+ *  on npm than the running version? `latest` is null + `error:'offline'` when the npm
+ *  registry was unreachable (the UI then stays silent — never a false "up to date"). */
+export type AppUpdate = {
+  /** The running version. */
+  installed: string
+  /** The npm `latest`, or null when the check failed (offline). */
+  latest: string | null
+  hasUpdate: boolean
+  checkedAt: string
+  error?: 'offline'
+  comparable: boolean
+}
+
 /** Live ComfyUI coordination state (GET /api/v1/status). Drives the "paused while
  *  ComfyUI renders" indicator and the reason a model load was refused. */
 export type ComfyRuntime = {

--- a/turbollm/web/src/screens/ModelsScreen.tsx
+++ b/turbollm/web/src/screens/ModelsScreen.tsx
@@ -130,7 +130,7 @@ export function ModelsScreen() {
   }
 
   return (
-    <div className="w-full px-6 py-6">
+    <div className="slim-scroll h-full w-full overflow-y-auto px-6 py-6">
       <ScreenHeader
         title="Models"
         description={

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle } from 'lucide-react'
+import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle, ArrowUpCircle } from 'lucide-react'
 import {
   PERSONAS, getDefaultPersonaId, getPersonalization, savePersonalization,
   setDefaultPersonaId, type PersonaId, type Personalization,
@@ -19,7 +19,9 @@ import {
   useStatus,
   useSysInfo,
   useTelemetryPreview,
+  useAppUpdate,
 } from '../lib/queries'
+import { CopyButton } from '../components/ui/copy-button'
 import { ModelDirs } from './models/ModelDirs'
 import { useConversationMutations } from '../lib/chat-queries'
 import { ApiError, type TelemetryLevel } from '../lib/api'
@@ -463,6 +465,9 @@ export function SettingsScreen() {
 
         {/* Advanced (spec 08 §2): daemon restart */}
         <AdvancedSection onRestart={requestRestart} />
+
+        {/* About + app self-update check (F-006) */}
+        <AboutSection />
 
         {/* Help */}
         <HelpSection />
@@ -1309,6 +1314,63 @@ function PersonalizationSection() {
           </Button>
         </div>
       </div>
+    </section>
+  )
+}
+
+// ── About + app self-update check (F-006, ADR-031) ────────────────────────────
+// Shows the running version and, when npm has a newer TurboLLM, an "update available"
+// chip with the install command to copy. Informational only — npm performs the upgrade;
+// the app never auto-updates itself. Offline-silent: when the npm check couldn't run we
+// just show the current version with no error (never a false "up to date").
+
+const APP_UPDATE_COMMAND = 'npm i -g turbollm'
+
+function AboutSection() {
+  // The running version always comes from /status (present immediately); the npm
+  // comparison rides the separate, offline-first app-update check.
+  const { data: status } = useStatus()
+  const { data: update } = useAppUpdate()
+  const installed = update?.installed || status?.version || ''
+  const hasUpdate = !!update?.hasUpdate && !!update?.latest
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-wide text-faint">About</h2>
+
+      <div className="flex items-center justify-between py-1">
+        <div>
+          <div className="text-[14px] font-medium text-ink">Version</div>
+          <div className="text-[12px] text-muted">The TurboLLM version this daemon is running</div>
+        </div>
+        <span className="font-mono text-[13px] text-ink">{installed ? `v${installed}` : '—'}</span>
+      </div>
+
+      {hasUpdate ? (
+        <div
+          className="mt-2 flex flex-col gap-2 rounded-md border p-3"
+          style={{
+            borderColor: 'color-mix(in srgb, var(--accent) 40%, var(--border))',
+            background: 'color-mix(in srgb, var(--accent) 6%, transparent)',
+          }}
+        >
+          <div className="flex items-center gap-2 text-[13px] font-medium" style={{ color: 'var(--accent)' }}>
+            <ArrowUpCircle size={15} />
+            TurboLLM v{update!.latest} is available
+          </div>
+          <div className="text-[12px] text-muted">Update from your terminal:</div>
+          <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-bg px-2.5 py-1.5">
+            <code className="select-all font-mono text-[12px] text-ink">{APP_UPDATE_COMMAND}</code>
+            <CopyButton text={APP_UPDATE_COMMAND} />
+          </div>
+        </div>
+      ) : update?.latest && !update.hasUpdate ? (
+        // Checked successfully and current — a quiet confirmation, no call to action.
+        <div className="mt-1 inline-flex items-center gap-1.5 text-[12px] text-faint">
+          <Check size={13} style={{ color: 'var(--ok)' }} />
+          You're on the latest version
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState, type ReactNode } from 'react'
+﻿import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, ExternalLink, Gauge, RotateCcw, Save, X, Zap } from 'lucide-react'
 import { ApiError } from '../../lib/api'
@@ -7,7 +7,7 @@ import type { LoadProfile, SysGpu } from '../../lib/types'
 import { defaultGpu, defaultVllm } from '../../lib/types'
 import { estimateVram, gpuBudgetMb } from '../../lib/vram'
 import { Button } from '../../components/ui/button'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../../components/ui/dialog'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../../components/ui/sheet'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -67,6 +67,24 @@ export function ModelDetailDialog({
   useEffect(() => {
     if (detail) setDraft(structuredClone(detail.profile))
   }, [detail])
+
+  // While the panel is open, mark <html> so the app shell pads to the right by the
+  // panel width (.app-shell in index.css) — content resizes instead of overlapping.
+  // On desktop only; on mobile the panel is a full-screen takeover (no padding).
+  // Also restore a previously dragged width (see ConfigResizeHandle).
+  useEffect(() => {
+    if (!modelKey) return
+    const root = document.documentElement
+    const saved = parseInt(readSavedConfigWidth() ?? '', 10)
+    if (saved > 0) {
+      // Clamp against the current viewport — a width saved on a wider screen must
+      // not overflow a narrower one.
+      const w = Math.min(Math.max(saved, CONFIG_MIN_W), configMaxW())
+      root.style.setProperty('--tllm-config-w', `${w}px`)
+    }
+    root.classList.add('tllm-config-open')
+    return () => root.classList.remove('tllm-config-open')
+  }, [modelKey])
 
   // After "Stop & benchmark", the eject takes a moment to drain the engine. Once the
   // status poll reports it stopped, fire the deferred sweep (the runner 409s while busy).
@@ -176,13 +194,20 @@ export function ModelDetailDialog({
 
   return (
     <>
-    <Dialog open={!!modelKey} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-h-[88vh] overflow-y-auto sm:max-w-[560px] slim-scroll">
-        <DialogHeader>
-          <DialogTitle className="truncate">{detail?.name ?? 'Model'}</DialogTitle>
-          <DialogDescription>
+    <Sheet open={!!modelKey} onOpenChange={(o) => !o && onClose()} modal={false}>
+      <SheetContent
+        className="overflow-y-auto p-5 slim-scroll"
+        // It's a push panel, not a modal: keep it open while the user works in
+        // the resized content behind it. Close is via the ✕, Esc, or the buttons.
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <ConfigResizeHandle />
+        <SheetHeader>
+          <SheetTitle className="truncate">{detail?.name ?? 'Model'}</SheetTitle>
+          <SheetDescription>
             {detail ? `${detail.arch} · ${detail.quant} · ${fmtSize(detail.sizeBytes)}` : 'Load settings'}
-          </DialogDescription>
+          </SheetDescription>
           {detail?.sourceRepo && onViewRepo && (
             <button
               type="button"
@@ -193,7 +218,7 @@ export function ModelDetailDialog({
               <ExternalLink size={12} /> Model card &amp; quants on Hugging Face
             </button>
           )}
-        </DialogHeader>
+        </SheetHeader>
 
         {!detail || !draft ? (
           <div className="py-10 text-center text-[13px] text-muted">Loading…</div>
@@ -478,8 +503,8 @@ export function ModelDetailDialog({
             </div>
           </div>
         )}
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
     <AutoTuneResultDialog
       result={benchDone && benchHere ? benchState?.result : undefined}
       modelName={detail?.name}
@@ -487,6 +512,61 @@ export function ModelDetailDialog({
       onCancel={onTuneCancel}
     />
     </>
+  )
+}
+
+// ── Resizable panel (desktop) ────────────────────────────────────────────────
+// The panel width is one CSS var, `--tllm-config-w`, read by both the panel and
+// the shell's right-pad — so updating it resizes both in lock-step. We drag it,
+// clamp it, and remember it across opens.
+const CONFIG_WIDTH_KEY = 'tllm-config-w'
+const CONFIG_MIN_W = 360
+/** Largest the panel may grow: never wider than ~760px, and always leave room for content. */
+function configMaxW() {
+  return Math.max(CONFIG_MIN_W, Math.min(760, window.innerWidth - 220))
+}
+function readSavedConfigWidth(): string | null {
+  try {
+    return localStorage.getItem(CONFIG_WIDTH_KEY)
+  } catch {
+    return null
+  }
+}
+
+/** Thin drag handle on the panel's left seam; updates `--tllm-config-w` live. */
+function ConfigResizeHandle() {
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    // Left button only; ignore on touch-less right/middle clicks.
+    if (e.button !== 0) return
+    e.preventDefault()
+    const root = document.documentElement
+    root.classList.add('tllm-config-resizing')
+    const onMove = (ev: PointerEvent) => {
+      // Panel is docked right, so its width is the distance from the right edge.
+      const w = Math.min(Math.max(window.innerWidth - ev.clientX, CONFIG_MIN_W), configMaxW())
+      root.style.setProperty('--tllm-config-w', `${Math.round(w)}px`)
+    }
+    const onUp = () => {
+      root.classList.remove('tllm-config-resizing')
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      try {
+        localStorage.setItem(CONFIG_WIDTH_KEY, getComputedStyle(root).getPropertyValue('--tllm-config-w').trim())
+      } catch {
+        /* ignore quota / disabled storage */
+      }
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+  return (
+    <div
+      className="tllm-config-resizer"
+      onPointerDown={onPointerDown}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize panel"
+    />
   )
 }
 


### PR DESCRIPTION
v1.1.0 bundles two changes.

---

## 1 · F-006 · App self-update check (ADR-031)

The **app** analog of the per-engine update check (ADR-085). The daemon compares the running TurboLLM version against npm's `latest`; **Settings → About** shows an "update available" chip with a copy-able `npm i -g turbollm` command when a newer release is published. Informational only — npm performs the upgrade; the app never auto-updates itself.

**Acceptance (STATUS done-when):**
- ✅ Chip shows when npm `latest` > running version
- ✅ Hidden when current (quiet "you're on the latest version" instead)
- ✅ Offline → no-ops silently (never a false "up to date")
- ✅ 24h cache

**What's in here:**
- `src/app-update.ts` — pure version compare (reuses the engine checker's semver comparator), npm `latest` fetch, 24h-cached `AppUpdateChecker` (offline-first: never fabricates a "latest"; keeps a prior success over a later network failure).
- `GET /api/v1/app/update` — non-blocking, offline-silent; stale/`?refresh=1` kicks a background re-check and serves the cache now. Warmed by a startup check.
- Settings → About — always shows the running version; chip only when npm > running.
- 11 new unit tests.

**Verified live against real npm:** current `1.0.0`→no chip; older `0.9.0` vs `1.0.0`→`hasUpdate:true`.

---

## 2 · Model config as a resizable side panel

Forward-port of commit `becb638` (authored 2026-06-20 on `feat/model-config-side-panel`) that **was never merged** — it branched off the post-v0.8.0 point and got orphaned when the v0.9.0 engine overhaul flowed to main/v1.0.0 without it. Cherry-picked here cleanly (the touched files were unchanged on main since the fork).

Converts the model config from a centered modal into a side panel, shared by the Chat header and Models page:
- New `Sheet` primitive (Radix dialog, non-modal, no backdrop).
- Desktop: right-docked **push** panel — the app shell pads right so content resizes instead of being overlapped; drag the left seam to resize (clamped 360–760px, persisted in localStorage).
- Mobile (<768px): full-screen takeover from the right.
- Panel width + shell padding share one CSS var (`--tllm-config-w`) so they stay in lock-step.

---

## Verification (whole PR)
- `354` tests pass (11 new) · root + web typecheck clean · web + dist build clean.
- ⚠️ Recommend a live UI pass on the side panel (desktop push/resize + mobile takeover) against a running daemon before release — it's a forward-port of previously-reviewed code, build-verified here.

## Notes
- `package.json` stays at `1.0.0` — bump to `1.1.0` is a release-ritual step after merge (ADR-079; `RELEASE.md`).