### PR TITLE
chore(release): v1.4.1 — rename repo Turbo-LLM → TurboLLM + link consistency

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,17 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.4.1] - 2026-06-23
+
+**Maintenance — brand-name consistency.** The GitHub repository was renamed `Turbo-LLM` →
+`TurboLLM` so the name matches everywhere (product, npm package `turbollm`, and repo). No
+runtime or behavior changes.
+
+### Changed
+- Repository renamed to `github.com/mohitsoni48/TurboLLM`; all in-repo links (package metadata,
+  README badges/images, the in-app "Register your engine" issue link) updated to the new URL.
+  Old links continue to redirect.
+
 ## [1.4.0] - 2026-06-23
 
 **Hygiene release — the small gaps that made the tool feel unfinished: stop the daemon from the CLI, launch Claude Code without pre-loading a model, see gateway-loaded models as loaded, and import chats from ChatGPT/Claude JSON.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/turbollm/web/public/brand/turbollm-icon-512.jpeg?v=2" width="92" height="92" alt="TurboLLM" />
+  <img src="https://raw.githubusercontent.com/mohitsoni48/TurboLLM/main/turbollm/web/public/brand/turbollm-icon-512.jpeg?v=2" width="92" height="92" alt="TurboLLM" />
 </p>
 
 <h1 align="center">TurboLLM</h1>
@@ -30,7 +30,7 @@ API any tool can talk to. TurboLLM is the **performance & bleeding-edge layer fo
 LLMs** — built for people who today hand-compile forks and hunt forums for the right flags.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/how-it-works.svg?v=2" width="860" alt="How TurboLLM works: clients -> one lightweight daemon -> any engine on your GPU" />
+  <img src="https://raw.githubusercontent.com/mohitsoni48/TurboLLM/main/assets/how-it-works.svg?v=2" width="860" alt="How TurboLLM works: clients -> one lightweight daemon -> any engine on your GPU" />
 </p>
 
 ---
@@ -469,6 +469,6 @@ shadcn/ui frontend. One TypeScript codebase, shipped as an npm package.
 Source-available under the **Functional Source License 1.1 (Apache-2.0 future grant)** — SPDX
 **`FSL-1.1-ALv2`**. Free for personal use, internal business use, education, and research; the
 only restriction is shipping a competing product. Each release converts to Apache-2.0 two
-years after it's published. Full text: [LICENSE.md](https://github.com/mohitsoni48/Turbo-LLM/blob/main/turbollm/LICENSE.md).
+years after it's published. Full text: [LICENSE.md](https://github.com/mohitsoni48/TurboLLM/blob/main/turbollm/LICENSE.md).
 
 <p align="center"><sub>Built for people who refuse to wait for the mainstream to bless the fast path. ⚡</sub></p>

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,17 +1,17 @@
 {
   "name": "turbollm",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",
-  "homepage": "https://github.com/mohitsoni48/Turbo-LLM#readme",
+  "homepage": "https://github.com/mohitsoni48/TurboLLM#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mohitsoni48/Turbo-LLM.git",
+    "url": "git+https://github.com/mohitsoni48/TurboLLM.git",
     "directory": "turbollm"
   },
   "bugs": {
-    "url": "https://github.com/mohitsoni48/Turbo-LLM/issues"
+    "url": "https://github.com/mohitsoni48/TurboLLM/issues"
   },
   "keywords": [
     "llm",

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -72,7 +72,7 @@ import {
 } from '../lib/engine-groups'
 
 const ISSUE_URL =
-  'https://github.com/mohitsoni48/Turbo-LLM/issues/new?template=engine-request.yml'
+  'https://github.com/mohitsoni48/TurboLLM/issues/new?template=engine-request.yml'
 
 /** Auto-downloaded official llama.cpp builds live in
  *  `<config>/engines/llama.cpp-<tag>-<backend>/`; everything else is a user fork. */


### PR DESCRIPTION
## What

Brand-name consistency: the GitHub repo was renamed `Turbo-LLM` → `TurboLLM` so the name matches everywhere (product = TurboLLM, npm package = `turbollm`, repo = TurboLLM). This PR updates every in-repo reference to the old name.

## Changes
- `package.json` — `homepage` / `repository.url` / `bugs.url` → new repo URL (+ version bump 1.4.0 → 1.4.1)
- `README.md` — badge/image raw URLs + license link → new repo URL
- `web/src/screens/EnginesScreen.tsx` — in-app "Register your engine" issue link → new repo URL
- `CHANGELOG.md` — `[1.4.1]` entry

## Not a de-confliction
This is cosmetic consistency only. It does **not** resolve the separate "TurboLLM"/"TurboQuant" external naming overlap (tracked in ADR-109) — see decision log.

## Verification
- 495/498 tests pass (3 skipped), 0 fail
- `tsc --noEmit` clean
- web build clean
- No behavior/runtime changes; `dist/` is regenerated from source by `prepublishOnly` at publish

ADR-110.