### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,9 +25,9 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
-## [1.3.1] - 2026-06-22
+## [1.3.2] - 2026-06-22
 
-**TurboQuant installs and updates on macOS again, plus a Linux build and a Metal first-run fix.**
+**TurboQuant now installs on macOS end-to-end — the Gatekeeper quarantine block, the per-platform release scan, and the Metal first-run timeout are all fixed — plus a Linux build.**
 
 ### Added
 - **CPU option on macOS.** The Apple-Silicon Metal binary also runs CPU-only, so it now appears
@@ -35,6 +35,10 @@ _Nothing yet._
 - **TurboQuant on Linux.** Linux x64 (Vulkan) is now listed as installable in the engine catalog.
 
 ### Fixed
+- **macOS Gatekeeper blocking engine binaries.** Downloaded engine binaries carry the
+  `com.apple.quarantine` attribute, which Gatekeeper uses to block execution — so the engine
+  probe timed out even after the right binary downloaded. TurboLLM now strips the quarantine
+  attribute from every extracted engine on macOS (and on re-install). Thanks @manish026.
 - **TurboQuant install/update failing on macOS** with `no_release_asset`. The resolver used
   GitHub's `/releases/latest`, but TurboQuant publishes one release per OS, so the latest tag was
   often Linux-only and Mac users got nothing. It now scans releases for the newest one carrying a

--- a/turbollm/package-lock.json
+++ b/turbollm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turbollm",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turbollm",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@hono/node-server": "^1.13.0",

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",


### PR DESCRIPTION
Release prep for **v1.3.2** (patch). Supersedes the tagged-but-unpublished 1.3.1.

Bumps `package.json`/`package-lock.json` to 1.3.2 and folds the 1.3.1 changelog into a `[1.3.2]` section with the Gatekeeper fix from #16.

### Ships in 1.3.2
- **Fixed:** macOS Gatekeeper quarantine blocking engine binaries (#16, @manish026).
- **Fixed:** TurboQuant macOS `no_release_asset` (per-platform release scan).
- **Fixed:** Metal probe first-run timeout (60s macOS / 15s elsewhere).
- **Added:** macOS CPU backend variant; TurboQuant on Linux.
- **Changed:** unified TurboQuant install/update resolver.