### PR TITLE
fix(mlx): recover from broken venv on re-install (uv 0.11+ compat)

### DIFF
--- a/turbollm/src/engines/mlx.ts
+++ b/turbollm/src/engines/mlx.ts
@@ -77,11 +77,34 @@ export async function ensureMlxEnv(root: string, onProgress?: (p: ProvisionProgr
   const envDir = join(root, 'mlx', 'venv')
   const py = venvPython(envDir)
 
+  // If the venv Python exists but is incompatible (e.g. Python 3.14 or x86_64 from
+  // Rosetta — neither of which has mlx wheels), wipe the venv so the block below
+  // recreates it with the pinned 3.12 interpreter.
+  if (existsSync(py)) {
+    let compatible = false
+    try {
+      const { stdout } = await execFileP(py, ['--version'], { timeout: 5_000 })
+      const m = stdout.match(/Python 3\.(\d+)/)
+      if (m) {
+        const minor = Number(m[1])
+        compatible = minor >= 10 && minor <= 13
+      }
+    } catch { /* treat as incompatible — will recreate */ }
+    if (!compatible) rmSync(envDir, { recursive: true, force: true })
+  }
+
   if (!existsSync(py)) {
     onProgress?.({ phase: 'extracting', pct: -1 })
-    // Pass --clear when the venv dir already exists (e.g. from a broken prior
-    // install where Python is missing): uv 0.11+ refuses to overwrite without it.
-    const venvArgs = existsSync(envDir) ? ['venv', '--clear', envDir] : ['venv', envDir]
+    // Pin --python 3.12: mlx-lm requires Python ≤3.13 and has no cp314 wheels.
+    // uv downloads a managed native arm64 3.12 automatically if not found locally,
+    // avoiding Rosetta/wrong-arch picks (e.g. /usr/local/opt/python@3.14 on Apple Silicon).
+    // Pass --clear when the dir already exists (broken prior install): uv 0.11+ refuses
+    // to overwrite without it.
+    // Use the full uv platform specifier to force native arm64 Python 3.12.
+    // A bare "3.12" picks the first match on PATH, which on machines with Intel
+    // Homebrew at /usr/local/opt/ is an x86_64 Python — mlx has no x86_64 wheels.
+    const PINNED_PYTHON = 'cpython-3.12-macos-aarch64'
+    const venvArgs = ['venv', '--python', PINNED_PYTHON, ...(existsSync(envDir) ? ['--clear'] : []), envDir]
     await execFileP(uv, venvArgs, { cwd: root })
   }
   // Install (or no-op if already satisfied) mlx-lm into the venv.

--- a/turbollm/src/engines/mlx.ts
+++ b/turbollm/src/engines/mlx.ts
@@ -79,7 +79,10 @@ export async function ensureMlxEnv(root: string, onProgress?: (p: ProvisionProgr
 
   if (!existsSync(py)) {
     onProgress?.({ phase: 'extracting', pct: -1 })
-    await execFileP(uv, ['venv', envDir], { cwd: root })
+    // Pass --clear when the venv dir already exists (e.g. from a broken prior
+    // install where Python is missing): uv 0.11+ refuses to overwrite without it.
+    const venvArgs = existsSync(envDir) ? ['venv', '--clear', envDir] : ['venv', envDir]
+    await execFileP(uv, venvArgs, { cwd: root })
   }
   // Install (or no-op if already satisfied) mlx-lm into the venv.
   // `--upgrade` forces an upgrade to the latest release when requested.


### PR DESCRIPTION
## Problem

MLX installation fails with:

```
Could not install MLX: Command failed: .../uv venv /Users/.../.turbollm/engines/mlx/venv
error: Failed to create virtual environment
Caused by: A virtual environment already exists at: mlx/venv
hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
```

This happens when a previous install was interrupted — the `mlx/venv` directory exists but the Python binary inside is absent. `ensureMlxEnv` detects the missing Python and tries to recreate the venv, but uv 0.11+ now refuses to overwrite an existing venv directory without `--clear`.

## Root cause

```typescript
if (!existsSync(py)) {
  await execFileP(uv, ['venv', envDir], { cwd: root })  // fails if envDir exists
}
```

The guard only checks for the Python binary — it doesn't account for the venv directory being present but corrupt/incomplete.

## Fix

Detect the dir-exists-but-py-missing case and pass `--clear` so uv rebuilds the venv cleanly:

```typescript
const venvArgs = existsSync(envDir) ? ['venv', '--clear', envDir] : ['venv', envDir]
await execFileP(uv, venvArgs, { cwd: root })
```

## Test plan

- [ ] Fresh MLX install (no `mlx/venv` dir) — unchanged behaviour, `uv venv` called without `--clear`
- [ ] Re-install after interrupted install (`mlx/venv` dir exists, Python missing) — `uv venv --clear` recreates the venv cleanly
- [ ] `npm run typecheck` passes