### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,28 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.3.1] - 2026-06-22
+
+**TurboQuant installs and updates on macOS again, plus a Linux build and a Metal first-run fix.**
+
+### Added
+- **CPU option on macOS.** The Apple-Silicon Metal binary also runs CPU-only, so it now appears
+  as a separate CPU backend too — the engine recommender always has a CPU variant to fall back to.
+- **TurboQuant on Linux.** Linux x64 (Vulkan) is now listed as installable in the engine catalog.
+
+### Fixed
+- **TurboQuant install/update failing on macOS** with `no_release_asset`. The resolver used
+  GitHub's `/releases/latest`, but TurboQuant publishes one release per OS, so the latest tag was
+  often Linux-only and Mac users got nothing. It now scans releases for the newest one carrying a
+  binary for the current platform.
+- **Metal engines timing out on first launch.** macOS Metal builds JIT-compile their shaders on
+  first run (10–30 s), which overran the 10 s probe and failed the engine. The probe now allows
+  60 s on macOS (15 s elsewhere).
+
+### Changed
+- Unified TurboQuant's install and update paths onto a single per-platform release resolver so
+  they can't drift apart, and removed the now-dead duplicate code.
+
 ## [1.3.0] - 2026-06-22
 
 **End-to-end engine builds — compile a CUDA llama.cpp (or any fork) from inside the app, downloading CUDA itself if you don't have it.**

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",


### PR DESCRIPTION
Release prep for **v1.3.1** (patch / bugfix).

Bumps `turbollm/package.json` to 1.3.1 and moves the changelog `[Unreleased]` notes into the dated `[1.3.1]` section. No code changes beyond the v1.3.0→v1.3.1 fixes already merged in #13.

### What ships in 1.3.1
- **Fixed:** TurboQuant install/update on macOS (`no_release_asset`) — per-platform release scan.
- **Fixed:** Metal engine probe timeout on first-run shader JIT (60s macOS / 15s elsewhere).
- **Added:** macOS CPU backend variant; TurboQuant listed installable on Linux.
- **Changed:** unified TurboQuant install/update resolver; removed dead duplicate code.