### PR TITLE
v1.4.2 — fix vLLM model load + chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/turbollm/web/public/brand/turbollm-icon-512.jpeg?v=2" width="92" height="92" alt="TurboLLM" />
+  <img src="https://raw.githubusercontent.com/mohitsoni48/TurboLLM/main/turbollm/web/public/brand/turbollm-icon-512.jpeg?v=2" width="92" height="92" alt="TurboLLM" />
 </p>
 
 <h1 align="center">TurboLLM</h1>
@@ -30,7 +30,7 @@ API any tool can talk to. TurboLLM is the **performance & bleeding-edge layer fo
 LLMs** — built for people who today hand-compile forks and hunt forums for the right flags.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mohitsoni48/Turbo-LLM/main/assets/how-it-works.svg?v=2" width="860" alt="How TurboLLM works: clients -> one lightweight daemon -> any engine on your GPU" />
+  <img src="https://raw.githubusercontent.com/mohitsoni48/TurboLLM/main/assets/how-it-works.svg?v=2" width="860" alt="How TurboLLM works: clients -> one lightweight daemon -> any engine on your GPU" />
 </p>
 
 ---
@@ -469,6 +469,6 @@ shadcn/ui frontend. One TypeScript codebase, shipped as an npm package.
 Source-available under the **Functional Source License 1.1 (Apache-2.0 future grant)** — SPDX
 **`FSL-1.1-ALv2`**. Free for personal use, internal business use, education, and research; the
 only restriction is shipping a competing product. Each release converts to Apache-2.0 two
-years after it's published. Full text: [LICENSE.md](https://github.com/mohitsoni48/Turbo-LLM/blob/main/turbollm/LICENSE.md).
+years after it's published. Full text: [LICENSE.md](https://github.com/mohitsoni48/TurboLLM/blob/main/turbollm/LICENSE.md).
 
 <p align="center"><sub>Built for people who refuse to wait for the mainstream to bless the fast path. ⚡</sub></p>

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,25 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.4.2] - 2026-06-23
+
+**Bugfix — vLLM (safetensors) models now load and chat correctly.** Three issues kept vLLM
+models from working: chat failed outright, the model card mislabeled them as MLX, and the
+context-length control was locked.
+
+### Fixed
+- **Chat on vLLM no longer fails with "Engine returned 400".** The chat path attached tool
+  definitions (web search, run code, …) to every engine, but vLLM rejects a `tools` array
+  unless it was launched with `--enable-auto-tool-choice` and a `--tool-call-parser`, so every
+  vLLM chat turn 400'd. Tools are now sent only to engines that accept them (the llama.cpp
+  family); vLLM chat works. Tool-calling on vLLM remains unsupported for now.
+- **vLLM/safetensors models are classified correctly.** Compressed-tensors checkpoints were
+  mislabeled as MLX `fp16`; the quantization is now read from `quantization_config` (e.g.
+  `w4a16`), so the model card shows the real quant instead of "MLX".
+- **The vLLM "Max model length" control is settable again.** Multimodal configs nest
+  `max_position_embeddings` under `text_config`; the scanner now reads it, so a model's native
+  context length is no longer reported as `0` (which had clamped the max-model-len input to 0).
+
 ## [1.4.1] - 2026-06-23
 
 **Maintenance — brand-name consistency.** The GitHub repository was renamed `Turbo-LLM` →

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -565,14 +565,21 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
         reqBody.reasoning_budget = 0
         reqBody.chat_template_kwargs = { enable_thinking: false }
       }
-      // Attach tools only when the engine kind supports them (llama.cpp + TurboQuant).
-      // MLX/vLLM passthrough is fine too — they ignore unknown fields gracefully.
-      if (toolDefs.length > 0) reqBody.tools = toolDefs
+      // Attach tools only to engines whose OpenAI server accepts a `tools` array as
+      // passthrough. vLLM is strict: a `tools` array (which defaults tool_choice to
+      // "auto") is REJECTED with HTTP 400 — "auto tool choice requires
+      // --enable-auto-tool-choice and --tool-call-parser to be set" — unless the
+      // server was launched with those flags (which we don't, and no built-in parser
+      // matches Gemma's tool format). Sending tools there breaks ALL vLLM chat, so we
+      // skip them. llama.cpp/forks accept them; mlx-lm ignores them harmlessly.
+      const toolsSupported = (d.registry.active()?.kind ?? '') !== 'vllm' && toolDefs.length > 0
+      if (toolsSupported) reqBody.tools = toolDefs
       // Force web_search on the first two iterations when the conversation has a
       // force_web_search policy (e.g. Research persona). This guarantees at least
       // two distinct searches before the model composes its answer. Iteration 3+
       // use "auto" so the model can continue searching or finish as it sees fit.
       if (
+        toolsSupported &&
         conv.toolPolicy === 'force_web_search' &&
         toolIter <= 2 &&
         toolDefs.some((t) => t.function.name === 'web_search')

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -344,7 +344,40 @@ interface MlxConfig {
   num_key_value_heads?: number
   num_local_experts?: number
   num_experts?: number
+  /** MLX-style on-disk quantization (mlx-lm convert). */
   quantization?: { bits?: number; group_size?: number }
+  /** HF/vLLM post-training quantization (compressed-tensors, awq, gptq, fp8…). */
+  quantization_config?: {
+    quant_method?: string
+    bits?: number
+    config_groups?: Record<string, { weights?: { num_bits?: number }; input_activations?: { num_bits?: number } | null }>
+  }
+  /** Multimodal models (gemma4_unified, llava, qwen-vl…) nest the language-model
+   *  fields under `text_config`; read ctx/layers/heads from there when absent up top. */
+  text_config?: Omit<MlxConfig, 'text_config'>
+}
+
+/** Human quant label for a safetensors model dir. Recognizes HF/vLLM post-training
+ *  quant (compressed-tensors → e.g. "w4a16", awq/gptq → "awq-4bit") and MLX-style
+ *  quant ("4bit"); falls back to "fp16" for an unquantized checkpoint. Keeps the label
+ *  engine-neutral — a safetensors dir loads on either MLX or vLLM (compat.ts). */
+function detectSafetensorsQuant(cfg: MlxConfig): string {
+  const qc = cfg.quantization_config
+  if (qc?.quant_method) {
+    const method = qc.quant_method.toLowerCase()
+    const group0 = qc.config_groups ? Object.values(qc.config_groups)[0] : undefined
+    const wBits = group0?.weights?.num_bits ?? qc.bits
+    if (method === 'compressed-tensors') {
+      if (wBits) {
+        const aBits = group0?.input_activations?.num_bits ?? 16
+        return `w${wBits}a${aBits}`
+      }
+      return 'compressed-tensors'
+    }
+    return wBits ? `${method}-${wBits}bit` : method
+  }
+  const mlxBits = cfg.quantization?.bits
+  return mlxBits ? `${mlxBits}bit` : 'fp16'
 }
 
 /** Build a ModelEntry for an MLX model directory by reading its config.json. */
@@ -392,10 +425,13 @@ export function mlxEntryFor(dir: string): ModelEntry {
     }
   } catch { /* best effort */ }
 
-  const expertCount = cfg.num_local_experts ?? cfg.num_experts ?? 0
-  const bits = cfg.quantization?.bits
-  const quant = bits ? `${bits}bit` : 'fp16'
-  const arch = cfg.model_type || cfg.architectures?.[0] || 'unknown'
+  // Multimodal configs nest the LM fields under text_config; fall back to it so
+  // ctx/layers/heads aren't reported as 0 (which would, e.g., lock the vLLM
+  // --max-model-len control to a [0,0] range in the UI).
+  const lm = cfg.text_config ?? {}
+  const expertCount = cfg.num_local_experts ?? cfg.num_experts ?? lm.num_local_experts ?? lm.num_experts ?? 0
+  const quant = detectSafetensorsQuant(cfg)
+  const arch = cfg.model_type || cfg.architectures?.[0] || lm.model_type || 'unknown'
   const name = basename(dir).replace(/[-_]/g, ' ').replace(/\s+/g, ' ').trim()
 
   return {
@@ -408,9 +444,9 @@ export function mlxEntryFor(dir: string): ModelEntry {
     sizeLabel: '',
     arch,
     quant,
-    nativeCtx: cfg.max_position_embeddings ?? 0,
-    blockCount: cfg.num_hidden_layers ?? 0,
-    headCountKv: cfg.num_key_value_heads ?? 0,
+    nativeCtx: cfg.max_position_embeddings ?? lm.max_position_embeddings ?? 0,
+    blockCount: cfg.num_hidden_layers ?? lm.num_hidden_layers ?? 0,
+    headCountKv: cfg.num_key_value_heads ?? lm.num_key_value_heads ?? 0,
     moe: expertCount > 0,
     expertCount,
     nextnLayers: 0,

--- a/turbollm/web/src/components/ModelLoadMenu.tsx
+++ b/turbollm/web/src/components/ModelLoadMenu.tsx
@@ -73,7 +73,7 @@ export function ModelLoadMenu({
               </span>
               <span className="min-w-0 flex-1 truncate">{m.name}</span>
               <span className="shrink-0 text-[11px] uppercase text-faint">
-                {m.format === 'mlx' ? 'MLX' : m.quant}
+                {m.quant}
               </span>
             </div>
           )

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -254,7 +254,7 @@ export function ModelDetailDialog({
             {isVllm && (
               <Section>
                 <Row label="Max model length" hint="vLLM --max-model-len. Max context tokens. 0 = derive from the model config.">
-                  <NumberInput value={draft.vllm?.maxModelLen ?? 0} min={0} max={Math.max(0, detail.nativeCtx || 0)} step={1024} onChange={(v) => setV('maxModelLen', v)} />
+                  <NumberInput value={draft.vllm?.maxModelLen ?? 0} min={0} max={detail.nativeCtx || 1_048_576} step={1024} onChange={(v) => setV('maxModelLen', v)} />
                 </Row>
                 <Slider
                   label="GPU memory utilization"


### PR DESCRIPTION
﻿Bugfix release **v1.4.2** — makes vLLM (safetensors) models load and chat correctly.

### Fixed
- **Chat on vLLM no longer 400s.** The chat path attached tool definitions to every engine; vLLM rejects a `tools` array without `--enable-auto-tool-choice` + a `--tool-call-parser`, so every vLLM chat turn returned "Engine returned 400". Tools are now sent only to engines that accept them (llama.cpp family).
- **Correct quant classification.** Compressed-tensors checkpoints were mislabeled as MLX `fp16`; quant is now read from `quantization_config` (e.g. `w4a16`), so the model card no longer shows "MLX" on vLLM.
- **"Max model length" is settable again.** Multimodal configs nest `max_position_embeddings` under `text_config`; the scanner now reads it, so native context is no longer reported as 0 (which had locked the input).

Verified: full test suite (495 pass / 0 fail), live vLLM chat (WSL) and llama.cpp chat + tools (Windows) both working; no regression to the llama.cpp/GGUF path.