### PR TITLE
feat: v1.2.0 — auto-tune sampling from the HF model card (#10, ADR-099)

### DIFF
--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -15,6 +15,15 @@ import type { Engine } from '../config/config'
 import type { Scanner, ModelEntry } from '../models/scanner'
 import { deriveDefault, profileToArgs, resolveProfile, type LoadProfile } from '../models/profile'
 import { getSysInfo, type SysInfo } from '../sysinfo/sysinfo'
+import type { HfClient } from '../hf/hf'
+import { inferRepoFromPath } from '../api/path-utils'
+import {
+  buildCardExtractionPrompt,
+  hasAnySampling,
+  parseCardSampling,
+  parseLlmSampling,
+  type CardSampling,
+} from '../models/card-sampling'
 
 /** A single candidate the sweep evaluated. `outcome` is 'ok' on a measured run, or
  *  the failure mode (timeout/crash/oom) — the sweep keeps going on a failure. */
@@ -39,7 +48,16 @@ export interface BenchState {
   error?: string
   /** The winning candidate, surfaced when a run finishes so the UI can show a Save/Cancel
    *  results dialog. The profile is NOT persisted until the user clicks Save (POST /bench/save). */
-  result?: { params: BenchCandidate['params']; tps: number; ttftMs: number; vramMb: number | null }
+  result?: {
+    params: BenchCandidate['params']
+    tps: number
+    ttftMs: number
+    vramMb: number | null
+    /** Recommended sampling read from the model's HF card (ADR-099), when one was found.
+     *  Already merged into the winning profile so Save persists it; surfaced here so the
+     *  results dialog can show what the card recommended. Absent when no card / nothing parsed. */
+    recommendedSampling?: CardSampling
+  }
 }
 
 // Hard limits (spec 09 §1).
@@ -93,6 +111,8 @@ export class BenchRunner {
     private scanner: Scanner,
     private registry: Registry,
     private version: string,
+    /** Used to fetch the model's HF card for card-derived sampling (ADR-099). */
+    private hf: HfClient,
   ) {}
 
   /** Live state for GET /status. */
@@ -200,15 +220,35 @@ export class BenchRunner {
     await this.manager.stopAndWait().catch(() => {})
 
     if (best) {
+      // Card-derived recommended sampling (ADR-099): read the model author's recommended
+      // temp/top_k/top_p/min_p from the HF card and merge into the winning profile so Save
+      // persists it. Fully fail-safe — no card / nothing parsed leaves sampling untouched
+      // (done-when: "no card → defaults unchanged"). The engine is stopped here; the LLM
+      // fallback (only when the heuristic finds nothing) reloads the winner briefly itself.
+      let recommended: CardSampling | undefined
+      if (!this.cancelled) {
+        recommended = await this.extractCardSampling(entry, best.profile, caps, sys).catch(() => undefined)
+        await this.manager.stopAndWait().catch(() => {}) // in case the LLM fallback loaded a model
+      }
+      const profile =
+        recommended && hasAnySampling(recommended)
+          ? { ...best.profile, sampling: { ...best.profile.sampling, ...recommended } }
+          : best.profile
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
-      this.winning = { modelKey, profile: best.profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }
+      this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }
       this.state = {
         running: false,
         modelKey,
         done: true,
         bestTps: best.cand.tps ?? undefined,
-        result: { params: best.cand.params, tps: best.cand.tps ?? 0, ttftMs: best.cand.ttftMs ?? 0, vramMb: best.cand.vramMb },
+        result: {
+          params: best.cand.params,
+          tps: best.cand.tps ?? 0,
+          ttftMs: best.cand.ttftMs ?? 0,
+          vramMb: best.cand.vramMb,
+          ...(recommended && hasAnySampling(recommended) ? { recommendedSampling: recommended } : {}),
+        },
         candidates: results,
       }
     } else {
@@ -634,6 +674,99 @@ export class BenchRunner {
     const t = data.timings
     if (!t || typeof t.predicted_per_second !== 'number') return null
     return { tps: t.predicted_per_second, ttftMs: typeof t.prompt_ms === 'number' ? t.prompt_ms : 0 }
+  }
+
+  // ---- card-derived recommended sampling (ADR-099) ------------------------
+
+  /** Resolve the model's HF card and extract recommended sampling (temp/top_k/top_p/min_p).
+   *  HYBRID: the deterministic heuristic parser runs first; only if it finds nothing does the
+   *  just-tuned local model read its own card and emit JSON (the LLM fallback). Returns
+   *  undefined when the model's repo can't be resolved (e.g. a hand-placed file), the card is
+   *  missing/unreachable, or nothing parseable is found — the caller then leaves sampling at the
+   *  resolved defaults. Never throws (all failures collapse to undefined). */
+  private async extractCardSampling(
+    entry: ModelEntry,
+    winningProfile: LoadProfile,
+    caps: Engine['capabilities'],
+    sys: SysInfo,
+  ): Promise<CardSampling | undefined> {
+    const repo = inferRepoFromPath(entry.path, this.store.snapshot().modelDirs)
+    if (!repo) return undefined // hand-placed file outside a model dir → no upstream card
+    this.state = { ...this.state, step: 'Reading model-card recommendations…' }
+    let card = ''
+    try {
+      card = await this.hf.fetchModelCard(repo)
+    } catch {
+      return undefined
+    }
+    if (!card) return undefined
+
+    const heuristic = parseCardSampling(card)
+    if (hasAnySampling(heuristic)) return heuristic // deterministic fast path
+
+    // LLM fallback: prose-only / unusual card — ask the just-tuned model to read it.
+    if (this.cancelled) return undefined
+    const llm = await this.llmExtractSampling(entry, winningProfile, caps, sys, card).catch(() => undefined)
+    return llm && hasAnySampling(llm) ? llm : undefined
+  }
+
+  /** LLM fallback for {@link extractCardSampling}: briefly reload the winning profile, ask the
+   *  model to extract recommended sampling as JSON, then stop. The recommendation is
+   *  model-specific (independent of the swept offload), so reusing the winning profile is exact.
+   *  Bounded by the readiness window + a short generation timeout; any failure → undefined, and
+   *  the engine is always left stopped. */
+  private async llmExtractSampling(
+    entry: ModelEntry,
+    profile: LoadProfile,
+    caps: Engine['capabilities'],
+    sys: SysInfo,
+    card: string,
+  ): Promise<CardSampling | undefined> {
+    const active = this.registry.active()
+    if (!active) return undefined
+    const opts: StartOpts = {
+      engine: active,
+      model: { key: entry.key, name: entry.name, quant: entry.quant, ctx: profile.ctx, vision: entry.vision },
+      modelPath: entry.path,
+      extraArgs: profileToArgs(profile, entry, caps, sys.cores),
+    }
+    try {
+      await this.manager.start(opts)
+    } catch {
+      return undefined
+    }
+    const ready = await this.awaitReady(Date.now() + READY_TIMEOUT_MS)
+    const target = ready === 'ok' ? this.manager.target() : null
+    if (!target) {
+      await this.manager.stopAndWait().catch(() => {})
+      return undefined
+    }
+    const text = await this.chatText(target, buildCardExtractionPrompt(card), 200, 60_000).catch(() => null)
+    await this.manager.stopAndWait().catch(() => {})
+    return text ? parseLlmSampling(text) : undefined
+  }
+
+  /** One non-streaming completion that returns the generated TEXT (vs {@link chat}, which
+   *  returns timings). Used by the card-sampling LLM fallback. Honors the per-call timeout and
+   *  the cancel kill-switch; null on a non-OK response. */
+  private async chatText(target: string, content: string, maxTokens: number, timeoutMs: number): Promise<string | null> {
+    const signals: AbortSignal[] = [AbortSignal.timeout(timeoutMs)]
+    if (this.abort) signals.push(this.abort.signal)
+    const res = await fetch(`${target}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'bench',
+        messages: [{ role: 'user', content }],
+        max_tokens: maxTokens,
+        temperature: 0,
+        stream: false,
+      }),
+      signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+    return data.choices?.[0]?.message?.content ?? null
   }
 
   /** Save the winning profile as the model's saved profile (tunedBy:'bench') and

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -225,10 +225,19 @@ export class BenchRunner {
       // persists it. Fully fail-safe — no card / nothing parsed leaves sampling untouched
       // (done-when: "no card → defaults unchanged"). The engine is stopped here; the LLM
       // fallback (only when the heuristic finds nothing) reloads the winner briefly itself.
+      // Gate on the global deadline too (not just cancel): a run that already spent the full
+      // TOTAL_BUDGET_MS must not spawn a multi-minute LLM-fallback reload past budget.
       let recommended: CardSampling | undefined
-      if (!this.cancelled) {
+      if (!this.cancelled && Date.now() <= this.deadline) {
         recommended = await this.extractCardSampling(entry, best.profile, caps, sys).catch(() => undefined)
         await this.manager.stopAndWait().catch(() => {}) // in case the LLM fallback loaded a model
+      }
+      // A cancel DURING extraction (the LLM fallback can run for minutes) must not resurrect the
+      // results dialog or re-hold a profile the user just discarded: cancel() cleared winning +
+      // result, but couldn't stop this still-running run. Re-check before committing the winner.
+      if (this.cancelled) {
+        this.state = { running: false, modelKey, done: true, candidates: results }
+        return
       }
       const profile =
         recommended && hasAnySampling(recommended)

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -154,7 +154,7 @@ const hf = new HfClient(() => store.snapshot().hf.token, version)
 const downloads = new DownloadManager(store, () => void scanner.rescan(), () => hf.authHeaders())
 // Auto-benchmark + auto-tune runner (Differentiator #2, spec 09). Owns the engine
 // exclusively for a run; reuses manager/profile control rather than reimplementing it.
-const bench = new BenchRunner(manager, store, scanner, registry, version)
+const bench = new BenchRunner(manager, store, scanner, registry, version, hf)
 // ComfyUI GPU coordinator (push): the installed ComfyUI gate node calls
 // /api/v1/comfyui/acquire|release to unload/reload the model around renders. Event-
 // driven — no polling. No-op until enabled in Settings + the node is installed.

--- a/turbollm/src/hf/hf.ts
+++ b/turbollm/src/hf/hf.ts
@@ -152,6 +152,12 @@ export class HfClient {
     }
   }
 
+  /** Public model-card fetch (ADR-099): the cleaned README for `owner/repo`, or '' when
+   *  missing/unreachable. Used by auto-tune to read recommended sampling from the card. */
+  fetchModelCard(repo: string): Promise<string> {
+    return this.getCard(repo)
+  }
+
   /** Fetch the repo README (the model card), strip its YAML frontmatter, and cap the
    *  length for display. Best-effort — a missing/unreachable README yields '' rather
    *  than failing the whole repo-detail request. Cached like other HF reads. */

--- a/turbollm/src/models/card-sampling.test.ts
+++ b/turbollm/src/models/card-sampling.test.ts
@@ -1,0 +1,136 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseCardSampling,
+  clampCardSampling,
+  hasAnySampling,
+  parseLlmSampling,
+  buildCardExtractionPrompt,
+  type CardSampling,
+} from './card-sampling'
+
+// ─── heuristic parse ─────────────────────────────────────────────────────────
+
+test('parseCardSampling: inline recommended-settings line', () => {
+  const card = 'We recommend using temperature=0.6, top_p=0.95, top_k=20, min_p=0 for best results.'
+  assert.deepEqual(parseCardSampling(card), { temp: 0.6, topP: 0.95, topK: 20, minP: 0 })
+})
+
+test('parseCardSampling: markdown table (Qwen-style)', () => {
+  const card = [
+    '## Best Practices',
+    '| Setting | Value |',
+    '|---|---|',
+    '| Temperature | 0.7 |',
+    '| Top-P | 0.8 |',
+    '| Top-K | 20 |',
+    '| Min-P | 0 |',
+  ].join('\n')
+  assert.deepEqual(parseCardSampling(card), { temp: 0.7, topP: 0.8, topK: 20, minP: 0 })
+})
+
+test('parseCardSampling: bold/colon and leading-dot decimals', () => {
+  const card = '**Temperature:** 0.8\n**top_p:** .95\n**Top K**: 40'
+  assert.deepEqual(parseCardSampling(card), { temp: 0.8, topP: 0.95, topK: 40 })
+})
+
+test('parseCardSampling: partial card (only some knobs stated)', () => {
+  // Only temperature is stated in a parseable `name <sep> value` form; the rest are absent.
+  assert.deepEqual(parseCardSampling('Recommended: temperature 0.5. Leave other settings at default.'), { temp: 0.5 })
+})
+
+test('parseCardSampling: prose-only with no numbers → empty (LLM fallback territory)', () => {
+  assert.deepEqual(parseCardSampling('Use a low temperature and a high top-p for creative output.'), {})
+})
+
+test('parseCardSampling: out-of-range values are dropped, not clamped', () => {
+  // temp 5 (>2), top_p 1.5 (>1) are mis-parses / non-recommendations → dropped; top_k 40 kept.
+  assert.deepEqual(parseCardSampling('temperature: 5  top_p: 1.5  top_k: 40'), { topK: 40 })
+})
+
+test('parseCardSampling: does not match lookalike words (laptop / attempt / temporary)', () => {
+  assert.deepEqual(parseCardSampling('On a laptop, the first attempt is temporary; see section 3.'), {})
+})
+
+test('parseCardSampling: empty / missing card → empty', () => {
+  assert.deepEqual(parseCardSampling(''), {})
+})
+
+test('parseCardSampling: ignores values inside fenced code blocks (usage demos ≠ recommendations)', () => {
+  // Verified live against Mistral-7B: `temperature=0` lives in a usage snippet, not a
+  // recommendation — it must NOT be extracted (would fall through to the LLM fallback).
+  const card = [
+    'Here is how to use it:',
+    '```python',
+    'pipe(messages, temperature=0, top_p=1.0)',
+    '```',
+    'That is all.',
+  ].join('\n')
+  assert.deepEqual(parseCardSampling(card), {})
+})
+
+test('parseCardSampling: real recommendation in a table survives alongside a code example', () => {
+  const card = [
+    '| Temperature | 0.6 |',
+    '| Top-P | 0.95 |',
+    '```python',
+    'generate(temperature=0.0)  # demo only',
+    '```',
+  ].join('\n')
+  assert.deepEqual(parseCardSampling(card), { temp: 0.6, topP: 0.95 })
+})
+
+test('parseCardSampling: min_p of 0 is kept (presence, not truthiness)', () => {
+  const r = parseCardSampling('min_p = 0')
+  assert.equal(r.minP, 0)
+  assert.equal(hasAnySampling(r), true)
+})
+
+// ─── clamp ───────────────────────────────────────────────────────────────────
+
+test('clampCardSampling: rounds top_k, drops out-of-range + non-finite', () => {
+  const dirty: CardSampling = { temp: 0.6, topP: 2, topK: 19.6, minP: Number.NaN }
+  // topP 2 (>1) dropped; topK rounded to 20; minP NaN dropped; temp kept.
+  assert.deepEqual(clampCardSampling(dirty), { temp: 0.6, topK: 20 })
+})
+
+// ─── hasAnySampling ──────────────────────────────────────────────────────────
+
+test('hasAnySampling: false on empty, true on any present (incl. 0)', () => {
+  assert.equal(hasAnySampling({}), false)
+  assert.equal(hasAnySampling({ minP: 0 }), true)
+  assert.equal(hasAnySampling({ temp: 0.7 }), true)
+})
+
+// ─── LLM fallback JSON parse ─────────────────────────────────────────────────
+
+test('parseLlmSampling: plain JSON object', () => {
+  const r = parseLlmSampling('{"temperature":0.6,"top_k":20,"top_p":0.95,"min_p":0.05}')
+  assert.deepEqual(r, { temp: 0.6, topK: 20, topP: 0.95, minP: 0.05 })
+})
+
+test('parseLlmSampling: fenced JSON with surrounding prose', () => {
+  const text = 'Here are the settings:\n```json\n{"temperature": 0.7, "top_p": 0.8, "top_k": null, "min_p": null}\n```\nHope this helps.'
+  assert.deepEqual(parseLlmSampling(text), { temp: 0.7, topP: 0.8 })
+})
+
+test('parseLlmSampling: numeric strings coerced; out-of-range dropped', () => {
+  const r = parseLlmSampling('{"temperature":"0.5","top_k":"40","top_p":3,"min_p":null}')
+  assert.deepEqual(r, { temp: 0.5, topK: 40 }) // top_p 3 dropped, min_p null absent
+})
+
+test('parseLlmSampling: non-JSON / garbage → empty, never throws', () => {
+  assert.deepEqual(parseLlmSampling('I could not find any recommended settings.'), {})
+  assert.deepEqual(parseLlmSampling('{ not valid json '), {})
+  assert.deepEqual(parseLlmSampling(''), {})
+})
+
+// ─── prompt builder ──────────────────────────────────────────────────────────
+
+test('buildCardExtractionPrompt: embeds (capped) card + asks for JSON-only', () => {
+  const prompt = buildCardExtractionPrompt('x'.repeat(20000))
+  assert.match(prompt, /ONLY a single JSON object/)
+  assert.match(prompt, /"temperature": number\|null/)
+  // card capped at 8000 chars, so the whole prompt stays well under the full 20k input.
+  assert.ok(prompt.length < 9000)
+})

--- a/turbollm/src/models/card-sampling.ts
+++ b/turbollm/src/models/card-sampling.ts
@@ -1,0 +1,141 @@
+// Card-derived recommended sampling (ADR-099, v1.2.0). Extracts the model author's
+// recommended sampling settings (temperature / top_k / top_p / min_p) from a Hugging
+// Face model card so auto-tune can prefill the profile's Sampling block.
+//
+// HYBRID extraction (ADR-099): a deterministic heuristic parser runs FIRST (this module's
+// `parseCardSampling`); only when it finds nothing does the bench runner fall back to
+// asking the just-tuned local model to read the card and emit JSON (`parseLlmSampling`
+// validates that reply). Both paths funnel through the same clamp so nothing out-of-range
+// or unparseable ever lands in a profile. PURE + unit-tested — the bench runner owns the
+// network/engine I/O around it.
+
+/** The four sampling knobs a model card commonly recommends. Field names match the
+ *  `Sampling` interface in profile.ts exactly, so a result spreads straight onto a
+ *  profile's `sampling` block with no remapping. All optional — only stated values land. */
+export interface CardSampling {
+  temp?: number
+  topP?: number
+  topK?: number
+  minP?: number
+}
+
+interface FieldSpec {
+  key: keyof CardSampling
+  /** Regex fragment matching the card's name(s) for this knob. */
+  alias: string
+  min: number
+  max: number
+  integer?: boolean
+}
+
+/** Per-knob aliases + valid ranges. Ranges double as the sanity gate (a value outside
+ *  them is dropped, never clamped-to-edge — an out-of-range number signals a mis-parse,
+ *  not a real recommendation). top_k is an integer count; the rest are floats. */
+const FIELDS: FieldSpec[] = [
+  { key: 'temp', alias: 'temp(?:erature)?', min: 0, max: 2 },
+  { key: 'topP', alias: 'top[_\\-\\s]?p', min: 0, max: 1 },
+  { key: 'topK', alias: 'top[_\\-\\s]?k', min: 0, max: 1000, integer: true },
+  { key: 'minP', alias: 'min[_\\-\\s]?p', min: 0, max: 1 },
+]
+
+// A number: integer or decimal, allowing a leading-dot form (".95"). No sign — all four
+// knobs are non-negative, and a stray "-" simply won't match (safer than negative noise).
+const NUM = '(\\d*\\.?\\d+)'
+// Separators allowed between a knob name and its value: whitespace, markdown table pipes,
+// bold/italic asterisks, colons/equals, quotes/backticks/tildes. Capped tight (≤6) so a
+// match can't reach across into an unrelated number further down the line.
+const SEP = '[\\s:=|*"\'`~]{0,6}'
+
+/** Sanity-filter a {@link CardSampling}: drop any field that's missing, non-finite, or
+ *  outside its valid range; round integer fields. The single gate both extraction paths
+ *  pass through. */
+export function clampCardSampling(s: CardSampling): CardSampling {
+  const out: CardSampling = {}
+  for (const f of FIELDS) {
+    const v = s[f.key]
+    if (v == null || !Number.isFinite(v)) continue
+    const n = f.integer ? Math.round(v) : v
+    if (n < f.min || n > f.max) continue
+    out[f.key] = n
+  }
+  return out
+}
+
+/** Heuristic (deterministic) parse of a model card's recommended sampling. Scans for the
+ *  FIRST `name <sep> number` occurrence of each knob — model cards state recommended
+ *  settings once, usually in a table or a "recommended settings" line near the top
+ *  (e.g. `temperature: 0.6`, `top_p = 0.95`, `| Top-K | 20 |`, `**min_p:** 0`). Misses
+ *  prose-only phrasings ("use a low temperature") on purpose — that's the LLM fallback's
+ *  job. Result is already clamped; an empty object means "found nothing parseable". */
+export function parseCardSampling(card: string): CardSampling {
+  const out: CardSampling = {}
+  if (!card) return out
+  // Strip fenced code blocks first: usage snippets (`temperature=0`, eval configs, etc.)
+  // carry demo values, NOT the author's recommendation — scanning them produces false
+  // positives (verified live: Mistral-7B's card has `temperature=0` in an example). Real
+  // recommendations live in prose/tables, which survive. Prose-only cards still fall through
+  // to the LLM fallback on the original (uncapped) card text.
+  const prose = card.replace(/```[\s\S]*?```/g, ' ').replace(/~~~[\s\S]*?~~~/g, ' ')
+  for (const f of FIELDS) {
+    const re = new RegExp(`\\b${f.alias}\\b${SEP}${NUM}`, 'i')
+    const m = re.exec(prose)
+    if (!m) continue
+    const v = Number(m[1])
+    if (Number.isFinite(v)) out[f.key] = v
+  }
+  return clampCardSampling(out)
+}
+
+/** True when at least one knob was extracted. (0 is a valid value — e.g. `min_p: 0` —
+ *  so this checks presence, not truthiness.) */
+export function hasAnySampling(s: CardSampling): boolean {
+  return s.temp != null || s.topP != null || s.topK != null || s.minP != null
+}
+
+/** Build the LLM-fallback prompt: ask the model to read its own card and emit ONLY a JSON
+ *  object of recommended sampling values (null for anything not stated). The card is
+ *  capped so a small-context model can still take it alongside the instruction. */
+export function buildCardExtractionPrompt(card: string): string {
+  const trimmed = card.slice(0, 8000)
+  return [
+    "Extract the model author's RECOMMENDED sampling settings from the model card below.",
+    'Output ONLY a single JSON object, no prose, with exactly these keys:',
+    '{"temperature": number|null, "top_k": number|null, "top_p": number|null, "min_p": number|null}',
+    'Use a value ONLY if the card explicitly recommends it; otherwise use null. Do not guess.',
+    '',
+    'MODEL CARD:',
+    trimmed,
+  ].join('\n')
+}
+
+/** Parse the LLM fallback's reply: pull the first JSON object out of the text (tolerating
+ *  ```json fences / surrounding prose), read the four keys (number or numeric string),
+ *  and clamp. Returns {} on anything unparseable — never throws. */
+export function parseLlmSampling(text: string): CardSampling {
+  const m = /\{[\s\S]*\}/.exec(text)
+  if (!m) return {}
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(m[0]) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+  if (typeof obj !== 'object' || obj === null) return {}
+  const num = (v: unknown): number | null => {
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+    if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v)
+    return null
+  }
+  const out: CardSampling = {}
+  const map: [string, keyof CardSampling][] = [
+    ['temperature', 'temp'],
+    ['top_p', 'topP'],
+    ['top_k', 'topK'],
+    ['min_p', 'minP'],
+  ]
+  for (const [jsonKey, field] of map) {
+    const v = num(obj[jsonKey])
+    if (v !== null) out[field] = v
+  }
+  return clampCardSampling(out)
+}

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -84,7 +84,24 @@ export type BenchState = {
   error?: string
   /** Winning candidate of a finished run — drives the Save/Cancel results dialog. The profile is
    *  only persisted when the user clicks Save (POST /bench/save). */
-  result?: { params: BenchCandidate['params']; tps: number; ttftMs: number; vramMb: number | null }
+  result?: {
+    params: BenchCandidate['params']
+    tps: number
+    ttftMs: number
+    vramMb: number | null
+    /** Sampling recommended by the model's HF card (ADR-099), already merged into the winning
+     *  profile so Save persists it. Absent when no card / nothing parsed. */
+    recommendedSampling?: CardSampling
+  }
+}
+
+/** Card-derived recommended sampling (ADR-099). Field names mirror the profile's `Sampling`
+ *  block; only the knobs the card stated are present. */
+export type CardSampling = {
+  temp?: number
+  topP?: number
+  topK?: number
+  minP?: number
 }
 
 /** Live per-request progress for the engine card (spec 11), from GET /api/v1/status.

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -587,8 +587,8 @@ function AutoTuneResultDialog({
   const recParts = rec
     ? ([
         rec.temp != null && `temp ${rec.temp}`,
-        rec.topK != null && `top_k ${rec.topK}`,
         rec.topP != null && `top_p ${rec.topP}`,
+        rec.topK != null && `top_k ${rec.topK}`,
         rec.minP != null && `min_p ${rec.minP}`,
       ].filter(Boolean) as string[])
     : []

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, ExternalLink, Gauge, RotateCcw, Save, X, Zap } from 'lucide-react'
 import { ApiError } from '../../lib/api'
 import { useBenchActions, useBenchState, useEngines, useModelActions, useModelDetail, useStatus } from '../../lib/queries'
-import type { LoadProfile, SysGpu } from '../../lib/types'
+import type { CardSampling, LoadProfile, SysGpu } from '../../lib/types'
 import { defaultGpu, defaultVllm } from '../../lib/types'
 import { estimateVram, gpuBudgetMb } from '../../lib/vram'
 import { Button } from '../../components/ui/button'
@@ -578,11 +578,20 @@ function AutoTuneResultDialog({
   onSave,
   onCancel,
 }: {
-  result?: { params: { ctx: number; ngl: number; nCpuMoe: number }; tps: number; vramMb: number | null }
+  result?: { params: { ctx: number; ngl: number; nCpuMoe: number }; tps: number; vramMb: number | null; recommendedSampling?: CardSampling }
   modelName?: string
   onSave: () => void
   onCancel: () => void
 }) {
+  const rec = result?.recommendedSampling
+  const recParts = rec
+    ? ([
+        rec.temp != null && `temp ${rec.temp}`,
+        rec.topK != null && `top_k ${rec.topK}`,
+        rec.topP != null && `top_p ${rec.topP}`,
+        rec.minP != null && `min_p ${rec.minP}`,
+      ].filter(Boolean) as string[])
+    : []
   return (
     <AlertDialog open={!!result} onOpenChange={(o) => { if (!o) onCancel() }}>
       <AlertDialogContent>
@@ -603,6 +612,19 @@ function AutoTuneResultDialog({
                   )}
                   {' '}· <span className="font-mono text-ink">{result.params.ctx.toLocaleString()}</span> ctx
                   {result.vramMb != null && <> · ~<span className="font-mono text-ink">{result.vramMb}</span> MB VRAM</>}
+                </span>
+              )}
+              {recParts.length > 0 && (
+                <span
+                  className="rounded-md border px-2.5 py-2"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent) 35%, var(--border))',
+                    background: 'color-mix(in srgb, var(--accent) 5%, transparent)',
+                  }}
+                >
+                  <span className="text-ink">Recommended sampling from the model card:</span>{' '}
+                  <span className="font-mono text-ink">{recParts.join(' · ')}</span>
+                  <span className="mt-0.5 block text-faint">Applied on Save — adjust any time in Sampling below.</span>
                 </span>
               )}
               <span className="text-faint">Save applies these settings to {modelName ?? 'this model'} and closes.</span>


### PR DESCRIPTION
## v1.2.0 · AI auto-tune sampling from the model card (#10, ADR-099)

During an auto-tune run, read the model author's recommended sampling (`temperature / top_k / top_p / min_p`) from the model's **Hugging Face card** and prefill the winning profile's `Sampling` block — surfaced in the existing Save/Cancel results dialog, applied on Save. **No card (or nothing parseable) → sampling left at the resolved defaults.**

### Acceptance (STATUS done-when)
- ✅ Card-derived sampling lands in the profile (merged into the winning profile; persisted via the existing `/bench/save`)
- ✅ No card → current defaults unchanged (repo unresolved / card missing / nothing parsed all collapse to "leave as-is")

### Hybrid extraction (the decision — ADR-099)
1. **Deterministic heuristic parser first** (`src/models/card-sampling.ts`) — scans for `name <sep> value` of each knob (tables, recommended-settings lines), drops out-of-range values, and **ignores fenced code blocks** (usage demos carry arbitrary values, not recommendations).
2. **Local-model LLM fallback** only when the heuristic finds nothing — briefly reload the winning profile, ask the just-tuned model to emit JSON, parse + clamp. The recommendation is model-specific (independent of the swept offload), so reusing the winner is exact. Fully fail-safe; engine always left stopped.

### Seams reused
- `HfClient.fetchModelCard()` exposes the existing README fetch (strip frontmatter, cap, cache).
- `inferRepoFromPath()` resolves the model's HF repo; `null` for hand-placed files.
- `BenchRunner` gains the `HfClient` dep; `recommendedSampling` rides `BenchState.result`.

### Verification
- **372 tests pass** (18 new card-sampling: heuristic, clamp, LLM-JSON, code-fence handling) · root + web typecheck clean · web build clean.
- **Heuristic live-verified against real HF cards:** Qwen3-8B → `{temp:0.6, top_p:0.95, top_k:20, min_p:0}`; Mistral-7B's `temperature=0` code example correctly **dropped** → LLM fallback; Qwen2.5 (no table) → LLM fallback.
- ⚠️ **Not yet live:** the full end-to-end auto-tune run on the GPU box, and specifically the **LLM-fallback reload** path — needs a live pass before release.

### Notes
- `package.json` stays at `1.0.0`; the bump to `1.2.0` is a release-ritual step after merge (ADR-079; `RELEASE.md`).