### PR TITLE
v1.3.0 — 1-click build from source + toolchain PATH override (ADR-100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ TurboLLM does the opposite:
 - Bring any `llama-server`-compatible engine — stock builds or community forks — with real capability probing
 - **Hardware-aware recommendation** — detects your GPU and tells you which engine/build fits; engines that can't run here are greyed with the reason
 - **Curated catalog** — llama.cpp, KoboldCpp, llamafile, MLX, vLLM, plus forks (ik_llama, TurboQuant) — one-click install where a prebuilt exists
-- **1-click build from source** (Windows + CUDA) — clone, `cmake`, compile `llama-server` and auto-register it from inside the app, with a live compiler log; point it at a conda-env / custom CUDA path if your toolchain isn't on PATH. (Manual command guide kept for other setups.)
+- **End-to-end build from source** (Windows + CUDA) — clone, `cmake` (Ninja + `nvcc`), compile `llama-server`, bundle its CUDA runtime, and auto-register it from inside the app, with a live compiler log and a success screen. **No CUDA Toolkit? Click "Download CUDA"** — it fetches NVIDIA's official build components (~0.5 GB) and assembles a toolkit for you. Or point it at a conda-env / custom CUDA path. (Manual command guide kept for other setups.)
 - **Honest updates** — checks the real upstream release/commit and flags *Update available* / *Rebuild available* (never a fake "you're on the latest"), with per-engine auto-update
 - Auto-provision a GPU-matched `llama-server` build on first run (CUDA / ROCm / Metal / SYCL / Vulkan, CPU fallback)
 - One engine dropdown, grouped — pick the engine; a version dropdown appears when you have more than one build

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ TurboLLM does the opposite:
 - Bring any `llama-server`-compatible engine — stock builds or community forks — with real capability probing
 - **Hardware-aware recommendation** — detects your GPU and tells you which engine/build fits; engines that can't run here are greyed with the reason
 - **Curated catalog** — llama.cpp, KoboldCpp, llamafile, MLX, vLLM, plus forks (ik_llama, TurboQuant) — one-click install where a prebuilt exists
-- **Build-from-source guide** for source-only forks (prerequisite check + the exact commands), then add the binary via a guided folder scan
+- **1-click build from source** (Windows + CUDA) — clone, `cmake`, compile `llama-server` and auto-register it from inside the app, with a live compiler log; point it at a conda-env / custom CUDA path if your toolchain isn't on PATH. (Manual command guide kept for other setups.)
 - **Honest updates** — checks the real upstream release/commit and flags *Update available* / *Rebuild available* (never a fake "you're on the latest"), with per-engine auto-update
 - Auto-provision a GPU-matched `llama-server` build on first run (CUDA / ROCm / Metal / SYCL / Vulkan, CPU fallback)
 - One engine dropdown, grouped — pick the engine; a version dropdown appears when you have more than one build

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -27,13 +27,20 @@ _Nothing yet._
 
 ## [1.3.0] - 2026-06-22
 
-**One-click engine builds — compile a CUDA llama.cpp (or any fork) from inside the app.**
+**End-to-end engine builds — compile a CUDA llama.cpp (or any fork) from inside the app, downloading CUDA itself if you don't have it.**
 
 ### Added
 - **1-click build from source (Windows + CUDA).** The build guide now compiles for you:
-  clone → `cmake` configure → compile `llama-server` → auto-register + activate the result,
-  with a live phase + streaming compiler log right in the dialog. No copy-pasting commands
-  into a terminal. The manual command path is kept as a fallback.
+  clone → `cmake` configure → compile `llama-server` → bundle its CUDA runtime → auto-register
+  + activate the result, with a live phase + streaming compiler log and a **success screen**
+  when the engine is ready. No copy-pasting commands. The manual command path is kept as a
+  fallback. Builds with **Ninja inside the MSVC dev environment** (driving `nvcc` directly), so
+  a standalone / conda CUDA works where the Visual Studio generator can't.
+- **Automatic CUDA download.** No CUDA Toolkit? Click **Download CUDA** — TurboLLM fetches
+  NVIDIA's official build components (nvcc + cudart + cuBLAS + headers, ~0.5 GB) and assembles a
+  toolkit for you, picking a version your GPU driver supports. No NVIDIA installer, no account.
+- **Self-contained builds.** The built engine bundles the CUDA runtime DLLs next to its binary,
+  so it runs even without a CUDA Toolkit on PATH (and is portable).
 - **Build environment (PATH override).** If your CUDA Toolkit or compiler lives in a conda
   env or a custom location (so `nvcc` wasn't on the system PATH and showed as "not
   available"), add that folder under **Build environment** and hit **Re-check** — those
@@ -44,6 +51,8 @@ _Nothing yet._
 ### Changed
 - Compile-from-source is no longer guidance-only; the prerequisite checker and the build
   both honor the configured toolchain dirs.
+
+## [1.2.1] - 2026-06-22
 
 **Auto-tuning that knows the model, a roomier config panel, and a built-in update check.**
 Bundles the work tracked internally as 1.1.0 + 1.2.0 + 1.2.1 into one release off 1.0.0.

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,7 +25,25 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
-## [1.2.1] - 2026-06-22
+## [1.3.0] - 2026-06-22
+
+**One-click engine builds — compile a CUDA llama.cpp (or any fork) from inside the app.**
+
+### Added
+- **1-click build from source (Windows + CUDA).** The build guide now compiles for you:
+  clone → `cmake` configure → compile `llama-server` → auto-register + activate the result,
+  with a live phase + streaming compiler log right in the dialog. No copy-pasting commands
+  into a terminal. The manual command path is kept as a fallback.
+- **Build environment (PATH override).** If your CUDA Toolkit or compiler lives in a conda
+  env or a custom location (so `nvcc` wasn't on the system PATH and showed as "not
+  available"), add that folder under **Build environment** and hit **Re-check** — those
+  dirs are prepended to PATH for both prerequisite detection and the actual build.
+- **One-click rebuild.** The "newer source available" chip on source-built engines now
+  recompiles at the latest commit in place, instead of just linking to the repo.
+
+### Changed
+- Compile-from-source is no longer guidance-only; the prerequisite checker and the build
+  both honor the configured toolchain dirs.
 
 **Auto-tuning that knows the model, a roomier config panel, and a built-in update check.**
 Bundles the work tracked internally as 1.1.0 + 1.2.0 + 1.2.1 into one release off 1.0.0.

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -96,7 +96,7 @@ TurboLLM does the opposite:
 - Bring any `llama-server`-compatible engine — stock builds or community forks — with real capability probing
 - **Hardware-aware recommendation** — detects your GPU and tells you which engine/build fits; engines that can't run here are greyed with the reason
 - **Curated catalog** — llama.cpp, KoboldCpp, llamafile, MLX, vLLM, plus forks (ik_llama, TurboQuant) — one-click install where a prebuilt exists
-- **1-click build from source** (Windows + CUDA) — clone, `cmake`, compile `llama-server` and auto-register it from inside the app, with a live compiler log; point it at a conda-env / custom CUDA path if your toolchain isn't on PATH. (Manual command guide kept for other setups.)
+- **End-to-end build from source** (Windows + CUDA) — clone, `cmake` (Ninja + `nvcc`), compile `llama-server`, bundle its CUDA runtime, and auto-register it from inside the app, with a live compiler log and a success screen. **No CUDA Toolkit? Click "Download CUDA"** — it fetches NVIDIA's official build components (~0.5 GB) and assembles a toolkit for you. Or point it at a conda-env / custom CUDA path. (Manual command guide kept for other setups.)
 - **Honest updates** — checks the real upstream release/commit and flags *Update available* / *Rebuild available* (never a fake "you're on the latest"), with per-engine auto-update
 - Auto-provision a GPU-matched `llama-server` build on first run (CUDA / ROCm / Metal / SYCL / Vulkan, CPU fallback)
 - One engine dropdown, grouped — pick the engine; a version dropdown appears when you have more than one build

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -96,7 +96,7 @@ TurboLLM does the opposite:
 - Bring any `llama-server`-compatible engine — stock builds or community forks — with real capability probing
 - **Hardware-aware recommendation** — detects your GPU and tells you which engine/build fits; engines that can't run here are greyed with the reason
 - **Curated catalog** — llama.cpp, KoboldCpp, llamafile, MLX, vLLM, plus forks (ik_llama, TurboQuant) — one-click install where a prebuilt exists
-- **Build-from-source guide** for source-only forks (prerequisite check + the exact commands), then add the binary via a guided folder scan
+- **1-click build from source** (Windows + CUDA) — clone, `cmake`, compile `llama-server` and auto-register it from inside the app, with a live compiler log; point it at a conda-env / custom CUDA path if your toolchain isn't on PATH. (Manual command guide kept for other setups.)
 - **Honest updates** — checks the real upstream release/commit and flags *Update available* / *Rebuild available* (never a fake "you're on the latest"), with per-engine auto-update
 - Auto-provision a GPU-matched `llama-server` build on first run (CUDA / ROCm / Metal / SYCL / Vulkan, CPU fallback)
 - One engine dropdown, grouped — pick the engine; a version dropdown appears when you have more than one build

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -37,7 +37,7 @@ import { ensureKoboldcpp, koboldcppBinPath, koboldcppDir, koboldcppProfileToArgs
 import { ensureLlamafile, llamafileBinPath, llamafileDir } from '../engines/llamafile'
 import { catalogForPlatform, catalogEngine } from '../engines/catalog'
 import { checkBuildPrereqs } from '../engines/build-prereqs'
-import { runBuild, buildDirName } from '../engines/build-runner'
+import { runBuild, buildDirName, sameRepo, sourceBuildBinary, sourceBuildDirOf } from '../engines/build-runner'
 import { provisionCuda } from '../engines/cuda-provision'
 import { detectHardware } from '../engines/hardware'
 import { recommendEngines } from '../engines/recommend'
@@ -367,7 +367,31 @@ export function registerApi(app: Hono, d: Deps): void {
         installed = existsSync(llamafileBinPath(enginesRoot))
         enabled = regEngines.some((x) => x.kind === 'llamafile')
       }
-      return { ...e, installed, enabled }
+      // Source-built recognition (ADR-100): a fork the user compiled from THIS catalog repo
+      // (matched by the engine's sourceRepo) is installed + enabled — so the card shows the
+      // manage menu (rebuild/disable/delete) instead of a stale "Build from source". Also
+      // detect a built-but-disabled engine (registry entry removed, build output still on disk)
+      // so Enable can re-register it.
+      const srcEng = regEngines.find((x) => sameRepo(x.sourceRepo, e.homepage))
+      let sourceBinPath: string | undefined = srcEng?.binPath
+      if (!srcEng) sourceBinPath = sourceBuildBinary(enginesRoot, e.homepage) ?? undefined
+      const sourceBuilt = !!srcEng || !!sourceBinPath
+      if (srcEng) {
+        installed = true
+        enabled = true
+      } else if (sourceBinPath) {
+        installed = true
+        enabled = enabled ?? false
+      }
+      return {
+        ...e,
+        installed,
+        enabled,
+        sourceBuilt,
+        sourceEngineId: srcEng?.id,
+        sourceBranch: srcEng?.sourceBranch ?? '',
+        sourceBinPath: sourceBinPath ?? '',
+      }
     })
     return c.json({ engines: items })
   })
@@ -1992,6 +2016,10 @@ function engineInstallDir(eng: Engine, enginesRoot: string): string | null {
     const d = llamafileDir(enginesRoot)
     return inside(d) ? d : null
   }
+  // Source-built engine (ADR-100): binary lives under engines/build/<slug>/ — purge the
+  // whole build dir (clone + objects + binary), which can be several GB.
+  const srcDir = sourceBuildDirOf(eng.binPath, enginesRoot)
+  if (srcDir) return inside(srcDir) ? srcDir : null
   return null
 }
 

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -38,6 +38,7 @@ import { ensureLlamafile, llamafileBinPath, llamafileDir } from '../engines/llam
 import { catalogForPlatform, catalogEngine } from '../engines/catalog'
 import { checkBuildPrereqs } from '../engines/build-prereqs'
 import { runBuild, buildDirName } from '../engines/build-runner'
+import { provisionCuda } from '../engines/cuda-provision'
 import { detectHardware } from '../engines/hardware'
 import { recommendEngines } from '../engines/recommend'
 import { engineAcceptsFormat } from '../engines/compat'
@@ -422,17 +423,33 @@ export function registerApi(app: Hono, d: Deps): void {
     d.build.start(name ?? repoUrl)
     void (async () => {
       try {
-        const out = await runBuild(
-          { repoUrl, branch, enginesRoot, toolchainDirs },
-          { phase: (p) => d.build.phase(p), log: (line) => d.build.log(line) },
-          ac.signal,
-        )
-        // Register (probe) the built binary, carrying its source provenance for the ADR-088
-        // "newer source → rebuild" check. For a REBUILD, match the existing engine by
-        // binPath OR by source repo+branch (a fresh compile can land at a slightly different
-        // binPath — e.g. an MSVC subdir — which would otherwise make add() throw NameTaken).
-        // Replace it in place (stop it first if it's the running active one) so the rebuild
-        // re-probes fresh capabilities and never duplicates or 'name taken'-fails post-compile.
+        let out
+        try {
+          out = await runBuild(
+            { repoUrl, branch, enginesRoot, toolchainDirs },
+            { phase: (p) => d.build.phase(p), log: (line) => d.build.log(line) },
+            ac.signal,
+          )
+        } catch (e) {
+          // The BUILD step (clone/configure/compile) failed or was cancelled: GC the partial
+          // tree so repeated attempts don't fill the disk with multi-GB CUDA objects. Only
+          // here — never after a binary was successfully produced (that would throw away a
+          // good build over a mere registration hiccup).
+          try { rmSync(buildRoot, { recursive: true, force: true }) } catch { /* best effort */ }
+          if ((e as Error)?.name === 'AbortError') {
+            d.build.log('Build cancelled.')
+            d.build.fail('Build cancelled.')
+          } else {
+            d.build.fail(e instanceof Error ? e.message : String(e))
+          }
+          return
+        }
+        // Build SUCCEEDED — the binary is good. Register (probe) it, carrying its source
+        // provenance for the ADR-088 "newer source → rebuild" check. For a REBUILD, match the
+        // existing engine by binPath OR by source repo+branch (a fresh compile can land at a
+        // slightly different binPath) and replace it in place (stop it first if it's the
+        // running active one) so we re-probe fresh capabilities without a NameTaken clash.
+        // A failure HERE keeps the built binary on disk (no GC) so it isn't thrown away.
         const engines = d.registry.list().engines
         const prior =
           engines.find((e) => e.binPath === out.binPath) ??
@@ -449,15 +466,9 @@ export function registerApi(app: Hono, d: Deps): void {
         d.build.log(`Registered "${eng.name}" — built from ${out.commit.slice(0, 8)}.`)
         d.build.done()
       } catch (e) {
-        // GC the (partial) build tree on failure/cancel so repeated attempts don't fill the
-        // disk with multi-GB CUDA objects. A successful build keeps it (the binary lives there).
-        try { rmSync(buildRoot, { recursive: true, force: true }) } catch { /* best effort */ }
-        if ((e as Error)?.name === 'AbortError') {
-          d.build.log('Build cancelled.')
-          d.build.fail('Build cancelled.')
-        } else {
-          d.build.fail(e instanceof Error ? e.message : String(e))
-        }
+        // Registration/probe failed AFTER a successful build: keep the binary (no GC), but
+        // tell the user it built yet couldn't be registered so they can retry/inspect.
+        d.build.fail(`Built successfully, but couldn't register the engine: ${e instanceof Error ? e.message : String(e)}`)
       } finally {
         if (buildAbort === ac) buildAbort = null
       }
@@ -472,6 +483,49 @@ export function registerApi(app: Hono, d: Deps): void {
       return c.json({ ok: true })
     }
     return c.json({ ok: false })
+  })
+
+  // Auto-download a CUDA Toolkit from NVIDIA's redistributable archives (ADR-101) when the
+  // user has no CUDA installed, so the 1-click build can compile. Streams via the same
+  // engineBuild channel (phase 'provisioning'); on success the toolkit's bin dir is added to
+  // build.toolchainDirs so the prereq check + build immediately find nvcc. Local-host + Win gated.
+  app.post('/api/v1/build/cuda', async (c) => {
+    if (!isLocalRequest(c, d))
+      return err(c, 403, 'forbidden', 'Downloading CUDA is only available on the machine running TurboLLM.')
+    if (process.platform !== 'win32')
+      return err(c, 409, 'unsupported_platform', 'Automatic CUDA download is currently Windows x86_64 only.')
+    const busy = engineWorkBusy(d)
+    if (busy) return err(c, 409, 'engine_already_running', busy)
+    const dataDir = d.store.dir()
+    const ac = new AbortController()
+    buildAbort = ac
+    d.build.start('CUDA Toolkit')
+    d.build.phase('provisioning')
+    void (async () => {
+      try {
+        const tk = await provisionCuda(
+          dataDir,
+          (p) => d.build.log(p.pct != null ? `${p.message} ${Math.round(p.pct * 100)}%` : p.message),
+          ac.signal,
+        )
+        // Persist the toolkit bin dir so detection + the build find nvcc + the runtime DLLs.
+        d.store.update((cfg) => {
+          if (!cfg.build.toolchainDirs.includes(tk.binDir)) cfg.build.toolchainDirs.unshift(tk.binDir)
+        })
+        d.build.log(`CUDA ${tk.version} installed and added to your build environment.`)
+        d.build.done()
+      } catch (e) {
+        if ((e as Error)?.name === 'AbortError') {
+          d.build.log('CUDA download cancelled.')
+          d.build.fail('CUDA download cancelled.')
+        } else {
+          d.build.fail(`Could not download CUDA: ${e instanceof Error ? e.message : String(e)}`)
+        }
+      } finally {
+        if (buildAbort === ac) buildAbort = null
+      }
+    })()
+    return c.json({ accepted: true }, 202)
   })
 
   // Provision the vLLM engine (ADR-044): uv → venv → `uv pip install vllm`, then

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -37,7 +37,7 @@ import { ensureKoboldcpp, koboldcppBinPath, koboldcppDir, koboldcppProfileToArgs
 import { ensureLlamafile, llamafileBinPath, llamafileDir } from '../engines/llamafile'
 import { catalogForPlatform, catalogEngine } from '../engines/catalog'
 import { checkBuildPrereqs } from '../engines/build-prereqs'
-import { runBuild } from '../engines/build-runner'
+import { runBuild, buildDirName } from '../engines/build-runner'
 import { detectHardware } from '../engines/hardware'
 import { recommendEngines } from '../engines/recommend'
 import { engineAcceptsFormat } from '../engines/compat'
@@ -178,7 +178,7 @@ export function registerApi(app: Hono, d: Deps): void {
     if (installedBackendServer(root, def.id)) {
       return c.json({ accepted: false, alreadyInstalled: true, build: LLAMA_BUILD })
     }
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const ac = new AbortController()
     provisionAbort = ac
     void (async () => {
@@ -225,7 +225,7 @@ export function registerApi(app: Hono, d: Deps): void {
     const root = join(d.store.dir(), 'engines')
     const oldBin = installedBackendServer(root, def.id)
     if (!oldBin) return err(c, 409, 'not_installed', 'Backend is not installed — download it first.')
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     // Honest upstream check FIRST: resolve the real latest tag. Offline → clear 503.
     let latestTag: string
     try {
@@ -316,7 +316,7 @@ export function registerApi(app: Hono, d: Deps): void {
     if (process.platform !== 'darwin') {
       return err(c, 409, 'unsupported_platform', 'MLX is only available on macOS (Apple Silicon).')
     }
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const root = join(d.store.dir(), 'engines')
     const upgrade = c.req.query('update') === '1'
     void (async () => {
@@ -404,37 +404,54 @@ export function registerApi(app: Hono, d: Deps): void {
     const repoUrl = (b.repoUrl ?? '').trim()
     if (!/^https?:\/\//i.test(repoUrl))
       return err(c, 400, 'invalid_config_value', 'A http(s) repo URL is required.')
-    if (d.provision.get().active)
-      return err(c, 409, 'engine_already_running', 'An engine download is in progress — wait for it to finish.')
-    if (d.build.isActive())
-      return err(c, 409, 'engine_already_running', 'A build is already in progress.')
     const branch = (b.branch ?? '').trim() || undefined
+    // A branch beginning with '-' would be parsed by git as an option (it sits before the
+    // positional URL). Reject it — belt-and-suspenders, even though builds are local-only.
+    if (branch && branch.startsWith('-'))
+      return err(c, 400, 'invalid_config_value', 'Branch name cannot start with "-".')
+    const busy = engineWorkBusy(d)
+    if (busy) return err(c, 409, 'engine_already_running', busy)
     const name = (b.name ?? '').trim() || undefined
     const enginesRoot = join(d.store.dir(), 'engines')
     const toolchainDirs = d.store.snapshot().build.toolchainDirs
+    const buildRoot = join(enginesRoot, 'build', buildDirName(repoUrl, branch))
+    // Reserve the build slot SYNCHRONOUSLY (before returning 202) so two near-simultaneous
+    // POSTs can't both pass the busy-check and race on the same buildRoot / clobber buildAbort.
     const ac = new AbortController()
     buildAbort = ac
+    d.build.start(name ?? repoUrl)
     void (async () => {
       try {
-        d.build.start(name ?? repoUrl)
         const out = await runBuild(
           { repoUrl, branch, enginesRoot, toolchainDirs },
           { phase: (p) => d.build.phase(p), log: (line) => d.build.log(line) },
           ac.signal,
         )
-        // Register (probe) the built binary, carrying its source provenance so the
-        // "newer source → rebuild" check (ADR-088) works. A rebuild of the same path
-        // re-probes the existing entry instead of adding a duplicate.
-        let eng = d.registry.list().engines.find((e) => e.binPath === out.binPath)
-        if (!eng) {
-          eng = (await d.registry.add(name ?? '', out.binPath, { sourceRepo: repoUrl, sourceBranch: branch })).engine
-        } else {
-          d.registry.setSource(eng.id, { sourceRepo: repoUrl, sourceBranch: branch })
+        // Register (probe) the built binary, carrying its source provenance for the ADR-088
+        // "newer source → rebuild" check. For a REBUILD, match the existing engine by
+        // binPath OR by source repo+branch (a fresh compile can land at a slightly different
+        // binPath — e.g. an MSVC subdir — which would otherwise make add() throw NameTaken).
+        // Replace it in place (stop it first if it's the running active one) so the rebuild
+        // re-probes fresh capabilities and never duplicates or 'name taken'-fails post-compile.
+        const engines = d.registry.list().engines
+        const prior =
+          engines.find((e) => e.binPath === out.binPath) ??
+          engines.find((e) => e.sourceRepo === repoUrl && (e.sourceBranch ?? '') === (branch ?? ''))
+        if (prior) {
+          if (d.registry.active()?.id === prior.id) await d.manager.stopAndWait()
+          try { d.registry.remove(prior.id) } catch { /* already gone */ }
         }
+        const eng = (await d.registry.add(prior?.name ?? name ?? '', out.binPath, {
+          sourceRepo: repoUrl,
+          sourceBranch: branch,
+        })).engine
         d.registry.activate(eng.id)
         d.build.log(`Registered "${eng.name}" — built from ${out.commit.slice(0, 8)}.`)
         d.build.done()
       } catch (e) {
+        // GC the (partial) build tree on failure/cancel so repeated attempts don't fill the
+        // disk with multi-GB CUDA objects. A successful build keeps it (the binary lives there).
+        try { rmSync(buildRoot, { recursive: true, force: true }) } catch { /* best effort */ }
         if ((e as Error)?.name === 'AbortError') {
           d.build.log('Build cancelled.')
           d.build.fail('Build cancelled.')
@@ -463,7 +480,7 @@ export function registerApi(app: Hono, d: Deps): void {
   // support level so the UI can warn before the user commits to a multi-GB install.
   // ?update=1 upgrades vllm to the latest release (passes -U to uv pip install).
   app.post('/api/v1/engines/vllm', (c) => {
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const root = join(d.store.dir(), 'engines')
     const upgrade = c.req.query('update') === '1'
     void (async () => {
@@ -492,7 +509,7 @@ export function registerApi(app: Hono, d: Deps): void {
     if (!entry.platforms.includes(process.platform)) {
       return err(c, 409, 'unsupported_platform', 'TurboQuant has no prebuilt binary for this operating system yet.')
     }
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const root = join(d.store.dir(), 'engines')
     const upgrade = c.req.query('update') === '1'
     void (async () => {
@@ -532,7 +549,7 @@ export function registerApi(app: Hono, d: Deps): void {
     if (!entry.platforms.includes(process.platform)) {
       return err(c, 409, 'unsupported_platform', 'KoboldCpp has no prebuilt binary for this operating system yet.')
     }
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const root = join(d.store.dir(), 'engines')
     const upgrade = c.req.query('update') === '1'
     const hasNvidia = primaryVendor(getSysInfo()) === 'nvidia'
@@ -568,7 +585,7 @@ export function registerApi(app: Hono, d: Deps): void {
     if (!entry.platforms.includes(process.platform)) {
       return err(c, 409, 'unsupported_platform', 'llamafile is not available for this operating system yet.')
     }
-    if (d.provision.get().active) return err(c, 409, 'engine_already_running', 'Another engine download is already in progress.')
+    { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const root = join(d.store.dir(), 'engines')
     const upgrade = c.req.query('update') === '1'
     void (async () => {
@@ -1815,6 +1832,15 @@ function localCountFor(d: Deps, repo: string): number {
     if (hay.includes(needle)) n++
   }
   return n
+}
+
+/** A download (engine provision) OR a 1-click build writes under `<dataDir>/engines` and
+ *  ends by mutating the registry + flipping the active engine. They must not run at once
+ *  (ADR-100). Returns a user-facing message when either is in flight, else null. */
+function engineWorkBusy(d: Deps): string | null {
+  if (d.provision.get().active) return 'An engine download is in progress — wait for it to finish.'
+  if (d.build.isActive()) return 'A build is in progress — wait for it to finish.'
+  return null
 }
 
 function hfErr(c: Context, e: unknown) {

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -321,7 +321,8 @@ export function registerApi(app: Hono, d: Deps): void {
     const root = join(d.store.dir(), 'engines')
     // Tag-agnostic: unregister + delete EVERY build of this backend (an update may have left
     // more than one tag-keyed dir / registry entry). Stop first if the active engine is one of them.
-    const backendDirRe = new RegExp(`[\\\\/]engines[\\\\/]llama\\.cpp-.+-${def.id}[\\\\/]`)
+    // `[^\\/]+` (not `.+`) so the tag can't greedily span path separators into another segment.
+    const backendDirRe = new RegExp(`[\\\\/]engines[\\\\/]llama\\.cpp-[^\\\\/]+-${def.id}[\\\\/]`)
     const engs = d.registry.list().engines.filter((e) => backendDirRe.test(e.binPath))
     const activeId = d.registry.active()?.id
     if (engs.some((e) => e.id === activeId)) await d.manager.stopAndWait()

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -19,8 +19,8 @@ import {
   availableBackends,
   backendDefAt,
   backendDir,
-  deleteBackend,
-  installedBackendServer,
+  deleteAllBackendBuilds,
+  installedBackendBuild,
   latestReleaseTag,
   provisionBackend,
   provisionTurboquant,
@@ -138,17 +138,28 @@ export function registerApi(app: Hono, d: Deps): void {
     const root = join(d.store.dir(), 'engines')
     const active = d.registry.active()
     const regEngines = d.registry.list().engines
+    // Backend state is REGISTRY-driven (the accurate source): a backend is installed when ANY
+    // official llama.cpp build of it is registered — not just the pinned LLAMA_BUILD tag (which
+    // a de-pinned update moves off, making the old check falsely report "not installed" and
+    // prompting a confusing re-download). The backend's engine = its newest installed build.
+    const backendOf = (p: string): string | undefined =>
+      p.match(/llama\.cpp-[^/\\]+-(cuda|rocm|sycl|vulkan|metal|cpu)/i)?.[1]?.toLowerCase()
+    const buildNumOf = (p: string): number => {
+      const m = p.match(/llama\.cpp-b(\d+)/i)
+      return m ? Number(m[1]) : -1
+    }
     const backends = availableBackends().map((b) => {
-      const bin = installedBackendServer(root, b.id)
-      // `enabled` = a registry engine is registered with this binary path.
-      const eng = bin ? regEngines.find((e) => e.binPath === bin) : undefined
+      const builds = regEngines
+        .filter((e) => backendOf(e.binPath) === b.id)
+        .sort((x, y) => buildNumOf(y.binPath) - buildNumOf(x.binPath))
+      const eng = builds[0]
       return {
         id: b.id,
         label: b.label,
-        installed: !!bin,
+        installed: !!eng,
         enabled: !!eng,
         recommended: b.id === recommended,
-        active: !!bin && !!active && active.binPath === bin,
+        active: !!eng && !!active && active.id === eng.id,
         engineId: eng?.id ?? '',
       }
     })
@@ -173,11 +184,13 @@ export function registerApi(app: Hono, d: Deps): void {
     const def = availableBackends().find((x) => x.id === b.backend)
     if (!def) return err(c, 400, 'invalid_config_value', 'Unknown backend for this platform.')
     const root = join(d.store.dir(), 'engines')
-    // First-install only: seed the pinned LLAMA_BUILD. When the pinned build is already
-    // on disk, this is a no-op (no real upstream check here — that's the Update path's
-    // job, which de-pins and resolves the REAL latest tag honestly, ADR-085).
-    if (installedBackendServer(root, def.id)) {
-      return c.json({ accepted: false, alreadyInstalled: true, build: LLAMA_BUILD })
+    // First-install only: seed the pinned LLAMA_BUILD. When ANY build of this backend is
+    // already on disk (tag-agnostic — an update may have de-pinned it off LLAMA_BUILD,
+    // ADR-085), this is a no-op so we never re-download a working install. The real upstream
+    // check is the Update path's job, which resolves the REAL latest tag honestly.
+    const existing = installedBackendBuild(root, def.id)
+    if (existing) {
+      return c.json({ accepted: false, alreadyInstalled: true, build: existing.tag })
     }
     { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     const ac = new AbortController()
@@ -224,7 +237,9 @@ export function registerApi(app: Hono, d: Deps): void {
     const def = availableBackends().find((x) => x.id === c.req.param('id'))
     if (!def) return err(c, 400, 'invalid_config_value', 'Unknown backend for this platform.')
     const root = join(d.store.dir(), 'engines')
-    const oldBin = installedBackendServer(root, def.id)
+    // Tag-agnostic: the currently-installed build may have been de-pinned off LLAMA_BUILD by a
+    // prior update (ADR-085), so resolve the newest build on disk rather than the pinned tag.
+    const oldBin = installedBackendBuild(root, def.id)?.bin ?? null
     if (!oldBin) return err(c, 409, 'not_installed', 'Backend is not installed — download it first.')
     { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }
     // Honest upstream check FIRST: resolve the real latest tag. Offline → clear 503.
@@ -288,10 +303,12 @@ export function registerApi(app: Hono, d: Deps): void {
     const def = availableBackends().find((x) => x.id === c.req.param('id'))
     if (!def) return err(c, 400, 'invalid_config_value', 'Unknown backend for this platform.')
     const root = join(d.store.dir(), 'engines')
-    const bin = installedBackendServer(root, def.id)
-    if (!bin) return err(c, 409, 'not_installed', 'Backend is not installed on disk — download it first.')
-    let eng = d.registry.list().engines.find((e) => e.binPath === bin)
-    if (!eng) eng = (await d.registry.add(`llama.cpp ${LLAMA_BUILD} (${def.id})`, bin)).engine
+    // Tag-agnostic: enable whatever build is on disk (a de-pinned update may have left a
+    // non-LLAMA_BUILD tag), naming the registry entry after that build's real tag.
+    const build = installedBackendBuild(root, def.id)
+    if (!build) return err(c, 409, 'not_installed', 'Backend is not installed on disk — download it first.')
+    let eng = d.registry.list().engines.find((e) => e.binPath === build.bin)
+    if (!eng) eng = (await d.registry.add(`llama.cpp ${build.tag} (${def.id})`, build.bin)).engine
     d.registry.activate(eng.id)
     return c.json({ ok: true, engineId: eng.id })
   })
@@ -302,11 +319,16 @@ export function registerApi(app: Hono, d: Deps): void {
     const def = availableBackends().find((x) => x.id === c.req.param('id'))
     if (!def) return err(c, 400, 'invalid_config_value', 'Unknown backend for this platform.')
     const root = join(d.store.dir(), 'engines')
-    const bin = installedBackendServer(root, def.id)
-    const eng = bin ? d.registry.list().engines.find((e) => e.binPath === bin) : undefined
-    if (eng && d.registry.active()?.id === eng.id) await d.manager.stopAndWait()
-    if (eng) d.registry.remove(eng.id)
-    deleteBackend(root, def.id, LLAMA_BUILD)
+    // Tag-agnostic: unregister + delete EVERY build of this backend (an update may have left
+    // more than one tag-keyed dir / registry entry). Stop first if the active engine is one of them.
+    const backendDirRe = new RegExp(`[\\\\/]engines[\\\\/]llama\\.cpp-.+-${def.id}[\\\\/]`)
+    const engs = d.registry.list().engines.filter((e) => backendDirRe.test(e.binPath))
+    const activeId = d.registry.active()?.id
+    if (engs.some((e) => e.id === activeId)) await d.manager.stopAndWait()
+    for (const e of engs) {
+      try { d.registry.remove(e.id) } catch { /* already gone */ }
+    }
+    deleteAllBackendBuilds(root, def.id)
     return c.json({ ok: true })
   })
 
@@ -2020,6 +2042,15 @@ function engineInstallDir(eng: Engine, enginesRoot: string): string | null {
   // whole build dir (clone + objects + binary), which can be several GB.
   const srcDir = sourceBuildDirOf(eng.binPath, enginesRoot)
   if (srcDir) return inside(srcDir) ? srcDir : null
+  // Official llama.cpp build (engines/llama.cpp-<tag>-<backend>/): purge THIS specific
+  // version's dir so a user can delete an individual build (e.g. an old b9744) without
+  // touching others. The generic backend-delete only knows the pinned tag, so without this
+  // a per-version delete would leave the files on disk.
+  const llamaMatch = eng.binPath.replace(/\\/g, '/').match(/\/(llama\.cpp-[^/]+)\//i)
+  if (llamaMatch) {
+    const d = join(enginesRoot, llamaMatch[1])
+    return inside(d) ? d : null
+  }
   return null
 }
 

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -37,6 +37,7 @@ import { ensureKoboldcpp, koboldcppBinPath, koboldcppDir, koboldcppProfileToArgs
 import { ensureLlamafile, llamafileBinPath, llamafileDir } from '../engines/llamafile'
 import { catalogForPlatform, catalogEngine } from '../engines/catalog'
 import { checkBuildPrereqs } from '../engines/build-prereqs'
+import { runBuild } from '../engines/build-runner'
 import { detectHardware } from '../engines/hardware'
 import { recommendEngines } from '../engines/recommend'
 import { engineAcceptsFormat } from '../engines/compat'
@@ -94,6 +95,8 @@ export function registerApi(app: Hono, d: Deps): void {
       bench: d.bench.status(),
       downloads: { active: d.downloads.activeCount() },
       engineProvision: d.provision.get(),
+      // In-app compile-from-source status (ADR-100): live phase + log tail while a build runs.
+      engineBuild: d.build.get(),
       // ComfyUI GPU coordination: lets the UI explain a paused/unloaded engine.
       // Also expose the installed gate node version so the UI can prompt an upgrade.
       comfyui: (() => {
@@ -124,6 +127,8 @@ export function registerApi(app: Hono, d: Deps): void {
   // ---- engine backends (ADR-025): hardware-aware default + override ----
   // Tracks the in-flight backend download so it can be cancelled.
   let provisionAbort: AbortController | null = null
+  // Tracks the in-flight 1-click build so it can be cancelled (ADR-100).
+  let buildAbort: AbortController | null = null
 
   app.get('/api/v1/engines/backends', (c) => {
     const sys = getSysInfo()
@@ -377,11 +382,80 @@ export function registerApi(app: Hono, d: Deps): void {
     return c.json({ hardware: hw, recommendation: rec })
   })
 
-  // Guided compile-from-source prereq check (ADR-089). Read-only: detects the
-  // Windows + CUDA build toolchain (git / cmake / CUDA / MSVC) so the build guide can
-  // show what's missing + install links. Off Windows it reports `supported:false`
+  // Compile-from-source prereq check (ADR-089). Read-only: detects the Windows + CUDA
+  // build toolchain (git / cmake / CUDA / MSVC) so the build guide can show what's missing
+  // + install links. The configured toolchain dirs (ADR-100) are prepended to PATH so a
+  // conda-env / custom-path CUDA Toolkit is found. Off Windows it reports `supported:false`
   // (Linux/macOS guided build is parked).
-  app.get('/api/v1/build/prereqs', async (c) => c.json(await checkBuildPrereqs()))
+  app.get('/api/v1/build/prereqs', async (c) =>
+    c.json(await checkBuildPrereqs(d.store.snapshot().build.toolchainDirs)),
+  )
+
+  // 1-click compile-from-source (ADR-100, Windows + CUDA). Clones the repo, runs cmake,
+  // compiles llama-server, then registers + activates the built binary. Long-running; 202
+  // immediately + live phase/log via GET /status engineBuild. Gated to the local host —
+  // it executes a compiler from a user-supplied repo, so a LAN client must not trigger it.
+  app.post('/api/v1/build/run', async (c) => {
+    if (!isLocalRequest(c, d))
+      return err(c, 403, 'forbidden', 'Building an engine is only available on the machine running TurboLLM.')
+    if (process.platform !== 'win32')
+      return err(c, 409, 'unsupported_platform', 'In-app build is currently Windows + CUDA only.')
+    const b = await body<{ repoUrl?: string; branch?: string; name?: string }>(c)
+    const repoUrl = (b.repoUrl ?? '').trim()
+    if (!/^https?:\/\//i.test(repoUrl))
+      return err(c, 400, 'invalid_config_value', 'A http(s) repo URL is required.')
+    if (d.provision.get().active)
+      return err(c, 409, 'engine_already_running', 'An engine download is in progress — wait for it to finish.')
+    if (d.build.isActive())
+      return err(c, 409, 'engine_already_running', 'A build is already in progress.')
+    const branch = (b.branch ?? '').trim() || undefined
+    const name = (b.name ?? '').trim() || undefined
+    const enginesRoot = join(d.store.dir(), 'engines')
+    const toolchainDirs = d.store.snapshot().build.toolchainDirs
+    const ac = new AbortController()
+    buildAbort = ac
+    void (async () => {
+      try {
+        d.build.start(name ?? repoUrl)
+        const out = await runBuild(
+          { repoUrl, branch, enginesRoot, toolchainDirs },
+          { phase: (p) => d.build.phase(p), log: (line) => d.build.log(line) },
+          ac.signal,
+        )
+        // Register (probe) the built binary, carrying its source provenance so the
+        // "newer source → rebuild" check (ADR-088) works. A rebuild of the same path
+        // re-probes the existing entry instead of adding a duplicate.
+        let eng = d.registry.list().engines.find((e) => e.binPath === out.binPath)
+        if (!eng) {
+          eng = (await d.registry.add(name ?? '', out.binPath, { sourceRepo: repoUrl, sourceBranch: branch })).engine
+        } else {
+          d.registry.setSource(eng.id, { sourceRepo: repoUrl, sourceBranch: branch })
+        }
+        d.registry.activate(eng.id)
+        d.build.log(`Registered "${eng.name}" — built from ${out.commit.slice(0, 8)}.`)
+        d.build.done()
+      } catch (e) {
+        if ((e as Error)?.name === 'AbortError') {
+          d.build.log('Build cancelled.')
+          d.build.fail('Build cancelled.')
+        } else {
+          d.build.fail(e instanceof Error ? e.message : String(e))
+        }
+      } finally {
+        if (buildAbort === ac) buildAbort = null
+      }
+    })()
+    return c.json({ accepted: true }, 202)
+  })
+
+  // Cancel an in-progress 1-click build (ADR-100). Kills the child compiler/clone.
+  app.post('/api/v1/build/cancel', (c) => {
+    if (buildAbort) {
+      buildAbort.abort()
+      return c.json({ ok: true })
+    }
+    return c.json({ ok: false })
+  })
 
   // Provision the vLLM engine (ADR-044): uv → venv → `uv pip install vllm`, then
   // register as a kind='vllm' engine. 202 + progress via GET /status engineProvision.
@@ -1120,6 +1194,7 @@ export function registerApi(app: Hono, d: Deps): void {
       gateway?: { autoSwap?: boolean; keepN?: number }
       tavilyApiKey?: string
       search?: { provider?: string; tavilyApiKey?: string; kagiApiKey?: string; searxngUrl?: string }
+      build?: { toolchainDirs?: string[] }
     }>(c)
 
     const updates: Record<string, unknown> = {}
@@ -1213,12 +1288,30 @@ export function registerApi(app: Hono, d: Deps): void {
       gwUpdates.keepN = v
     }
 
+    // Build toolchain dirs (ADR-100): absolute folders prepended to PATH for the prereq
+    // probe + 1-click build, so a conda-env / custom-path CUDA Toolkit is found. Validate
+    // here for a clean 400 (config.validate() would otherwise throw a 500 on update()).
+    let toolchainDirs: string[] | undefined
+    if (b.build?.toolchainDirs !== undefined) {
+      if (!Array.isArray(b.build.toolchainDirs)) {
+        return err(c, 400, 'invalid_config_value', 'build.toolchainDirs must be an array of paths.')
+      }
+      const dirs = b.build.toolchainDirs.map((p) => String(p).trim()).filter(Boolean)
+      for (const dir of dirs) {
+        if (!/^([a-zA-Z]:[\\/]|[\\/])/.test(dir)) {
+          return err(c, 400, 'invalid_config_value', `build.toolchainDirs: "${dir}" must be an absolute path.`)
+        }
+      }
+      toolchainDirs = dirs
+    }
+
     const before = d.store.snapshot().daemon
     d.store.update((cfg) => {
       Object.assign(cfg.daemon, updates)
       Object.assign(cfg.modelDefaults, mdUpdates)
       Object.assign(cfg.comfyui, cuUpdates)
       Object.assign(cfg.gateway, gwUpdates)
+      if (toolchainDirs !== undefined) cfg.build.toolchainDirs = toolchainDirs
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
       // HF token (spec 10 §4): write-only. An explicit '' clears it. Never logged.
@@ -1653,6 +1746,9 @@ function settingsPayload(d: Deps) {
       searxngUrl: cfg.tools.search?.searxngUrl ?? '',
     },
     mcp: cfg.mcp,
+    // Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
+    // conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back.
+    build: { toolchainDirs: cfg.build.toolchainDirs },
   }
 }
 

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -440,7 +440,16 @@ export function registerApi(app: Hono, d: Deps): void {
             d.build.log('Build cancelled.')
             d.build.fail('Build cancelled.')
           } else {
-            d.build.fail(e instanceof Error ? e.message : String(e))
+            // Friendlier message for the common "fork needs a GAS/MinGW assembler" case: some
+            // forks (e.g. TurboQuant) enable the generic CMake `ASM` language, which on Windows
+            // requires a GAS assembler — MSVC can't provide it, so the build can't run here.
+            const asmIssue = d.build.get().log.some((l) => /No CMAKE_ASM_COMPILER could be found|ASM compiler identification is unknown/i.test(l))
+            const raw = e instanceof Error ? e.message : String(e)
+            d.build.fail(
+              asmIssue
+                ? "This fork needs a GAS/MinGW assembler (it enables CMake's generic ASM language), which isn't available with the MSVC toolchain — so it can't be built here on Windows. Use a prebuilt binary, or build it under MSYS2/MinGW and add it via “Add your own engine.”"
+                : raw,
+            )
           }
           return
         }

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -8,6 +8,7 @@ import { Manager, killTrackedEnginesSync, reapStaleEngines, type StartOpts } fro
 import { ComfyGuard } from './engines/comfy-guard'
 import { Registry } from './engines/registry'
 import { ProvisionState } from './engines/provision-state'
+import { BuildState } from './engines/build-state'
 import { UpdateChecker } from './engines/update'
 import { UpdateScheduler } from './engines/update-scheduler'
 import { AppUpdateChecker } from './app-update'
@@ -136,6 +137,8 @@ const registry = new Registry(store)
 const pruned = registry.pruneDeadManagedBuilds()
 if (pruned > 0) console.log(`pruned ${pruned} dangling engine build(s)`)
 const provision = new ProvisionState()
+// In-app compile-from-source status (ADR-100): live phase + log tail while a build runs.
+const build = new BuildState()
 // Honest update checker (ADR-085): per-engine installed/latest/hasUpdate, in-memory cached.
 const updates = new UpdateChecker()
 const enginesDir = join(store.dir(), 'engines')
@@ -174,7 +177,7 @@ const startedAt = Date.now()
 // this cache offline-first; the startup check below warms it so the chip is ready.
 const appUpdates = new AppUpdateChecker(version)
 // `requestRestart` is attached after the server is created (it must close over it).
-const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, updates, appUpdates, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
+const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, build, updates, appUpdates, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
 const app = createApp(deps)
 
 // Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -153,6 +153,15 @@ export interface ComfyUI {
    *  text-only. See slot-cache.ts. */
   cachePersist: boolean
 }
+/** Guided/1-click compile-from-source settings (ADR-089 + ADR-100). The build runs
+ *  `git clone` + `cmake` in the daemon process, which inherits the daemon's PATH. When
+ *  the user's CUDA Toolkit / compiler lives in a conda env or a custom location (not on
+ *  the system PATH), `nvcc` etc. aren't found and the build can't see CUDA. These dirs are
+ *  prepended to PATH for BOTH the prerequisite probe and the actual build, so the user can
+ *  point at their conda env's bin (or the CUDA bin) and have it picked up. Absolute paths. */
+export interface BuildConfig {
+  toolchainDirs: string[]
+}
 /** Global model defaults (spec 05 §3): the base LoadProfile values applied when a
  *  model is first seen and has no saved per-model profile. Saved profiles and
  *  per-request overrides still take precedence; these only replace the built-in
@@ -197,6 +206,8 @@ export interface Config {
   gateway: Gateway
   tools: ToolsConfig
   mcp: McpConfig
+  /** Compile-from-source settings (ADR-089/100): toolchain dirs prepended to PATH. */
+  build: BuildConfig
   devModel?: DevModel
 }
 
@@ -306,6 +317,7 @@ export function defaultConfig(): Config {
     gateway: { autoSwap: true, keepN: 1 },
     tools: {},
     mcp: { servers: [] },
+    build: { toolchainDirs: [] },
   }
 }
 
@@ -501,6 +513,14 @@ function normalize(c: Config): void {
           (s.transport === 'stdio' || s.transport === 'sse'))
       : [],
   }
+  // Compile-from-source toolchain dirs (ADR-089/100): absent in pre-build configs → [].
+  // Keep only non-empty strings; the validator enforces absolute paths.
+  const bd = (c.build ?? {}) as Partial<BuildConfig>
+  c.build = {
+    toolchainDirs: Array.isArray(bd.toolchainDirs)
+      ? bd.toolchainDirs.filter((p): p is string => typeof p === 'string' && p.trim() !== '').map((p) => p.trim())
+      : [],
+  }
   // Telemetry level (spec 09 §3): the UI exposes 'off' | 'anon' | 'full'. Migrate
   // legacy/unknown values safely → 'off' (the conservative, opt-in default).
   c.telemetry.level = normalizeTelemetryLevel(c.telemetry.level)
@@ -548,6 +568,11 @@ function validate(c: Config): void {
   // if set, it must be an http(s):// origin so the `POST {url}/free` call is well-formed.
   if (c.comfyui.url && !/^https?:\/\//i.test(c.comfyui.url)) {
     throw new ValueError('comfyui.url', 'must be an http(s):// origin (e.g. http://127.0.0.1:8188)')
+  }
+  // Build toolchain dirs (ADR-089/100): must be absolute so they resolve the same no
+  // matter the daemon's cwd when it spawns git/cmake.
+  for (const dir of c.build.toolchainDirs) {
+    if (!isAbsolutePath(dir)) throw new ValueError('build.toolchainDirs', 'toolchain directories must be absolute paths')
   }
 }
 

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -3,6 +3,7 @@ import type { Manager } from './engines/manager'
 import type { ComfyGuard } from './engines/comfy-guard'
 import type { Registry } from './engines/registry'
 import type { ProvisionState } from './engines/provision-state'
+import type { BuildState } from './engines/build-state'
 import type { UpdateChecker } from './engines/update'
 import type { AppUpdateChecker } from './app-update'
 import type { Scanner } from './models/scanner'
@@ -22,6 +23,9 @@ export interface Deps {
   hashes: HashStore
   db: ConversationStore
   provision: ProvisionState
+  /** Live status of an in-app compile-from-source run (ADR-100). One build at a time;
+   *  guarded alongside `provision` so a build and a download never run concurrently. */
+  build: BuildState
   /** Honest engine update checker (ADR-085): per-engine installed/latest/hasUpdate with
    *  an in-memory cache. Optional — absent in tests that don't exercise the update routes. */
   updates?: UpdateChecker

--- a/turbollm/src/engines/build-prereqs.test.ts
+++ b/turbollm/src/engines/build-prereqs.test.ts
@@ -1,6 +1,34 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildCommands } from './build-prereqs'
+import { delimiter } from 'node:path'
+import { buildCommands, buildEnv } from './build-prereqs'
+
+const PATH_KEY = Object.keys(process.env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
+
+test('buildEnv: no dirs → a copy of process.env (PATH unchanged)', () => {
+  const env = buildEnv([])
+  assert.equal(env[PATH_KEY], process.env[PATH_KEY])
+  assert.notEqual(env, process.env) // a copy, not the live object
+})
+
+test('buildEnv: prepends dirs to PATH in order, before the inherited PATH', () => {
+  const env = buildEnv(['C:\\conda\\env\\bin', 'C:\\cuda\\bin'])
+  const parts = (env[PATH_KEY] ?? '').split(delimiter)
+  assert.equal(parts[0], 'C:\\conda\\env\\bin')
+  assert.equal(parts[1], 'C:\\cuda\\bin')
+  assert.ok((env[PATH_KEY] ?? '').endsWith(process.env[PATH_KEY] ?? ''))
+})
+
+test('buildEnv: drops empty/whitespace dirs', () => {
+  const env = buildEnv(['', '   ', 'C:\\real'])
+  assert.equal((env[PATH_KEY] ?? '').split(delimiter)[0], 'C:\\real')
+})
+
+test('buildEnv: does not create a duplicate PATH/Path key', () => {
+  const env = buildEnv(['C:\\x'])
+  const pathKeys = Object.keys(env).filter((k) => k.toLowerCase() === 'path')
+  assert.equal(pathKeys.length, Object.keys(process.env).filter((k) => k.toLowerCase() === 'path').length)
+})
 
 test('buildCommands: includes --branch when a branch is given', () => {
   const cmds = buildCommands('https://github.com/owner/repo', 'main')

--- a/turbollm/src/engines/build-prereqs.test.ts
+++ b/turbollm/src/engines/build-prereqs.test.ts
@@ -11,21 +11,23 @@ test('buildEnv: no dirs → a copy of process.env (PATH unchanged)', () => {
   assert.notEqual(env, process.env) // a copy, not the live object
 })
 
+// NOTE: use delimiter-free dir names below — on Linux `path.delimiter` is ':', so a Windows
+// drive path like "C:\\x" would split on its own colon and make these assertions platform-fragile.
 test('buildEnv: prepends dirs to PATH in order, before the inherited PATH', () => {
-  const env = buildEnv(['C:\\conda\\env\\bin', 'C:\\cuda\\bin'])
-  const parts = (env[PATH_KEY] ?? '').split(delimiter)
-  assert.equal(parts[0], 'C:\\conda\\env\\bin')
-  assert.equal(parts[1], 'C:\\cuda\\bin')
+  const a = 'tllm_dir_a'
+  const b = 'tllm_dir_b'
+  const env = buildEnv([a, b])
+  assert.ok((env[PATH_KEY] ?? '').startsWith(a + delimiter + b + delimiter))
   assert.ok((env[PATH_KEY] ?? '').endsWith(process.env[PATH_KEY] ?? ''))
 })
 
 test('buildEnv: drops empty/whitespace dirs', () => {
-  const env = buildEnv(['', '   ', 'C:\\real'])
-  assert.equal((env[PATH_KEY] ?? '').split(delimiter)[0], 'C:\\real')
+  const env = buildEnv(['', '   ', 'tllm_real_dir'])
+  assert.ok((env[PATH_KEY] ?? '').startsWith('tllm_real_dir' + delimiter))
 })
 
 test('buildEnv: does not create a duplicate PATH/Path key', () => {
-  const env = buildEnv(['C:\\x'])
+  const env = buildEnv(['tllm_x'])
   const pathKeys = Object.keys(env).filter((k) => k.toLowerCase() === 'path')
   assert.equal(pathKeys.length, Object.keys(process.env).filter((k) => k.toLowerCase() === 'path').length)
 })

--- a/turbollm/src/engines/build-prereqs.ts
+++ b/turbollm/src/engines/build-prereqs.ts
@@ -1,13 +1,30 @@
-// Guided compile-from-source (Windows + CUDA) — prerequisite checker + build guide
-// (ADR-089). This is a GUIDED flow only: we detect the build toolchain, tell the user
-// what's missing (with install links), and show the exact Windows + CUDA build commands
-// for a repo. We do NOT run the build in-app (that's a parked TODO). Linux/macOS are
-// parked too — `checkBuildPrereqs` reports `supported:false` off Windows.
+// Compile-from-source (Windows + CUDA) — prerequisite checker + build commands
+// (ADR-089). Detects the build toolchain (git/cmake/CUDA/MSVC), tells the user what's
+// missing (with install links), and the in-app 1-click build (ADR-100, build-runner.ts)
+// runs the exact commands here. Linux/macOS are parked — `checkBuildPrereqs` reports
+// `supported:false` off Windows.
+//
+// Toolchain dirs (ADR-100): the daemon inherits the system PATH, so a CUDA Toolkit /
+// compiler installed in a conda env or a custom location isn't found. {@link buildEnv}
+// prepends user-configured dirs to PATH for BOTH the probe below and the real build, so
+// pointing at e.g. a conda env's bin makes `nvcc` resolve.
 import { execFile } from 'node:child_process'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileP = promisify(execFile)
+
+/** Build a child-process env with `toolchainDirs` prepended to PATH. Empty/blank dirs are
+ *  dropped. PATH is matched case-insensitively (Windows uses `Path`); we write back to the
+ *  same key name the parent used so we never end up with a duplicate `PATH`/`Path` pair. */
+export function buildEnv(toolchainDirs: string[] = []): NodeJS.ProcessEnv {
+  const dirs = toolchainDirs.map((d) => d.trim()).filter(Boolean)
+  if (dirs.length === 0) return { ...process.env }
+  const env = { ...process.env }
+  const key = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
+  env[key] = [...dirs, env[key] ?? ''].filter(Boolean).join(delimiter)
+  return env
+}
 
 /** One build-toolchain prerequisite (git / cmake / CUDA / MSVC). */
 export interface BuildPrereqTool {
@@ -34,12 +51,14 @@ const INSTALL_URLS: Record<BuildPrereqTool['id'], string> = {
 
 /** Run a version command with a short timeout; return its trimmed stdout (or stderr —
  *  some tools, e.g. nvcc, print to stdout; vswhere to stdout too). Throws if the tool
- *  is missing or errors, which the caller turns into `found:false`. */
-async function runVersion(cmd: string, args: string[]): Promise<string> {
+ *  is missing or errors, which the caller turns into `found:false`. `env` carries the
+ *  PATH override (ADR-100) so tools in a conda env / custom dir are found. */
+async function runVersion(cmd: string, args: string[], env: NodeJS.ProcessEnv): Promise<string> {
   const { stdout, stderr } = await execFileP(cmd, args, {
     timeout: 8000,
     windowsHide: true,
     maxBuffer: 1024 * 1024,
+    env,
   })
   return (stdout || stderr || '').trim()
 }
@@ -64,11 +83,11 @@ function parseNvccVersion(out: string): string {
   return m ? m[1] : ''
 }
 
-async function checkGit(): Promise<BuildPrereqTool> {
+async function checkGit(env: NodeJS.ProcessEnv): Promise<BuildPrereqTool> {
   let found = false
   let version: string | undefined
   try {
-    version = parseGitVersion(await runVersion('git', ['--version'])) || undefined
+    version = parseGitVersion(await runVersion('git', ['--version'], env)) || undefined
     found = true
   } catch {
     found = false
@@ -76,11 +95,11 @@ async function checkGit(): Promise<BuildPrereqTool> {
   return { id: 'git', name: 'Git', found, version, installUrl: INSTALL_URLS.git }
 }
 
-async function checkCmake(): Promise<BuildPrereqTool> {
+async function checkCmake(env: NodeJS.ProcessEnv): Promise<BuildPrereqTool> {
   let found = false
   let version: string | undefined
   try {
-    version = parseCmakeVersion(await runVersion('cmake', ['--version'])) || undefined
+    version = parseCmakeVersion(await runVersion('cmake', ['--version'], env)) || undefined
     found = true
   } catch {
     found = false
@@ -88,11 +107,11 @@ async function checkCmake(): Promise<BuildPrereqTool> {
   return { id: 'cmake', name: 'CMake', found, version, installUrl: INSTALL_URLS.cmake }
 }
 
-async function checkCuda(): Promise<BuildPrereqTool> {
+async function checkCuda(env: NodeJS.ProcessEnv): Promise<BuildPrereqTool> {
   let found = false
   let version: string | undefined
   try {
-    version = parseNvccVersion(await runVersion('nvcc', ['--version'])) || undefined
+    version = parseNvccVersion(await runVersion('nvcc', ['--version'], env)) || undefined
     found = true
   } catch {
     found = false
@@ -104,7 +123,7 @@ async function checkCuda(): Promise<BuildPrereqTool> {
  *  it for the latest install that has the C++ x64/x86 tools component and return its
  *  installationVersion. A missing component (no version printed) or a missing vswhere →
  *  not found. */
-async function checkMsvc(): Promise<BuildPrereqTool> {
+async function checkMsvc(env: NodeJS.ProcessEnv): Promise<BuildPrereqTool> {
   let found = false
   let version: string | undefined
   try {
@@ -115,7 +134,7 @@ async function checkMsvc(): Promise<BuildPrereqTool> {
       '-products', '*',
       '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
       '-property', 'installationVersion',
-    ])
+    ], env)
     version = out.split(/\r?\n/)[0]?.trim() || undefined
     found = !!version
   } catch {
@@ -131,12 +150,14 @@ async function checkMsvc(): Promise<BuildPrereqTool> {
 }
 
 /** Detect the Windows + CUDA build toolchain. On non-Windows the guided build is parked,
- *  so this returns `{ supported:false, tools:[] }` without probing anything. */
-export async function checkBuildPrereqs(): Promise<BuildPrereqs> {
+ *  so this returns `{ supported:false, tools:[] }` without probing anything. `toolchainDirs`
+ *  (ADR-100) are prepended to PATH so a conda-env / custom-path CUDA Toolkit is detected. */
+export async function checkBuildPrereqs(toolchainDirs: string[] = []): Promise<BuildPrereqs> {
   if (process.platform !== 'win32') {
     return { supported: false, tools: [] }
   }
-  const tools = await Promise.all([checkGit(), checkCmake(), checkCuda(), checkMsvc()])
+  const env = buildEnv(toolchainDirs)
+  const tools = await Promise.all([checkGit(env), checkCmake(env), checkCuda(env), checkMsvc(env)])
   return { supported: true, tools }
 }
 

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,0 +1,25 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildDirName, CMAKE_CONFIGURE_ARGS } from './build-runner'
+
+test('buildDirName: repo name from a .git URL, branch appended', () => {
+  assert.equal(buildDirName('https://github.com/ikawrakow/ik_llama.cpp.git', 'sidestream'), 'ik_llama.cpp-sidestream')
+})
+
+test('buildDirName: no branch → bare repo name; trailing slash + .git stripped', () => {
+  assert.equal(buildDirName('https://github.com/ggml-org/llama.cpp'), 'llama.cpp')
+  assert.equal(buildDirName('https://github.com/ggml-org/llama.cpp.git/'), 'llama.cpp')
+})
+
+test('buildDirName: sanitizes unsafe chars in branch to single dashes', () => {
+  assert.equal(buildDirName('https://github.com/owner/repo', 'feature/foo bar'), 'repo-feature-foo-bar')
+})
+
+test('buildDirName: unparseable URL falls back to "engine"', () => {
+  assert.equal(buildDirName(''), 'engine')
+  assert.equal(buildDirName('   '), 'engine')
+})
+
+test('CMAKE_CONFIGURE_ARGS: enables CUDA + Release', () => {
+  assert.deepEqual(CMAKE_CONFIGURE_ARGS, ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release'])
+})

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildDirName, CMAKE_CONFIGURE_ARGS, pickGenerator, vcvarsBatch, stripGenericAsmLanguage } from './build-runner'
+import { buildDirName, CMAKE_CONFIGURE_ARGS, pickGenerator, vcvarsBatch, stripGenericAsmLanguage, sameRepo, sourceBuildDirOf } from './build-runner'
+import { join } from 'node:path'
 
 test('buildDirName: repo name from a .git URL, branch appended', () => {
   assert.equal(buildDirName('https://github.com/ikawrakow/ik_llama.cpp.git', 'sidestream'), 'ik_llama.cpp-sidestream')
@@ -74,4 +75,27 @@ test('stripGenericAsmLanguage: does not touch unrelated tokens containing the le
   const { text, changed } = stripGenericAsmLanguage('set(MY_WASM_FLAG ON)')
   assert.equal(changed, false)
   assert.ok(text.includes('MY_WASM_FLAG'))
+})
+
+test('sameRepo: matches a homepage URL to a stored sourceRepo regardless of scheme/.git/case', () => {
+  assert.ok(sameRepo('https://github.com/AtomicBot-ai/atomic-llama-cpp-turboquant', 'https://github.com/atomicbot-ai/atomic-llama-cpp-turboquant'))
+  assert.ok(sameRepo('https://github.com/owner/repo', 'owner/repo'))
+  assert.ok(sameRepo('https://github.com/owner/repo.git', 'https://github.com/owner/repo/'))
+})
+
+test('sameRepo: distinct repos do not match; empty never matches', () => {
+  assert.ok(!sameRepo('https://github.com/owner/repo-a', 'https://github.com/owner/repo-b'))
+  assert.ok(!sameRepo('', 'owner/repo'))
+  assert.ok(!sameRepo(undefined, undefined))
+})
+
+test('sourceBuildDirOf: derives the build dir from a source-built binPath', () => {
+  const root = join('C:', 'Users', 'x', '.turbollm', 'engines')
+  const bin = join(root, 'build', 'atomic-llama-cpp-turboquant', 'build', 'bin', 'llama-server.exe')
+  assert.equal(sourceBuildDirOf(bin, root), join(root, 'build', 'atomic-llama-cpp-turboquant'))
+})
+
+test('sourceBuildDirOf: null for a non-source-build binary path', () => {
+  const root = join('C:', 'e')
+  assert.equal(sourceBuildDirOf(join(root, 'turboquant', 'llama-server.exe'), root), null)
 })

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildDirName, CMAKE_CONFIGURE_ARGS, pickGenerator, vcvarsBatch } from './build-runner'
+import { buildDirName, CMAKE_CONFIGURE_ARGS, pickGenerator, vcvarsBatch, stripGenericAsmLanguage } from './build-runner'
 
 test('buildDirName: repo name from a .git URL, branch appended', () => {
   assert.equal(buildDirName('https://github.com/ikawrakow/ik_llama.cpp.git', 'sidestream'), 'ik_llama.cpp-sidestream')
@@ -43,4 +43,35 @@ test('vcvarsBatch: calls vcvars x64, then cmake, quotes spaced args, propagates 
 test('vcvarsBatch: leaves space-free args unquoted', () => {
   const bat = vcvarsBatch('C:\\vc.bat', ['-G', 'Ninja', '-DGGML_CUDA=ON'])
   assert.ok(bat.includes('cmake -G Ninja -DGGML_CUDA=ON'))
+})
+
+test('stripGenericAsmLanguage: removes ASM from a project() language list (TurboQuant case)', () => {
+  const { text, changed } = stripGenericAsmLanguage('project("ggml" C CXX ASM)\nset(X 1)')
+  assert.equal(changed, true)
+  assert.match(text, /project\("ggml" C CXX\)/)
+  assert.ok(!/\bASM\b/.test(text))
+})
+
+test('stripGenericAsmLanguage: handles unquoted project name + extra spacing', () => {
+  const { text } = stripGenericAsmLanguage('project(ggml-htp C CXX ASM)')
+  assert.equal(text, 'project(ggml-htp C CXX)')
+})
+
+test('stripGenericAsmLanguage: comments out a standalone enable_language(ASM)', () => {
+  const { text, changed } = stripGenericAsmLanguage('    enable_language(ASM)')
+  assert.equal(changed, true)
+  assert.match(text, /^#\s+enable_language\(ASM\)/)
+})
+
+test('stripGenericAsmLanguage: leaves CMake without ASM untouched', () => {
+  const src = 'project("ggml" C CXX)\nenable_language(CUDA)\n'
+  const { text, changed } = stripGenericAsmLanguage(src)
+  assert.equal(changed, false)
+  assert.equal(text, src)
+})
+
+test('stripGenericAsmLanguage: does not touch unrelated tokens containing the letters ASM', () => {
+  const { text, changed } = stripGenericAsmLanguage('set(MY_WASM_FLAG ON)')
+  assert.equal(changed, false)
+  assert.ok(text.includes('MY_WASM_FLAG'))
 })

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildDirName, CMAKE_CONFIGURE_ARGS } from './build-runner'
+import { buildDirName, CMAKE_CONFIGURE_ARGS, pickGenerator, vcvarsBatch } from './build-runner'
 
 test('buildDirName: repo name from a .git URL, branch appended', () => {
   assert.equal(buildDirName('https://github.com/ikawrakow/ik_llama.cpp.git', 'sidestream'), 'ik_llama.cpp-sidestream')
@@ -22,4 +22,25 @@ test('buildDirName: unparseable URL falls back to "engine"', () => {
 
 test('CMAKE_CONFIGURE_ARGS: enables CUDA + Release', () => {
   assert.deepEqual(CMAKE_CONFIGURE_ARGS, ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release'])
+})
+
+test('pickGenerator: Ninja when available, NMake fallback otherwise', () => {
+  assert.equal(pickGenerator(true), 'Ninja')
+  assert.equal(pickGenerator(false), 'NMake Makefiles')
+})
+
+test('vcvarsBatch: calls vcvars x64, then cmake, quotes spaced args, propagates exit code', () => {
+  const bat = vcvarsBatch('C:\\Program Files\\VC\\vcvarsall.bat', ['-G', 'NMake Makefiles', '-B', 'C:\\b dir'])
+  const lines = bat.split('\r\n')
+  assert.equal(lines[0], '@echo off')
+  assert.equal(lines[1], 'call "C:\\Program Files\\VC\\vcvarsall.bat" x64')
+  assert.equal(lines[2], 'if errorlevel 1 exit /b 1')
+  // spaced args quoted, unspaced left bare
+  assert.equal(lines[3], 'cmake -G "NMake Makefiles" -B "C:\\b dir"')
+  assert.equal(lines[4], 'exit /b %errorlevel%')
+})
+
+test('vcvarsBatch: leaves space-free args unquoted', () => {
+  const bat = vcvarsBatch('C:\\vc.bat', ['-G', 'Ninja', '-DGGML_CUDA=ON'])
+  assert.ok(bat.includes('cmake -G Ninja -DGGML_CUDA=ON'))
 })

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -1,18 +1,26 @@
-// In-app 1-click compile-from-source (ADR-100, Windows + CUDA). Runs the same commands
-// the guide shows (git clone → cmake configure → cmake build llama-server) inside the
-// daemon, streaming each line to a {@link BuildState} so the UI can show live progress,
-// then hands the built binary to the registry. The toolchain PATH override (ADR-100,
-// build-prereqs.ts `buildEnv`) is applied so a conda-env / custom-path CUDA Toolkit and
-// compiler are found by both `cmake`'s detection and `nvcc`.
+// In-app 1-click compile-from-source (ADR-100, Windows + CUDA). Runs git clone → cmake
+// configure → cmake build inside the daemon, streaming each line to a {@link BuildState}
+// so the UI shows live progress, then hands the built binary to the registry.
 //
-// Scope mirrors the guide: Windows + CUDA only (the caller gates on `checkBuildPrereqs`).
-// We never run the build off Windows.
-import { spawn } from 'node:child_process'
-import { mkdirSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+// Generator choice matters (ADR-100 follow-up). The default "Visual Studio" generator needs
+// the CUDA *Visual Studio integration* (.props) that only the full CUDA installer adds — a
+// standalone / conda CUDA Toolkit doesn't have it, so the VS generator fails with "No CUDA
+// toolset found". We instead build with **Ninja** (or NMake as a no-extra-install fallback)
+// *inside the MSVC developer environment* (vcvars): that generator drives `nvcc` directly off
+// PATH (no VS integration needed) and is much faster. vcvars is required because Ninja/NMake —
+// unlike the VS generator — don't auto-find cl.exe; vcvars puts cl/ml64/INCLUDE/LIB on PATH.
+//
+// The toolchain PATH override (build-prereqs.ts `buildEnv`) is applied so a conda-env /
+// custom-path CUDA Toolkit (and a user-provided ninja) are found. Windows + CUDA only.
+import { execFile, spawn } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { delimiter, dirname, join } from 'node:path'
+import { promisify } from 'node:util'
 import { buildEnv, checkBuildPrereqs } from './build-prereqs'
 import { resolveServerBinary } from './scan'
 import type { BuildPhase } from './build-state'
+
+const execFileP = promisify(execFile)
 
 export interface BuildRequest {
   repoUrl: string
@@ -49,8 +57,130 @@ export function buildDirName(repoUrl: string, branch?: string): string {
   return raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'engine'
 }
 
-/** The cmake configure args (Windows + CUDA). Kept here so the runner and any test agree. */
+/** PURE: prefer Ninja (fast, parallel) when a ninja.exe is reachable; else NMake Makefiles
+ *  (ships with the MSVC Build Tools — always available after vcvars, just single-threaded). */
+export function pickGenerator(hasNinja: boolean): 'Ninja' | 'NMake Makefiles' {
+  return hasNinja ? 'Ninja' : 'NMake Makefiles'
+}
+
+/** The cmake CUDA flags (single-config generators honor CMAKE_BUILD_TYPE). */
 export const CMAKE_CONFIGURE_ARGS = ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release']
+
+/** PURE: a Windows .bat that enters the MSVC dev env (vcvars x64) then runs one cmake step.
+ *  All paths are quoted (vcvars/src/build dirs can contain spaces); the cmake exit code is
+ *  propagated so a non-zero build fails the step. `cmakeArgs` is the full cmake argv. */
+export function vcvarsBatch(vcvars: string, cmakeArgs: string[]): string {
+  const quoted = cmakeArgs.map((a) => (/[\s"]/.test(a) ? `"${a}"` : a)).join(' ')
+  return [
+    '@echo off',
+    `call "${vcvars}" x64`,
+    'if errorlevel 1 exit /b 1',
+    `cmake ${quoted}`,
+    'exit /b %errorlevel%',
+    '',
+  ].join('\r\n')
+}
+
+/** True if `exe` is reachable from any directory on the env's PATH. */
+function onPath(env: NodeJS.ProcessEnv, exe: string): boolean {
+  const key = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
+  return (env[key] ?? '')
+    .split(delimiter)
+    .filter(Boolean)
+    .some((dir) => {
+      try {
+        return existsSync(join(dir, exe))
+      } catch {
+        return false
+      }
+    })
+}
+
+/** CUDA runtime DLLs a llama.cpp CUDA build links against at runtime. A SOURCE build does
+ *  NOT bundle these (unlike the prebuilt release zips), so the produced exe can't start —
+ *  and our probe (`--version`) fails — unless they sit beside it or on PATH. We copy them
+ *  next to the exe so the engine is self-contained + portable (works even after the CUDA
+ *  toolkit dir is removed). Versioned names (e.g. cudart64_13.dll) → match by prefix. */
+const CUDA_RUNTIME_DLL_PREFIXES = ['cudart64_', 'cublas64_', 'cublaslt64_', 'nvrtc64_', 'nvrtc-builtins64_', 'nvjitlink_']
+
+/** Find the directories that hold the CUDA toolkit's runtime DLLs, version-matched to the
+ *  build by anchoring on the toolkit that owns `nvcc` (NOT a stray cudart from an unrelated
+ *  app on PATH — e.g. a PyTorch install, which would bundle the wrong version). CUDA 13 ships
+ *  the runtime DLLs in `<bin>\x64`; CUDA 12 in `<bin>` itself, so we return both when present.
+ *  The build already required nvcc on PATH, so it is found here by construction. */
+function cudaDllSourceDirs(env: NodeJS.ProcessEnv): string[] {
+  const key = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
+  const pathDirs = (env[key] ?? '').split(delimiter).filter(Boolean)
+  const nvccDir = pathDirs.find((dir) => {
+    try {
+      return existsSync(join(dir, 'nvcc.exe'))
+    } catch {
+      return false
+    }
+  })
+  if (!nvccDir) return []
+  return [nvccDir, join(nvccDir, 'x64')].filter((d) => {
+    try {
+      return existsSync(d)
+    } catch {
+      return false
+    }
+  })
+}
+
+/** Copy the CUDA runtime DLLs from the build's CUDA toolkit into `destDir`, so the produced
+ *  exe is self-contained (a source build doesn't bundle them, unlike the prebuilt release
+ *  zips). Each DLL name is copied at most once (first/toolkit source wins). Returns the count. */
+function copyCudaRuntimeDlls(env: NodeJS.ProcessEnv, destDir: string, log: (l: string) => void): number {
+  const sources = cudaDllSourceDirs(env)
+  if (sources.length === 0) {
+    log('Note: could not find the CUDA toolkit DLLs to bundle — the engine may need the CUDA bin on PATH to run.')
+    return 0
+  }
+  const seen = new Set<string>()
+  let copied = 0
+  for (const dir of sources) {
+    let names: string[]
+    try {
+      names = readdirSync(dir)
+    } catch {
+      continue
+    }
+    for (const name of names) {
+      const lower = name.toLowerCase()
+      if (!lower.endsWith('.dll')) continue
+      if (seen.has(lower)) continue
+      if (!CUDA_RUNTIME_DLL_PREFIXES.some((p) => lower.startsWith(p))) continue
+      try {
+        copyFileSync(join(dir, name), join(destDir, name))
+        seen.add(lower)
+        copied++
+      } catch {
+        /* skip a locked/unreadable DLL — best effort */
+      }
+    }
+  }
+  if (copied > 0) log(`Bundled ${copied} CUDA runtime DLL(s) next to the binary so the engine is self-contained.`)
+  return copied
+}
+
+/** Locate vcvarsall.bat via vswhere (ships with VS / Build Tools). Returns null if VS with
+ *  the C++ tools isn't installed or vswhere can't find it. */
+async function findVcvarsall(): Promise<string | null> {
+  try {
+    const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)'
+    const vswhere = join(programFilesX86, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+    const { stdout } = await execFileP(
+      vswhere,
+      ['-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '-find', 'VC\\Auxiliary\\Build\\vcvarsall.bat'],
+      { timeout: 8000, windowsHide: true, maxBuffer: 1024 * 1024 },
+    )
+    const p = stdout.split(/\r?\n/).map((s) => s.trim()).find(Boolean)
+    return p && existsSync(p) ? p : null
+  } catch {
+    return null
+  }
+}
 
 /** Run one child process, streaming combined stdout+stderr line-by-line to `onLine` and
  *  resolving with the full stdout text. Rejects with a clear message on a non-zero exit or
@@ -117,6 +247,14 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
         `add that folder under Build environment so TurboLLM can find them.`,
     )
   }
+  // We compile with Ninja/NMake (not the VS generator), so we need the MSVC dev env.
+  const vcvars = await findVcvarsall()
+  if (!vcvars) {
+    throw new Error(
+      'Could not locate the Visual Studio C++ build environment (vcvarsall.bat). Install the ' +
+        '"Desktop development with C++" workload from the Visual Studio Build Tools.',
+    )
+  }
 
   const buildRoot = join(req.enginesRoot, 'build', buildDirName(req.repoUrl, req.branch))
   const srcDir = join(buildRoot, 'src')
@@ -135,27 +273,35 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
   // Record the built commit (ADR-088 provenance / rebuild comparison).
   const commit = (await runStep('git', ['-C', srcDir, 'rev-parse', 'HEAD'], { env, signal, onLine: () => {} })).trim()
 
-  // 2) Configure.
+  // Pick the generator from what's reachable on PATH (incl. the user's toolchain dirs).
+  const generator = pickGenerator(onPath(env, 'ninja.exe'))
+  hooks.log(
+    generator === 'Ninja'
+      ? 'Using the Ninja generator (drives nvcc directly — no Visual Studio CUDA integration needed).'
+      : 'Ninja not found on PATH — using the NMake generator (works, but single-threaded and slower; ' +
+          'add a folder containing ninja.exe under Build environment for much faster builds).',
+  )
+
+  // 2) Configure — inside the MSVC dev env so cl/ml64/INCLUDE/LIB are set; nvcc comes off PATH.
   hooks.phase('configuring')
-  await runStep('cmake', ['-B', buildSubdir, '-S', srcDir, ...CMAKE_CONFIGURE_ARGS], {
-    env,
-    signal,
-    onLine: hooks.log,
-  })
+  const configureBat = join(buildRoot, '_tllm_configure.bat')
+  writeFileSync(configureBat, vcvarsBatch(vcvars, ['-G', generator, '-B', buildSubdir, '-S', srcDir, ...CMAKE_CONFIGURE_ARGS]))
+  await runStep('cmd.exe', ['/c', configureBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
 
-  // 3) Compile just the server target.
+  // 3) Compile just the server target (Ninja parallelizes with -j; NMake ignores it).
   hooks.phase('compiling')
-  await runStep('cmake', ['--build', buildSubdir, '--config', 'Release', '-j', '--target', 'llama-server'], {
-    env,
-    signal,
-    onLine: hooks.log,
-  })
+  const compileBat = join(buildRoot, '_tllm_build.bat')
+  writeFileSync(compileBat, vcvarsBatch(vcvars, ['--build', buildSubdir, '-j', '--target', 'llama-server']))
+  await runStep('cmd.exe', ['/c', compileBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
 
-  // 4) Locate the produced binary (MSVC: build/bin/Release/llama-server.exe; others vary).
+  // 4) Locate the produced binary (Ninja: build/bin/llama-server.exe; layouts vary).
   hooks.phase('registering')
   const binPath = resolveServerBinary(buildSubdir) ?? resolveServerBinary(buildRoot)
   if (!binPath) {
     throw new Error('Build finished but no llama-server binary was found in the output — see the log above.')
   }
+  // Make the engine self-contained: a source build doesn't bundle the CUDA runtime DLLs, so
+  // copy them next to the exe (else the probe + every launch fail to start with missing DLLs).
+  copyCudaRuntimeDlls(env, dirname(binPath), hooks.log)
   return { binPath, commit, buildRoot }
 }

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -99,7 +99,10 @@ function runStep(
 /** Run the full clone → configure → compile → locate flow. Throws on any failure (the
  *  caller surfaces it via BuildState.fail); on success returns the built binary + commit. */
 export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: AbortSignal): Promise<BuildOutput> {
-  const env = buildEnv(req.toolchainDirs)
+  // Force git to FAIL fast instead of blocking on an interactive credential prompt (a
+  // private/typo'd URL would otherwise hang the build with stdin ignored). GCM_INTERACTIVE
+  // disables the Git Credential Manager GUI on Windows.
+  const env = { ...buildEnv(req.toolchainDirs), GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'never' }
 
   // Fail fast with actionable guidance if the toolchain isn't usable, rather than a deep
   // cryptic cmake error. CUDA is required because we build with -DGGML_CUDA=ON.

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -1,0 +1,158 @@
+// In-app 1-click compile-from-source (ADR-100, Windows + CUDA). Runs the same commands
+// the guide shows (git clone → cmake configure → cmake build llama-server) inside the
+// daemon, streaming each line to a {@link BuildState} so the UI can show live progress,
+// then hands the built binary to the registry. The toolchain PATH override (ADR-100,
+// build-prereqs.ts `buildEnv`) is applied so a conda-env / custom-path CUDA Toolkit and
+// compiler are found by both `cmake`'s detection and `nvcc`.
+//
+// Scope mirrors the guide: Windows + CUDA only (the caller gates on `checkBuildPrereqs`).
+// We never run the build off Windows.
+import { spawn } from 'node:child_process'
+import { mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { buildEnv, checkBuildPrereqs } from './build-prereqs'
+import { resolveServerBinary } from './scan'
+import type { BuildPhase } from './build-state'
+
+export interface BuildRequest {
+  repoUrl: string
+  branch?: string
+  /** `<dataDir>/engines` — builds live under `<enginesRoot>/build/<slug>/`. */
+  enginesRoot: string
+  /** Dirs prepended to PATH for the build (ADR-100). */
+  toolchainDirs: string[]
+}
+
+export interface BuildHooks {
+  phase: (p: BuildPhase) => void
+  log: (line: string) => void
+}
+
+export interface BuildOutput {
+  /** Absolute path to the compiled `llama-server[.exe]`. */
+  binPath: string
+  /** The exact commit that was built (HEAD of the cloned shallow checkout). */
+  commit: string
+  /** Directory the build lives in (so the caller can GC on failure if desired). */
+  buildRoot: string
+}
+
+/** PURE: a filesystem-safe directory slug for a repo+branch, so a rebuild of the same
+ *  source reuses (overwrites) the same dir. e.g. ("https://github.com/ikawrakow/ik_llama.cpp.git",
+ *  "sidestream") → "ik_llama.cpp-sidestream". Falls back to "engine" for an unparseable URL. */
+export function buildDirName(repoUrl: string, branch?: string): string {
+  const last = repoUrl.trim().replace(/\/+$/, '').split(/[\\/]/).pop() ?? ''
+  const repo = last.replace(/\.git$/i, '').trim() || 'engine'
+  const b = (branch ?? '').trim()
+  const raw = b ? `${repo}-${b}` : repo
+  // Keep it tame on disk: collapse anything outside [A-Za-z0-9._-] to a single dash.
+  return raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'engine'
+}
+
+/** The cmake configure args (Windows + CUDA). Kept here so the runner and any test agree. */
+export const CMAKE_CONFIGURE_ARGS = ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release']
+
+/** Run one child process, streaming combined stdout+stderr line-by-line to `onLine` and
+ *  resolving with the full stdout text. Rejects with a clear message on a non-zero exit or
+ *  spawn error; aborting `signal` kills the child (Node throws AbortError, name preserved). */
+function runStep(
+  cmd: string,
+  args: string[],
+  opts: { cwd?: string; env: NodeJS.ProcessEnv; signal: AbortSignal; onLine: (line: string) => void },
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      signal: opts.signal,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let outBuf = ''
+    let errBuf = ''
+    const pump = (chunk: string, isErr: boolean) => {
+      if (!isErr) stdout += chunk
+      let buf = isErr ? errBuf + chunk : outBuf + chunk
+      let nl: number
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        opts.onLine(buf.slice(0, nl).replace(/\r$/, ''))
+        buf = buf.slice(nl + 1)
+      }
+      if (isErr) errBuf = buf
+      else outBuf = buf
+    }
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (c: string) => pump(c, false))
+    child.stderr.on('data', (c: string) => pump(c, true))
+    child.on('error', (e) => reject(e)) // includes AbortError when signal fires
+    child.on('close', (code) => {
+      if (outBuf) opts.onLine(outBuf.replace(/\r$/, ''))
+      if (errBuf) opts.onLine(errBuf.replace(/\r$/, ''))
+      if (code === 0) resolve(stdout)
+      else reject(new Error(`${cmd} exited with code ${code}`))
+    })
+  })
+}
+
+/** Run the full clone → configure → compile → locate flow. Throws on any failure (the
+ *  caller surfaces it via BuildState.fail); on success returns the built binary + commit. */
+export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: AbortSignal): Promise<BuildOutput> {
+  const env = buildEnv(req.toolchainDirs)
+
+  // Fail fast with actionable guidance if the toolchain isn't usable, rather than a deep
+  // cryptic cmake error. CUDA is required because we build with -DGGML_CUDA=ON.
+  hooks.phase('preparing')
+  const prereqs = await checkBuildPrereqs(req.toolchainDirs)
+  if (!prereqs.supported) throw new Error('In-app build is currently Windows + CUDA only.')
+  const missing = prereqs.tools.filter((t) => (t.id === 'git' || t.id === 'cmake' || t.id === 'cuda') && !t.found)
+  if (missing.length > 0) {
+    const names = missing.map((t) => t.name).join(', ')
+    throw new Error(
+      `Missing build prerequisite(s): ${names}. Install them, or — if they live in a conda env / custom path — ` +
+        `add that folder under Build environment so TurboLLM can find them.`,
+    )
+  }
+
+  const buildRoot = join(req.enginesRoot, 'build', buildDirName(req.repoUrl, req.branch))
+  const srcDir = join(buildRoot, 'src')
+  const buildSubdir = join(buildRoot, 'build')
+  // Start clean so a rebuild never mixes old + new objects.
+  rmSync(buildRoot, { recursive: true, force: true })
+  mkdirSync(buildRoot, { recursive: true })
+
+  // 1) Shallow clone.
+  hooks.phase('cloning')
+  const cloneArgs = ['clone', '--depth', '1']
+  if ((req.branch ?? '').trim()) cloneArgs.push('--branch', req.branch!.trim())
+  cloneArgs.push(req.repoUrl, srcDir)
+  await runStep('git', cloneArgs, { env, signal, onLine: hooks.log })
+
+  // Record the built commit (ADR-088 provenance / rebuild comparison).
+  const commit = (await runStep('git', ['-C', srcDir, 'rev-parse', 'HEAD'], { env, signal, onLine: () => {} })).trim()
+
+  // 2) Configure.
+  hooks.phase('configuring')
+  await runStep('cmake', ['-B', buildSubdir, '-S', srcDir, ...CMAKE_CONFIGURE_ARGS], {
+    env,
+    signal,
+    onLine: hooks.log,
+  })
+
+  // 3) Compile just the server target.
+  hooks.phase('compiling')
+  await runStep('cmake', ['--build', buildSubdir, '--config', 'Release', '-j', '--target', 'llama-server'], {
+    env,
+    signal,
+    onLine: hooks.log,
+  })
+
+  // 4) Locate the produced binary (MSVC: build/bin/Release/llama-server.exe; others vary).
+  hooks.phase('registering')
+  const binPath = resolveServerBinary(buildSubdir) ?? resolveServerBinary(buildRoot)
+  if (!binPath) {
+    throw new Error('Build finished but no llama-server binary was found in the output — see the log above.')
+  }
+  return { binPath, commit, buildRoot }
+}

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -57,6 +57,38 @@ export function buildDirName(repoUrl: string, branch?: string): string {
   return raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'engine'
 }
 
+/** PURE: loose equality of two repo identifiers (full URL or `owner/repo`), ignoring scheme,
+ *  a `github.com/` host prefix, a trailing `.git`/slash, and case. Lets us match a catalog
+ *  entry's homepage to a source-built engine's stored `sourceRepo`. */
+export function sameRepo(a?: string, b?: string): boolean {
+  const norm = (s?: string) =>
+    (s ?? '')
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, '')
+      .replace(/^github\.com\//, '')
+      .replace(/\.git$/, '')
+      .replace(/\/+$/, '')
+  const na = norm(a)
+  return na !== '' && na === norm(b)
+}
+
+/** The built `llama-server` for a repo (+optional branch) under `enginesRoot`, or null. Used
+ *  to detect a source-built engine whose registry entry was removed (disabled) but whose build
+ *  output still sits on disk under `engines/build/<slug>/`. */
+export function sourceBuildBinary(enginesRoot: string, repoUrl: string, branch?: string): string | null {
+  const root = join(enginesRoot, 'build', buildDirName(repoUrl, branch))
+  return resolveServerBinary(join(root, 'build')) ?? resolveServerBinary(root)
+}
+
+/** PURE: given a built engine's binPath, the `engines/build/<slug>` dir it lives under (for
+ *  purge), or null when the path isn't a source-build output. */
+export function sourceBuildDirOf(binPath: string, enginesRoot: string): string | null {
+  const m = binPath.replace(/\\/g, '/').match(/\/engines\/build\/([^/]+)(?:\/|$)/i)
+  if (!m) return null
+  return join(enginesRoot, 'build', m[1])
+}
+
 /** PURE: prefer Ninja (fast, parallel) when a ninja.exe is reachable; else NMake Makefiles
  *  (ships with the MSVC Build Tools — always available after vcvars, just single-threaded). */
 export function pickGenerator(hasNinja: boolean): 'Ninja' | 'NMake Makefiles' {

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -13,7 +13,7 @@
 // The toolchain PATH override (build-prereqs.ts `buildEnv`) is applied so a conda-env /
 // custom-path CUDA Toolkit (and a user-provided ninja) are found. Windows + CUDA only.
 import { execFile, spawn } from 'node:child_process'
-import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { delimiter, dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import { buildEnv, checkBuildPrereqs } from './build-prereqs'
@@ -226,6 +226,91 @@ function runStep(
   })
 }
 
+/** True if `dir` (recursively) contains any assembly source the build could compile. We skip
+ *  VCS / build / dep dirs. Used to decide whether an enabled CMake `ASM` language is real or
+ *  gratuitous. */
+function hasAssemblySources(dir: string): boolean {
+  const SKIP = new Set(['.git', 'build', 'node_modules', '.cache', 'vendor'])
+  const stack = [dir]
+  while (stack.length) {
+    const d = stack.pop()!
+    let entries
+    try {
+      entries = readdirSync(d, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (!SKIP.has(e.name.toLowerCase()) && !e.name.startsWith('.')) stack.push(join(d, e.name))
+      } else if (/\.(s|asm)$/i.test(e.name)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+/** PURE: remove the generic CMake `ASM` language enablement from one CMakeLists' text. Strips
+ *  the `ASM` token from `project(... ASM ...)` and comments out standalone `enable_language(ASM)`
+ *  lines. Returns the new text + whether anything changed. Only safe to apply when the repo has
+ *  NO assembly sources (nothing to actually assemble). */
+export function stripGenericAsmLanguage(text: string): { text: string; changed: boolean } {
+  let changed = false
+  const out = text.split(/\r?\n/).map((line) => {
+    if (/\bproject\s*\(/i.test(line) && /\bASM\b/.test(line)) {
+      const next = line.replace(/\s+ASM\b/g, '')
+      if (next !== line) {
+        changed = true
+        return next
+      }
+    }
+    if (/^\s*enable_language\s*\(\s*ASM\s*\)/i.test(line)) {
+      changed = true
+      return `# ${line}  # neutralized by TurboLLM (no assembly sources)`
+    }
+    return line
+  })
+  return { text: out.join('\n'), changed }
+}
+
+/** Some llama.cpp forks (e.g. TurboQuant) enable CMake's generic `ASM` language in their ggml
+ *  project even though they ship NO assembly sources. On modern CMake (CMP0194 NEW) MSVC isn't
+ *  accepted as an ASM assembler, so configure dies with "No CMAKE_ASM_COMPILER could be found"
+ *  for a language nothing uses. When the repo genuinely has no `.s`/`.asm` files, strip that
+ *  unused declaration from its CMakeLists so the MSVC build can proceed — provably a no-op
+ *  (there is no assembly to compile). If real assembly exists, we leave it alone. */
+function neutralizeGratuitousAsm(srcDir: string, log: (l: string) => void): void {
+  if (hasAssemblySources(srcDir)) return // real assembly — needs a real assembler; don't touch
+  // The CMakeLists files that can enable the generic ASM language for our Windows+CUDA config.
+  const candidates = [join(srcDir, 'CMakeLists.txt'), join(srcDir, 'ggml', 'CMakeLists.txt')]
+  let patched = 0
+  for (const file of candidates) {
+    if (!existsSync(file)) continue
+    let text: string
+    try {
+      text = readFileSync(file, 'utf8')
+    } catch {
+      continue
+    }
+    const { text: next, changed } = stripGenericAsmLanguage(text)
+    if (changed) {
+      try {
+        writeFileSync(file, next)
+        patched++
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+  if (patched > 0) {
+    log(
+      'Removed an unused CMake ASM-language declaration (the repo ships no assembly sources) so ' +
+        'the build works with MSVC — this fork enables ASM gratuitously, which modern CMake rejects with MSVC.',
+    )
+  }
+}
+
 /** Run the full clone → configure → compile → locate flow. Throws on any failure (the
  *  caller surfaces it via BuildState.fail); on success returns the built binary + commit. */
 export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: AbortSignal): Promise<BuildOutput> {
@@ -272,6 +357,10 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
 
   // Record the built commit (ADR-088 provenance / rebuild comparison).
   const commit = (await runStep('git', ['-C', srcDir, 'rev-parse', 'HEAD'], { env, signal, onLine: () => {} })).trim()
+
+  // Drop a gratuitous ASM-language declaration some forks ship (no assembly sources) so the
+  // MSVC build doesn't die on "No CMAKE_ASM_COMPILER could be found" for a language nothing uses.
+  neutralizeGratuitousAsm(srcDir, hooks.log)
 
   // Pick the generator from what's reachable on PATH (incl. the user's toolchain dirs).
   const generator = pickGenerator(onPath(env, 'ninja.exe'))

--- a/turbollm/src/engines/build-state.ts
+++ b/turbollm/src/engines/build-state.ts
@@ -1,0 +1,61 @@
+// Live status of an in-app compile-from-source run (ADR-100), surfaced via GET
+// /api/v1/status as `engineBuild` so the web UI can show a phase + a live log tail while
+// `git clone` + `cmake` run. A build can take many minutes, so — unlike a download — the
+// useful signal is the streaming compiler output, not a byte percentage. Single in-process
+// holder; only one build runs at a time (guarded alongside the download ProvisionState).
+
+/** Coarse build phase, in order. `done`/`error` are terminal and clear `active`. */
+export type BuildPhase = 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
+
+export interface BuildStatus {
+  active: boolean
+  phase: BuildPhase
+  /** Human label for the engine being built (e.g. "ik_llama.cpp"). */
+  engine: string
+  /** Tail of the most recent log lines (clone/cmake stdout+stderr), oldest→newest. */
+  log: string[]
+  /** Error message when `phase === 'error'`; null otherwise. */
+  error: string | null
+}
+
+const LOG_TAIL = 200
+
+export class BuildState {
+  private s: BuildStatus = { active: false, phase: 'preparing', engine: '', log: [], error: null }
+
+  get(): BuildStatus {
+    return { ...this.s, log: [...this.s.log] }
+  }
+
+  /** True while a build is running — used to reject a concurrent build/download. */
+  isActive(): boolean {
+    return this.s.active
+  }
+
+  start(engine: string): void {
+    this.s = { active: true, phase: 'preparing', engine, log: [], error: null }
+  }
+
+  phase(phase: BuildPhase): void {
+    if (!this.s.active) return
+    this.s.phase = phase
+  }
+
+  /** Append a log line (split multi-line chunks upstream). Keeps only the last N. */
+  log(line: string): void {
+    if (!this.s.active) return
+    const trimmed = line.replace(/\r?\n$/, '')
+    if (trimmed === '') return
+    this.s.log.push(trimmed)
+    if (this.s.log.length > LOG_TAIL) this.s.log.splice(0, this.s.log.length - LOG_TAIL)
+  }
+
+  done(): void {
+    // Keep the log visible but mark inactive + terminal so the UI can show "Built".
+    this.s = { ...this.s, active: false, phase: 'done', error: null }
+  }
+
+  fail(error: string): void {
+    this.s = { ...this.s, active: false, phase: 'error', error }
+  }
+}

--- a/turbollm/src/engines/build-state.ts
+++ b/turbollm/src/engines/build-state.ts
@@ -4,8 +4,9 @@
 // useful signal is the streaming compiler output, not a byte percentage. Single in-process
 // holder; only one build runs at a time (guarded alongside the download ProvisionState).
 
-/** Coarse build phase, in order. `done`/`error` are terminal and clear `active`. */
-export type BuildPhase = 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
+/** Coarse build phase, in order. `provisioning` is the optional CUDA-download step (ADR-101)
+ *  that runs before a build when no CUDA Toolkit is found. `done`/`error` are terminal. */
+export type BuildPhase = 'provisioning' | 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
 
 export interface BuildStatus {
   active: boolean

--- a/turbollm/src/engines/cuda-provision.test.ts
+++ b/turbollm/src/engines/cuda-provision.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { majorMinor, cmpMajorMinor, pickCudaVersion } from './cuda-provision'
+
+test('majorMinor: takes the first two components', () => {
+  assert.equal(majorMinor('13.0.1'), '13.0')
+  assert.equal(majorMinor('12.6.85'), '12.6')
+  assert.equal(majorMinor('13'), '13.0')
+})
+
+test('cmpMajorMinor: orders by major then minor', () => {
+  assert.ok(cmpMajorMinor('12.8', '13.0') < 0)
+  assert.ok(cmpMajorMinor('13.0', '12.8') > 0)
+  assert.equal(cmpMajorMinor('12.6', '12.6'), 0)
+  assert.ok(cmpMajorMinor('12.6', '12.8') < 0)
+})
+
+const KNOWN = ['13.0.1', '13.0.0', '12.8.1', '12.6.3', '12.4.1']
+
+test('pickCudaVersion: newest version the driver supports', () => {
+  // Driver maxes at 13.0 → newest 13.0.x is fine.
+  assert.equal(pickCudaVersion('13.0', KNOWN), '13.0.1')
+  // Driver maxes at 12.8 → skip the 13.0 entries, take 12.8.1.
+  assert.equal(pickCudaVersion('12.8', KNOWN), '12.8.1')
+  // Driver maxes at 12.6 → 12.6.3.
+  assert.equal(pickCudaVersion('12.6', KNOWN), '12.6.3')
+})
+
+test('pickCudaVersion: handles a driver newer than anything we know (takes newest known)', () => {
+  assert.equal(pickCudaVersion('99.9', KNOWN), '13.0.1')
+})
+
+test('pickCudaVersion: driver older than all known → oldest known (best effort)', () => {
+  assert.equal(pickCudaVersion('11.0', KNOWN), '12.4.1')
+})
+
+test('pickCudaVersion: unknown driver → newest known', () => {
+  assert.equal(pickCudaVersion(null, KNOWN), '13.0.1')
+})
+
+test('pickCudaVersion: accepts a full driver-max like "13.0.88"', () => {
+  assert.equal(pickCudaVersion('13.0.88', KNOWN), '13.0.1')
+})

--- a/turbollm/src/engines/cuda-provision.ts
+++ b/turbollm/src/engines/cuda-provision.ts
@@ -1,0 +1,180 @@
+// CUDA Toolkit auto-provisioning from NVIDIA's official redistributable archives (ADR-101).
+// When a 1-click build can't find a CUDA Toolkit, we download the minimal component set
+// needed to COMPILE llama.cpp with CUDA — nvcc + cudart + cublas + the CCCL/nvrtc headers —
+// extract them, and MERGE them into one toolkit root under `<dataDir>/cuda/<version>/`. The
+// resulting `bin` dir is then used as a build toolchain dir (it holds nvcc + the runtime DLLs).
+//
+// Source: https://developer.download.nvidia.com/compute/cuda/redist/ — the same per-component
+// archives conda-forge/pip wheels are built from. Each version has a `redistrib_<ver>.json`
+// manifest mapping every component to a per-platform { relative_path, sha256, size }.
+//
+// Windows + x86_64 only, matching the guided build's scope (Linux/macOS build is parked).
+import { execFile } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { downloadFile, extractArchive } from './download'
+
+const execFileP = promisify(execFile)
+
+const REDIST_BASE = 'https://developer.download.nvidia.com/compute/cuda/redist/'
+
+/** Components required to BUILD (not just run) a CUDA llama.cpp:
+ *  - cuda_nvcc:   the compiler (nvcc, ptxas, cicc) + the CRT headers it needs
+ *  - cuda_cudart: the runtime (cudart.lib/dll + cuda_runtime.h)
+ *  - libcublas:   cuBLAS + cuBLASLt (libs + DLLs + headers) — the large one (~430 MB)
+ *  - cuda_cccl:   Thrust/CUB headers that ggml-cuda includes
+ *  - cuda_nvrtc:  runtime compilation (linked by some ggml-cuda paths) */
+export const CUDA_BUILD_COMPONENTS = ['cuda_nvcc', 'cuda_cudart', 'libcublas', 'cuda_cccl', 'cuda_nvrtc']
+
+/** Redist versions we know how to assemble, newest first. We pick the newest whose
+ *  major.minor the installed driver supports. 12.8+ is required for Blackwell (sm_120);
+ *  13.0 for the very newest. Older entries keep things working on older drivers. */
+export const KNOWN_CUDA_VERSIONS = ['13.0.1', '13.0.0', '12.8.1', '12.6.3', '12.4.1']
+
+export interface CudaProvisionProgress {
+  phase: 'resolving' | 'downloading' | 'extracting' | 'assembling'
+  /** Human line for the build log. */
+  message: string
+  /** 0..1 within the current component download, when known. */
+  pct?: number
+}
+
+export interface CudaToolkit {
+  /** Toolkit root (`<dataDir>/cuda/<version>`). */
+  root: string
+  /** `<root>/bin` — contains nvcc + the runtime DLLs; use as a build toolchain dir. */
+  binDir: string
+  version: string
+}
+
+/** PURE: `major.minor` of a version string ("13.0.1" → "13.0"), for driver comparison. */
+export function majorMinor(v: string): string {
+  const p = v.split('.')
+  return `${p[0] ?? '0'}.${p[1] ?? '0'}`
+}
+
+/** PURE: numeric compare of "X.Y" strings; ≤ 0 when a ≤ b. */
+export function cmpMajorMinor(a: string, b: string): number {
+  const [am, an] = a.split('.').map(Number)
+  const [bm, bn] = b.split('.').map(Number)
+  return am !== bm ? am - bm : (an || 0) - (bn || 0)
+}
+
+/** The max CUDA version the installed NVIDIA driver supports, via `nvidia-smi` ("CUDA
+ *  Version: 13.0" in its header). Null if nvidia-smi is absent/unparseable. */
+export async function driverMaxCuda(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileP('nvidia-smi', [], { timeout: 8000, windowsHide: true, maxBuffer: 1024 * 1024 })
+    const m = stdout.match(/CUDA Version:\s*([\d.]+)/i)
+    return m ? m[1] : null
+  } catch {
+    return null
+  }
+}
+
+/** PURE: from `KNOWN_CUDA_VERSIONS` (newest first), the newest whose major.minor is ≤ the
+ *  driver's max. When the driver is unknown, fall back to the newest known version. */
+export function pickCudaVersion(driverMax: string | null, known = KNOWN_CUDA_VERSIONS): string {
+  if (!driverMax) return known[0]
+  const dm = majorMinor(driverMax)
+  return known.find((v) => cmpMajorMinor(majorMinor(v), dm) <= 0) ?? known[known.length - 1]
+}
+
+type RedistManifest = Record<string, undefined | { ['windows-x86_64']?: { relative_path: string } }>
+
+/** Fetch the redist manifest for `version`; null if it doesn't exist (so the caller can
+ *  fall back to an older known version). */
+async function fetchManifest(version: string, signal: AbortSignal): Promise<RedistManifest | null> {
+  const res = await fetch(`${REDIST_BASE}redistrib_${version}.json`, { redirect: 'follow', signal })
+  if (!res.ok) return null
+  return (await res.json()) as RedistManifest
+}
+
+/** Resolve a usable CUDA version + its manifest: starting at the driver-preferred version,
+ *  walk `KNOWN_CUDA_VERSIONS` until a manifest actually exists. Throws if none resolve. */
+async function resolveVersion(driverMax: string | null, signal: AbortSignal): Promise<{ version: string; manifest: RedistManifest }> {
+  const preferred = pickCudaVersion(driverMax)
+  const ordered = [preferred, ...KNOWN_CUDA_VERSIONS.filter((v) => v !== preferred)]
+  for (const version of ordered) {
+    const manifest = await fetchManifest(version, signal)
+    if (manifest) return { version, manifest }
+  }
+  throw new Error('Could not reach NVIDIA to resolve a CUDA Toolkit version (offline?).')
+}
+
+/** Download the build component set for a resolved version, extract each, and merge them
+ *  into one toolkit root. Idempotent: if `<dataDir>/cuda/<version>/bin/nvcc.exe` already
+ *  exists we reuse it. Returns the toolkit (its `bin` dir is a ready build toolchain dir). */
+export async function provisionCuda(
+  dataDir: string,
+  onProgress: (p: CudaProvisionProgress) => void,
+  signal: AbortSignal,
+): Promise<CudaToolkit> {
+  if (process.platform !== 'win32') {
+    throw new Error('Automatic CUDA download is currently Windows x86_64 only.')
+  }
+  onProgress({ phase: 'resolving', message: 'Checking your NVIDIA driver and resolving a CUDA version…' })
+  const driverMax = await driverMaxCuda()
+  const { version, manifest } = await resolveVersion(driverMax, signal)
+  onProgress({
+    phase: 'resolving',
+    message: `Using CUDA ${version}${driverMax ? ` (driver supports up to ${driverMax})` : ''}.`,
+  })
+
+  const root = join(dataDir, 'cuda', version)
+  const binDir = join(root, 'bin')
+  // Reuse a complete prior install.
+  if (existsSync(join(binDir, 'nvcc.exe'))) {
+    onProgress({ phase: 'assembling', message: `CUDA ${version} already downloaded — reusing it.` })
+    return { root, binDir, version }
+  }
+
+  // Resolve the component archive URLs up front (fail fast if any is missing).
+  const components = CUDA_BUILD_COMPONENTS.map((id) => {
+    const rel = manifest[id]?.['windows-x86_64']?.relative_path
+    if (!rel) throw new Error(`CUDA ${version} manifest is missing ${id} for windows-x86_64.`)
+    return { id, url: REDIST_BASE + rel }
+  })
+
+  const work = join(tmpdir(), `tllm-cuda-${version}`)
+  rmSync(work, { recursive: true, force: true })
+  mkdirSync(work, { recursive: true })
+  // Build into a temp root first, then atomically swap in, so an interrupted download never
+  // leaves a half-assembled toolkit that looks complete.
+  const stageRoot = `${root}.partial`
+  rmSync(stageRoot, { recursive: true, force: true })
+  mkdirSync(stageRoot, { recursive: true })
+
+  try {
+    for (let i = 0; i < components.length; i++) {
+      const { id, url } = components[i]
+      const zip = join(work, `${id}.zip`)
+      onProgress({ phase: 'downloading', message: `Downloading ${id} (${i + 1}/${components.length})…`, pct: 0 })
+      await downloadFile(url, zip, (p) => onProgress({ phase: 'downloading', message: `Downloading ${id} (${i + 1}/${components.length})…`, pct: p.pct }), signal)
+      const exDir = join(work, id)
+      mkdirSync(exDir, { recursive: true })
+      onProgress({ phase: 'extracting', message: `Extracting ${id}…` })
+      await extractArchive(zip, exDir)
+      // Each archive contains a single `<id>-windows-x86_64-<ver>-archive/` folder with
+      // bin/ include/ lib/ … — merge that folder's contents into the shared toolkit root.
+      const inner = readdirSync(exDir).map((n) => join(exDir, n)).find((p) => existsSync(join(p, 'include')) || existsSync(join(p, 'bin')) || existsSync(join(p, 'lib')))
+      const srcRoot = inner ?? join(exDir, readdirSync(exDir)[0] ?? '')
+      cpSync(srcRoot, stageRoot, { recursive: true, force: true })
+      rmSync(zip, { force: true })
+    }
+    if (!existsSync(join(stageRoot, 'bin', 'nvcc.exe'))) {
+      throw new Error('Assembled CUDA toolkit is missing bin/nvcc.exe — the component set may have changed.')
+    }
+    // Swap staged → final.
+    rmSync(root, { recursive: true, force: true })
+    mkdirSync(join(dataDir, 'cuda'), { recursive: true })
+    cpSync(stageRoot, root, { recursive: true, force: true })
+    onProgress({ phase: 'assembling', message: `CUDA ${version} ready.` })
+    return { root, binDir, version }
+  } finally {
+    rmSync(work, { recursive: true, force: true })
+    rmSync(stageRoot, { recursive: true, force: true })
+  }
+}

--- a/turbollm/src/engines/cuda-provision.ts
+++ b/turbollm/src/engines/cuda-provision.ts
@@ -20,13 +20,23 @@ const execFileP = promisify(execFile)
 
 const REDIST_BASE = 'https://developer.download.nvidia.com/compute/cuda/redist/'
 
-/** Components required to BUILD (not just run) a CUDA llama.cpp:
- *  - cuda_nvcc:   the compiler (nvcc, ptxas, cicc) + the CRT headers it needs
- *  - cuda_cudart: the runtime (cudart.lib/dll + cuda_runtime.h)
- *  - libcublas:   cuBLAS + cuBLASLt (libs + DLLs + headers) — the large one (~430 MB)
+/** Components required to BUILD a CUDA llama.cpp:
+ *  - cuda_nvcc:   the compiler DRIVER (nvcc, ptxas) — but NOT cicc (see libnvvm below)
+ *  - cuda_cudart: the runtime (cudart.lib/dll + cuda_runtime.h + the `crt/` header WRAPPERS)
+ *  - libcublas:   cuBLAS + cuBLASLt (libs + DLLs + headers) — the large one (~400 MB)
  *  - cuda_cccl:   Thrust/CUB headers that ggml-cuda includes
- *  - cuda_nvrtc:  runtime compilation (linked by some ggml-cuda paths) */
-export const CUDA_BUILD_COMPONENTS = ['cuda_nvcc', 'cuda_cudart', 'libcublas', 'cuda_cccl', 'cuda_nvrtc']
+ *  We deliberately do NOT pull cuda_nvrtc (~318 MB): ggml-cuda is ahead-of-time compiled,
+ *  so runtime compilation isn't needed — the prebuilt llama.cpp CUDA releases omit it too. */
+export const CUDA_REQUIRED_COMPONENTS = ['cuda_nvcc', 'cuda_cudart', 'libcublas', 'cuda_cccl']
+
+/** Optional components — present in newer redists (CUDA 13+), skipped silently when absent
+ *  (in CUDA 12.x they're folded into cuda_nvcc / cuda_cudart, so they don't exist separately):
+ *  - libnvvm:  `nvvm/bin/cicc` — the internal compiler nvcc shells out to. Without it nvcc's
+ *    own compiler-identification step fails ("cicc … error 0x1"), so NOTHING CUDA compiles.
+ *  - cuda_crt: the REAL `include/crt/*.h` headers (host_config.h, …). In CUDA 13+, cuda_cudart
+ *    ships only thin `include/<name>.h` wrappers that `#include "crt/<name>"`; the real headers
+ *    live here. Without it every CUDA compile dies on "Cannot open include file: 'crt/host_config.h'". */
+export const CUDA_OPTIONAL_COMPONENTS = ['libnvvm', 'cuda_crt']
 
 /** Redist versions we know how to assemble, newest first. We pick the newest whose
  *  major.minor the installed driver supports. 12.8+ is required for Blackwell (sm_120);
@@ -131,12 +141,19 @@ export async function provisionCuda(
     return { root, binDir, version }
   }
 
-  // Resolve the component archive URLs up front (fail fast if any is missing).
-  const components = CUDA_BUILD_COMPONENTS.map((id) => {
-    const rel = manifest[id]?.['windows-x86_64']?.relative_path
+  // Resolve the component archive URLs up front. Required components fail fast if missing;
+  // optional ones (e.g. cuda_crt, absent on CUDA 12.x) are simply skipped when not present.
+  const relOf = (id: string) => manifest[id]?.['windows-x86_64']?.relative_path
+  const components: { id: string; url: string }[] = []
+  for (const id of CUDA_REQUIRED_COMPONENTS) {
+    const rel = relOf(id)
     if (!rel) throw new Error(`CUDA ${version} manifest is missing ${id} for windows-x86_64.`)
-    return { id, url: REDIST_BASE + rel }
-  })
+    components.push({ id, url: REDIST_BASE + rel })
+  }
+  for (const id of CUDA_OPTIONAL_COMPONENTS) {
+    const rel = relOf(id)
+    if (rel) components.push({ id, url: REDIST_BASE + rel })
+  }
 
   const work = join(tmpdir(), `tllm-cuda-${version}`)
   rmSync(work, { recursive: true, force: true })

--- a/turbollm/src/engines/download.installed.test.ts
+++ b/turbollm/src/engines/download.installed.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { installedBackendBuild, deleteAllBackendBuilds } from './download'
+
+const serverBin = process.platform === 'win32' ? 'llama-server.exe' : 'llama-server'
+
+function tmpRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'tllm-dl-'))
+}
+
+/** Create an extracted backend build dir `llama.cpp-<tag>-<id>/` with a server binary. */
+function seedBuild(root: string, tag: string, id: string): string {
+  const dir = join(root, `llama.cpp-${tag}-${id}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, serverBin), '')
+  return dir
+}
+
+test('installedBackendBuild is tag-agnostic — finds a build de-pinned off LLAMA_BUILD', () => {
+  const root = tmpRoot()
+  // Only a b9754 build exists (no pinned b9608) — the old pinned check would miss it.
+  seedBuild(root, 'b9754', 'cuda')
+  const found = installedBackendBuild(root, 'cuda')
+  assert.ok(found, 'should find the de-pinned build')
+  assert.equal(found!.tag, 'b9754')
+  assert.ok(found!.bin.endsWith(serverBin))
+})
+
+test('installedBackendBuild picks the NEWEST build when several are present', () => {
+  const root = tmpRoot()
+  seedBuild(root, 'b9744', 'cuda')
+  seedBuild(root, 'b9754', 'cuda')
+  seedBuild(root, 'b9700', 'cuda')
+  assert.equal(installedBackendBuild(root, 'cuda')!.tag, 'b9754')
+})
+
+test('installedBackendBuild does not cross backends', () => {
+  const root = tmpRoot()
+  seedBuild(root, 'b9754', 'cuda')
+  assert.equal(installedBackendBuild(root, 'rocm'), null)
+  assert.equal(installedBackendBuild(root, 'cuda')!.tag, 'b9754')
+})
+
+test('installedBackendBuild ignores a build dir with no server binary', () => {
+  const root = tmpRoot()
+  mkdirSync(join(root, 'llama.cpp-b9754-cuda'), { recursive: true }) // empty, no binary
+  assert.equal(installedBackendBuild(root, 'cuda'), null)
+})
+
+test('installedBackendBuild returns null for a missing engines root', () => {
+  assert.equal(installedBackendBuild(join(tmpdir(), 'tllm-does-not-exist-xyz'), 'cuda'), null)
+})
+
+test('deleteAllBackendBuilds removes every build of a backend, leaving others intact', () => {
+  const root = tmpRoot()
+  seedBuild(root, 'b9744', 'cuda')
+  seedBuild(root, 'b9754', 'cuda')
+  seedBuild(root, 'b9754', 'rocm')
+  const removed = deleteAllBackendBuilds(root, 'cuda')
+  assert.equal(removed, 2)
+  assert.ok(!existsSync(join(root, 'llama.cpp-b9744-cuda')))
+  assert.ok(!existsSync(join(root, 'llama.cpp-b9754-cuda')))
+  assert.ok(existsSync(join(root, 'llama.cpp-b9754-rocm')), 'rocm build is untouched')
+  assert.deepEqual(readdirSync(root), ['llama.cpp-b9754-rocm'])
+})

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -122,6 +122,38 @@ export function installedBackendServer(enginesRoot: string, id: BackendId, tag =
   return existsSync(dir) ? findServer(dir) : null
 }
 
+/** An installed official-llama build of a backend, tag-AGNOSTIC: scans the engines root for
+ *  every `llama.cpp-<tag>-<id>` dir and returns the NEWEST (highest `b<N>` build number) that
+ *  has a server binary, or null. Use this instead of `installedBackendServer` whenever a build
+ *  may have been de-pinned off `LLAMA_BUILD` by an update (ADR-085) — otherwise a working,
+ *  updated install falsely reads as "not installed". */
+export function installedBackendBuild(
+  enginesRoot: string,
+  id: BackendId,
+): { dir: string; tag: string; bin: string } | null {
+  let entries: string[]
+  try {
+    entries = readdirSync(enginesRoot)
+  } catch {
+    return null // no engines dir yet
+  }
+  const re = new RegExp(`^llama\\.cpp-(.+)-${id}$`)
+  const buildNum = (tag: string): number => {
+    const m = tag.match(/^b(\d+)$/)
+    return m ? Number(m[1]) : -1
+  }
+  let best: { dir: string; tag: string; bin: string } | null = null
+  for (const name of entries) {
+    const m = re.exec(name)
+    if (!m) continue
+    const dir = join(enginesRoot, name)
+    const bin = findServer(dir)
+    if (!bin) continue
+    if (!best || buildNum(m[1]) > buildNum(best.tag)) best = { dir, tag: m[1], bin }
+  }
+  return best
+}
+
 /** Recursively find a file by exact name under dir (first match), or null.
  *  `skipDir(name)` lets a caller prune subtrees (e.g. node_modules / dotdirs) so a
  *  huge tree can't make the scan hang — default keeps the original full-walk
@@ -242,6 +274,25 @@ export function deleteBackend(enginesRoot: string, id: BackendId, tag = LLAMA_BU
   if (!existsSync(dir)) return false
   rmSync(dir, { recursive: true, force: true })
   return true
+}
+
+/** Remove EVERY installed build of a backend, tag-agnostic (`llama.cpp-<tag>-<id>` dirs —
+ *  e.g. both b9744 and b9754 after a de-pinned update). Returns how many dirs were removed. */
+export function deleteAllBackendBuilds(enginesRoot: string, id: BackendId): number {
+  let entries: string[]
+  try {
+    entries = readdirSync(enginesRoot)
+  } catch {
+    return 0
+  }
+  const re = new RegExp(`^llama\\.cpp-(.+)-${id}$`)
+  let removed = 0
+  for (const name of entries) {
+    if (!re.test(name)) continue
+    rmSync(join(enginesRoot, name), { recursive: true, force: true })
+    removed++
+  }
+  return removed
 }
 
 // ─── Generic fork provisioning from a GitHub release (ADR-044) ──────────────

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -116,17 +116,10 @@ export function backendDefAt(id: BackendId, tag: string): BackendDef | null {
   return availableBackends(tag).find((b) => b.id === id) ?? null
 }
 
-/** Path to an already-extracted backend's server binary, or null if not installed. */
-export function installedBackendServer(enginesRoot: string, id: BackendId, tag = LLAMA_BUILD): string | null {
-  const dir = backendDir(enginesRoot, id, tag)
-  return existsSync(dir) ? findServer(dir) : null
-}
-
 /** An installed official-llama build of a backend, tag-AGNOSTIC: scans the engines root for
  *  every `llama.cpp-<tag>-<id>` dir and returns the NEWEST (highest `b<N>` build number) that
- *  has a server binary, or null. Use this instead of `installedBackendServer` whenever a build
- *  may have been de-pinned off `LLAMA_BUILD` by an update (ADR-085) — otherwise a working,
- *  updated install falsely reads as "not installed". */
+ *  has a server binary, or null. Resolving by scan (not by the pinned `LLAMA_BUILD` tag) is what
+ *  keeps a build de-pinned by an update (ADR-085) from falsely reading as "not installed". */
 export function installedBackendBuild(
   enginesRoot: string,
   id: BackendId,
@@ -266,14 +259,6 @@ export async function provisionBackend(
   const bin = findServer(destDir)
   if (!bin) throw new Error('llama-server not found in extracted archive(s)')
   return bin
-}
-
-/** Remove an installed backend's extracted files. Returns true if anything existed. */
-export function deleteBackend(enginesRoot: string, id: BackendId, tag = LLAMA_BUILD): boolean {
-  const dir = backendDir(enginesRoot, id, tag)
-  if (!existsSync(dir)) return false
-  rmSync(dir, { recursive: true, force: true })
-  return true
 }
 
 /** Remove EVERY installed build of a backend, tag-agnostic (`llama.cpp-<tag>-<id>` dirs —

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -161,10 +161,22 @@ export function getEngineRecommendation(): Promise<EngineRecommendationResult> {
   return request<EngineRecommendationResult>('/api/v1/engines/recommendation')
 }
 
-/** Guided compile-from-source prereq check (ADR-089). Read-only: detects the
- *  Windows + CUDA build toolchain. `supported:false` off Windows (parked elsewhere). */
+/** Compile-from-source prereq check (ADR-089/100). Read-only: detects the Windows + CUDA
+ *  build toolchain (with the configured toolchain-dir PATH override applied).
+ *  `supported:false` off Windows (parked elsewhere). */
 export function getBuildPrereqs(): Promise<BuildPrereqs> {
   return request<BuildPrereqs>('/api/v1/build/prereqs')
+}
+
+/** Start a 1-click in-app build (ADR-100). 202 immediately; progress streams via
+ *  GET /api/v1/status `engineBuild`. Windows + CUDA only; local-host only. */
+export function runBuild(args: { repoUrl: string; branch?: string; name?: string }): Promise<{ accepted: boolean }> {
+  return request('/api/v1/build/run', { method: 'POST', json: args })
+}
+
+/** Cancel an in-progress 1-click build (ADR-100). */
+export function cancelBuild(): Promise<{ ok: boolean }> {
+  return request('/api/v1/build/cancel', { method: 'POST', json: {} })
 }
 
 export function installVllm(): Promise<{ accepted: true; engine: 'vllm' }> {
@@ -500,6 +512,9 @@ export type DaemonSettings = {
   }
   /** MCP server list. */
   mcp: { servers: McpServer[] }
+  /** Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
+   *  conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back. */
+  build: { toolchainDirs: string[] }
 }
 
 export type SearchProvider = 'tavily' | 'kagi' | 'searxng'

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -179,6 +179,13 @@ export function cancelBuild(): Promise<{ ok: boolean }> {
   return request('/api/v1/build/cancel', { method: 'POST', json: {} })
 }
 
+/** Auto-download a CUDA Toolkit from NVIDIA (ADR-101) so a build can compile. 202 + progress
+ *  via GET /status engineBuild (phase 'provisioning'); on success its bin dir is added to the
+ *  build environment. Windows + local-host only. */
+export function provisionCuda(): Promise<{ accepted: boolean }> {
+  return request('/api/v1/build/cuda', { method: 'POST', json: {} })
+}
+
 export function installVllm(): Promise<{ accepted: true; engine: 'vllm' }> {
   return request('/api/v1/engines/vllm', { method: 'POST', json: {} })
 }

--- a/turbollm/web/src/lib/engine-groups.test.ts
+++ b/turbollm/web/src/lib/engine-groups.test.ts
@@ -27,9 +27,14 @@ const turboquant = eng({ id: 'c', binPath: '/root/.turbollm/engines/turboquant/l
 const mlx = eng({ id: 'd', kind: 'mlx', binPath: '/usr/bin/mlx_lm.server' })
 const userFork = eng({ id: 'e', name: 'My Fork', binPath: '/opt/ik_llama/server', kind: 'llama-server' })
 
-test('engineGroupKey collapses official llama.cpp builds regardless of backend/tag', () => {
-  assert.equal(engineGroupKey(llamaCuda9608), 'official-llama')
-  assert.equal(engineGroupKey(llamaCuda9736), 'official-llama')
+test('engineGroupKey groups official llama.cpp per backend; same backend collapses across tags', () => {
+  // Each backend is its own engine; multiple builds of the SAME backend still collapse.
+  assert.equal(engineGroupKey(llamaCuda9608), 'official-llama-cuda')
+  assert.equal(engineGroupKey(llamaCuda9736), 'official-llama-cuda')
+  // A different backend gets a distinct key (its own dropdown entry).
+  const llamaRocm = eng({ id: 'r', binPath: '/root/.turbollm/engines/llama.cpp-b9736-rocm/llama-server' })
+  assert.equal(engineGroupKey(llamaRocm), 'official-llama-rocm')
+  assert.notEqual(engineGroupKey(llamaCuda9608), engineGroupKey(llamaRocm))
 })
 
 test('engineGroupKey maps pip engines to their kind', () => {
@@ -75,12 +80,12 @@ test('latestMemberId is null when no tags parse', () => {
   assert.equal(latestMemberId([turboquant, mlx]), null)
 })
 
-test('groupEngines collapses two llama builds into one group, others stay separate', () => {
+test('groupEngines collapses two same-backend llama builds into one group, others stay separate', () => {
   const groups = groupEngines([llamaCuda9608, llamaCuda9736, turboquant, mlx])
-  const official = groups.find((g) => g.key === 'official-llama')
+  const official = groups.find((g) => g.key === 'official-llama-cuda')
   assert.ok(official)
   assert.equal(official!.members.length, 2)
-  assert.equal(official!.label, 'llama.cpp')
+  assert.equal(official!.label, 'llama.cpp (CUDA)')
   assert.equal(official!.latestId, 'b')
   assert.equal(groups.length, 3)
 })

--- a/turbollm/web/src/lib/engine-groups.ts
+++ b/turbollm/web/src/lib/engine-groups.ts
@@ -14,11 +14,17 @@ export function isOfficialLlama(binPath: string): boolean {
 }
 
 /** A logical-engine grouping key. Engines that share a key collapse into one row.
- *  Official llama.cpp builds (any backend/tag) all share `'official-llama'`; pip
- *  engines share their kind; TurboQuant builds share `'turboquant'`; everything else
- *  is treated as a distinct user-added engine (`'user:'+id`) and never merged. */
+ *  Each official llama.cpp BACKEND is its own engine (`'official-llama-<backend>'`, e.g.
+ *  cuda/rocm) so the "Running now" dropdown lists them individually — the user switches
+ *  among "llama.cpp (CUDA)", "llama.cpp (ROCm)", TurboQuant, … from there. Multiple builds
+ *  of the SAME backend (after an update) still collapse into that backend's group. Pip
+ *  engines share their kind; TurboQuant builds share `'turboquant'`; everything else is a
+ *  distinct user-added engine (`'user:'+id`). */
 export function engineGroupKey(e: Engine): string {
-  if (isOfficialLlama(e.binPath)) return 'official-llama'
+  if (isOfficialLlama(e.binPath)) {
+    const backend = parseLlamaBuild(e.binPath)?.backend
+    return backend ? `official-llama-${backend}` : 'official-llama'
+  }
   if (e.kind === 'koboldcpp' || e.kind === 'mlx' || e.kind === 'vllm') return e.kind
   if (/[\\/]engines[\\/]turboquant[\\/]/.test(e.binPath)) return 'turboquant'
   return `user:${e.id}`
@@ -32,9 +38,13 @@ const GROUP_LABEL: Record<string, string> = {
   turboquant: 'TurboQuant',
 }
 
-/** Display label for a logical-engine group. User-added engines (no fixed label)
- *  fall back to the engine's own name. */
+/** Display label for a logical-engine group. Per-backend llama.cpp groups read as
+ *  "llama.cpp (CUDA)"; user-added engines fall back to the engine's own name. */
 export function groupLabel(key: string, members: Engine[]): string {
+  if (key.startsWith('official-llama-')) {
+    const backend = key.slice('official-llama-'.length)
+    return `llama.cpp (${BACKEND_LABEL[backend] ?? backend.toUpperCase()})`
+  }
   return GROUP_LABEL[key] ?? members[0]?.name ?? key
 }
 
@@ -117,7 +127,14 @@ export function groupEngines(engines: Engine[]): EngineGroup[] {
   }
   return order.map((key) => {
     const members = byKey.get(key)!
-    return { key, label: groupLabel(key, members), members, latestId: latestMemberId(members) }
+    // Newest build first (e.g. b9754 before b9744) so the version dropdown reads latest→oldest;
+    // members without a parseable build number keep their relative order at the end.
+    const sorted = [...members].sort((a, b) => {
+      const na = llamaBuildNumber(parseLlamaBuild(a.binPath)?.tag)
+      const nb = llamaBuildNumber(parseLlamaBuild(b.binPath)?.tag)
+      return (nb ?? -1) - (na ?? -1)
+    })
+    return { key, label: groupLabel(key, sorted), members: sorted, latestId: latestMemberId(sorted) }
   })
 }
 

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -59,6 +59,7 @@ import {
   getBuildPrereqs,
   runBuild as apiRunBuild,
   cancelBuild,
+  provisionCuda as apiProvisionCuda,
   listDownloads,
   listEngines,
   loadModel,
@@ -257,6 +258,11 @@ export function useBuild() {
       onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.status }),
     }),
     cancel: useMutation({ mutationFn: () => cancelBuild(), onSuccess: refresh }),
+    /** Auto-download a CUDA Toolkit (ADR-101); progress streams via the status poll. */
+    cuda: useMutation({
+      mutationFn: () => apiProvisionCuda(),
+      onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.status }),
+    }),
     /** Call when a build settles (done/error) to pull the new engine into the lists. */
     refresh,
   }

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -57,6 +57,8 @@ import {
   getEngineCatalog,
   getEngineRecommendation,
   getBuildPrereqs,
+  runBuild as apiRunBuild,
+  cancelBuild,
   listDownloads,
   listEngines,
   loadModel,
@@ -128,7 +130,11 @@ export function useStatus(): UseQueryResult<Status> {
     // Poll faster (1s) while an auto-tune sweep runs OR a completion is actively
     // streaming, so the inline progress and the live "Generating…" indicator stay live.
     refetchInterval: (q) =>
-      q.state.data?.bench.running || (q.state.data?.engineStats?.activeRequests ?? 0) > 0 ? 1000 : 2000,
+      q.state.data?.bench.running ||
+      q.state.data?.engineBuild?.active ||
+      (q.state.data?.engineStats?.activeRequests ?? 0) > 0
+        ? 1000
+        : 2000,
     refetchIntervalInBackground: false,
     // Keep the prior value visible while a poll is in flight to avoid flicker.
     placeholderData: (prev) => prev,
@@ -232,6 +238,28 @@ export function useBuildPrereqs(enabled = true): UseQueryResult<BuildPrereqs> {
     staleTime: 60_000,
     retry: false,
   })
+}
+
+/** 1-click in-app build (ADR-100): start a compile + cancel. Progress streams via the
+ *  status poll (`engineBuild`); on a settled build we refresh engines/catalog/status so
+ *  the newly-built engine shows up + becomes active. */
+export function useBuild() {
+  const qc = useQueryClient()
+  const refresh = () => {
+    void qc.invalidateQueries({ queryKey: queryKeys.engines })
+    void qc.invalidateQueries({ queryKey: queryKeys.engineCatalog })
+    void qc.invalidateQueries({ queryKey: queryKeys.engineUpdates })
+    void qc.invalidateQueries({ queryKey: queryKeys.status })
+  }
+  return {
+    start: useMutation({
+      mutationFn: (v: { repoUrl: string; branch?: string; name?: string }) => apiRunBuild(v),
+      onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.status }),
+    }),
+    cancel: useMutation({ mutationFn: () => cancelBuild(), onSuccess: refresh }),
+    /** Call when a build settles (done/error) to pull the new engine into the lists. */
+    refresh,
+  }
 }
 
 export function useBackendInstall() {

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -51,7 +51,7 @@ export type EngineProvision = {
  *  a phase + a log tail (clone/cmake output) rather than a byte percentage. */
 export type EngineBuild = {
   active: boolean
-  phase: 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
+  phase: 'provisioning' | 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
   engine: string
   log: string[]
   error: string | null

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -47,6 +47,16 @@ export type EngineProvision = {
   error: string | null
 }
 
+/** In-app compile-from-source status (ADR-100), from GET /api/v1/status. A build streams
+ *  a phase + a log tail (clone/cmake output) rather than a byte percentage. */
+export type EngineBuild = {
+  active: boolean
+  phase: 'preparing' | 'cloning' | 'configuring' | 'compiling' | 'registering' | 'done' | 'error'
+  engine: string
+  log: string[]
+  error: string | null
+}
+
 /** Live running-session stats (B4), from GET /api/v1/status. Null unless the
  *  engine is running; resets each time the engine starts/stops. */
 export type EngineStats = {
@@ -126,6 +136,8 @@ export type Status = {
   bench: BenchState
   downloads: { active: number }
   engineProvision?: EngineProvision
+  /** In-app compile-from-source status (ADR-100). */
+  engineBuild?: EngineBuild
   /** ComfyUI GPU coordination state (null when the feature is off / not wired). */
   comfyui?: ComfyRuntime | null
   telemetryLevel: string

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -299,6 +299,15 @@ export type CatalogEngine = {
   installed?: boolean
   /** Whether a registry engine entry exists for this engine (files installed AND registered). */
   enabled?: boolean
+  /** This catalog engine was compiled from source (ADR-100): manage it via Rebuild, not a
+   *  prebuilt Update. True whether currently registered or just on disk (disabled). */
+  sourceBuilt?: boolean
+  /** Registry id of the matched source-built engine (when enabled) — for disable/delete/policy. */
+  sourceEngineId?: string
+  /** Branch the source-built engine was compiled from (for a Rebuild). */
+  sourceBranch?: string
+  /** Path to the built binary (used to Enable a built-but-disabled source engine). */
+  sourceBinPath?: string
 }
 
 export type EngineCatalog = {

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Check,
   ChevronDown,
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import {
   useBackendInstall,
+  useBuild,
   useEngineBackends,
   useEngineCatalog,
   useEngineMutations,
@@ -189,7 +190,20 @@ function StatusHero({
   const mut = useEngineMutations()
   const { data: sys } = useSysInfo()
   const { data: updates } = useEngineUpdates()
+  const { data: status } = useStatus()
+  const build = useBuild()
   const [rebuildOpen, setRebuildOpen] = useState(false)
+
+  // Pull the newly-built engine into the lists whenever ANY in-app build settles — even if
+  // the build dialog that started it was closed mid-build (ADR-100). Watches the active→
+  // settled transition on the status poll's `engineBuild` so we refresh exactly once.
+  const wasBuilding = useRef(false)
+  const buildActive = !!status?.engineBuild?.active
+  useEffect(() => {
+    if (wasBuilding.current && !buildActive) build.refresh()
+    wasBuilding.current = buildActive
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buildActive])
 
   // Rebuild chip: show when the active engine is source-built and has a newer commit.
   const upd = activeEngine ? updates?.updates[activeEngine.id] : undefined

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -216,9 +216,11 @@ function StatusHero({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buildActive])
 
-  // Rebuild chip: show when the active engine is source-built and has a newer commit.
+  // Rebuild chip: only when the active source-built engine actually has a NEWER commit.
+  // `rebuild` just flags "updates via rebuild" (always true for source engines); the
+  // availability signal is `hasUpdate` (built commit ≠ repo HEAD).
   const upd = activeEngine ? updates?.updates[activeEngine.id] : undefined
-  const showRebuildChip = !!upd?.rebuild && !!activeEngine?.sourceRepo
+  const showRebuildChip = !!upd?.rebuild && !!upd?.hasUpdate && !!activeEngine?.sourceRepo
 
   // Hardware line — prefer the recommendation's hardware, fall back to sysinfo.
   const hw = rec?.hardware
@@ -755,7 +757,7 @@ function CatalogFitRow({
                 // Source-built engines update by RECOMPILING at the latest commit (ADR-088/100),
                 // not by downloading a prebuilt. `rebuild` flags a newer commit on the source repo.
                 <DropdownMenuItem onSelect={() => setRebuildOpen(true)} disabled={anyPending}>
-                  <RefreshCw size={14} /> {updateStatus?.rebuild ? 'Rebuild (new commit)' : 'Rebuild'}
+                  <RefreshCw size={14} /> {updateStatus?.hasUpdate ? 'Rebuild (new commit)' : 'Rebuild'}
                 </DropdownMenuItem>
               ) : (
                 <DropdownMenuItem onSelect={() => onUpdate(catalog)} disabled={provisioning}>

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -8,6 +8,7 @@ import {
   Layers,
   Loader2,
   MoreHorizontal,
+  RefreshCw,
   Settings2,
   Sparkles,
   Wrench,
@@ -195,12 +196,22 @@ function StatusHero({
   const [rebuildOpen, setRebuildOpen] = useState(false)
 
   // Pull the newly-built engine into the lists whenever ANY in-app build settles — even if
-  // the build dialog that started it was closed mid-build (ADR-100). Watches the active→
-  // settled transition on the status poll's `engineBuild` so we refresh exactly once.
+  // the build dialog that started it was closed mid-build (ADR-100) — and surface a global
+  // success/error toast so the user always gets confirmation the engine was added. Watches
+  // the active→settled transition on the status poll's `engineBuild` so it fires exactly once.
   const wasBuilding = useRef(false)
-  const buildActive = !!status?.engineBuild?.active
+  const eb = status?.engineBuild
+  const buildActive = !!eb?.active
   useEffect(() => {
-    if (wasBuilding.current && !buildActive) build.refresh()
+    if (wasBuilding.current && !buildActive && eb) {
+      build.refresh()
+      // The CUDA-download step also uses engineBuild; only celebrate an actual engine build.
+      if (eb.phase === 'done' && eb.engine && eb.engine !== 'CUDA Toolkit') {
+        toast.success(`${eb.engine} built and added — it's now your active engine.`)
+      } else if (eb.phase === 'error' && eb.error && eb.engine !== 'CUDA Toolkit') {
+        toast.error(eb.error)
+      }
+    }
     wasBuilding.current = buildActive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [buildActive])
@@ -463,6 +474,8 @@ function InstallManageCatalog({
   }
   const registryEngineId = (e: CatalogEngine): string | undefined => {
     const eng = registry?.engines ?? []
+    // Source-built engines (ADR-100): the backend already matched the registry entry by repo.
+    if (e.sourceEngineId) return e.sourceEngineId
     if (e.provision === 'pip') return eng.find((x) => x.kind === e.kind)?.id
     if (e.id === 'turboquant') return eng.find((x) => /[\\/]engines[\\/]turboquant[\\/]/.test(x.binPath))?.id
     if (e.id === 'koboldcpp' || e.id === 'llamafile') return eng.find((x) => x.kind === e.kind)?.id
@@ -476,6 +489,18 @@ function InstallManageCatalog({
     })
   }
   const doEnable = (e: CatalogEngine) => {
+    // Source-built engine that was disabled (registry entry removed, build output still on
+    // disk): re-register the built binary rather than the prebuilt-install path (ADR-100).
+    if (e.sourceBuilt && e.sourceBinPath) {
+      engineMut.add.mutate(
+        { binPath: e.sourceBinPath, name: e.name, sourceRepo: e.homepage, sourceBranch: e.sourceBranch || undefined },
+        {
+          onSuccess: () => toast.success(`${e.name} enabled`),
+          onError: (err) => toast.error(err instanceof ApiError ? err.message : `Could not enable ${e.name}.`),
+        },
+      )
+      return
+    }
     const m = installFor(e)
     if (!m) return
     m.mutate(undefined, {
@@ -637,7 +662,9 @@ function CatalogFitRow({
 }) {
   const e = fit.engine
   const [guideOpen, setGuideOpen] = useState(false)
+  const [rebuildOpen, setRebuildOpen] = useState(false)
   const isLlama = e.id === 'llama.cpp'
+  const sourceBuilt = !!catalog?.sourceBuilt
   const incompatible = fit.compatible.length === 0
   // Compatible here, but no prebuilt for this OS (e.g. ik_llama everywhere, TurboQuant
   // on Windows/Linux) → "build from source → Add your own" instead of a dead Install.
@@ -714,6 +741,7 @@ function CatalogFitRow({
           // llama.cpp is the built-in default — its builds are managed in Zone 3.
           <span className="text-[12px] text-faint">built-in</span>
         ) : !catalog ? null : isInstalled ? (
+          <>
           <DropdownMenu>
             <DropdownMenuTrigger
               aria-label={`Actions for ${e.name}`}
@@ -723,9 +751,17 @@ function CatalogFitRow({
               <MoreHorizontal size={16} />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => onUpdate(catalog)} disabled={provisioning}>
-                <Download size={14} /> {updateStatus?.hasUpdate ? 'Update now' : 'Update'}
-              </DropdownMenuItem>
+              {sourceBuilt ? (
+                // Source-built engines update by RECOMPILING at the latest commit (ADR-088/100),
+                // not by downloading a prebuilt. `rebuild` flags a newer commit on the source repo.
+                <DropdownMenuItem onSelect={() => setRebuildOpen(true)} disabled={anyPending}>
+                  <RefreshCw size={14} /> {updateStatus?.rebuild ? 'Rebuild (new commit)' : 'Rebuild'}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onSelect={() => onUpdate(catalog)} disabled={provisioning}>
+                  <Download size={14} /> {updateStatus?.hasUpdate ? 'Update now' : 'Update'}
+                </DropdownMenuItem>
+              )}
               {isEnabled ? (
                 <DropdownMenuItem onSelect={() => onDisable(catalog)}>Disable</DropdownMenuItem>
               ) : (
@@ -757,6 +793,18 @@ function CatalogFitRow({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          {/* Rebuild: recompile the source-built engine at the latest commit (ADR-088/100). */}
+          {sourceBuilt && catalog && (
+            <BuildGuideDialog
+              open={rebuildOpen}
+              onOpenChange={setRebuildOpen}
+              repoUrl={catalog.homepage}
+              branch={catalog.sourceBranch || undefined}
+              engineName={e.name}
+              mode="rebuild"
+            />
+          )}
+          </>
         ) : buildYourself ? (
           // Build-it-yourself fork — compatible here but no prebuilt for this OS
           // (ik_llama everywhere; TurboQuant on Windows/Linux). Open the guided build

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -43,11 +43,6 @@ import { Button } from '../components/ui/button'
 import { Skeleton } from '../components/ui/skeleton'
 import { toast } from '../components/ui/sonner'
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '../components/ui/collapsible'
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -161,11 +156,12 @@ export function EnginesScreen() {
             rec={recQ.data}
             isLoading={recQ.isLoading}
             activeCatalogId={activeEngine ? catalogIdFor(activeEngine) : null}
-            list={list}
-            backends={backendsQ.data}
             provisioning={provisioning}
           />
         )}
+
+        {/* Other installed llama.cpp builds — separate, below all engines (newest-first). */}
+        <OtherLlamaBuildsSection />
 
         {/* Live engine log */}
         {activeEngine && <EngineLogPanel open={logPanelOpen} onOpenChange={setLogPanelOpen} />}
@@ -407,15 +403,11 @@ function InstallManageCatalog({
   rec,
   isLoading,
   activeCatalogId,
-  list,
-  backends,
   provisioning,
 }: {
   rec: EngineRecommendationResult | undefined
   isLoading: boolean
   activeCatalogId: string | null
-  list: EnginesList | undefined
-  backends: EngineBackends | undefined
   provisioning: boolean
 }) {
   const catalogQ = useEngineCatalog(provisioning)
@@ -571,17 +563,9 @@ function InstallManageCatalog({
         // llama.cpp is the built-in default: its GPU builds are managed inline here (no
         // separate "Advanced" section), so it gets a dedicated row, not the generic one.
         if (fit.engine.id === 'llama.cpp') {
-          return (
-            <LlamaCppManageRow
-              key={fit.engine.id}
-              fit={fit}
-              catalog={catalogById.get(fit.engine.id)}
-              isActive={activeCatalogId === fit.engine.id}
-              list={list}
-              backends={backends}
-              provisioning={provisioning}
-            />
-          )
+          // llama.cpp = the recommended backend (e.g. CUDA), as its own manage-only row.
+          // The other backends live in the "Other llama.cpp builds" section below all engines.
+          return <LlamaCppBackendRows key={fit.engine.id} filter="recommended" />
         }
         const regId = registryEngineId(catalogById.get(fit.engine.id) ?? fit.engine as CatalogEngine)
         return (
@@ -873,150 +857,44 @@ function CatalogFitRow({
   )
 }
 
-// ─── llama.cpp manage row — its GPU builds live inline (no separate "Advanced" zone) ──
+// ─── "Other llama.cpp" section — the non-recommended backends, below all engines ──────
 
-/** llama.cpp is the built-in default, so instead of a second "Advanced" section we manage
- *  it right in its "Install & manage" row: the GPU-build (backend) picker inline, and an
- *  expandable list of installed builds for per-build update/delete. */
-function LlamaCppManageRow({
-  fit,
-  catalog,
-  isActive,
-  list,
-  backends,
-  provisioning,
-}: {
-  fit: EngineFit
-  catalog: CatalogEngine | undefined
-  isActive: boolean
-  list: EnginesList | undefined
-  backends: EngineBackends | undefined
-  provisioning: boolean
-}) {
-  const e = fit.engine
+/** A section BELOW all engines listing the OTHER official llama.cpp backends (ROCm, CPU,
+ *  Vulkan, SYCL — everything except the GPU-recommended one, which lives in "Install &
+ *  manage"). Manage-only (download / update / delete); switching the active engine is done
+ *  from the top "Running now" dropdown, not here. */
+function OtherLlamaBuildsSection() {
+  // Collapsed by default — these are the non-recommended backends, secondary to the catalog.
   const [open, setOpen] = useState(false)
   return (
-    <div className="flex flex-col gap-3 rounded-[var(--radius)] border border-border bg-panel p-4">
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-sm font-semibold text-ink">{e.name}</span>
-            {fit.recommended ? (
-              <Badge variant="accent">
-                <Sparkles size={10} /> Recommended for you
-              </Badge>
-            ) : isActive ? (
-              <span className="flex items-center gap-1 text-[11px] font-medium" style={{ color: 'var(--ok)' }}>
-                <Check size={11} /> Active
-              </span>
-            ) : (
-              <span className="flex items-center gap-1 text-[11px] font-medium text-muted">
-                <Check size={11} /> Installed
-              </span>
-            )}
-            <Badge variant="mono">built-in</Badge>
-            {catalog && (
-              <a
-                href={catalog.homepage}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center gap-0.5 text-[11px] text-muted hover:text-ink"
-                title={catalog.homepage}
-              >
-                <ExternalLink size={10} /> docs
-              </a>
-            )}
-          </div>
-          <div className="mt-0.5 text-[12px] text-muted">{e.description}</div>
+    <section className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 text-left"
+      >
+        <ChevronDown
+          size={14}
+          className="shrink-0 text-muted transition-transform"
+          style={{ transform: open ? 'rotate(0deg)' : 'rotate(-90deg)' }}
+        />
+        <SectionLabel>Other llama.cpp builds</SectionLabel>
+        <span className="text-[11px] text-faint">ROCm · CPU · Vulkan · SYCL</span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-2">
+          <p className="text-[12px] text-muted">
+            The other GPU/CPU backends for llama.cpp. Download one, then switch to it from the engine
+            dropdown up top. The recommended backend is in “Install &amp; manage”.
+          </p>
+          <LlamaCppBackendRows filter="others" />
         </div>
-        <div className="shrink-0 pt-0.5">
-          <BuildPicker list={list} backends={backends} provisioning={provisioning} />
-        </div>
-      </div>
-
-      <Collapsible open={open} onOpenChange={setOpen}>
-        <CollapsibleTrigger className="flex items-center gap-1.5 text-[12px] text-muted hover:text-ink">
-          <ChevronDown size={14} className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
-          Installed builds
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="mt-2">
-            <LlamaCppBackendRows />
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+      )}
+    </section>
   )
 }
 
-/** GPU build dropdown for official llama.cpp (the Build-dropdown behavior lifted out
- *  of the old EngineSelector). Selecting an installed build activates it; selecting an
- *  uninstalled build downloads (then activates) it. */
-function BuildPicker({
-  list,
-  backends,
-  provisioning,
-}: {
-  list: EnginesList | undefined
-  backends: EngineBackends | undefined
-  provisioning: boolean
-}) {
-  const mut = useEngineMutations()
-  const install = useBackendInstall()
-
-  if (!list || !backends) return null
-
-  const busy = provisioning || mut.activate.isPending || install.backend.isPending
-  const activeBuild = backends.backends.find((b) => b.active)
-
-  const selectBuild = (b: EngineBackends['backends'][number]) => {
-    if (b.active) return
-    if (b.installed && b.engineId) {
-      mut.activate.mutate(b.engineId, {
-        onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not switch build.'),
-      })
-    } else {
-      install.backend.mutate(b.id, {
-        onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not download build.'),
-      })
-    }
-  }
-
-  return (
-    <label className="flex flex-col gap-1">
-      <span className="text-[11px] font-medium uppercase tracking-wide text-faint">Build (GPU backend)</span>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          disabled={busy}
-          className="flex h-9 min-w-[220px] items-center gap-2 rounded-lg border border-border bg-bg px-3 text-[13px] text-ink transition-colors hover:border-[color:var(--accent)] disabled:opacity-60"
-        >
-          <Layers size={15} className="text-accent" />
-          <span className="flex-1 truncate text-left">{activeBuild?.label ?? 'Choose a build'}</span>
-          <ChevronDown size={14} className="shrink-0 text-muted" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-[260px]">
-          <div className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
-            Build — which GPU backend
-          </div>
-          {backends.backends.map((b) => (
-            <DropdownMenuItem key={b.id} onSelect={() => selectBuild(b)} className="flex items-center gap-2">
-              <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-                {b.active && <Check size={14} className="text-accent" />}
-              </span>
-              <span className="min-w-0 flex-1 truncate text-ink">{b.label}</span>
-              {b.recommended && (
-                <Sparkles size={11} className="shrink-0 text-accent" aria-label="recommended" />
-              )}
-              <span className="shrink-0 text-[11px] text-muted">
-                {b.active ? 'active' : b.installed ? 'installed' : 'download'}
-              </span>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </label>
-  )
-}
 
 // ─── shared helpers ───────────────────────────────────────────────────────────
 

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -9,7 +9,6 @@ import {
   Loader2,
   MoreHorizontal,
   RefreshCw,
-  Settings2,
   Sparkles,
   Wrench,
 } from 'lucide-react'
@@ -162,11 +161,11 @@ export function EnginesScreen() {
             rec={recQ.data}
             isLoading={recQ.isLoading}
             activeCatalogId={activeEngine ? catalogIdFor(activeEngine) : null}
+            list={list}
+            backends={backendsQ.data}
+            provisioning={provisioning}
           />
         )}
-
-        {/* Zone 3 — Advanced */}
-        <AdvancedSection list={list} backends={backendsQ.data} provisioning={provisioning} />
 
         {/* Live engine log */}
         {activeEngine && <EngineLogPanel open={logPanelOpen} onOpenChange={setLogPanelOpen} />}
@@ -408,13 +407,17 @@ function InstallManageCatalog({
   rec,
   isLoading,
   activeCatalogId,
+  list,
+  backends,
+  provisioning,
 }: {
   rec: EngineRecommendationResult | undefined
   isLoading: boolean
   activeCatalogId: string | null
+  list: EnginesList | undefined
+  backends: EngineBackends | undefined
+  provisioning: boolean
 }) {
-  const { data: status } = useStatus()
-  const provisioning = !!status?.engineProvision?.active
   const catalogQ = useEngineCatalog(provisioning)
   const { data: registry } = useEngines()
   const { data: updates } = useEngineUpdates(provisioning)
@@ -565,6 +568,21 @@ function InstallManageCatalog({
           return fit.engine.id === 'vllm' || !c || c.supportedHere !== false
         })
         .map((fit) => {
+        // llama.cpp is the built-in default: its GPU builds are managed inline here (no
+        // separate "Advanced" section), so it gets a dedicated row, not the generic one.
+        if (fit.engine.id === 'llama.cpp') {
+          return (
+            <LlamaCppManageRow
+              key={fit.engine.id}
+              fit={fit}
+              catalog={catalogById.get(fit.engine.id)}
+              isActive={activeCatalogId === fit.engine.id}
+              list={list}
+              backends={backends}
+              provisioning={provisioning}
+            />
+          )
+        }
         const regId = registryEngineId(catalogById.get(fit.engine.id) ?? fit.engine as CatalogEngine)
         return (
         <CatalogFitRow
@@ -855,42 +873,79 @@ function CatalogFitRow({
   )
 }
 
-// ─── Zone 3 — Advanced ────────────────────────────────────────────────────────
+// ─── llama.cpp manage row — its GPU builds live inline (no separate "Advanced" zone) ──
 
-function AdvancedSection({
+/** llama.cpp is the built-in default, so instead of a second "Advanced" section we manage
+ *  it right in its "Install & manage" row: the GPU-build (backend) picker inline, and an
+ *  expandable list of installed builds for per-build update/delete. */
+function LlamaCppManageRow({
+  fit,
+  catalog,
+  isActive,
   list,
   backends,
   provisioning,
 }: {
+  fit: EngineFit
+  catalog: CatalogEngine | undefined
+  isActive: boolean
   list: EnginesList | undefined
   backends: EngineBackends | undefined
   provisioning: boolean
 }) {
+  const e = fit.engine
   const [open, setOpen] = useState(false)
   return (
-    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-panel-2">
-      <CollapsibleTrigger className="flex w-full items-center gap-2 px-4 py-3 text-left">
-        <Settings2 size={15} className="shrink-0 text-muted" />
-        <span className="flex-1 text-[13px] font-medium text-ink">
-          Advanced — pick a specific GPU build · manage installed backends
-        </span>
-        <ChevronDown size={15} className={`shrink-0 text-muted transition-transform ${open ? 'rotate-180' : ''}`} />
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="flex flex-col gap-3 border-t border-border px-4 py-4">
-          <div>
-            <div className="mb-2 text-[12px] text-muted">
-              The GPU build is the only place you choose llama.cpp&apos;s compiled backend (CUDA, Vulkan, Metal, CPU).
-            </div>
-            <BuildPicker list={list} backends={backends} provisioning={provisioning} />
+    <div className="flex flex-col gap-3 rounded-[var(--radius)] border border-border bg-panel p-4">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-sm font-semibold text-ink">{e.name}</span>
+            {fit.recommended ? (
+              <Badge variant="accent">
+                <Sparkles size={10} /> Recommended for you
+              </Badge>
+            ) : isActive ? (
+              <span className="flex items-center gap-1 text-[11px] font-medium" style={{ color: 'var(--ok)' }}>
+                <Check size={11} /> Active
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-[11px] font-medium text-muted">
+                <Check size={11} /> Installed
+              </span>
+            )}
+            <Badge variant="mono">built-in</Badge>
+            {catalog && (
+              <a
+                href={catalog.homepage}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-0.5 text-[11px] text-muted hover:text-ink"
+                title={catalog.homepage}
+              >
+                <ExternalLink size={10} /> docs
+              </a>
+            )}
           </div>
-          <div className="flex flex-col gap-2">
-            <SectionLabel>Installed llama.cpp builds</SectionLabel>
+          <div className="mt-0.5 text-[12px] text-muted">{e.description}</div>
+        </div>
+        <div className="shrink-0 pt-0.5">
+          <BuildPicker list={list} backends={backends} provisioning={provisioning} />
+        </div>
+      </div>
+
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="flex items-center gap-1.5 text-[12px] text-muted hover:text-ink">
+          <ChevronDown size={14} className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+          Installed builds
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-2">
             <LlamaCppBackendRows />
           </div>
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
   )
 }
 

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -368,6 +368,7 @@ function StatusHero({
           repoUrl={activeEngine.sourceRepo}
           branch={activeEngine.sourceBranch}
           engineName={activeEngine.name}
+          mode="rebuild"
         />
       )}
     </div>

--- a/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
+++ b/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
@@ -1,7 +1,17 @@
-import { useState } from 'react'
-import { CheckCircle2, Copy, ExternalLink, Loader2, XCircle } from 'lucide-react'
-import { useBuildPrereqs } from '../../lib/queries'
-import type { BuildPrereqTool } from '../../lib/types'
+import { useEffect, useRef, useState } from 'react'
+import {
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Hammer,
+  Loader2,
+  Plus,
+  RefreshCw,
+  X,
+  XCircle,
+} from 'lucide-react'
+import { useBuild, useBuildPrereqs, useSettings, useStatus } from '../../lib/queries'
+import type { BuildPrereqTool, EngineBuild } from '../../lib/types'
 import { Button } from '../../components/ui/button'
 import {
   Dialog,
@@ -14,8 +24,8 @@ import {
 import { AddEngineDialog } from './AddEngineDialog'
 
 /** The exact Windows + CUDA build command list for a repo (mirrors the backend's PURE
- *  `buildCommands` in src/engines/build-prereqs.ts — kept in lockstep so the guide shows
- *  what the docs describe). */
+ *  `buildCommands` in src/engines/build-prereqs.ts — kept in lockstep so the manual path
+ *  matches what the 1-click build runs). */
 function buildCommands(repoUrl: string, branch?: string): string[] {
   const b = (branch ?? '').trim()
   const clone = b
@@ -30,31 +40,76 @@ function buildCommands(repoUrl: string, branch?: string): string[] {
   ]
 }
 
-/** Guided compile-from-source dialog (ADR-089). GUIDED only — we never build in-app.
- *  On Windows: a prereq checklist (with install links for what's missing), the exact
- *  Windows + CUDA build commands with a copy button, then a hand-off to "Add your own
- *  engine" with the repo prefilled. Off Windows the guided build is parked, so we just
- *  point at the repo + its upstream build docs. */
+const PHASE_LABEL: Record<EngineBuild['phase'], string> = {
+  preparing: 'Preparing…',
+  cloning: 'Cloning the repository…',
+  configuring: 'Configuring (cmake)…',
+  compiling: 'Compiling llama-server… this can take several minutes',
+  registering: 'Registering the built engine…',
+  done: 'Built and registered ✓',
+  error: 'Build failed',
+}
+
+/** Compile-from-source dialog (ADR-089 + ADR-100). On Windows + CUDA: a prereq checklist,
+ *  an editable "Build environment" (PATH dirs so a conda-env / custom CUDA Toolkit is found),
+ *  a 1-click "Build it for me" that clones + compiles + registers in-app with live progress,
+ *  and the manual command path as a fallback. Off Windows the guided build is parked. */
 export function BuildGuideDialog({
   open,
   onOpenChange,
   repoUrl,
   engineName,
   branch,
+  mode = 'build',
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   repoUrl: string
   engineName: string
   branch?: string
+  /** 'rebuild' relabels the action for the ADR-088 "newer source" chip. */
+  mode?: 'build' | 'rebuild'
 }) {
   // Only probe the toolchain while the dialog is open.
   const prereqsQ = useBuildPrereqs(open)
+  const settings = useSettings()
+  const statusQ = useStatus()
+  const build = useBuild()
   const [copied, setCopied] = useState(false)
   const [addOpen, setAddOpen] = useState(false)
+  const [buildStarted, setBuildStarted] = useState(false)
+
+  // Build-environment editor draft (null until edited → show the saved dirs).
+  const savedDirs = settings.query.data?.build.toolchainDirs ?? []
+  const [draftDirs, setDraftDirs] = useState<string[] | null>(null)
+  const dirs = draftDirs ?? savedDirs
 
   const commands = buildCommands(repoUrl, branch)
   const commandText = commands.join('\n')
+
+  const supported = prereqsQ.data?.supported ?? null
+  const tools = prereqsQ.data?.tools ?? []
+  const missingRequired = tools.filter((t) => (t.id === 'git' || t.id === 'cmake' || t.id === 'cuda') && !t.found)
+
+  const engineBuild = statusQ.data?.engineBuild
+  const buildActive = !!engineBuild?.active
+  const provisionActive = !!statusQ.data?.engineProvision?.active
+  const showProgress = buildStarted || buildActive
+  const canBuild = supported === true && missingRequired.length === 0 && !buildActive && !provisionActive
+
+  // When a build we kicked off settles, pull the new/updated engine into the lists.
+  useEffect(() => {
+    if (buildStarted && engineBuild && !engineBuild.active && (engineBuild.phase === 'done' || engineBuild.phase === 'error')) {
+      build.refresh()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [buildStarted, engineBuild?.active, engineBuild?.phase])
+
+  // Auto-scroll the log to the newest line.
+  const logRef = useRef<HTMLPreElement>(null)
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [engineBuild?.log])
 
   const copy = () => {
     void navigator.clipboard.writeText(commandText).then(() => {
@@ -63,15 +118,31 @@ export function BuildGuideDialog({
     })
   }
 
-  const supported = prereqsQ.data?.supported ?? null
+  const recheck = async () => {
+    // Persist the edited dirs (filtering blanks), then re-probe with the new PATH.
+    await settings.save.mutateAsync({ build: { toolchainDirs: dirs.map((d) => d.trim()).filter(Boolean) } })
+    setDraftDirs(null)
+    void prereqsQ.refetch()
+  }
+
+  const startBuild = () => {
+    setBuildStarted(true)
+    build.start.mutate({ repoUrl, branch, name: engineName })
+  }
+
+  const actionLabel = mode === 'rebuild' ? 'Rebuild now' : 'Build it for me'
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Build {engineName} from source</DialogTitle>
+          <DialogTitle>
+            {mode === 'rebuild' ? 'Rebuild' : 'Build'} {engineName} from source
+          </DialogTitle>
           <DialogDescription>
-            No prebuilt binary for your system — compile it yourself, then add the binary.
+            {mode === 'rebuild'
+              ? 'A newer commit is available — recompile from source and replace the binary.'
+              : 'No prebuilt binary for your system — compile it here, or build it yourself and add it.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -84,7 +155,7 @@ export function BuildGuideDialog({
           // Parked OS (Linux/macOS): point at the repo + upstream build docs.
           <div className="flex flex-col gap-3">
             <div className="rounded-lg border border-border bg-panel p-4 text-[13px] text-muted">
-              Guided build is currently <span className="font-medium text-ink">Windows + CUDA</span> only.
+              In-app build is currently <span className="font-medium text-ink">Windows + CUDA</span> only.
               On your system, clone the repo and follow its upstream build instructions, then add the
               resulting <code className="font-mono">llama-server</code> binary via “Add your own engine”.
             </div>
@@ -98,46 +169,100 @@ export function BuildGuideDialog({
             </a>
           </div>
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="flex max-h-[60vh] flex-col gap-4 overflow-y-auto">
             {/* Prereq checklist */}
             <div className="flex flex-col gap-1.5">
-              <p className="text-[11px] font-medium uppercase tracking-wide text-faint">
-                Build prerequisites
-              </p>
+              <p className="text-[11px] font-medium uppercase tracking-wide text-faint">Build prerequisites</p>
               <div className="flex flex-col gap-1.5 rounded-lg border border-border bg-panel p-3">
-                {(prereqsQ.data?.tools ?? []).map((t) => (
+                {tools.map((t) => (
                   <PrereqRow key={t.id} tool={t} />
                 ))}
               </div>
             </div>
 
-            {/* Build commands */}
+            {/* Build environment (PATH override) — ADR-100 */}
             <div className="flex flex-col gap-1.5">
-              <div className="flex items-center justify-between">
-                <p className="text-[11px] font-medium uppercase tracking-wide text-faint">
-                  Build commands (Windows + CUDA)
+              <p className="text-[11px] font-medium uppercase tracking-wide text-faint">Build environment</p>
+              <div className="flex flex-col gap-2 rounded-lg border border-border bg-panel p-3">
+                <p className="text-[12px] text-muted">
+                  If your CUDA Toolkit or compiler lives in a conda env or a custom location (not on the
+                  system PATH), add that folder — e.g. the env’s <code className="font-mono">bin</code> — so
+                  TurboLLM finds <code className="font-mono">nvcc</code>. Then re-check.
                 </p>
-                <button
-                  type="button"
-                  onClick={copy}
-                  className="inline-flex items-center gap-1 text-[12px] text-muted hover:text-ink"
-                >
-                  {copied ? <CheckCircle2 size={13} style={{ color: 'var(--ok)' }} /> : <Copy size={13} />}
-                  {copied ? 'Copied' : 'Copy'}
-                </button>
+                {dirs.map((dir, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <input
+                      value={dir}
+                      onChange={(e) => {
+                        const next = [...dirs]
+                        next[i] = e.target.value
+                        setDraftDirs(next)
+                      }}
+                      placeholder="C:\\Users\\you\\miniconda3\\envs\\cuda\\Library\\bin"
+                      className="min-w-0 flex-1 rounded-md border border-border bg-panel-2 px-2 py-1 font-mono text-[12px] text-ink outline-none focus:border-accent"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setDraftDirs(dirs.filter((_, j) => j !== i))}
+                      className="shrink-0 rounded-md p-1 text-faint hover:text-ink"
+                      aria-label="Remove folder"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ))}
+                <div className="flex items-center justify-between">
+                  <button
+                    type="button"
+                    onClick={() => setDraftDirs([...dirs, ''])}
+                    className="inline-flex items-center gap-1 text-[12px] text-muted hover:text-ink"
+                  >
+                    <Plus size={13} /> Add folder
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void recheck()}
+                    disabled={settings.save.isPending || prereqsQ.isFetching}
+                    className="inline-flex items-center gap-1 text-[12px] text-accent hover:underline disabled:opacity-50"
+                  >
+                    {settings.save.isPending || prereqsQ.isFetching ? (
+                      <Loader2 size={13} className="animate-spin" />
+                    ) : (
+                      <RefreshCw size={13} />
+                    )}
+                    Re-check
+                  </button>
+                </div>
               </div>
-              <pre className="overflow-x-auto rounded-lg border border-border bg-panel-2 p-3 font-mono text-[12px] leading-relaxed text-ink">
-                {commandText}
-              </pre>
-              <a
-                href={repoUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 self-start text-[12px] text-muted hover:text-ink"
-              >
-                Open {engineName} repo <ExternalLink size={11} />
-              </a>
             </div>
+
+            {/* Live build progress (ADR-100) */}
+            {showProgress && engineBuild && (
+              <BuildProgress build={engineBuild} logRef={logRef} onCancel={() => build.cancel.mutate()} />
+            )}
+
+            {/* Manual build commands (fallback / transparency) */}
+            <details className="group">
+              <summary className="cursor-pointer list-none text-[11px] font-medium uppercase tracking-wide text-faint hover:text-muted">
+                Or build it yourself (manual commands)
+              </summary>
+              <div className="mt-1.5 flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <p className="text-[11px] text-faint">Windows + CUDA</p>
+                  <button
+                    type="button"
+                    onClick={copy}
+                    className="inline-flex items-center gap-1 text-[12px] text-muted hover:text-ink"
+                  >
+                    {copied ? <CheckCircle2 size={13} style={{ color: 'var(--ok)' }} /> : <Copy size={13} />}
+                    {copied ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+                <pre className="overflow-x-auto rounded-lg border border-border bg-panel-2 p-3 font-mono text-[12px] leading-relaxed text-ink">
+                  {commandText}
+                </pre>
+              </div>
+            </details>
           </div>
         )}
 
@@ -146,9 +271,15 @@ export function BuildGuideDialog({
             Close
           </Button>
           {supported !== false && (
-            <Button onClick={() => setAddOpen(true)} disabled={prereqsQ.isLoading}>
-              I&apos;ve built it → Add your own engine
-            </Button>
+            <>
+              <Button variant="outline" onClick={() => setAddOpen(true)} disabled={prereqsQ.isLoading || buildActive}>
+                I&apos;ve built it
+              </Button>
+              <Button onClick={startBuild} disabled={!canBuild}>
+                <Hammer size={15} className="mr-1.5" />
+                {buildActive ? 'Building…' : actionLabel}
+              </Button>
+            </>
           )}
         </DialogFooter>
       </DialogContent>
@@ -161,6 +292,49 @@ export function BuildGuideDialog({
         trigger={null}
       />
     </Dialog>
+  )
+}
+
+/** Live phase + scrolling log while a build runs, with a Cancel while active. */
+function BuildProgress({
+  build,
+  logRef,
+  onCancel,
+}: {
+  build: EngineBuild
+  logRef: React.RefObject<HTMLPreElement | null>
+  onCancel: () => void
+}) {
+  const isError = build.phase === 'error'
+  const isDone = build.phase === 'done'
+  const accent = isError ? 'var(--err, #ef4444)' : isDone ? 'var(--ok)' : 'var(--accent)'
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-panel p-3">
+      <div className="flex items-center gap-2 text-[13px]">
+        {build.active ? (
+          <Loader2 size={15} className="shrink-0 animate-spin" style={{ color: accent }} />
+        ) : isError ? (
+          <XCircle size={15} className="shrink-0" style={{ color: accent }} />
+        ) : (
+          <CheckCircle2 size={15} className="shrink-0" style={{ color: accent }} />
+        )}
+        <span className="text-ink">{PHASE_LABEL[build.phase]}</span>
+        {build.active && (
+          <button type="button" onClick={onCancel} className="ml-auto text-[12px] text-faint hover:text-ink">
+            Cancel
+          </button>
+        )}
+      </div>
+      {isError && build.error && <p className="text-[12px]" style={{ color: accent }}>{build.error}</p>}
+      {build.log.length > 0 && (
+        <pre
+          ref={logRef}
+          className="max-h-40 overflow-auto rounded-md border border-border bg-panel-2 p-2 font-mono text-[11px] leading-relaxed text-muted"
+        >
+          {build.log.join('\n')}
+        </pre>
+      )}
+    </div>
   )
 }
 

--- a/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
+++ b/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import {
   CheckCircle2,
   Copy,
+  Download,
   ExternalLink,
   Hammer,
   Loader2,
@@ -41,6 +42,7 @@ function buildCommands(repoUrl: string, branch?: string): string[] {
 }
 
 const PHASE_LABEL: Record<EngineBuild['phase'], string> = {
+  provisioning: 'Downloading CUDA Toolkit…',
   preparing: 'Preparing…',
   cloning: 'Cloning the repository…',
   configuring: 'Configuring (cmake)…',
@@ -77,7 +79,9 @@ export function BuildGuideDialog({
   const build = useBuild()
   const [copied, setCopied] = useState(false)
   const [addOpen, setAddOpen] = useState(false)
-  const [buildStarted, setBuildStarted] = useState(false)
+  // What the user last kicked off, so we can tell a CUDA download apart from a build (both
+  // stream through engineBuild + end at phase 'done', but only a build shows the success screen).
+  const [intent, setIntent] = useState<'build' | 'cuda' | null>(null)
 
   // Build-environment editor draft (null until edited → show the saved dirs).
   const savedDirs = settings.query.data?.build.toolchainDirs ?? []
@@ -94,16 +98,28 @@ export function BuildGuideDialog({
   const engineBuild = statusQ.data?.engineBuild
   const buildActive = !!engineBuild?.active
   const provisionActive = !!statusQ.data?.engineProvision?.active
-  const showProgress = buildStarted || buildActive
+  const showProgress = intent !== null || buildActive
+  const cudaMissing = tools.some((t) => t.id === 'cuda' && !t.found)
   const canBuild = supported === true && missingRequired.length === 0 && !buildActive && !provisionActive
 
-  // When a build we kicked off settles, pull the new/updated engine into the lists.
+  // When the step we kicked off settles: a finished CUDA download → re-probe so CUDA flips to
+  // ✓ and the build enables (and hide the progress); a finished build → pull the new engine
+  // into the lists. A CUDA *error* stays visible so the user sees why it failed.
   useEffect(() => {
-    if (buildStarted && engineBuild && !engineBuild.active && (engineBuild.phase === 'done' || engineBuild.phase === 'error')) {
+    if (!intent || !engineBuild || engineBuild.active) return
+    if (engineBuild.phase === 'done') {
+      if (intent === 'cuda') {
+        void prereqsQ.refetch()
+        void settings.query.refetch()
+        setIntent(null)
+      } else {
+        build.refresh()
+      }
+    } else if (engineBuild.phase === 'error' && intent === 'build') {
       build.refresh()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [buildStarted, engineBuild?.active, engineBuild?.phase])
+  }, [intent, engineBuild?.active, engineBuild?.phase])
 
   // Auto-scroll the log to the newest line.
   const logRef = useRef<HTMLPreElement>(null)
@@ -126,8 +142,13 @@ export function BuildGuideDialog({
   }
 
   const startBuild = () => {
-    setBuildStarted(true)
+    setIntent('build')
     build.start.mutate({ repoUrl, branch, name: engineName })
+  }
+
+  const downloadCuda = () => {
+    setIntent('cuda')
+    build.cuda.mutate()
   }
 
   const actionLabel = mode === 'rebuild' ? 'Rebuild now' : 'Build it for me'
@@ -175,9 +196,20 @@ export function BuildGuideDialog({
               <p className="text-[11px] font-medium uppercase tracking-wide text-faint">Build prerequisites</p>
               <div className="flex flex-col gap-1.5 rounded-lg border border-border bg-panel p-3">
                 {tools.map((t) => (
-                  <PrereqRow key={t.id} tool={t} />
+                  <PrereqRow
+                    key={t.id}
+                    tool={t}
+                    // CUDA can be auto-downloaded (ADR-101); offer it instead of just a link.
+                    onDownload={t.id === 'cuda' && !t.found && !showProgress ? downloadCuda : undefined}
+                  />
                 ))}
               </div>
+              {cudaMissing && !showProgress && (
+                <p className="text-[11px] text-faint">
+                  No CUDA Toolkit found. <span className="text-muted">Download CUDA</span> grabs NVIDIA’s
+                  official build components (~0.5&nbsp;GB) automatically — no installer needed.
+                </p>
+              )}
             </div>
 
             {/* Build environment (PATH override) — ADR-100 */}
@@ -238,7 +270,13 @@ export function BuildGuideDialog({
 
             {/* Live build progress (ADR-100) */}
             {showProgress && engineBuild && (
-              <BuildProgress build={engineBuild} logRef={logRef} onCancel={() => build.cancel.mutate()} />
+              <BuildProgress
+                build={engineBuild}
+                kind={intent === 'cuda' ? 'cuda' : 'build'}
+                logRef={logRef}
+                onCancel={() => build.cancel.mutate()}
+                onClose={() => onOpenChange(false)}
+              />
             )}
 
             {/* Manual build commands (fallback / transparency) */}
@@ -295,19 +333,55 @@ export function BuildGuideDialog({
   )
 }
 
-/** Live phase + scrolling log while a build runs, with a Cancel while active. */
+/** Live phase + scrolling log while a build runs, with a Cancel while active. On success it
+ *  becomes a celebratory "engine ready" screen; on failure it shows the error + log. */
 function BuildProgress({
   build,
+  kind,
   logRef,
   onCancel,
+  onClose,
 }: {
   build: EngineBuild
+  /** 'build' shows the celebratory engine-ready screen on success; 'cuda' (a toolkit
+   *  download) just streams progress — its completion is handled by re-probing prereqs. */
+  kind: 'build' | 'cuda'
   logRef: React.RefObject<HTMLPreElement | null>
   onCancel: () => void
+  onClose: () => void
 }) {
   const isError = build.phase === 'error'
   const isDone = build.phase === 'done'
   const accent = isError ? 'var(--err, #ef4444)' : isDone ? 'var(--ok)' : 'var(--accent)'
+
+  // Success screen — distinct, celebratory; the engine is built + active. Only for a build;
+  // a finished CUDA download is dismissed by the parent (which re-probes prereqs).
+  if (isDone && kind === 'build') {
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-lg border p-5 text-center" style={{ borderColor: 'color-mix(in srgb, var(--ok) 40%, var(--border))', background: 'color-mix(in srgb, var(--ok) 8%, transparent)' }}>
+        <div className="flex h-12 w-12 items-center justify-center rounded-full" style={{ background: 'color-mix(in srgb, var(--ok) 18%, transparent)' }}>
+          <CheckCircle2 size={28} style={{ color: 'var(--ok)' }} />
+        </div>
+        <div className="flex flex-col gap-1">
+          <p className="text-[15px] font-semibold text-ink">Engine ready 🎉</p>
+          <p className="text-[13px] text-muted">
+            <span className="font-medium text-ink">{build.engine}</span> was built from source, bundled
+            with its CUDA runtime, and set as your active engine. Load a model to start using it.
+          </p>
+        </div>
+        <details className="w-full">
+          <summary className="cursor-pointer list-none text-[11px] uppercase tracking-wide text-faint hover:text-muted">
+            Build log
+          </summary>
+          <pre className="mt-1.5 max-h-40 overflow-auto rounded-md border border-border bg-panel-2 p-2 text-left font-mono text-[11px] leading-relaxed text-muted">
+            {build.log.join('\n')}
+          </pre>
+        </details>
+        <Button onClick={onClose} className="mt-1">Done</Button>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border bg-panel p-3">
       <div className="flex items-center gap-2 text-[13px]">
@@ -338,8 +412,9 @@ function BuildProgress({
   )
 }
 
-/** One prereq row: ✓ found (with version) or ✗ missing (with an install link). */
-function PrereqRow({ tool }: { tool: BuildPrereqTool }) {
+/** One prereq row: ✓ found (with version) or ✗ missing. A missing tool offers an install
+ *  link; CUDA additionally offers a one-click auto-download (`onDownload`, ADR-101). */
+function PrereqRow({ tool, onDownload }: { tool: BuildPrereqTool; onDownload?: () => void }) {
   return (
     <div className="flex items-center gap-2 text-[13px]">
       {tool.found ? (
@@ -350,14 +425,26 @@ function PrereqRow({ tool }: { tool: BuildPrereqTool }) {
       <span className="text-ink">{tool.name}</span>
       {tool.found && tool.version && <span className="text-[12px] text-muted">{tool.version}</span>}
       {!tool.found && (
-        <a
-          href={tool.installUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="ml-auto inline-flex items-center gap-1 text-[12px] text-accent hover:underline"
-        >
-          Install <ExternalLink size={11} />
-        </a>
+        <span className="ml-auto inline-flex items-center gap-3">
+          {onDownload && (
+            <button
+              type="button"
+              onClick={onDownload}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[12px] font-medium transition-colors hover:opacity-80"
+              style={{ background: 'color-mix(in srgb, var(--accent) 15%, transparent)', color: 'var(--accent)' }}
+            >
+              <Download size={12} /> Download CUDA
+            </button>
+          )}
+          <a
+            href={tool.installUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-[12px] text-accent hover:underline"
+          >
+            {onDownload ? 'or install manually' : 'Install'} <ExternalLink size={11} />
+          </a>
+        </span>
       )}
     </div>
   )

--- a/turbollm/web/src/screens/engines/ManagedEngines.tsx
+++ b/turbollm/web/src/screens/engines/ManagedEngines.tsx
@@ -35,6 +35,12 @@ const SIZE_HINT: Record<string, string> = {
   cuda: '~550 MB', rocm: '~320 MB', sycl: '~110 MB', vulkan: '~40 MB', metal: '~11 MB', cpu: '~16 MB',
 }
 
+/** Short backend name so rows read "llama.cpp (CUDA)" / "llama.cpp (ROCm)" — each official
+ *  llama.cpp backend is presented as its own engine variant. */
+const SHORT_BACKEND: Record<string, string> = {
+  cuda: 'CUDA', rocm: 'ROCm', sycl: 'SYCL', vulkan: 'Vulkan', metal: 'Metal', cpu: 'CPU',
+}
+
 const POLICY_LABEL: Record<UpdatePolicy, string> = {
   off: 'Off',
   notify: 'Notify',
@@ -80,11 +86,11 @@ function UpdateStatusLine({ st }: { st: EngineUpdateStatus | undefined }) {
   )
 }
 
-/** One flat row per official llama.cpp backend variant. 3-state lifecycle:
- *  Not installed → Download button.
- *  Installed + enabled → "Installed" indicator + ⋯ menu (Update / Disable / Delete).
- *  Installed + disabled → "Disabled" badge + ⋯ menu (Update / Enable / Delete). */
-export function LlamaCppBackendRows() {
+/** One flat row per official llama.cpp backend variant. Manage-only (download / update /
+ *  delete) — switching the active engine is done from the top "Running now" dropdown, not here.
+ *  `filter` splits the list: 'recommended' shows only the GPU-recommended backend (for the
+ *  catalog), 'others' shows the rest (for the "Other llama.cpp" section). */
+export function LlamaCppBackendRows({ filter }: { filter?: 'recommended' | 'others' } = {}) {
   const { data: status } = useStatus()
   const provisioning = !!status?.engineProvision?.active
   const { data, isLoading } = useEngineBackends(provisioning)
@@ -163,9 +169,13 @@ export function LlamaCppBackendRows() {
       },
     })
 
+  const rows = data.backends.filter((b) =>
+    filter === 'recommended' ? b.recommended : filter === 'others' ? !b.recommended : true,
+  )
+
   return (
     <>
-      {data.backends.map((b) => {
+      {rows.map((b) => {
         const up = statusFor(b.engineId)
         const policy = policyFor(b.engineId)
         return (
@@ -175,8 +185,7 @@ export function LlamaCppBackendRows() {
         >
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-sm font-semibold text-ink">{b.label}</span>
-              <Badge variant="default">official</Badge>
+              <span className="text-sm font-semibold text-ink">llama.cpp ({SHORT_BACKEND[b.id] ?? b.label})</span>
               {b.recommended && (
                 <span className="flex items-center gap-0.5 text-[11px] text-accent">
                   <Sparkles size={10} /> recommended


### PR DESCRIPTION
## What

Makes the in-app **compile-from-source** flow genuinely end-to-end on Windows + CUDA, including **downloading CUDA itself** when it's not installed — plus an **Engines-screen rework** so every llama.cpp backend is its own engine.

### 1-click build (ADR-089 → ADR-100)
- Build guide now *runs* the build: clone → `cmake` → compile `llama-server` → **bundle the CUDA runtime DLLs** → **probe + register + activate**, with a live phase + streaming compiler log and a **success screen**. Manual command path kept as a fallback.
- Builds with **Ninja inside the MSVC dev env** (`vcvarsall`, located via vswhere), driving `nvcc` directly (NMake fallback). This is what makes a **standalone / conda CUDA** work — the default Visual Studio generator needs the CUDA VS-integration props a standalone toolkit lacks.
- **Self-contained output**: copies `cudart`/`cublas`/`cublasLt` next to the exe (anchored on nvcc's toolkit, incl. CUDA 13's `bin\x64` layout) so it runs without CUDA on PATH.

### Editable build environment (the reported CUDA-not-found fix)
- `build.toolchainDirs` — folders prepended to PATH for both detection and the build, so a CUDA Toolkit / compiler in a **conda env or custom path** is found. Editable in the dialog with a **Re-check** button.

### Automatic CUDA download (ADR-101)
- No CUDA Toolkit? **Download CUDA** assembles one from NVIDIA's official redist component archives — required `cuda_nvcc`/`cuda_cudart`/`libcublas`/`cuda_cccl` + (CUDA 13) `libnvvm` (the `cicc` compiler) + `cuda_crt` (the real `crt/` headers); **driver-aware version pick** via `nvidia-smi`. ~490 MB (deliberately skips the 318 MB `nvrtc` — ggml-cuda is AOT-compiled). Streams via the `engineBuild` `provisioning` phase.

### Engines screen rework — each backend is its own engine
- Every official llama.cpp backend (**CUDA/ROCm/CPU/Vulkan/SYCL**) is presented as its own engine, switched **only** from the top "Running now" dropdown — no per-row Use buttons.
- The **recommended** backend shows in "Install & manage"; the rest live in a **collapsible "Other llama.cpp builds"** section (collapsed by default) below all engines.
- Grouping is per-backend (`official-llama-<backend>`, labelled "llama.cpp (CUDA)"); multiple builds of one backend still collapse into that engine, sorted **newest-first**.

### Tag-agnostic backend management (fixes "not installed" / duplicate downloads)
- The update/enable/delete/install routes checked only the **pinned `LLAMA_BUILD`** tag, so a build **de-pinned by a prior update** (ADR-085) falsely read as *not installed* — producing `Backend is not installed — download it first` and duplicate re-downloads.
- New tag-agnostic `installedBackendBuild()` (newest build on disk for a backend) + `deleteAllBackendBuilds()`. Update/enable/delete/install-precheck now resolve the **real** installed build regardless of tag; delete removes **all** builds + registry entries.

### Source-built engine management + Rebuild (ADR-088)
- A fork compiled from the catalog repo shows the manage menu (rebuild/disable/delete) instead of a stale "Build from source"; the "newer source available" chip recompiles in place at the latest commit (gated on a real git-commit comparison).

## Live verification (RTX 5070 Ti)
- Built mainline llama.cpp **against a standalone CUDA**, **against the auto-downloaded CUDA 13.0.1 with no local toolkit** (download → compile ggml-cuda `.cu` kernels → link → bundle → register), and exercised the toolchain-PATH override (✗→✓ CUDA detection).
- Engines rework + the backend fix verified live: per-backend dropdown, collapsible section, and an **end-to-end Update** (resolved a newer upstream build, swapped active, GC'd the old build — one clean CUDA engine left).
- **410 tests pass** (backend + web typecheck + build clean).

## Notes / safety
- Windows + CUDA only (Linux/macOS build parked). Build + CUDA-download routes are **local-host gated** (compiler runs from a user-supplied repo); `spawn` without a shell (no injection); build↔download mutually exclusive; cancellable.
- No tag/publish in this PR — build/test/PR only, per the ADR-079 dev cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
