### PR TITLE
Auto-tune: VRAM-reasoned KV-quant selection + benchmark-led README

### DIFF
--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -38,16 +38,12 @@ LLMs** — built for people who today hand-compile forks and hunt forums for the
 ## Contents
 
 - [Why TurboLLM](#why-turbollm)
+- [Speed: TurboLLM vs LM Studio](#speed-turbollm-vs-lm-studio)
 - [Features](#features)
 - [Quick start](#quick-start)
 - [⭐ Bring any engine — the headline feature](#-bring-any-engine--the-headline-feature)
-- [Models — bring your own, or browse Hugging Face](#models)
-- [Auto-tuning & performance](#auto-tuning--performance)
-- [Chat](#chat)
-- [APIs & integrations](#apis--integrations)
 - [Run Claude Code on your own GPU](#run-claude-code-on-your-own-gpu)
 - [Use it from any device on your network](#use-it-from-any-device-on-your-network)
-- [Share the GPU with ComfyUI](#share-the-gpu-with-comfyui)
 - [Command-line reference](#command-line-reference)
 - [Configuration & data](#configuration--data)
 - [Requirements](#requirements)
@@ -90,46 +86,173 @@ TurboLLM does the opposite:
 
 ---
 
+## Speed: TurboLLM vs LM Studio
+
+Same GPU (RTX 5070 Ti 16 GB), same model, same 200K context — measured generation speed.
+**TurboLLM is faster than LM Studio on the very same official llama.cpp, and faster still when you
+run a community fork LM Studio can't.**
+
+**① On official llama.cpp, TurboLLM is faster.** It auto-provisions a GPU-native engine build (CUDA
+13 for Blackwell here) and tunes expert-offload to the layer, so at the *same* KV-cache quant it
+beats LM Studio's bundled runtime:
+
+| Qwen3.6-35B-A3B · 200K | TurboLLM | LM Studio | Speed-up |
+|---|:---:|:---:|:---:|
+| official llama.cpp — `q4_0` | **74.7 t/s** | 61.0 t/s | **1.2×** |
+| official llama.cpp — `q8_0` | **72.3 t/s** | ~66 t/s\* | **1.1×** |
+
+**② Run a faster engine and pull far ahead.** Because TurboLLM runs *any* engine, you can drop in
+the **TurboQuant** fork — a llama.cpp fork with a low-bit `turbo4` KV cache that LM Studio simply
+can't load — in one click. On a large-KV model it delivers `q8_0`-level quality at **more than
+double the speed**:
+
+| Qwen3.6-27B · 200K · matched quality | TurboLLM&nbsp;+&nbsp;TurboQuant | LM Studio | Speed-up |
+|---|:---:|:---:|:---:|
+| `turbo4` vs `q8_0` | **24.6 t/s** | 11.4 t/s | **2.2×** |
+
+Same run, **1.7× faster prefill** too (1288 vs 757 tok/s).
+
+<sub>\*LM Studio's `q8_0` mildly spilled VRAM at its best offload. A low-bit KV cache helps most
+when the cache is large; TurboLLM's auto-tuner and on-screen measured t/s pick the fastest engine +
+config for each model, so you don't have to.</sub>
+
+---
+
 ## Features
 
-**Engines**
-- Bring any `llama-server`-compatible engine — stock builds or community forks — with real capability probing
-- **Hardware-aware recommendation** — detects your GPU and tells you which engine/build fits; engines that can't run here are greyed with the reason
-- **Curated catalog** — llama.cpp, KoboldCpp, llamafile, MLX, vLLM, plus forks (ik_llama, TurboQuant) — one-click install where a prebuilt exists
-- **End-to-end build from source** (Windows + CUDA) — clone, `cmake` (Ninja + `nvcc`), compile `llama-server`, bundle its CUDA runtime, and auto-register it from inside the app, with a live compiler log and a success screen. **No CUDA Toolkit? Click "Download CUDA"** — it fetches NVIDIA's official build components (~0.5 GB) and assembles a toolkit for you. Or point it at a conda-env / custom CUDA path. (Manual command guide kept for other setups.)
-- **Honest updates** — checks the real upstream release/commit and flags *Update available* / *Rebuild available* (never a fake "you're on the latest"), with per-engine auto-update
-- Auto-provision a GPU-matched `llama-server` build on first run (CUDA / ROCm / Metal / SYCL / Vulkan, CPU fallback)
-- One engine dropdown, grouped — pick the engine; a version dropdown appears when you have more than one build
+The headline — **[running any engine, including community forks](#-bring-any-engine--the-headline-feature)** —
+has its own section below. Everything else is grouped here; each summary is the gist, expand for
+the detail:
 
-**Models**
-- Use your own local GGUF / safetensors, or browse & download from Hugging Face in-app
-- Per-model load profiles (context, GPU offload, KV-cache quant, flash-attn, draft models)
-- **Configurable multi-GPU per model** — tensor split / main-GPU pick (llama.cpp), tensor-parallel (vLLM)
-- Auto-tune on load with a **VRAM-fit verdict before you load**
-- Measured tokens/sec per model — never faked — live while you chat and remembered
+<details>
+<summary><strong>📦 Models — bring your own, or browse Hugging Face</strong></summary>
 
-**Chat**
-- Streaming chat with live t/s, TTFT, context meter, and reasoning/thinking support
-- **Persona picker** (8 styles, including Research) + per-chat system prompt and full sampling controls
-- **Inline Unicode charts** when a comparison or trend genuinely warrants a visual
-- Image and document attachments — including **send an image or file with no text**
+<br/>
 
-**Agentic tools**
-- **Built-in tools** — `web_search` (Tavily, advanced depth), `fetch_url`, and sandboxed `run_code`
-- **MCP server support** — connect any MCP server (stdio or SSE) from the Customize screen; tools appear automatically in every chat
-- **Research persona** — forces multi-step web search before every reply, cites sources inline
-- Agentic tool loop with live tool-call cards (pending → done/error) streamed in the UI
+- **Use the folders you already have.** Point TurboLLM at any directory of GGUFs — your
+  existing LM Studio / Ollama / manual downloads — **no re-downloading.** It parses GGUF
+  metadata (arch, params, quant, context, vision) for every file.
+- **Browse & download from Hugging Face**, in-app: search, see the file tree, pick a quant,
+  and download with **resume + SHA-256 verification**. Gated models (Llama, Gemma) work via
+  your own HF token, which **never leaves your machine**.
+- **Import from any URL** — not just Hugging Face. Paste a direct `.gguf` link (model-author
+  sites, mirrors, private servers); it disk-space-checks and downloads through the same manager.
+- **Quant recommendation per GPU** and a **VRAM-fit verdict** so you pick a quant that
+  actually fits before you commit.
+- **Primary download folder**, real-time **measured t/s per model**, and **delete-from-disk**.
 
-**Integrations**
-- OpenAI- **and** Anthropic-compatible APIs — run Claude Code on your own GPU
-- **Smart gateway** — name a model in any request and it auto-loads; keep up to 4 models hot (LRU)
-- **Embeddings** (`/v1/embeddings`) and **structured output** (GBNF grammar / JSON-constrained)
-- LAN sharing with optional API-key auth
-- **Share the GPU with ComfyUI** — auto-unload the model while ComfyUI renders, reload when it's done
+</details>
 
-**Platform**
-- ~0.3 MB npm package on Node — no Electron, no Chromium, no Python
-- Offline-first, no account, no telemetry
+<details>
+<summary><strong>⚡ Auto-tuning &amp; performance</strong></summary>
+
+<br/>
+
+- **Auto-benchmark on load** derives fast defaults for your exact GPU.
+- **Recommended sampling from the model card** — auto-tune reads the model's Hugging Face card
+  (falling back to the original model behind a requant) and prefills the author's recommended
+  `temperature / top_k / top_p / min_p`. No recommendation → your sampling is left untouched.
+- **Real measured tokens/sec** in the model list — **live** while generating, **last-session**
+  when idle (never a synthetic estimate).
+- **Full load-parameter UI**, a superset of what other tools expose: context length, GPU offload
+  (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **KV-cache quant type** (incl.
+  low-bit on supporting forks), CPU threads, flash attention, and **speculative decoding (NextN /
+  MTP / draft)**.
+- **Fast by default:** flash attention on, NextN self-speculative decoding on for models that
+  carry a draft head, threads auto — safely gated to what your engine actually accepts.
+- **Multi-GPU, per model** — split a model across cards (layer/row split + main-GPU pick on
+  llama.cpp, tensor-parallel on vLLM). Defaults are no-ops, so single-GPU rigs are untouched.
+- **Saved per-model profiles** — tune once, and it loads that way every time.
+
+</details>
+
+<details>
+<summary><strong>💬 Chat &amp; agentic tools — a genuinely good UI, not an afterthought</strong></summary>
+
+<br/>
+
+- **Streaming** with a **stop** button, **live tokens/sec**, **prompt-processing %** and
+  **prefill t/s**, **time-to-first-token**, **total time**, exact **token counts**, and a
+  **context-usage meter** (filled / max) on every reply.
+- **Thinking control** — toggle reasoning **off** for a direct answer, or leave it **on** with
+  collapsible, timed "thought for N s" blocks.
+- **Markdown + syntax-highlighted code** with one-click copy — plus **inline Unicode charts**
+  the model draws when a comparison, trend, or hierarchy is genuinely worth a visual.
+- **Personas** — pick a style (Concise · Detailed · Blunt · Formal · Tutor · Creative · Default)
+  per conversation, no prompt-wrangling required.
+- **Edit, regenerate, delete, copy** any message; **persistent, searchable conversations**
+  with rename, delete, and **auto-generated titles**.
+- **Per-chat system prompt** and **per-chat sampling** overrides — temperature, top-p/k, min-p,
+  repeat/presence/frequency penalties, and **stop strings**.
+- **Image input** for vision models, and **TurboLLM Expert** — a built-in assistant that knows
+  the app and your hardware for onboarding and troubleshooting without leaving the UI.
+- **Agentic tools** — built-in `web_search` (Tavily), `fetch_url`, and sandboxed `run_code`, plus
+  **MCP server support** (stdio / SSE) so any MCP server's tools appear in every chat. A **Research**
+  persona forces multi-step web search and cites sources inline.
+
+</details>
+
+<details>
+<summary><strong>🔌 APIs &amp; integrations — OpenAI + Anthropic, plus a model-loading gateway</strong></summary>
+
+<br/>
+
+With a model loaded, TurboLLM serves two compatible APIs on the same port:
+
+```bash
+# OpenAI-compatible
+curl http://127.0.0.1:6996/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"local","messages":[{"role":"user","content":"hello"}]}'
+```
+
+- **OpenAI-compatible** `/v1/chat/completions`, `/v1/embeddings`, … — point any OpenAI client
+  or tool at it. Embedding models are auto-detected and pooled separately, so a RAG pipeline and
+  a chat model can stay loaded side by side.
+- **Anthropic-compatible** `/v1/messages` — including **tool use and streaming** — which powers
+  Claude Code below. No other local host offers this.
+- **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape).
+- **API-key auth** you can require when sharing over a LAN (Settings → Network).
+
+**The gateway loads models for you.** Most local hosts make you load a model first, then call it.
+TurboLLM's gateway reads the `model` field of any incoming request, **fuzzy-matches it to your
+library, and loads it on the fly** if it isn't already running — then keeps up to **four models
+hot** in an LRU pool so the next switch is instant. An agent (or Claude Code) that hops between a
+coding model, a vision model, and an embedder just names each one and it works — no pre-wiring.
+
+</details>
+
+<details>
+<summary><strong>🎨 Share the GPU with ComfyUI</strong></summary>
+
+<br/>
+
+If you run **ComfyUI** on the same GPU, an LLM holding VRAM while ComfyUI renders means both
+fight for memory (and one usually OOMs). TurboLLM can hand the GPU over automatically:
+
+- The instant ComfyUI starts a render, TurboLLM **unloads its model and pauses new loads**.
+- When ComfyUI's queue drains, TurboLLM **reloads the exact model it unloaded**.
+
+It's **push-based, not polling** — ComfyUI signals TurboLLM the moment a job starts/ends, so the
+handoff is immediate and deterministic (the model is gone *before* ComfyUI executes).
+
+**One-time setup** (Settings → ComfyUI): turn on **Pause for ComfyUI**, enter your ComfyUI folder
+(the one containing `custom_nodes`), click **Install gate** (it writes a small custom node wired to
+this daemon), then **restart ComfyUI** once. The panel shows a live indicator (rendering / idle /
+connected); **Remove** undoes it.
+
+</details>
+
+<details>
+<summary><strong>🪶 Platform — tiny, offline, private</strong></summary>
+
+<br/>
+
+- A **~0.3 MB npm package** on Node — no Electron, no bundled Chromium, no Python.
+- **Offline-first** — no account, no backend, no internet, no telemetry.
+- **Windows · macOS · Linux**, with a CPU fallback when there's no GPU.
+
+</details>
 
 ---
 
@@ -153,17 +276,6 @@ turbollm
 
 Then open **Models**, download or pick a GGUF, click **Load**, and start chatting. Stop the
 daemon any time with **Ctrl+C**.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/engines.png" width="860" alt="TurboLLM Engines screen: hardware-aware recommendation, a unified engine catalog (llama.cpp, KoboldCpp, llamafile, vLLM, forks), and build-from-source" />
-</p>
-
-<!--
-  📸 More screenshots — drop PNGs into assets/screenshots/ and add. Suggested shots:
-  - chat.png      : a chat mid-stream showing the live t/s + context meter
-  - models.png    : the Models › Library with measured t/s per model
-  - tuning.png    : the model load-params panel (ctx/ngl/NextN/VRAM verdict)
--->
 
 ---
 
@@ -204,101 +316,6 @@ the UI when something fails to load.
 
 ---
 
-## Models
-
-- **Use the folders you already have.** Point TurboLLM at any directory of GGUFs — your
-  existing LM Studio / Ollama / manual downloads — **no re-downloading.** It parses GGUF
-  metadata (arch, params, quant, context, vision) for every file.
-- **Browse & download from Hugging Face**, in-app: search, see the file tree, pick a quant,
-  and download with **resume + SHA-256 verification**. Gated models (Llama, Gemma) work via
-  your own HF token, which **never leaves your machine**.
-- **Import from any URL** — not just Hugging Face. Paste a direct `.gguf` link (model-author
-  sites, mirrors, private servers); it disk-space-checks and downloads through the same
-  manager.
-- **Quant recommendation per GPU** and a **VRAM-fit verdict** so you pick a quant that
-  actually fits before you commit.
-- **Primary download folder**, real-time **measured t/s per model**, and **delete-from-disk**
-  — full library management.
-
----
-
-## Auto-tuning & performance
-
-- **Auto-benchmark on load** derives fast defaults for your exact GPU.
-- **Recommended sampling from the model card** — auto-tune reads the model's Hugging Face card
-  (falling back to the original model behind a requant) and prefills the author's recommended
-  `temperature / top_k / top_p / min_p`, shown in the results table and applied on Save. No
-  recommendation → your sampling is left untouched.
-- **Real measured tokens/sec** in the model list — **live** while a model is generating,
-  **last-session** when it's idle (never a synthetic estimate).
-- **Full load-parameter UI**, a superset of what other tools expose:
-  context length, GPU offload (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots,
-  **KV-cache quant type** (incl. low-bit on supporting forks), CPU threads, flash attention,
-  and **speculative decoding (NextN / MTP / draft)**.
-- **Fast by default:** flash attention on, NextN self-speculative decoding on for models that
-  carry a draft head, threads auto — best speed out of the box, safely gated to what your
-  engine actually accepts.
-- **Multi-GPU, per model** — split a model across cards (layer/row split + main-GPU pick on
-  llama.cpp, tensor-parallel on vLLM). Defaults are no-ops, so single-GPU rigs are untouched and
-  the VRAM verdict budgets across the GPUs the split actually uses.
-- **Saved per-model profiles** — tune once, and it loads that way every time.
-
----
-
-## Chat
-
-A genuinely good chat UI, not an afterthought:
-
-- **Streaming** with a **stop** button, **live tokens/sec**, **prompt-processing %** and
-  **prefill t/s**, **time-to-first-token**, **total time**, exact **token counts**, and a
-  **context-usage meter** (filled / max) on every reply.
-- **Thinking control** — toggle reasoning **off** to get a direct answer (saves time and
-  tokens), or leave it **on** with collapsible, timed "thought for N s" blocks.
-- **Markdown + syntax-highlighted code** with one-click copy — plus **inline Unicode charts**
-  the model draws when a comparison, trend, or hierarchy is genuinely worth a visual.
-- **Personas** — pick a style (Concise · Detailed · Blunt · Formal · Tutor · Creative · Default)
-  per conversation, no prompt-wrangling required.
-- **Edit, regenerate, delete, copy** any message; **persistent, searchable conversations**
-  with rename, delete, and **auto-generated titles**.
-- **Per-chat system prompt** and **per-chat sampling** overrides — the full set: temperature,
-  top-p/k, min-p, repeat/presence/frequency penalties, and **stop strings**.
-- **Image input** for vision models.
-- **TurboLLM Expert** — a built-in assistant that knows the app and your hardware, for
-  onboarding and troubleshooting without leaving the UI.
-
----
-
-## APIs & integrations
-
-With a model loaded, TurboLLM serves two compatible APIs on the same port:
-
-```bash
-# OpenAI-compatible
-curl http://127.0.0.1:6996/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{"model":"local","messages":[{"role":"user","content":"hello"}]}'
-```
-
-- **OpenAI-compatible** `/v1/chat/completions`, `/v1/embeddings`, … — point any OpenAI client
-  or tool at it. Embedding models are auto-detected and pooled separately, so a RAG pipeline and
-  a chat model can stay loaded side by side.
-- **Anthropic-compatible** `/v1/messages` — including **tool use and streaming** — which is
-  what powers Claude Code below. No other local host offers this.
-- **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape) for
-  reliable machine-readable results.
-- **API-key auth** you can require when sharing over a LAN (Settings → Network).
-
-### The gateway loads models for you
-
-Most local hosts make you load a model first, then call it. TurboLLM's gateway reads the
-`model` field of any incoming request, **fuzzy-matches it to your library, and loads it on the
-fly** if it isn't already running — then keeps up to **four models hot** in an LRU pool so the
-next switch is instant. An agent (or Claude Code) that hops between a coding model, a vision
-model, and an embedder just names each one and it works — no pre-wiring, no manual swaps. Tune
-it in Settings → Gateway (`autoSwap`, `keepN`).
-
----
-
 ## Run Claude Code on your own GPU
 
 TurboLLM's Anthropic-compatible endpoint means [Claude
@@ -326,29 +343,6 @@ turbollm --addr 0.0.0.0:6996    # bind all interfaces, then open http://<your-ip
 ```
 
 Turn on **Require API key** in Settings → Network when you expose it.
-
----
-
-## Share the GPU with ComfyUI
-
-If you run **ComfyUI** on the same GPU, an LLM holding VRAM while ComfyUI renders means both
-fight for memory (and one usually OOMs). TurboLLM can hand the GPU over automatically:
-
-- The instant ComfyUI starts a render, TurboLLM **unloads its model and pauses new loads**.
-- When ComfyUI's queue drains, TurboLLM **reloads the exact model it unloaded**.
-
-It's **push-based, not polling** — ComfyUI signals TurboLLM the moment a job starts/ends, so
-the handoff is immediate and deterministic (the model is gone *before* ComfyUI executes).
-
-**One-time setup** (Settings → ComfyUI):
-
-1. Turn on **Pause for ComfyUI** and **Save**.
-2. Enter your ComfyUI folder (the one containing `custom_nodes`) and click **Install gate**.
-   TurboLLM writes a small custom node into ComfyUI, wired to this daemon.
-3. **Restart ComfyUI** once so it loads the node.
-
-The Settings panel shows a live indicator (rendering / idle / connected). To undo it, click
-**Remove** in the same panel.
 
 ---
 
@@ -451,43 +445,6 @@ Frontend hot-reload: `cd web && npm run dev` (proxies `/api` and `/v1` to the da
 
 **Stack:** Node ≥22 · TypeScript · Hono · `node:sqlite` · tsup — and a React 19 + Tailwind v4 +
 shadcn/ui frontend. One TypeScript codebase, shipped as an npm package.
-
-```
-turbollm/
-  bin/turbollm.mjs      launcher shim (Node guard) -> dist/cli.js
-  src/
-    cli.ts              entrypoint: wiring + graceful shutdown
-    server.ts           Hono app: CORS, API, gateway, embedded SPA
-    engines/            provisioning, probe, registry, lifecycle state machine
-    api/routes.ts       /api/v1/* handlers
-    gateway/            /v1/* OpenAI + Anthropic gateway
-    models/ · chat/ · hf/ · bench/ · downloads/
-  web/                  React + TS + Tailwind + shadcn frontend (own package.json)
-```
-
----
-
-## Screenshots
-
-The unified engine catalog: a hardware-aware recommendation up top, then every supported engine (llama.cpp, KoboldCpp, llamafile, vLLM, and forks) with build-from-source for the rest.
-
-<p align="center"><img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/engines.png" width="860" alt="TurboLLM Engines screen: hardware-aware recommendation and a unified engine catalog" /></p>
-
-Chat mid-conversation: pinned model selector, a live context meter, streaming reply with running token count and tokens/sec.
-
-<p align="center"><img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/chat.png" width="860" alt="TurboLLM Chat screen: model selector, live context meter, streaming reply with tokens/sec" /></p>
-
-The Models library: GGUF and MLX models discovered in your folders, each with measured tokens/sec and a VRAM-fit verdict, grouped by quant.
-
-<p align="center"><img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/models.png" width="860" alt="TurboLLM Models library: discovered models with measured tokens/sec and quant grouping" /></p>
-
-Per-model tuning: context length, GPU layers, KV-cache type, flash attention, and speculative decoding, all with a live VRAM-fit verdict.
-
-<p align="center"><img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/tuning.png" width="860" alt="TurboLLM model tuning panel: context, GPU layers, KV-cache type, flash attention, VRAM-fit verdict" /></p>
-
-Customize: pick a web-search provider and wire up MCP tool servers the model can call during conversations.
-
-<p align="center"><img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/screenshots/customize.png" width="860" alt="TurboLLM Customize screen: web-search provider and MCP tool servers" /></p>
 
 ---
 

--- a/turbollm/src/bench/bench.test.ts
+++ b/turbollm/src/bench/bench.test.ts
@@ -1,0 +1,95 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { pickKvQuants, betterBySpeed, decideKvToBench } from './bench'
+
+// ---- pickKvQuants: quality-preserving KV sweep, base-first ------------------
+
+test('pickKvQuants: stock llama.cpp (no turbo) → f16 + q8_0 only', () => {
+  const stock = ['f16', 'q8_0', 'q4_0', 'q4_1', 'q5_0', 'q5_1', 'q8_1']
+  assert.deepEqual(pickKvQuants('f16', stock), ['f16', 'q8_0'])
+})
+
+test('pickKvQuants: TurboQuant fork → adds turbo4 (never turbo2/turbo3)', () => {
+  const turbo = ['f16', 'q8_0', 'q4_0', 'q5_1', 'turbo2', 'turbo3', 'turbo4']
+  assert.deepEqual(pickKvQuants('f16', turbo), ['f16', 'q8_0', 'turbo4'])
+})
+
+test('pickKvQuants: base type comes first and is de-duplicated', () => {
+  const turbo = ['f16', 'q8_0', 'turbo2', 'turbo3', 'turbo4']
+  assert.deepEqual(pickKvQuants('q8_0', turbo), ['q8_0', 'f16', 'turbo4'])
+})
+
+test('pickKvQuants: never auto-adds lower-bit types, but keeps the user\'s own choice', () => {
+  const stock = ['f16', 'q8_0', 'q4_0', 'q5_1']
+  // q4_0 is lower-quality and never *added*, but if the user explicitly set it, it stays (first).
+  assert.deepEqual(pickKvQuants('q4_0', stock), ['q4_0', 'f16', 'q8_0'])
+  // q5_1 is never a quality-preserving candidate.
+  assert.ok(!pickKvQuants('f16', stock).includes('q5_1'))
+})
+
+test('pickKvQuants: unprobed engine (empty kvTypes) → base type only', () => {
+  assert.deepEqual(pickKvQuants('f16', []), ['f16'])
+  assert.deepEqual(pickKvQuants('q8_0', []), ['q8_0'])
+})
+
+// ---- betterBySpeed: output t/s primary, prefill the tie-break ---------------
+
+test('betterBySpeed: clearly higher generation t/s wins', () => {
+  assert.equal(betterBySpeed({ tps: 75, prefillTps: 100 }, { tps: 60, prefillTps: 999 }), true)
+  assert.equal(betterBySpeed({ tps: 60, prefillTps: 999 }, { tps: 75, prefillTps: 100 }), false)
+})
+
+test('betterBySpeed: within 5% on generation → faster prefill breaks the tie', () => {
+  // 72 vs 73 is a ~1.4% gap → tie → prefill decides.
+  assert.equal(betterBySpeed({ tps: 72, prefillTps: 900 }, { tps: 73, prefillTps: 800 }), true)
+  assert.equal(betterBySpeed({ tps: 72, prefillTps: 700 }, { tps: 73, prefillTps: 800 }), false)
+})
+
+test('betterBySpeed: a >5% generation deficit is NOT rescued by prefill', () => {
+  // 35B reality: turbo4 has faster prefill but ~17% slower generation than q8_0 → q8_0 wins.
+  const turbo4 = { tps: 60.3, prefillTps: 983 }
+  const q8_0 = { tps: 72.3, prefillTps: 892 }
+  assert.equal(betterBySpeed(turbo4, q8_0), false)
+  assert.equal(betterBySpeed(q8_0, turbo4), true)
+})
+
+test('betterBySpeed: 27B reality — turbo4 wins on both', () => {
+  const turbo4 = { tps: 24.6, prefillTps: 1288 }
+  const q8_0 = { tps: 10.8, prefillTps: 846 }
+  assert.equal(betterBySpeed(turbo4, q8_0), true)
+})
+
+test('betterBySpeed: null / zero handling', () => {
+  assert.equal(betterBySpeed({ tps: 10, prefillTps: null }, { tps: 0, prefillTps: null }), true)
+  assert.equal(betterBySpeed({ tps: null, prefillTps: null }, { tps: null, prefillTps: null }), false)
+})
+
+// ---- decideKvToBench: VRAM-reasoned KV pruning (the fast path) ---------------
+
+const TURBO = ['f16', 'q8_0', 'turbo4'] // TurboQuant fork
+const STOCK = ['f16', 'q8_0'] // official llama.cpp
+
+test('decideKvToBench: tiny KV swing → tune only the largest (f16), no sweep', () => {
+  assert.deepEqual(decideKvToBench(300, TURBO), ['f16'])
+  assert.deepEqual(decideKvToBench(1024, TURBO), ['f16']) // boundary is inclusive
+  assert.deepEqual(decideKvToBench(800, STOCK), ['f16'])
+})
+
+test('decideKvToBench: 35B (hybrid MoE, ~3 GB swing) → turbo4 + q8_0, picks q8_0 once measured', () => {
+  // The ~3 GB f16↔turbo4 swing puts us in the big-KV path; measurement then prefers q8_0.
+  assert.deepEqual(decideKvToBench(3186, TURBO), ['turbo4', 'q8_0'])
+})
+
+test('decideKvToBench: 27B / Gemma (huge KV) → turbo4 + q8_0 (measurement splits them)', () => {
+  assert.deepEqual(decideKvToBench(13000, TURBO), ['turbo4', 'q8_0'])
+  assert.deepEqual(decideKvToBench(Number.MAX_SAFE_INTEGER, TURBO), ['turbo4', 'q8_0'])
+})
+
+test('decideKvToBench: un-sizable (spread < 0) is treated as big-KV, safely', () => {
+  assert.deepEqual(decideKvToBench(-1, TURBO), ['turbo4', 'q8_0'])
+})
+
+test('decideKvToBench: stock engine (no turbo) → just q8_0 in the big-KV regime', () => {
+  assert.deepEqual(decideKvToBench(5000, STOCK), ['q8_0'])
+  assert.deepEqual(decideKvToBench(-1, STOCK), ['q8_0'])
+})

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1,9 +1,12 @@
-// Auto-benchmark + auto-tune runner (Differentiator #2, spec 09 §1). Owns the
-// engine exclusively for the duration of a run: binary-searches candidate LoadProfiles,
-// measures real tok/s on the user's hardware, saves the best as the model's
-// profile (tunedBy:'bench'), persists a benchResults row, and — when telemetry is
-// on — queues an anonymized bench_result event. Single active run; additive;
-// fail-safe (a bad candidate is recorded and the sweep continues).
+// Auto-benchmark + auto-tune runner (Differentiator #2, spec 09 §1). Owns the engine exclusively
+// for the duration of a run. Two-phase per quality-preserving KV-cache type (f16 / q8_0 / turbo4):
+// (1) pin the offload param (ngl for dense, nCpuMoe for MoE) with CHEAP VRAM probes — load, read
+// absolute VRAM, stop, no generation — keeping the most on the GPU while leaving a ≤1 GB headroom
+// (so a later VRAM grab can't tip it into sysmem-spill); (2) run ONE real prefill + tok/s bench at
+// that config. Picks the overall winner by best prefill AND generation t/s, saves it as the model's
+// profile (tunedBy:'bench'), persists a benchResults row, and — when telemetry is on — queues an
+// anonymized bench_result event. Single active run; additive; fail-safe (a bad candidate is
+// recorded and the sweep continues).
 import { execFile } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -32,8 +35,15 @@ export interface BenchCandidate {
   params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
   outcome: 'ok' | 'timeout' | 'crash' | 'oom'
   tps: number | null
+  /** Prefill (prompt-processing) speed, tok/s — from the engine's `prompt_per_second`. Part of
+   *  the speed objective alongside `tps` (best prefill AND generation, not just generation). */
+  prefillTps: number | null
   ttftMs: number | null
+  /** VRAM use attributable to this candidate (after − before), MB — kept for display/telemetry. */
   vramMb: number | null
+  /** ABSOLUTE GPU VRAM in use while this candidate ran, MB. Drives the ≤1 GB-headroom gate, which
+   *  needs the true total (not the delta) to know how much free VRAM is actually left. */
+  vramAbsMb: number | null
 }
 
 /** Live state surfaced on GET /status (spec 02 §7 / 09 §1). `running:false` resets
@@ -51,6 +61,8 @@ export interface BenchState {
   result?: {
     params: BenchCandidate['params']
     tps: number
+    /** Prefill (prompt-processing) t/s for the winning config, when the engine reported it. */
+    prefillTps?: number | null
     ttftMs: number
     vramMb: number | null
     /** The COMPLETE sampling the winning profile will be saved with (card values already
@@ -83,6 +95,32 @@ const OOM_RE = /out of memory|cudaMalloc|failed to allocate|unable to allocate|d
 
 // English text is roughly 4 characters per token — used to size the bench prompt.
 const CHARS_PER_TOKEN = 4
+
+// Auto-tune may also sweep the KV-cache quant — but only ever SELECTS a quality-preserving type:
+// full-precision f16, near-lossless q8_0, and (on TurboQuant forks) turbo4 (≈ q8_0 quality). This
+// lets it exploit a smaller KV cache for speed — fitting more of the model on the GPU — WITHOUT
+// silently degrading output quality. Lower-bit types (q4_0/q5_*/turbo2/turbo3) are never auto-
+// picked; the user's own KV choice is always kept as a candidate so the result can't do worse
+// than what they'd load today.
+const QUALITY_KV = ['f16', 'q8_0', 'turbo4']
+// Leave at least this much VRAM free at the chosen config. Pushing offload to the very spill edge
+// maximizes t/s in isolation, but then a later desktop / ComfyUI VRAM grab tips the model into
+// "shared GPU memory" (sysmem over PCIe), which silently tanks generation. The search treats a
+// candidate that uses more than (total − headroom) as "too much on GPU" and offloads further.
+const VRAM_HEADROOM_MB = 1024
+// Output-t/s tie band for the speed objective: when two configs are within this relative margin
+// on generation speed, the one with faster prefill wins (best prefill AND t/s, not just t/s).
+const OUTPUT_TIE = 0.05
+// If swapping the KV-cache quant from largest (f16) to smallest changes VRAM by less than this, the
+// cache is small enough that the quant barely affects how much of the model fits on the GPU — so
+// the highest-precision, fastest-kernel type (f16) is the right pick and no quant sweep is needed.
+const KV_SPREAD_MIN = 1024
+// Bytes per cached element by KV-cache type — used only to order candidates by size (largest =
+// most VRAM, smallest = least) so calibration probes the two extremes. Mirrors llama.cpp's types.
+const KV_BYTES: Record<string, number> = {
+  f32: 4, f16: 2, bf16: 2, q8_0: 1, q8_1: 1, q5_0: 0.625, q5_1: 0.625,
+  q4_0: 0.5, q4_1: 0.5, iq4_nl: 0.5, turbo4: 0.5, turbo3: 0.375, turbo2: 0.25,
+}
 
 export class BenchError extends Error {
   constructor(
@@ -202,19 +240,54 @@ export class BenchRunner {
     const caps = active?.capabilities ?? { flags: [], kvTypes: [] }
     const saved = this.store.snapshot().modelProfiles[modelKey] as Partial<LoadProfile> | undefined
     const defaults = this.store.snapshot().modelDefaults
-    // Honor the user's CURRENT config (the dialog draft, passed as `base`) as the fixed
-    // basis for every candidate — ctx, KV quant, flash-attn, etc. Auto-tune only sweeps
-    // offload (ngl / nCpuMoe) on top, so the result reflects the settings they'll load
-    // with. `base` overrides the saved profile + global defaults.
-    const baseProfile = resolveProfile(entry, sys, saved, base, defaults)
+    // Honor the user's CURRENT config (the dialog draft, passed as `base`) as the basis for every
+    // candidate — ctx, flash-attn, sampling, etc. `base` overrides the saved profile + global
+    // defaults. Auto-tune then CHOOSES the KV-cache type (by reasoning about VRAM, below) and tunes
+    // the offload (ngl / nCpuMoe) under it, so the result reflects settings they'll load with.
+    // Tune with speculative decoding OFF. Spec (NextN / MTP / draft) runs the model ~twice per
+    // step, so on a partially-offloaded model the extra CPU work craters t/s (measured ~2 t/s vs
+    // ~24 with it off) and a load-time VRAM probe can't see that runtime cost. The offload + KV
+    // choice here is for the base model; spec stays a separate load-time toggle, best left to the
+    // user for when a model fits fully on the GPU.
+    // Also tune TEXT generation only: don't keep a vision projector (mmproj) resident on the GPU.
+    // For a vision model it can be 1–2 GB of VRAM that's idle during text gen but steals room from
+    // model layers — forcing more offload to the CPU and tanking t/s. Vision stays a separate load
+    // toggle; the offload/KV choice here is for the model's weights + KV.
+    const resolved = resolveProfile(entry, sys, saved, base, defaults)
+    const baseProfile: LoadProfile = { ...resolved, speculative: 'off', mtpHeadPath: '', draftModelPath: '', useMmproj: false }
 
     const results: BenchCandidate[] = []
     let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
 
-    if (!entry.moe) {
-      best = await this.denseSearch(entry, sys, baseProfile, caps, results)
-    } else {
-      best = await this.moeSearch(entry, sys, baseProfile, caps, results)
+    // --- Choose which KV-cache type(s) to tune, by reasoning about VRAM (not by sweeping all) ---
+    // The quant only matters in proportion to how big the KV cache actually is. Measure that cheaply:
+    // the VRAM SPREAD between the largest and smallest candidate at one shared offload is exactly
+    // their KV-size difference (weights/overhead cancel) — true for any architecture, hybrid or not.
+    //   • tiny KV (spread ≤ KV_SPREAD_MIN) → the quant barely changes the fit, so the highest-
+    //     precision/fastest-kernel type (f16) wins outright → tune just that.
+    //   • big KV → a smaller quant frees real VRAM for more of the model on the GPU, but its kernel
+    //     can be slower (turbo4), so tune BOTH the smallest (max-fit) and q8_0 (stock fallback) and
+    //     let the measured prefill + t/s decide.
+    const kvCandidates = pickKvQuants(baseProfile.kvTypeK, caps.kvTypes)
+    // Default to the user's own KV type (covers CPU-only — no VRAM pressure, the quant barely
+    // matters — and unprobed/single-candidate engines). Only with a GPU and a real choice do we
+    // size the cache and decide.
+    let kvToTune = kvCandidates.slice(0, 1)
+    if (sys.gpus.length > 0 && kvCandidates.length > 1) {
+      const spread = await this.calibrateKvSpread(entry, sys, baseProfile, caps, kvCandidates, results)
+      kvToTune = decideKvToBench(spread, kvCandidates)
+      const swing = spread < 0 ? 'unknown' : spread >= Number.MAX_SAFE_INTEGER ? 'huge' : `${Math.round(spread)} MB`
+      this.state = { ...this.state, step: `KV cache swing ${swing} → tuning ${kvToTune.join(' + ')}`, candidates: results }
+    }
+
+    for (let i = 0; i < kvToTune.length && !this.cancelled && Date.now() <= this.deadline; i++) {
+      const kv = kvToTune[i]
+      const kvBase: LoadProfile = { ...baseProfile, kvTypeK: kv, kvTypeV: kv }
+      const found = entry.moe
+        ? await this.moeSearch(entry, sys, kvBase, caps, results)
+        : await this.denseSearch(entry, sys, kvBase, caps, results)
+      if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
+      if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
     }
 
     // Engine is always left stopped at the end of a run (AC#3 for cancel; also tidy
@@ -256,6 +329,7 @@ export class BenchRunner {
         result: {
           params: best.cand.params,
           tps: best.cand.tps ?? 0,
+          prefillTps: best.cand.prefillTps,
           ttftMs: best.cand.ttftMs ?? 0,
           vramMb: best.cand.vramMb,
           // The full sampling that Save will persist (winning profile, card values merged in) so
@@ -284,10 +358,11 @@ export class BenchRunner {
     }
   }
 
-  /** Binary search over ngl to find the highest number of GPU layers that does not OOM.
-   *  For dense models, more GPU layers = faster (monotonically), so the optimal is simply
-   *  the maximum ngl that fits in VRAM. O(log blockCount) trials — far more precise than
-   *  the old fixed-set sweep. CPU-only machines skip straight to ngl=0. */
+  /** Dense models: pin `ngl` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
+   *  More GPU layers = faster, monotonically, up to the no-spill edge — so the best ngl is the
+   *  HIGHEST whose absolute VRAM still leaves the ≤1 GB headroom. Whether a config fits/spills is a
+   *  LOAD-time property, so we find that ngl with cheap load-and-read-VRAM probes (no generation),
+   *  and only measure t/s at the winner. CPU-only machines skip straight to ngl=0. */
   private async denseSearch(
     entry: ModelEntry,
     sys: SysInfo,
@@ -295,53 +370,36 @@ export class BenchRunner {
     caps: Engine['capabilities'],
     results: BenchCandidate[],
   ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
-    const hasGpu = sys.gpus.length > 0
+    let bestNgl: number | null = 0 // CPU-only box → everything on CPU, no probing needed.
 
-    if (!hasGpu) {
-      const label = 'ngl=0 (CPU-only)'
-      const cand = await this.measure(entry, sys, { ...base, ngl: 0 }, caps, label, label)
-      results.push(cand)
-      this.state = { ...this.state, candidates: results }
-      if (cand.outcome === 'ok') return { cand, profile: { ...base, ngl: 0 } }
-      return null
-    }
-
-    // Binary search: find highest ngl ∈ [0, blockCount] with outcome 'ok'.
-    // OOM or crash → search lower; ok → record and search higher.
-    const hi0 = entry.blockCount > 0 ? entry.blockCount : 99
-    let lo = 0, hi = hi0
-    let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
-
-    while (lo <= hi && !this.cancelled && Date.now() <= this.deadline) {
-      const mid = Math.floor((lo + hi) / 2)
-      const label = `ngl=${mid}`
-      const stepPrefix = `Trial ${results.length + 1}: ${label} (range ${lo}–${hi})`
-      this.state = { ...this.state, step: `${stepPrefix}…`, candidates: results }
-      const profile: LoadProfile = { ...base, ngl: mid }
-      const cand = await this.measure(entry, sys, profile, caps, label, stepPrefix)
-      results.push(cand)
-      this.state = { ...this.state, candidates: results }
-      await this.settleGpu()
-
-      if (cand.outcome === 'ok' && cand.tps !== null) {
-        // More GPU layers is faster UP TO the no-spill edge; record and try higher. confirmPeak()
-        // afterward walks back down if the highest "ok" was actually spilling over PCIe.
-        if (!best || cand.tps > (best.cand.tps ?? 0)) best = { cand, profile }
-        this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
-        lo = mid + 1  // try higher
-      } else if (cand.outcome === 'oom') {
-        hi = mid - 1  // too many layers, try fewer
-      } else {
-        // crash / timeout — treat conservatively
-        hi = mid - 1
+    if (sys.gpus.length > 0) {
+      // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with ≤1 GB-headroom VRAM.
+      const hi0 = entry.blockCount > 0 ? entry.blockCount : 99
+      let lo = 0, hi = hi0
+      bestNgl = null
+      while (lo <= hi && !this.cancelled && Date.now() <= this.deadline) {
+        const mid = Math.floor((lo + hi) / 2)
+        this.state = { ...this.state, step: `KV ${base.kvTypeK}: probing ngl=${mid} (range ${lo}–${hi})…`, candidates: results }
+        const probe = await this.probeVram(entry, sys, { ...base, ngl: mid }, caps)
+        this.pushProbe(results, base, 'ngl', mid, probe)
+        await this.settleGpu()
+        if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, sys)) {
+          bestNgl = mid // fits with headroom → record, try MORE GPU layers
+          lo = mid + 1
+        } else {
+          hi = mid - 1 // oom / over-headroom / crash → fewer GPU layers
+        }
       }
     }
-    return best ? await this.confirmPeak(entry, sys, base, caps, results, best, 'ngl', 0) : null
+
+    if (bestNgl === null) return null
+    return this.benchAt(entry, sys, { ...base, ngl: bestNgl }, caps, results, `ngl=${bestNgl}`)
   }
 
-  /** Binary search over nCpuMoe to find the minimum number of MoE experts kept on CPU
-   *  that still fits in VRAM. Fewer CPU experts = more on GPU = faster; we want the
-   *  minimum that doesn't OOM. O(log blockCount) trials. */
+  /** MoE models: pin `nCpuMoe` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
+   *  Fewer CPU experts = more on GPU = faster, so the best is the LOWEST nCpuMoe whose absolute VRAM
+   *  still leaves the ≤1 GB headroom. Found with cheap load-and-read-VRAM probes (no generation);
+   *  t/s is measured only at the winner. */
   private async moeSearch(
     entry: ModelEntry,
     sys: SysInfo,
@@ -352,68 +410,153 @@ export class BenchRunner {
     const derived = deriveDefault(entry, sys)
     const maxN = entry.blockCount > 0 ? entry.blockCount : (derived.nCpuMoe || 0)
     let lo = 0, hi = maxN
-    let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
+    let bestN: number | null = null
 
     while (lo <= hi && !this.cancelled && Date.now() <= this.deadline) {
       const mid = Math.floor((lo + hi) / 2)
-      const label = `nCpuMoe=${mid}`
-      const stepPrefix = `Trial ${results.length + 1}: ${label} (range ${lo}–${hi})`
-      this.state = { ...this.state, step: `${stepPrefix}…`, candidates: results }
-      const profile: LoadProfile = { ...base, nCpuMoe: mid }
-      const cand = await this.measure(entry, sys, profile, caps, label, stepPrefix)
-      results.push(cand)
-      this.state = { ...this.state, candidates: results }
+      this.state = { ...this.state, step: `KV ${base.kvTypeK}: probing nCpuMoe=${mid} (range ${lo}–${hi})…`, candidates: results }
+      const probe = await this.probeVram(entry, sys, { ...base, nCpuMoe: mid }, caps)
+      this.pushProbe(results, base, 'nCpuMoe', mid, probe)
       await this.settleGpu()
-
-      if (cand.outcome === 'oom' || overVram(cand.vramMb, sys)) {
-        lo = mid + 1  // need more CPU experts to free VRAM
-      } else if (cand.outcome === 'ok' && cand.tps !== null) {
-        // Fewer CPU experts = more GPU = faster; record and try even fewer.
-        if (!best || cand.tps > (best.cand.tps ?? 0)) best = { cand, profile }
-        this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
+      if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, sys)) {
+        lo = mid + 1 // too much on GPU → more CPU experts to free VRAM / restore the headroom
+      } else if (probe.outcome === 'ok') {
+        bestN = mid // fits with headroom → record, try FEWER CPU experts (more on GPU)
         hi = mid - 1
       } else {
-        lo = mid + 1  // crash / timeout → treat as memory pressure
+        lo = mid + 1 // crash / timeout → treat as memory pressure
       }
     }
-    return best ? await this.confirmPeak(entry, sys, base, caps, results, best, 'nCpuMoe', maxN) : null
+
+    if (bestN === null) return null
+    return this.benchAt(entry, sys, { ...base, nCpuMoe: bestN }, caps, results, `nCpuMoe=${bestN}`)
   }
 
-  /** Spill correction (unimodal throughput). The binary search picks the config that "fits", but a
-   *  config that overflows VRAM into shared memory passes the fit/prefill check yet is PCIe-bottlenecked
-   *  — so t/s actually PEAKS at the no-spill edge and drops once spilling. After the search, step ONE
-   *  toward LESS GPU (moe: +1 expert on CPU; dense: -1 GPU layer) and keep it only while it's faster:
-   *  if the pick was spilling, this follows the curve up to the real peak; if not, it confirms the pick
-   *  in one extra trial. */
-  private async confirmPeak(
+  /** Measure how much the KV-cache QUANT swings VRAM at this context — so we tune only the quant(s)
+   *  that matter instead of sweeping all. Two cheap probes (largest vs smallest candidate) at ONE
+   *  shared offload: their VRAM difference is exactly the KV-size difference (weights + overhead are
+   *  identical at the same offload), valid for any architecture. Returns that swing in MB scaled to
+   *  the full model, `Number.MAX_SAFE_INTEGER` if even the largest quant won't load (cache enormous
+   *  → definitely the big-KV regime), or -1 if it couldn't be sized at all. */
+  private async calibrateKvSpread(
     entry: ModelEntry,
     sys: SysInfo,
     base: LoadProfile,
     caps: Engine['capabilities'],
+    candidates: string[],
     results: BenchCandidate[],
-    best: { cand: BenchCandidate; profile: LoadProfile },
-    knob: 'ngl' | 'nCpuMoe',
-    maxNCpuMoe: number,
-  ): Promise<{ cand: BenchCandidate; profile: LoadProfile }> {
-    for (let guard = 0; guard < 8 && !this.cancelled && Date.now() <= this.deadline; guard++) {
-      const cur = knob === 'nCpuMoe' ? best.cand.params.nCpuMoe : best.cand.params.ngl
-      const next = knob === 'nCpuMoe' ? cur + 1 : cur - 1 // one step toward LESS GPU
-      if (knob === 'nCpuMoe' ? next > maxNCpuMoe : next < 0) break
-      const label = `${knob}=${next}`
-      this.state = { ...this.state, step: `Confirming ${label} (spill check)…`, candidates: results }
-      const profile: LoadProfile = knob === 'nCpuMoe' ? { ...base, nCpuMoe: next } : { ...base, ngl: next }
-      const cand = await this.measure(entry, sys, profile, caps, label, `Confirming ${label}`)
-      results.push(cand)
-      this.state = { ...this.state, candidates: results }
-      await this.settleGpu()
-      if (cand.outcome === 'ok' && cand.tps !== null && cand.tps > (best.cand.tps ?? 0)) {
-        best = { cand, profile } // the previous pick was spilling — this one's faster
-        this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
-      } else {
-        break // no improvement → the previous pick is the peak
-      }
+  ): Promise<number> {
+    const big = kvLargest(candidates)
+    const small = kvSmallest(candidates)
+    if (big === small) return 0
+
+    // A shared offload where the KV is resident on the GPU (so the swing is measurable) yet the
+    // model loads even with the LARGEST cache: MoE → all experts on CPU (attention + KV stay on
+    // GPU); dense → a small fraction of layers on GPU.
+    const blocks = entry.blockCount > 0 ? entry.blockCount : 32
+    const moeMax = entry.blockCount > 0 ? entry.blockCount : deriveDefault(entry, sys).nCpuMoe || 0
+    const refNgl = Math.max(1, Math.floor(blocks / 4))
+    const refOffload: Partial<LoadProfile> = entry.moe ? { nCpuMoe: moeMax, ngl: 99 } : { ngl: refNgl }
+    const knob: 'ngl' | 'nCpuMoe' = entry.moe ? 'nCpuMoe' : 'ngl'
+    const knobVal = entry.moe ? moeMax : refNgl
+
+    this.state = { ...this.state, step: `Sizing the KV cache (${big} vs ${small})…`, candidates: results }
+    const pBig = await this.probeVram(entry, sys, { ...base, kvTypeK: big, kvTypeV: big, ...refOffload }, caps)
+    this.pushProbe(results, { ...base, kvTypeK: big, ...refOffload }, knob, knobVal, pBig)
+    await this.settleGpu()
+    const pSmall = await this.probeVram(entry, sys, { ...base, kvTypeK: small, kvTypeV: small, ...refOffload }, caps)
+    this.pushProbe(results, { ...base, kvTypeK: small, ...refOffload }, knob, knobVal, pSmall)
+    await this.settleGpu()
+
+    if (pBig.outcome !== 'ok' || pBig.vramAbsMb === null) return Number.MAX_SAFE_INTEGER // huge cache
+    if (pSmall.outcome !== 'ok' || pSmall.vramAbsMb === null) return -1 // couldn't size it
+    let spread = pBig.vramAbsMb - pSmall.vramAbsMb
+    // Dense: only the GPU layers' KV is resident at refNgl, so scale the partial swing up to the
+    // whole model. (MoE keeps every attention layer's KV on GPU already → no scaling.)
+    if (!entry.moe) spread = spread * (blocks / refNgl)
+    return Math.max(0, spread)
+  }
+
+  /** A cheap VRAM probe (Phase 1 of a search): load the candidate, wait for readiness — by which
+   *  point the weights, the full KV cache, AND the compute buffers are all allocated — read the
+   *  absolute GPU VRAM in use, then stop. NO prefill, NO generation. The offload param is decided
+   *  from this alone: whether a config fits-with-headroom or spills is a load-time property, so
+   *  measuring t/s at every search step would be wasted — we bench ONCE, at the chosen config. */
+  private async probeVram(
+    entry: ModelEntry,
+    sys: SysInfo,
+    profile: LoadProfile,
+    caps: Engine['capabilities'],
+  ): Promise<{ outcome: 'ok' | 'timeout' | 'crash' | 'oom'; vramAbsMb: number | null }> {
+    const active = this.registry.active()
+    if (!active) return { outcome: 'crash', vramAbsMb: null }
+    const testDeadline = Math.min(Date.now() + READY_TIMEOUT_MS + 5_000, this.deadline)
+    const opts: StartOpts = {
+      engine: active,
+      model: { key: entry.key, name: entry.name, quant: entry.quant, ctx: profile.ctx, vision: entry.vision },
+      modelPath: entry.path,
+      extraArgs: profileToArgs(profile, entry, caps, sys.cores),
     }
-    return best
+    try {
+      await this.manager.start(opts)
+    } catch {
+      return { outcome: 'crash', vramAbsMb: null }
+    }
+    const outcome = await this.awaitReady(testDeadline)
+    let vramAbsMb: number | null = null
+    if (outcome === 'ok') {
+      await sleep(800) // let the allocator settle so the VRAM reading is final
+      vramAbsMb = await readNvidiaVramMb()
+    }
+    await this.manager.stopAndWait().catch(() => {})
+    return { outcome, vramAbsMb }
+  }
+
+  /** Record a VRAM-probe trial in the candidate list (tps/prefill are null — nothing was generated;
+   *  only the load outcome and absolute VRAM are known). */
+  private pushProbe(
+    results: BenchCandidate[],
+    base: LoadProfile,
+    knob: 'ngl' | 'nCpuMoe',
+    value: number,
+    probe: { outcome: BenchCandidate['outcome']; vramAbsMb: number | null },
+  ): void {
+    results.push({
+      label: `probe ${knob}=${value}`,
+      params: {
+        ctx: base.ctx,
+        ngl: knob === 'ngl' ? value : base.ngl,
+        nCpuMoe: knob === 'nCpuMoe' ? value : base.nCpuMoe,
+        parallel: base.parallel,
+        kvTypeK: base.kvTypeK,
+        flashAttn: base.flashAttn,
+      },
+      outcome: probe.outcome,
+      tps: null,
+      prefillTps: null,
+      ttftMs: null,
+      vramMb: null,
+      vramAbsMb: probe.vramAbsMb,
+    })
+    this.state = { ...this.state, candidates: results }
+  }
+
+  /** Phase 2: the single full prefill + t/s benchmark, at the offload the VRAM probe chose. Pushes
+   *  the candidate and returns it as this KV quant's winner (null if the final measurement faulted). */
+  private async benchAt(
+    entry: ModelEntry,
+    sys: SysInfo,
+    profile: LoadProfile,
+    caps: Engine['capabilities'],
+    results: BenchCandidate[],
+    label: string,
+  ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
+    this.state = { ...this.state, step: `KV ${profile.kvTypeK}: measuring best (${label})…`, candidates: results }
+    const cand = await this.measure(entry, sys, profile, caps, label, `Measuring ${label}`)
+    results.push(cand)
+    this.state = { ...this.state, candidates: results, bestTps: cand.tps ?? this.state.bestTps }
+    await this.settleGpu()
+    return cand.outcome === 'ok' && cand.tps !== null ? { cand, profile } : null
   }
 
   /** The measurement primitive (spec 09 §1): launch the candidate, detect
@@ -435,7 +578,7 @@ export class BenchRunner {
       kvTypeK: profile.kvTypeK,
       flashAttn: profile.flashAttn,
     }
-    const fail = (outcome: BenchCandidate['outcome']): BenchCandidate => ({ label, params, outcome, tps: null, ttftMs: null, vramMb: null })
+    const fail = (outcome: BenchCandidate['outcome']): BenchCandidate => ({ label, params, outcome, tps: null, prefillTps: null, ttftMs: null, vramMb: null, vramAbsMb: null })
     // Live sub-phase progress so each (possibly multi-minute) trial isn't a silent wait.
     const phase = (p: string) => { this.state = { ...this.state, step: `${stepPrefix} — ${p}` } }
 
@@ -480,7 +623,7 @@ export class BenchRunner {
     }
     const logPath = this.manager.logPath()
 
-    // Bench prompt = 75% of the configured ctx, capped at 50k (see benchPromptTokens).
+    // Bench prompt = 75% of the configured ctx, capped at 8k (see benchPromptTokens).
     const promptContent = makeBenchContent(benchPromptTokens(profile.ctx))
 
     // Prefill gate (doubles as warmup): stream the prompt and fail fast if it's spilling/crawling
@@ -499,7 +642,7 @@ export class BenchRunner {
 
     if ('fault' in measured) return fail(measured.fault)
     const vramMb = vramBefore !== null && vramAfter !== null ? Math.max(0, vramAfter - vramBefore) : vramAfter
-    return { label, params, outcome: 'ok', tps: measured.tps, ttftMs: measured.ttftMs, vramMb }
+    return { label, params, outcome: 'ok', tps: measured.tps, prefillTps: measured.prefillTps, ttftMs: measured.ttftMs, vramMb, vramAbsMb: vramAfter }
   }
 
   /** Poll the manager state until the engine is running, the readiness window
@@ -554,7 +697,7 @@ export class BenchRunner {
     maxTokens: number,
     budgetMs: number,
     logPath: string,
-  ): Promise<{ tps: number; ttftMs: number } | { fault: 'oom' | 'crash' | 'timeout' }> {
+  ): Promise<{ tps: number; prefillTps: number | null; ttftMs: number } | { fault: 'oom' | 'crash' | 'timeout' }> {
     const probe = new AbortController()
     let fault: 'oom' | 'crash' | null = null
     const watch = (async () => {
@@ -572,7 +715,7 @@ export class BenchRunner {
       }
     })()
 
-    let timed: { tps: number; ttftMs: number } | null = null
+    let timed: { tps: number; prefillTps: number | null; ttftMs: number } | null = null
     try {
       timed = await this.chat(target, content, maxTokens, budgetMs, probe.signal)
     } catch {
@@ -671,7 +814,7 @@ export class BenchRunner {
 
   /** One non-streaming /v1/chat/completions request. Returns engine-reported tps + ttftMs, or null.
    *  Aborts on the per-test timeout, the cancel kill-switch, or `extraSignal` (the fault watchdog). */
-  private async chat(target: string, content: string, maxTokens: number, timeoutMs: number, extraSignal?: AbortSignal): Promise<{ tps: number; ttftMs: number } | null> {
+  private async chat(target: string, content: string, maxTokens: number, timeoutMs: number, extraSignal?: AbortSignal): Promise<{ tps: number; prefillTps: number | null; ttftMs: number } | null> {
     const signals: AbortSignal[] = [AbortSignal.timeout(timeoutMs)]
     if (this.abort) signals.push(this.abort.signal)
     if (extraSignal) signals.push(extraSignal)
@@ -685,14 +828,22 @@ export class BenchRunner {
         temperature: 0,
         seed: 42,
         stream: false,
+        // Re-process the prompt instead of reusing the warmup's cached prefill — otherwise the
+        // engine only evaluates the few new template tokens and `prompt_per_second` reflects ~4
+        // tokens, not the real prefill throughput over the whole bench prompt.
+        cache_prompt: false,
       }),
       signal: signals.length > 1 ? AbortSignal.any(signals) : signals[0],
     })
     if (!res.ok) return null
-    const data = (await res.json()) as { timings?: { predicted_per_second?: number; prompt_ms?: number } }
+    const data = (await res.json()) as { timings?: { predicted_per_second?: number; prompt_per_second?: number; prompt_ms?: number } }
     const t = data.timings
     if (!t || typeof t.predicted_per_second !== 'number') return null
-    return { tps: t.predicted_per_second, ttftMs: typeof t.prompt_ms === 'number' ? t.prompt_ms : 0 }
+    return {
+      tps: t.predicted_per_second,
+      prefillTps: typeof t.prompt_per_second === 'number' ? t.prompt_per_second : null,
+      ttftMs: typeof t.prompt_ms === 'number' ? t.prompt_ms : 0,
+    }
   }
 
   // ---- card-derived recommended sampling (ADR-099) ------------------------
@@ -894,20 +1045,83 @@ function makeBenchContent(targetTokens: number): string {
   return BENCH_BASE.repeat(reps).slice(0, targetChars) + '\n\nSummarize the passage above in one sentence.'
 }
 
-/** How many prompt tokens to use for a bench trial: 75% of the configured context, capped at
- *  50k tokens. The 0.75 factor keeps the prompt a realistic fraction of the window (leaving room
- *  for generation); the 50k cap stops very large-ctx models from spending the whole trial
- *  prefilling a huge prompt (which would risk the per-test timeout). KV/VRAM is allocated for the
- *  full ctx at load regardless, so this only sizes the prefill-speed measurement, not VRAM fit. */
+/** How many prompt tokens to use for a bench trial: 75% of the configured context, capped at 8k.
+ *  The cap matters for BOTH speed and accuracy. Speed: a huge model at 200K would otherwise spend
+ *  the whole trial prefilling tens of thousands of tokens. Accuracy: generation t/s falls with how
+ *  deep the context is, and a very deep measurement reflects a worst case, not typical use — an 8k
+ *  context is representative of normal prompts and makes the per-token attention cost (which is
+ *  where a low-bit KV's slower kernel shows up) realistic rather than exaggerated. KV/VRAM is
+ *  allocated for the full ctx at load regardless, so this only sizes the speed measurement. */
 function benchPromptTokens(ctx: number): number {
-  return Math.max(256, Math.min(50_000, Math.floor(ctx * 0.75)))
+  return Math.max(256, Math.min(8_192, Math.floor(ctx * 0.75)))
 }
 
-/** True when a measured VRAM figure exceeds 95% of the primary GPU's VRAM. */
-function overVram(vramMb: number | null, sys: SysInfo): boolean {
-  const total = sys.gpus[0]?.vramMb ?? 0
-  if (!vramMb || total <= 0) return false
-  return vramMb > total * 0.95
+/** Total dedicated VRAM across all GPUs, MB (0 when none / non-NVIDIA). */
+function totalVramMb(sys: SysInfo): number {
+  return sys.gpus.reduce((s, g) => s + (g.vramMb || 0), 0)
+}
+
+/** True when a candidate's ABSOLUTE VRAM use leaves less than VRAM_HEADROOM_MB free — i.e. it's
+ *  too close to the spill edge. The search then offloads more so the chosen config keeps a safety
+ *  margin against a later desktop / ComfyUI VRAM grab. Unknown VRAM (non-NVIDIA) → never blocks. */
+function overHeadroom(vramAbsMb: number | null, sys: SysInfo): boolean {
+  const total = totalVramMb(sys)
+  if (!vramAbsMb || total <= 0) return false
+  return vramAbsMb > total - VRAM_HEADROOM_MB
+}
+
+/** The quality-preserving KV-cache types to try, in search order. The model's current/base type
+ *  comes first (so a budget-truncated run is never worse than today), then the other near-lossless
+ *  options the engine actually supports. An unprobed engine (empty kvTypes) is treated as f16-only,
+ *  so only the base type is offered. See {@link QUALITY_KV}. */
+export function pickKvQuants(baseKv: string, kvTypes: string[]): string[] {
+  const supported = (t: string) => (kvTypes.length === 0 ? t === baseKv : kvTypes.includes(t))
+  const out: string[] = []
+  for (const t of [baseKv, ...QUALITY_KV]) if (supported(t) && !out.includes(t)) out.push(t)
+  return out
+}
+
+/** Speed objective ("best prefill AND t/s"): generation t/s is primary; when two configs are within
+ *  OUTPUT_TIE of each other on generation t/s, the one with faster prefill wins. Returns true when
+ *  `a` beats `b`. */
+export function betterBySpeed(
+  a: { tps: number | null; prefillTps: number | null },
+  b: { tps: number | null; prefillTps: number | null },
+): boolean {
+  const at = a.tps ?? 0
+  const bt = b.tps ?? 0
+  if (bt <= 0) return at > 0
+  const rel = (at - bt) / bt
+  if (rel > OUTPUT_TIE) return true
+  if (rel < -OUTPUT_TIE) return false
+  return (a.prefillTps ?? 0) > (b.prefillTps ?? 0)
+}
+
+/** Bytes per cached element for a KV-cache type (defaults to f16's 2 for unknown types). */
+function kvBytes(t: string): number {
+  return KV_BYTES[t] ?? 2
+}
+/** The largest / smallest KV-cache type in a candidate set (by bytes per element). */
+function kvLargest(c: string[]): string {
+  return c.reduce((a, b) => (kvBytes(b) > kvBytes(a) ? b : a), c[0])
+}
+function kvSmallest(c: string[]): string {
+  return c.reduce((a, b) => (kvBytes(b) < kvBytes(a) ? b : a), c[0])
+}
+
+/** Decide which quality-preserving KV-cache type(s) to actually tune, from the measured VRAM swing
+ *  (see {@link calibrateKvSpread}). Tiny swing → the cache is small, so the quant barely changes
+ *  the fit and the highest-precision/fastest-kernel type (f16) wins → tune only it. Big (or
+ *  un-sizable, spread < 0) swing → the smallest type frees real VRAM for more of the model on the
+ *  GPU, but its kernel can be slower (turbo4), so tune BOTH the smallest and the q8_0 stock fallback
+ *  and let the measured prefill + t/s pick the winner. */
+export function decideKvToBench(spreadMb: number, candidates: string[]): string[] {
+  const has = (t: string) => candidates.includes(t)
+  const largest = kvLargest(candidates)
+  if (spreadMb >= 0 && spreadMb <= KV_SPREAD_MIN) return [largest]
+  const smallest = has('turbo4') ? 'turbo4' : kvSmallest(candidates)
+  const stock = has('q8_0') ? 'q8_0' : largest
+  return [...new Set([smallest, stock])]
 }
 
 /** Best-effort current NVIDIA VRAM use in MB (sum across GPUs). Null on non-NVIDIA

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -864,6 +864,8 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
     ttftMs,
     totalMs,
     thinkMs,
+    // Full context occupancy: cache-reused prompt tokens still sit in the KV cache / context
+    // window (they're skipped only for recomputation), so they must stay counted here.
     ctxUsed: (finalUsage.prompt_tokens ?? 0) + (finalUsage.completion_tokens ?? 0),
     ctxMax,
     model: ms.model?.name ?? '',

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -84,24 +84,31 @@ test('streamToAnthropic publishes prefill % then token counts, and never forward
 
 // ── streamToAnthropic usage mapping ─────────────────────────────────────────
 
-test('streamToAnthropic maps prompt_tokens/completion_tokens to Anthropic usage with cache reuse', async () => {
+async function cacheReadFromTimings(timingsJson: string): Promise<number> {
   const upstream = sseStream([
     'data: {"choices":[{"delta":{"content":"Hi"}}]}',
-    'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":50},"timings":{"prompt_n_reuse":20}}',
+    `data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":50},"timings":${timingsJson}}`,
     'data: [DONE]',
   ])
-
   const events: { event: string; data: string }[] = []
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_2')) {
-    events.push(evt)
-  }
-
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_2')) events.push(evt)
   const delta = events.find((e) => e.event === 'message_delta')
   assert.ok(delta, 'message_delta event must be emitted')
-  const parsed = JSON.parse(delta!.data) as { usage: { output_tokens: number; input_tokens: number; cache_read_input_tokens: number } }
-  assert.equal(parsed.usage.output_tokens, 50)
+  const parsed = JSON.parse(delta!.data) as { usage: { input_tokens: number; cache_read_input_tokens: number } }
   assert.equal(parsed.usage.input_tokens, 100)
-  assert.equal(parsed.usage.cache_read_input_tokens, 20)
+  return parsed.usage.cache_read_input_tokens
+}
+
+test('streamToAnthropic reads cache-reuse from `cache_n` (current llama.cpp field)', async () => {
+  assert.equal(await cacheReadFromTimings('{"cache_n":20}'), 20)
+})
+
+test('streamToAnthropic still honors legacy `prompt_n_reuse` (older builds)', async () => {
+  assert.equal(await cacheReadFromTimings('{"prompt_n_reuse":20}'), 20)
+})
+
+test('streamToAnthropic prefers `cache_n` over a stale `prompt_n_reuse`', async () => {
+  assert.equal(await cacheReadFromTimings('{"cache_n":20,"prompt_n_reuse":0}'), 20)
 })
 
 test('streamToAnthropic emits cache_read_input_tokens: 0 when no timings field', async () => {

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -285,8 +285,11 @@ export async function* streamToAnthropic(
         const usage = chunk.usage as { prompt_tokens?: number; completion_tokens?: number } | undefined
         if (usage?.completion_tokens) outputTokens = usage.completion_tokens
         if (usage?.prompt_tokens) inputTokens = usage.prompt_tokens
-        const timings = chunk.timings as { prompt_n_reuse?: number } | undefined
-        if (timings?.prompt_n_reuse != null) cacheReadTokens = timings.prompt_n_reuse
+        // Cache-reused prompt tokens: current llama.cpp reports `cache_n`; older builds used
+        // `prompt_n_reuse`. Accept either so cache_read_input_tokens isn't silently stuck at 0.
+        const timings = chunk.timings as { cache_n?: number; prompt_n_reuse?: number } | undefined
+        const cacheN = timings?.cache_n ?? timings?.prompt_n_reuse
+        if (cacheN != null) cacheReadTokens = cacheN
 
         const choices = chunk.choices as Array<{ delta?: OAIDelta; finish_reason?: string | null }> | undefined
         if (!choices?.length) continue


### PR DESCRIPTION
Three changes on this branch:

**README** — lead with measured TurboLLM-vs-LM-Studio speed (real 200K-context benchmarks on an RTX 5070 Ti). Removed all app screenshots + the Screenshots section; folded the deep feature sections into collapsible `<details>` so nothing duplicates the Features list. Framed honestly: TurboLLM is faster on the same official llama.cpp, and faster still running the TurboQuant fork's turbo4 KV.

**Auto-tune (bench.ts)** — now *reasons about VRAM* instead of sweeping every KV quant:
- Sizes the KV cache with two cheap probes (VRAM swing between largest/smallest quant at one offload = the real KV size, for any architecture), then tunes only the quant(s) that matter: tiny KV -> f16; big KV -> turbo4 + q8_0, measured.
- Offload (`ngl`/`--n-cpu-moe`) pinned by VRAM probing (load -> read VRAM -> stop, no generation) to within a 1 GB headroom (no spill edge); a single full prefill+t/s bench at the chosen config.
- Winner by best prefill AND t/s. New unit tests cover the decision logic on real 27B/35B/Gemma data.

**Fix (stats / Anthropic)** — count cache-reused prompt tokens in the context-fill meter (they still occupy the window); read `cache_n` (current llama.cpp) with a `prompt_n_reuse` fallback so Anthropic `cache_read_input_tokens` isn't stuck at 0.

454 tests pass; typecheck clean.