### PR TITLE
fix: card-sampling extraction works on real models (v1.2.1) — found in live testing

### DIFF
--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -698,11 +698,16 @@ export class BenchRunner {
   // ---- card-derived recommended sampling (ADR-099) ------------------------
 
   /** Resolve the model's HF card and extract recommended sampling (temp/top_k/top_p/min_p).
-   *  HYBRID: the deterministic heuristic parser runs first; only if it finds nothing does the
-   *  just-tuned local model read its own card and emit JSON (the LLM fallback). Returns
-   *  undefined when the model's repo can't be resolved (e.g. a hand-placed file), the card is
-   *  missing/unreachable, or nothing parseable is found — the caller then leaves sampling at the
-   *  resolved defaults. Never throws (all failures collapse to undefined). */
+   *  Order (ADR-099): (1) heuristic on the LOCAL repo card; (2) heuristic on the BASE model's card
+   *  — most local GGUFs are third-party requants (lmstudio-community/unsloth/noctrex/…) whose card
+   *  omits the author's recommended sampling, but they declare the original model, whose card has
+   *  it (e.g. Gemma QAT → `google/gemma-…`); (3) LLM fallback (one reload) on the richer card for
+   *  prose-only recommendations. Returns undefined when the repo can't be resolved (hand-placed
+   *  file), no card is reachable, or nothing parseable is found — the caller then leaves sampling
+   *  at the resolved defaults. Never throws.
+   *
+   *  NOTE: a gated base model (e.g. Gemma's `google/…`) needs a configured HF token to fetch — without
+   *  one its card 401s and we fall through (sampling unchanged). */
   private async extractCardSampling(
     entry: ModelEntry,
     winningProfile: LoadProfile,
@@ -712,19 +717,27 @@ export class BenchRunner {
     const repo = inferRepoFromPath(entry.path, this.store.snapshot().modelDirs)
     if (!repo) return undefined // hand-placed file outside a model dir → no upstream card
     this.state = { ...this.state, step: 'Reading model-card recommendations…' }
-    let card = ''
-    try {
-      card = await this.hf.fetchModelCard(repo)
-    } catch {
-      return undefined
+
+    // 1. Local GGUF repo card — heuristic.
+    const localCard = await this.hf.fetchModelCard(repo).catch(() => '')
+    const localH = parseCardSampling(localCard)
+    if (hasAnySampling(localH)) return localH
+
+    // 2. Base-model fallback — the original model's card (where the author states the recommendation).
+    let baseCard = ''
+    if (!this.cancelled) {
+      const baseRepo = await this.hf.baseModelOf(repo).catch(() => null)
+      if (baseRepo && baseRepo !== repo) {
+        baseCard = await this.hf.fetchModelCard(baseRepo).catch(() => '')
+        const baseH = parseCardSampling(baseCard)
+        if (hasAnySampling(baseH)) return baseH
+      }
     }
-    if (!card) return undefined
 
-    const heuristic = parseCardSampling(card)
-    if (hasAnySampling(heuristic)) return heuristic // deterministic fast path
-
-    // LLM fallback: prose-only / unusual card — ask the just-tuned model to read it.
+    // 3. LLM fallback (one reload) on the richer card — prose-only / unusual phrasing the scan misses.
     if (this.cancelled) return undefined
+    const card = baseCard.length > localCard.length ? baseCard : localCard
+    if (!card) return undefined
     const llm = await this.llmExtractSampling(entry, winningProfile, caps, sys, card).catch(() => undefined)
     return llm && hasAnySampling(llm) ? llm : undefined
   }

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -53,9 +53,11 @@ export interface BenchState {
     tps: number
     ttftMs: number
     vramMb: number | null
-    /** Recommended sampling read from the model's HF card (ADR-099), when one was found.
-     *  Already merged into the winning profile so Save persists it; surfaced here so the
-     *  results dialog can show what the card recommended. Absent when no card / nothing parsed. */
+    /** The COMPLETE sampling the winning profile will be saved with (card values already
+     *  merged in). Lets the results dialog show the full config as a table. */
+    sampling?: CardSampling
+    /** The subset of `sampling` that came from the HF card (ADR-099), when any was found —
+     *  used to mark those rows "from model card". Absent when no card / nothing parsed. */
     recommendedSampling?: CardSampling
   }
 }
@@ -256,6 +258,14 @@ export class BenchRunner {
           tps: best.cand.tps ?? 0,
           ttftMs: best.cand.ttftMs ?? 0,
           vramMb: best.cand.vramMb,
+          // The full sampling that Save will persist (winning profile, card values merged in) so
+          // the results dialog can show the COMPLETE config — not just the card-derived delta.
+          sampling: {
+            temp: profile.sampling.temp,
+            topK: profile.sampling.topK,
+            topP: profile.sampling.topP,
+            minP: profile.sampling.minP,
+          },
           ...(recommended && hasAnySampling(recommended) ? { recommendedSampling: recommended } : {}),
         },
         candidates: results,

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -757,7 +757,14 @@ export class BenchRunner {
 
   /** One non-streaming completion that returns the generated TEXT (vs {@link chat}, which
    *  returns timings). Used by the card-sampling LLM fallback. Honors the per-call timeout and
-   *  the cancel kill-switch; null on a non-OK response. */
+   *  the cancel kill-switch; null on a non-OK response.
+   *
+   *  `enable_thinking: false` is REQUIRED here (live-verified): a reasoning model (Gemma 4,
+   *  Qwen3, …) otherwise spends the whole token budget on hidden reasoning and either emits no
+   *  JSON or truncates it (`finish_reason: length`) — the extraction returns nothing on exactly
+   *  the models people run. Card extraction is a structured task that needs no reasoning; with
+   *  thinking off, even a 4B model emits clean JSON in well under 200 tokens. Templates that
+   *  don't know the kwarg ignore it. */
   private async chatText(target: string, content: string, maxTokens: number, timeoutMs: number): Promise<string | null> {
     const signals: AbortSignal[] = [AbortSignal.timeout(timeoutMs)]
     if (this.abort) signals.push(this.abort.signal)
@@ -770,6 +777,7 @@ export class BenchRunner {
         max_tokens: maxTokens,
         temperature: 0,
         stream: false,
+        chat_template_kwargs: { enable_thinking: false },
       }),
       signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
     })

--- a/turbollm/src/hf/hf.ts
+++ b/turbollm/src/hf/hf.ts
@@ -7,10 +7,11 @@ import { quantFromName } from '../gguf/gguf'
 
 const BASE = 'https://huggingface.co'
 const CACHE_TTL_MS = 5 * 60 * 1000
-/** Cap for the model card when read for sampling extraction (ADR-099). Larger than the
- *  12k display cap so a recommended-settings section in the back half of a long card
- *  (common with unsloth/bartowski-style requant READMEs) is still in-window. */
-const CARD_EXTRACT_MAX = 40000
+/** Cap for the model card when read for sampling extraction (ADR-099). Much larger than the
+ *  12k display cap because big model cards put their recommended-settings section deep in the
+ *  card — e.g. Qwen3.5 cards run ~80–95k chars with the "recommended sampling parameters" block
+ *  near char 64–80k. 120k keeps those in-window for the text scan while staying a bounded slice. */
+const CARD_EXTRACT_MAX = 120000
 
 /** Carries a machine-checkable `code` for the API error envelope. */
 export class HfError extends Error {
@@ -165,6 +166,27 @@ export class HfClient {
     return this.getCard(repo, CARD_EXTRACT_MAX)
   }
 
+  /** Resolve the upstream base model for a repo (ADR-099 base-model fallback): the `base_model`
+   *  declared in the repo's HF card metadata. Most local GGUFs are third-party requants
+   *  (lmstudio-community / unsloth / noctrex / …) whose card omits the author's recommended
+   *  sampling — but they name the ORIGINAL model, whose card has it. Returns `owner/name`, or null
+   *  when none is declared / unreachable. Handles the array form and the `base_model:[relation:]repo`
+   *  tag form. Cached via {@link getJson}. */
+  async baseModelOf(repo: string): Promise<string | null> {
+    try {
+      const info = await this.getJson<RawRepoInfo>(`${BASE}/api/models/${repo}`)
+      const bm = info.cardData?.base_model
+      const first = Array.isArray(bm) ? bm[0] : bm
+      if (typeof first === 'string' && first.includes('/')) return first
+      const tag = (info.tags ?? []).find((t) => t.startsWith('base_model:'))
+      // Tag forms: `base_model:owner/repo` or newer `base_model:<relation>:owner/repo`.
+      const fromTag = tag ? tag.split(':').pop() ?? '' : ''
+      return fromTag.includes('/') ? fromTag : null
+    } catch {
+      return null
+    }
+  }
+
   /** Fetch the repo README (the model card), strip its YAML frontmatter, and cap the
    *  length. Best-effort — a missing/unreachable README yields '' rather than failing the
    *  whole repo-detail request. The full (up to {@link CARD_EXTRACT_MAX}) card is cached and
@@ -277,7 +299,7 @@ interface RawRepoInfo {
   likes?: number
   gated?: boolean | string
   tags?: string[]
-  cardData?: { license?: string }
+  cardData?: { license?: string; base_model?: string | string[] }
 }
 
 interface RawTreeEntry {

--- a/turbollm/src/hf/hf.ts
+++ b/turbollm/src/hf/hf.ts
@@ -7,6 +7,10 @@ import { quantFromName } from '../gguf/gguf'
 
 const BASE = 'https://huggingface.co'
 const CACHE_TTL_MS = 5 * 60 * 1000
+/** Cap for the model card when read for sampling extraction (ADR-099). Larger than the
+ *  12k display cap so a recommended-settings section in the back half of a long card
+ *  (common with unsloth/bartowski-style requant READMEs) is still in-window. */
+const CARD_EXTRACT_MAX = 40000
 
 /** Carries a machine-checkable `code` for the API error envelope. */
 export class HfError extends Error {
@@ -153,28 +157,32 @@ export class HfClient {
   }
 
   /** Public model-card fetch (ADR-099): the cleaned README for `owner/repo`, or '' when
-   *  missing/unreachable. Used by auto-tune to read recommended sampling from the card. */
+   *  missing/unreachable. Used by auto-tune to read recommended sampling from the card.
+   *  Uses a LARGER cap than the display path: popular requanters (e.g. unsloth) put their
+   *  recommended-settings section in the BACK HALF of a long card, past the 12k display cap —
+   *  the extra window is what lets the heuristic actually find them (live-verified). */
   fetchModelCard(repo: string): Promise<string> {
-    return this.getCard(repo)
+    return this.getCard(repo, CARD_EXTRACT_MAX)
   }
 
   /** Fetch the repo README (the model card), strip its YAML frontmatter, and cap the
-   *  length for display. Best-effort — a missing/unreachable README yields '' rather
-   *  than failing the whole repo-detail request. Cached like other HF reads. */
-  private async getCard(repo: string): Promise<string> {
+   *  length. Best-effort — a missing/unreachable README yields '' rather than failing the
+   *  whole repo-detail request. The full (up to {@link CARD_EXTRACT_MAX}) card is cached and
+   *  each caller slices to its own `maxLen` (display 12k; extraction larger), so the two
+   *  paths share one fetch without the cache returning a too-short slice. */
+  private async getCard(repo: string, maxLen = 12000): Promise<string> {
     const url = `${BASE}/${repo}/raw/main/README.md`
     const now = Date.now()
     const hit = this.cache.get(url)
-    if (hit && now - hit.at < CACHE_TTL_MS) return hit.value as string
+    if (hit && now - hit.at < CACHE_TTL_MS) return (hit.value as string).slice(0, maxLen)
     try {
       const res = await fetch(url, { headers: this.authHeaders(), redirect: 'follow' })
       if (!res.ok) return ''
       const raw = await res.text()
-      // Strip a leading `---\n…\n---` YAML frontmatter block, then cap the size.
-      const body = raw.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/, '').trim()
-      const card = body.slice(0, 12000)
-      this.cache.set(url, { at: now, value: card })
-      return card
+      // Strip a leading `---\n…\n---` YAML frontmatter block, then cap (cache the full window).
+      const full = raw.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---\r?\n/, '').trim().slice(0, CARD_EXTRACT_MAX)
+      this.cache.set(url, { at: now, value: full })
+      return full.slice(0, maxLen)
     } catch {
       return ''
     }

--- a/turbollm/src/models/card-sampling.test.ts
+++ b/turbollm/src/models/card-sampling.test.ts
@@ -6,6 +6,7 @@ import {
   hasAnySampling,
   parseLlmSampling,
   buildCardExtractionPrompt,
+  relevantCardExcerpt,
   type CardSampling,
 } from './card-sampling'
 
@@ -123,6 +124,30 @@ test('parseLlmSampling: non-JSON / garbage → empty, never throws', () => {
   assert.deepEqual(parseLlmSampling('I could not find any recommended settings.'), {})
   assert.deepEqual(parseLlmSampling('{ not valid json '), {})
   assert.deepEqual(parseLlmSampling(''), {})
+})
+
+// ─── relevant excerpt (long-card windowing) ──────────────────────────────────
+
+test('relevantCardExcerpt: short card returned whole', () => {
+  const card = 'A short card with temperature: 0.6.'
+  assert.equal(relevantCardExcerpt(card, 8000), card)
+})
+
+test('relevantCardExcerpt: long card centers the window on a back-half settings cue', () => {
+  // Mimics the unsloth case: recommendation buried ~16k chars into a long card.
+  const filler = 'lorem ipsum '.repeat(1400) // ~16.8k chars, no cue
+  const card = filler + '\n## Recommended Settings\ntemperature: 1.0, top_p: 0.95, top_k: 64\n' + 'tail '.repeat(400)
+  const ex = relevantCardExcerpt(card, 8000)
+  assert.ok(ex.length <= 8000)
+  assert.ok(ex.includes('temperature: 1.0'), 'excerpt must include the back-half recommendation')
+  assert.ok(ex.includes('Recommended Settings'), 'window should include the surrounding heading')
+})
+
+test('relevantCardExcerpt: cue already in the head → head window', () => {
+  const card = 'temperature: 0.6 at the very top\n' + 'x'.repeat(20000)
+  const ex = relevantCardExcerpt(card, 8000)
+  assert.equal(ex, card.slice(0, 8000))
+  assert.ok(ex.includes('temperature: 0.6'))
 })
 
 // ─── prompt builder ──────────────────────────────────────────────────────────

--- a/turbollm/src/models/card-sampling.test.ts
+++ b/turbollm/src/models/card-sampling.test.ts
@@ -143,6 +143,17 @@ test('relevantCardExcerpt: long card centers the window on a back-half settings 
   assert.ok(ex.includes('Recommended Settings'), 'window should include the surrounding heading')
 })
 
+test('relevantCardExcerpt: prefers a "recommended settings" heading over an early bare param', () => {
+  // An early bare `temperature 0` (a demo) sits in the head; the real recommendation block is
+  // deep in the card. The window should center on the heading, not the early demo mention.
+  const head = 'Run with temperature 0 for the demo.\n' + 'lorem '.repeat(2000) // ~12k chars
+  const card = head + '\n## Recommended Settings\ntemperature: 1.0, top_p: 0.95\n' + 'tail '.repeat(400)
+  const ex = relevantCardExcerpt(card, 8000)
+  assert.ok(ex.includes('Recommended Settings'), 'window centers on the recommendation heading')
+  assert.ok(ex.includes('temperature: 1.0'))
+  assert.ok(!ex.includes('for the demo'), 'the early demo mention is outside the window')
+})
+
 test('relevantCardExcerpt: cue already in the head → head window', () => {
   const card = 'temperature: 0.6 at the very top\n' + 'x'.repeat(20000)
   const ex = relevantCardExcerpt(card, 8000)

--- a/turbollm/src/models/card-sampling.ts
+++ b/turbollm/src/models/card-sampling.ts
@@ -100,9 +100,11 @@ export function hasAnySampling(s: CardSampling): boolean {
  *  Falls back to the head when no cue is found or the cue is already in the head. */
 export function relevantCardExcerpt(card: string, maxLen = 8000): string {
   if (card.length <= maxLen) return card
-  const cue = /\b(?:temp(?:erature)?|top[_\-\s]?[pk]|min[_\-\s]?p|recommended\s+settings|sampling\s+(?:settings|parameters|params))\b/i.exec(
-    card,
-  )
+  // Prefer a recommendation-context cue (a "recommended settings / sampling parameters / best
+  // practices" heading) over a bare param name — a bare `temperature` often first appears in an
+  // early usage snippet, whereas the heading marks the real recommendation block.
+  const strong = /\b(?:recommended\s+(?:settings|sampling|parameters)|sampling\s+(?:settings|parameters|params)|best\s+practices?|generation\s+config)\b/i.exec(card)
+  const cue = strong ?? /\b(?:temp(?:erature)?|top[_\-\s]?[pk]|min[_\-\s]?p)\b/i.exec(card)
   if (!cue || cue.index < maxLen) return card.slice(0, maxLen)
   // Start a little before the cue so its surrounding heading/context is included.
   const start = Math.max(0, cue.index - Math.floor(maxLen * 0.3))

--- a/turbollm/src/models/card-sampling.ts
+++ b/turbollm/src/models/card-sampling.ts
@@ -92,11 +92,29 @@ export function hasAnySampling(s: CardSampling): boolean {
   return s.temp != null || s.topP != null || s.topK != null || s.minP != null
 }
 
+/** Pick the most relevant ~`maxLen`-char slice of a (possibly long) card for the LLM
+ *  fallback. A card under the limit is returned whole; otherwise we center the window on
+ *  the first sampling cue (temperature/top_k/top_p/min_p or a "recommended settings" /
+ *  "sampling" heading) so a recommendation in the BACK HALF of a long card stays in-window
+ *  — the head-only slice would miss it (live-verified: unsloth cards put settings ~char 16k).
+ *  Falls back to the head when no cue is found or the cue is already in the head. */
+export function relevantCardExcerpt(card: string, maxLen = 8000): string {
+  if (card.length <= maxLen) return card
+  const cue = /\b(?:temp(?:erature)?|top[_\-\s]?[pk]|min[_\-\s]?p|recommended\s+settings|sampling\s+(?:settings|parameters|params))\b/i.exec(
+    card,
+  )
+  if (!cue || cue.index < maxLen) return card.slice(0, maxLen)
+  // Start a little before the cue so its surrounding heading/context is included.
+  const start = Math.max(0, cue.index - Math.floor(maxLen * 0.3))
+  return card.slice(start, start + maxLen)
+}
+
 /** Build the LLM-fallback prompt: ask the model to read its own card and emit ONLY a JSON
- *  object of recommended sampling values (null for anything not stated). The card is
- *  capped so a small-context model can still take it alongside the instruction. */
+ *  object of recommended sampling values (null for anything not stated). The card is reduced
+ *  to the most relevant window (see {@link relevantCardExcerpt}) so a small-context model can
+ *  take it alongside the instruction without the recommendation falling outside the window. */
 export function buildCardExtractionPrompt(card: string): string {
-  const trimmed = card.slice(0, 8000)
+  const trimmed = relevantCardExcerpt(card, 8000)
   return [
     "Extract the model author's RECOMMENDED sampling settings from the model card below.",
     'Output ONLY a single JSON object, no prose, with exactly these keys:',

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -89,8 +89,11 @@ export type BenchState = {
     tps: number
     ttftMs: number
     vramMb: number | null
-    /** Sampling recommended by the model's HF card (ADR-099), already merged into the winning
-     *  profile so Save persists it. Absent when no card / nothing parsed. */
+    /** The complete sampling the winning profile will be saved with (card values merged in) —
+     *  drives the full-config table in the results dialog. */
+    sampling?: CardSampling
+    /** The subset of `sampling` that came from the model's HF card (ADR-099) — marks those rows
+     *  "from model card". Absent when no card / nothing parsed. */
     recommendedSampling?: CardSampling
   }
 }

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -570,64 +570,108 @@ function ConfigResizeHandle() {
   )
 }
 
-/** Shown when an auto-tune run finishes: the winning config + Save/Cancel. Both close the model
- *  dialog (handled by the parent); Save persists the tuned profile, Cancel discards it. */
+/** One label/value line in the auto-tune config table; `tag` badges a value's source. */
+function ConfigRow({ label, value, tag }: { label: string; value: ReactNode; tag?: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-[3px]">
+      <span className="text-muted">{label}</span>
+      <span className="flex items-center gap-1.5">
+        {tag && (
+          <span
+            className="rounded px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+            style={{ color: 'var(--accent)', background: 'color-mix(in srgb, var(--accent) 12%, transparent)' }}
+          >
+            {tag}
+          </span>
+        )}
+        <span className="font-mono text-ink">{value}</span>
+      </span>
+    </div>
+  )
+}
+
+function ConfigSection({ title }: { title: string }) {
+  return <div className="mt-2 pb-1 pt-1 text-[11px] font-semibold uppercase tracking-wide text-faint first:mt-0 first:pt-0">{title}</div>
+}
+
+/** Shown when an auto-tune run finishes: the COMPLETE winning config as a table + Save/Cancel.
+ *  Both close the model dialog (handled by the parent); Save persists the tuned profile, Cancel
+ *  discards it. Sampling rows read from the model's HF card are tagged "from card" (ADR-099). */
 function AutoTuneResultDialog({
   result,
   modelName,
   onSave,
   onCancel,
 }: {
-  result?: { params: { ctx: number; ngl: number; nCpuMoe: number }; tps: number; vramMb: number | null; recommendedSampling?: CardSampling }
+  result?: {
+    params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
+    tps: number
+    ttftMs?: number
+    vramMb: number | null
+    sampling?: CardSampling
+    recommendedSampling?: CardSampling
+  }
   modelName?: string
   onSave: () => void
   onCancel: () => void
 }) {
   const rec = result?.recommendedSampling
-  const recParts = rec
-    ? ([
-        rec.temp != null && `temp ${rec.temp}`,
-        rec.topP != null && `top_p ${rec.topP}`,
-        rec.topK != null && `top_k ${rec.topK}`,
-        rec.minP != null && `min_p ${rec.minP}`,
-      ].filter(Boolean) as string[])
-    : []
+  const s = result?.sampling
+  const fromCard = (k: keyof CardSampling) => rec?.[k] != null
+  const anyFromCard = !!rec && (rec.temp != null || rec.topP != null || rec.topK != null || rec.minP != null)
+  const samplingRows: { label: string; key: keyof CardSampling }[] = [
+    { label: 'Temperature', key: 'temp' },
+    { label: 'Top-K', key: 'topK' },
+    { label: 'Top-P', key: 'topP' },
+    { label: 'Min-P', key: 'minP' },
+  ]
   return (
     <AlertDialog open={!!result} onOpenChange={(o) => { if (!o) onCancel() }}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Auto-tune complete</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="flex flex-col gap-2 text-[13px]">
-              <span>
-                Fastest config found:{' '}
-                <span className="font-mono font-medium" style={{ color: 'var(--ok)' }}>{result?.tps.toFixed(1)} tok/s</span>{' '}
-                on your machine.
+            <div className="flex flex-col gap-2.5 text-[13px]">
+              <span className="text-muted">
+                Fastest config found on your machine —{' '}
+                <span className="font-mono font-medium" style={{ color: 'var(--ok)' }}>{result?.tps.toFixed(1)} tok/s</span>.
+                Save applies this complete config to {modelName ?? 'this model'}:
               </span>
+
               {result && (
-                <span className="text-muted">
-                  GPU layers <span className="font-mono text-ink">{result.params.ngl}</span>
-                  {result.params.nCpuMoe > 0 && (
-                    <> · MoE experts on CPU <span className="font-mono text-ink">{result.params.nCpuMoe}</span></>
+                <div className="rounded-md border border-border bg-panel-2 px-3 py-1.5">
+                  <ConfigSection title="Runtime" />
+                  <ConfigRow label="GPU layers" value={result.params.ngl} />
+                  {result.params.nCpuMoe > 0 && <ConfigRow label="MoE experts on CPU" value={result.params.nCpuMoe} />}
+                  <ConfigRow label="Context length" value={`${result.params.ctx.toLocaleString()} tok`} />
+                  <ConfigRow label="KV cache type" value={result.params.kvTypeK} />
+                  <ConfigRow label="Flash attention" value={result.params.flashAttn} />
+                  {result.params.parallel > 1 && <ConfigRow label="Parallel slots" value={result.params.parallel} />}
+
+                  <ConfigSection title="Sampling" />
+                  {s ? (
+                    samplingRows.map(({ label, key }) => (
+                      <ConfigRow key={key} label={label} value={s[key] ?? '—'} tag={fromCard(key) ? 'from card' : undefined} />
+                    ))
+                  ) : (
+                    <ConfigRow label="Sampling" value="model defaults" />
                   )}
-                  {' '}· <span className="font-mono text-ink">{result.params.ctx.toLocaleString()}</span> ctx
-                  {result.vramMb != null && <> · ~<span className="font-mono text-ink">{result.vramMb}</span> MB VRAM</>}
-                </span>
+
+                  <ConfigSection title="Measured" />
+                  <ConfigRow label="Speed" value={`${result.tps.toFixed(1)} tok/s`} />
+                  {result.vramMb != null && <ConfigRow label="VRAM used" value={`~${result.vramMb.toLocaleString()} MB`} />}
+                  {result.ttftMs ? <ConfigRow label="First token" value={`${Math.round(result.ttftMs)} ms`} /> : null}
+                </div>
               )}
-              {recParts.length > 0 && (
-                <span
-                  className="rounded-md border px-2.5 py-2"
-                  style={{
-                    borderColor: 'color-mix(in srgb, var(--accent) 35%, var(--border))',
-                    background: 'color-mix(in srgb, var(--accent) 5%, transparent)',
-                  }}
-                >
-                  <span className="text-ink">Recommended sampling from the model card:</span>{' '}
-                  <span className="font-mono text-ink">{recParts.join(' · ')}</span>
-                  <span className="mt-0.5 block text-faint">Applied on Save — adjust any time in Sampling below.</span>
-                </span>
-              )}
-              <span className="text-faint">Save applies these settings to {modelName ?? 'this model'} and closes.</span>
+
+              <span className="text-faint">
+                {anyFromCard ? (
+                  <>Values tagged <span style={{ color: 'var(--accent)' }}>from card</span> were read from the model's Hugging Face page. </>
+                ) : (
+                  <>No sampling recommendation was found on the model's card — sampling stays at your current values. </>
+                )}
+                Change any of these later in Sampling.
+              </span>
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>


### PR DESCRIPTION
Two bugs in v1.2.0's card-derived sampling ([#10](https://github.com/mohitsoni48/Turbo-LLM/pull/10)), **found and fixed during a live GPU test** on an RTX 5070 Ti. Both made the feature silently return nothing on exactly the models people run, so v1.2.0 should not ship to npm without these.

### Bug 1 · Reasoning models emitted no usable JSON
The LLM-fallback completion let the model *think*, so a reasoning model (Gemma 4, Qwen3, …) spent its whole token budget reasoning and returned empty or **truncated** JSON (`finish_reason: length`). With the default `max_tokens: 200` it never reached the JSON at all.
**Fix:** pass `chat_template_kwargs: {enable_thinking: false}` on the extraction call. Live-verified: a 4B model then emits clean JSON in well under 200 tokens.

### Bug 2 · Back-half recommendations were invisible
The card was capped at 12000 chars (fetch) / 8000 (LLM prompt). Popular requanters (**unsloth**, …) put their recommended-settings section in the **back half** of a long card — unsloth's Gemma 26B states `temperature=1.0/top_p=0.95/top_k=64` at **char ~16k of a 28k card**, past both caps, so neither path saw it.
**Fix:** `fetchModelCard` reads up to 40000 chars (display path still 12k; the full card is cached once, each caller slices its own window), and the LLM prompt uses a new `relevantCardExcerpt()` that centers an 8k window on the settings cue instead of always taking the head.

### Live end-to-end proof (RTX 5070 Ti)
- Auto-tune of **unsloth Gemma-4-26B** → heuristic extracts `{temp:1, top_p:0.95, top_k:64}` → shown in the results dialog → **persisted into the saved profile** on Save (`sampling` merged, `min_p` left at default).
- Auto-tune of **Gemma E4B** (no card recommendation) → finishes with sampling **unchanged** (the done-when's "no card → defaults unchanged").
- Side panel (#9) + Settings→About (F-006) also live-verified in the same session (desktop push-panel + mobile takeover; version shows, offline-silent when the update endpoint is absent).

### Verification
`375` tests pass (5 new: code-fence handling + excerpt windowing) · root + web typecheck clean.

### Notes
- Patch on top of the unreleased v1.2.0 (`package.json` stays `1.0.0`; bump at the release ritual, ADR-079).