### PR TITLE
feat(v1.5.0): background agents + inline artifacts + Designer persona

### DIFF
--- a/turbollm/src/agents/agent-routes.ts
+++ b/turbollm/src/agents/agent-routes.ts
@@ -1,0 +1,85 @@
+// Background agent HTTP routes.
+// POST   /api/v1/agents/runs        — create + queue a run
+// GET    /api/v1/agents/runs        — list runs (newest first)
+// GET    /api/v1/agents/runs/:id    — get run + messages
+// DELETE /api/v1/agents/runs/:id    — cancel
+// GET    /api/v1/agents/runs/:id/stream — SSE live-tail (replay + live)
+import type { Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import type { Deps } from '../deps'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function err(c: any, status: number, code: string, message: string) {
+  return c.json({ error: { code, message } }, status)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function body<T>(c: any): Promise<T> {
+  try { return (await c.req.json()) as T } catch { return {} as T }
+}
+
+export function registerAgentRoutes(app: Hono, d: Deps): void {
+  // Create and queue a run
+  app.post('/api/v1/agents/runs', async (c) => {
+    if (!d.agentRunner) return err(c, 501, 'not_implemented', 'Agent runner not available.')
+    const b = await body<{ title?: string; systemPrompt?: string; userMessage?: string; allowedTools?: string[] }>(c)
+    if (!b.userMessage?.trim()) return err(c, 400, 'invalid_input', 'userMessage is required.')
+
+    const id = await d.agentRunner.launch({
+      title: b.title?.trim() || 'Agent run',
+      systemPrompt: b.systemPrompt ?? '',
+      userMessage: b.userMessage.trim(),
+      allowedTools: Array.isArray(b.allowedTools) ? b.allowedTools : [],
+    })
+
+    const run = d.db.getAgentRun?.(id)
+    return c.json(run, 201)
+  })
+
+  // List runs (newest first)
+  app.get('/api/v1/agents/runs', (c) => {
+    if (!d.db.listAgentRuns) return err(c, 501, 'not_implemented', 'Agent runner not available.')
+    return c.json(d.db.listAgentRuns())
+  })
+
+  // Get a single run with its conversation messages
+  app.get('/api/v1/agents/runs/:id', (c) => {
+    const id = c.req.param('id')
+    if (!d.db.getAgentRun) return err(c, 501, 'not_implemented', 'Agent runner not available.')
+    const run = d.db.getAgentRun(id)
+    if (!run) return err(c, 404, 'not_found', 'Run not found.')
+    const conv = d.db.getConversation(run.convId, true)
+    return c.json({ ...run, messages: conv?.messages ?? [] })
+  })
+
+  // Cancel a run
+  app.delete('/api/v1/agents/runs/:id', (c) => {
+    const id = c.req.param('id')
+    if (!d.agentRunner) return err(c, 501, 'not_implemented', 'Agent runner not available.')
+    const ok = d.agentRunner.cancel(id)
+    if (!ok) return err(c, 404, 'not_found', 'Run not found or already complete.')
+    return c.json({ ok: true })
+  })
+
+  // SSE stream — replay buffered events from `fromSeq`, then live-tail
+  app.get('/api/v1/agents/runs/:id/stream', (c) => {
+    const id = c.req.param('id')
+    const fromSeq = Math.max(0, Number(c.req.query('fromSeq') ?? '0'))
+    if (!d.agentRunner) return err(c, 501, 'not_implemented', 'Agent runner not available.')
+    const run = d.db.getAgentRun?.(id)
+    if (!run) return err(c, 404, 'not_found', 'Run not found.')
+
+    return streamSSE(c, async (stream) => {
+      const sub = d.agentRunner!.subscribe(id, fromSeq)
+      stream.onAbort(() => sub.close())
+      try {
+        for await (const ev of sub) {
+          await stream.writeSSE({ event: ev.event, data: JSON.stringify(ev.data) })
+          if (ev.event === 'done' || ev.event === 'error') break
+        }
+      } finally {
+        sub.close()
+      }
+    })
+  })
+}

--- a/turbollm/src/agents/gate.ts
+++ b/turbollm/src/agents/gate.ts
@@ -1,0 +1,42 @@
+// GenerationGate — priority-queue mutex shared between the foreground chat SSE
+// handler and the background agent runner. Foreground ('fg') requests jump ahead
+// of queued background ('bg') callers so the user's chat always feels snappy.
+// Acquired once per engine call; released before tool execution.
+
+interface Waiter {
+  priority: 'fg' | 'bg'
+  resolve: (release: () => void) => void
+}
+
+export class GenerationGate {
+  private held = false
+  private queue: Waiter[] = []
+
+  async acquire(priority: 'fg' | 'bg'): Promise<() => void> {
+    if (!this.held) {
+      this.held = true
+      return this.makeRelease()
+    }
+    return new Promise<() => void>((resolve) => {
+      const waiter: Waiter = { priority, resolve }
+      if (priority === 'fg') {
+        // fg jumps ahead of all bg waiters
+        const firstBg = this.queue.findIndex((w) => w.priority === 'bg')
+        this.queue.splice(firstBg >= 0 ? firstBg : this.queue.length, 0, waiter)
+      } else {
+        this.queue.push(waiter)
+      }
+    })
+  }
+
+  private makeRelease(): () => void {
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const next = this.queue.shift()
+      if (next) next.resolve(this.makeRelease())
+      else this.held = false
+    }
+  }
+}

--- a/turbollm/src/agents/runner.ts
+++ b/turbollm/src/agents/runner.ts
@@ -1,0 +1,245 @@
+// Background agent runner — one active run at a time; extras queue.
+// Each run gets a dedicated conversation (kind='agent') and its own AbortController.
+// Events are stored in a ring buffer (cap 2000) and live-tailed via EventEmitter.
+import { EventEmitter } from 'node:events'
+import type { Deps } from '../deps'
+import { runGeneration } from '../chat/generation'
+
+const BUFFER_CAP = 2000
+
+export interface BufferedEvent {
+  seq: number
+  event: string
+  data: unknown
+}
+
+class RunBuffer {
+  private events: BufferedEvent[] = []
+  private next = 0
+
+  push(event: string, data: unknown): BufferedEvent {
+    const ev: BufferedEvent = { seq: this.next++, event, data }
+    this.events.push(ev)
+    if (this.events.length > BUFFER_CAP) this.events.shift()
+    return ev
+  }
+
+  since(fromSeq: number): BufferedEvent[] {
+    return this.events.filter((e) => e.seq >= fromSeq)
+  }
+}
+
+export interface LaunchParams {
+  title: string
+  systemPrompt?: string
+  userMessage: string
+  allowedTools: string[]
+  maxToolIter?: number
+}
+
+interface PendingRun extends LaunchParams {
+  id: string
+  convId: string
+}
+
+export class AgentRunner {
+  private d: Deps
+  private buffers = new Map<string, RunBuffer>()
+  private emitters = new Map<string, EventEmitter>()
+  private acs = new Map<string, AbortController>()
+  private queue: PendingRun[] = []
+  private active: string | null = null
+
+  constructor(d: Deps) { this.d = d }
+
+  /** On startup: mark any DB runs left in queued/running state as interrupted. */
+  reconcileOnStartup(): void {
+    const runs = this.d.db.listAgentRuns?.({ statuses: ['queued', 'running'] }) ?? []
+    for (const run of runs) {
+      this.d.db.updateAgentRun?.(run.id, { status: 'interrupted', endedAt: new Date().toISOString() })
+    }
+  }
+
+  /** Create a new agent run and queue it. Returns the run ID immediately. */
+  async launch(params: LaunchParams): Promise<string> {
+    const db = this.d.db
+
+    // Create a dedicated conversation for this run
+    const conv = db.createConversation({
+      title: params.title,
+      systemPrompt: params.systemPrompt ?? '',
+      kind: 'agent',
+    })
+
+    const run = db.createAgentRun?.({
+      convId: conv.id,
+      title: params.title,
+      allowedTools: params.allowedTools,
+    })
+    if (!run) throw new Error('createAgentRun not available (DB migration pending?)')
+
+    this.queue.push({ ...params, id: run.id, convId: conv.id })
+    void this.processNext()
+    return run.id
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.active !== null || this.queue.length === 0) return
+    const pending = this.queue.shift()!
+    this.active = pending.id
+
+    const buffer = new RunBuffer()
+    const emitter = new EventEmitter()
+    emitter.setMaxListeners(50)
+    const ac = new AbortController()
+
+    this.buffers.set(pending.id, buffer)
+    this.emitters.set(pending.id, emitter)
+    this.acs.set(pending.id, ac)
+
+    const sink = ({ event, data }: { event: string; data: unknown }) => {
+      const ev = buffer.push(event, data)
+      emitter.emit('event', ev)
+    }
+
+    this.d.db.updateAgentRun?.(pending.id, { status: 'running', startedAt: new Date().toISOString() })
+
+    const ms = this.d.manager.status()
+    const target = this.d.manager.target()
+
+    if (ms.state !== 'running' || !ms.model || !target) {
+      this.d.db.updateAgentRun?.(pending.id, { status: 'failed', error: 'Model not loaded', endedAt: new Date().toISOString() })
+      sink({ event: 'error', data: { code: 'model_not_loaded', message: 'Load a model first.' } })
+      this.finish(pending.id)
+      return
+    }
+
+    const conv = this.d.db.getConversation(pending.convId)!
+
+    this.d.db.addMessage(pending.convId, 'user', pending.userMessage)
+    this.d.db.addMessage(pending.convId, 'assistant', '', { stats: { aborted: false } })
+    const assistantMsg = this.d.db.getLastMessage(pending.convId)!
+
+    const engineMessages: { role: string; content: unknown }[] = []
+    if (conv.systemPrompt) engineMessages.push({ role: 'system', content: conv.systemPrompt })
+    engineMessages.push({ role: 'user', content: pending.userMessage })
+
+    try {
+      await runGeneration(this.d, sink, {
+        convId: pending.convId,
+        conv,
+        engineMessages,
+        assistantMsg,
+        ms,
+        target,
+        ac,
+        disableThinking: false,
+        maxToolIter: pending.maxToolIter ?? 30,
+        allowedTools: pending.allowedTools,
+        skipAutoTitle: true,
+        gatePriority: 'bg',
+      })
+      this.d.db.updateAgentRun?.(pending.id, { status: 'done', endedAt: new Date().toISOString() })
+    } catch (e) {
+      const isAbort = (e as Error)?.name === 'AbortError'
+      this.d.db.updateAgentRun?.(pending.id, {
+        status: isAbort ? 'cancelled' : 'failed',
+        error: isAbort ? undefined : (e as Error).message,
+        endedAt: new Date().toISOString(),
+      })
+    } finally {
+      this.finish(pending.id)
+    }
+  }
+
+  private finish(id: string): void {
+    this.emitters.get(id)?.emit('done')
+    this.acs.delete(id)
+    this.active = null
+    void this.processNext()
+  }
+
+  cancel(id: string): boolean {
+    // Active run: abort it
+    const ac = this.acs.get(id)
+    if (ac) {
+      ac.abort()
+      this.d.db.updateAgentRun?.(id, { status: 'cancelled', endedAt: new Date().toISOString() })
+      return true
+    }
+    // Queued but not started yet
+    const qIdx = this.queue.findIndex((r) => r.id === id)
+    if (qIdx >= 0) {
+      this.queue.splice(qIdx, 1)
+      this.d.db.updateAgentRun?.(id, { status: 'cancelled', endedAt: new Date().toISOString() })
+      return true
+    }
+    return false
+  }
+
+  /** Called by the engine manager when the active model is evicted. */
+  interruptActive(): void {
+    if (!this.active) return
+    this.acs.get(this.active)?.abort()
+    this.d.db.updateAgentRun?.(this.active, { status: 'interrupted', endedAt: new Date().toISOString() })
+  }
+
+  subscribe(runId: string, fromSeq: number): AsyncIterable<BufferedEvent> & { close: () => void } {
+    const buffer = this.buffers.get(runId)
+    const emitter = this.emitters.get(runId)
+
+    // Run already finished or unknown — return a closed iterable
+    if (!emitter) {
+      return {
+        close() {},
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => ({ value: undefined as unknown as BufferedEvent, done: true as const }),
+            return: async () => ({ value: undefined as unknown as BufferedEvent, done: true as const }),
+          }
+        },
+      }
+    }
+
+    let closed = false
+    const pending: BufferedEvent[] = buffer ? buffer.since(fromSeq) : []
+    let resolver: ((v: IteratorResult<BufferedEvent>) => void) | null = null
+
+    const onEvent = (ev: BufferedEvent) => {
+      if (closed) return
+      if (resolver) { const r = resolver; resolver = null; r({ value: ev, done: false }) }
+      else pending.push(ev)
+    }
+    const onDone = () => {
+      if (resolver) { const r = resolver; resolver = null; r({ value: undefined as unknown as BufferedEvent, done: true }) }
+    }
+
+    emitter.on('event', onEvent)
+    emitter.once('done', onDone)
+
+    function close() {
+      if (closed) return
+      closed = true
+      emitter!.off('event', onEvent)
+      emitter!.off('done', onDone)
+      if (resolver) { const r = resolver; resolver = null; r({ value: undefined as unknown as BufferedEvent, done: true }) }
+    }
+
+    return {
+      close,
+      [Symbol.asyncIterator]() {
+        return {
+          next(): Promise<IteratorResult<BufferedEvent>> {
+            if (closed) return Promise.resolve({ value: undefined as unknown as BufferedEvent, done: true })
+            if (pending.length > 0) return Promise.resolve({ value: pending.shift()!, done: false })
+            return new Promise<IteratorResult<BufferedEvent>>((res) => { resolver = res })
+          },
+          return(): Promise<IteratorResult<BufferedEvent>> {
+            close()
+            return Promise.resolve({ value: undefined as unknown as BufferedEvent, done: true })
+          },
+        }
+      },
+    }
+  }
+}

--- a/turbollm/src/chat/chat-export.test.ts
+++ b/turbollm/src/chat/chat-export.test.ts
@@ -16,6 +16,7 @@ function makeConv(overrides: Partial<Conversation & { messages: Message[] }> = {
     sampling: {},
     expertMode: false,
     toolPolicy: undefined,
+    kind: 'chat',
     createdAt: '2026-06-19T00:00:00.000Z',
     updatedAt: '2026-06-19T00:00:01.000Z',
     messages: [],

--- a/turbollm/src/chat/chat-import.test.ts
+++ b/turbollm/src/chat/chat-import.test.ts
@@ -18,6 +18,7 @@ function makeConv(overrides: Partial<Conversation & { messages: Message[] }> = {
     sampling: {},
     expertMode: false,
     toolPolicy: 'force_web_search',
+    kind: 'chat',
     createdAt: '2026-06-19T00:00:00.000Z',
     updatedAt: '2026-06-19T00:00:01.000Z',
     messages: [],

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -67,7 +67,7 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
 
   app.get('/api/v1/conversations', (c) => {
     const q = c.req.query('q')
-    return c.json({ conversations: db.listConversations(q) })
+    return c.json({ conversations: db.listConversations(q, 'chat') })
   })
 
   app.post('/api/v1/conversations', async (c) => {

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -17,9 +17,25 @@ export interface Conversation {
   /** Tool-calling policy for this conversation. 'force_web_search' forces the model
    *  to call web_search on the first iteration before composing a reply. */
   toolPolicy?: string
+  /** Conversation kind: 'chat' (default user-facing) or 'agent' (background agent run). */
+  kind: 'chat' | 'agent'
   createdAt: string
   updatedAt: string
   messages?: Message[]
+}
+
+/** A background agent run record (v8 migration). */
+export interface AgentRun {
+  id: string
+  convId: string
+  title: string
+  status: 'queued' | 'running' | 'done' | 'failed' | 'cancelled' | 'interrupted'
+  allowedTools: string[]
+  error?: string
+  createdAt: string
+  updatedAt: string
+  startedAt?: string
+  endedAt?: string
 }
 
 export interface MessageStats {
@@ -92,7 +108,8 @@ export interface Message {
   createdAt: string
 }
 
-interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; created_at: string; updated_at: string }
+interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; created_at: string; updated_at: string }
+interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
@@ -101,7 +118,18 @@ type P = Record<string, SQLInputValue>
 function safeJson(s: string): unknown { try { return JSON.parse(s) } catch { return {} } }
 
 function rowToConv(r: ConvRow): Conversation {
-  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at }
+  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), createdAt: r.created_at, updatedAt: r.updated_at }
+}
+
+function rowToAgentRun(r: AgentRunRow): AgentRun {
+  return {
+    id: r.id, convId: r.conv_id, title: r.title,
+    status: r.status as AgentRun['status'],
+    allowedTools: safeJson(r.allowed_tools) as string[],
+    error: r.error ?? undefined,
+    createdAt: r.created_at, updatedAt: r.updated_at,
+    startedAt: r.started_at ?? undefined, endedAt: r.ended_at ?? undefined,
+  }
 }
 
 function rowToMsg(r: MsgRow): Message {
@@ -195,26 +223,60 @@ export class ConversationStore {
         PRAGMA user_version = 7;
       `)
     }
+    // v8 (ADR-112): background agent runs table. Each run maps to a dedicated
+    // conversation of kind='agent'. Ring buffer events are in-memory only;
+    // this table stores the durable run record and status.
+    if (v < 8) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS agent_runs (
+          id TEXT PRIMARY KEY,
+          conv_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+          title TEXT NOT NULL DEFAULT 'Agent run',
+          status TEXT NOT NULL DEFAULT 'queued',
+          allowed_tools TEXT NOT NULL DEFAULT '[]',
+          error TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          started_at TEXT,
+          ended_at TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_runs_status ON agent_runs(status, created_at);
+        PRAGMA user_version = 8;
+      `)
+    }
+    // v9 (ADR-112): conversations.kind column — 'chat' (default) or 'agent'.
+    // Agent conversations are owned by a run and excluded from the chat sidebar.
+    if (v < 9) {
+      this.db.exec(`
+        ALTER TABLE conversations ADD COLUMN kind TEXT NOT NULL DEFAULT 'chat';
+        PRAGMA user_version = 9;
+      `)
+    }
   }
 
-  listConversations(q?: string): Conversation[] {
+  listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
     if (q) {
+      const kindClause = kind !== 'all' ? ' AND c.kind = $kind' : ''
+      const params = kind !== 'all' ? { $q: `%${q}%`, $kind: kind } : { $q: `%${q}%` }
       const rows = this.db.prepare(`
         SELECT DISTINCT c.* FROM conversations c
         LEFT JOIN messages m ON m.conv_id = c.id
-        WHERE c.title LIKE $q OR m.content LIKE $q
+        WHERE (c.title LIKE $q OR m.content LIKE $q)${kindClause}
         ORDER BY c.updated_at DESC LIMIT 200
-      `).all({ $q: `%${q}%` } as P) as unknown as ConvRow[]
+      `).all(params as P) as unknown as ConvRow[]
       return rows.map(rowToConv)
+    }
+    if (kind !== 'all') {
+      return (this.db.prepare(`SELECT * FROM conversations WHERE kind = $kind ORDER BY updated_at DESC LIMIT 200`).all({ $kind: kind } as P) as unknown as ConvRow[]).map(rowToConv)
     }
     return (this.db.prepare(`SELECT * FROM conversations ORDER BY updated_at DESC LIMIT 200`).all() as unknown as ConvRow[]).map(rowToConv)
   }
 
-  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy'>>): Conversation {
+  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy' | 'kind'>>): Conversation {
     const now = new Date().toISOString()
     const id = randomUUID()
-    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$now,$now)`)
-      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $now: now } as P)
+    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,kind,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$kind,$now,$now)`)
+      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $kind: partial?.kind ?? 'chat', $now: now } as P)
     return this.getConversation(id)!
   }
 
@@ -316,6 +378,42 @@ export class ConversationStore {
   getLastMessage(convId: string): Message | null {
     const row = this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id ORDER BY seq DESC LIMIT 1`).get({ $id: convId } as P) as unknown as MsgRow | undefined
     return row ? rowToMsg(row) : null
+  }
+
+  // ── Agent run methods (v8 migration) ──────────────────────────────────────
+
+  createAgentRun(params: { convId: string; title: string; allowedTools: string[] }): AgentRun {
+    const id = randomUUID()
+    const now = new Date().toISOString()
+    this.db.prepare(`INSERT INTO agent_runs (id,conv_id,title,status,allowed_tools,created_at,updated_at) VALUES ($id,$cid,$title,'queued',$at,$now,$now)`)
+      .run({ $id: id, $cid: params.convId, $title: params.title, $at: JSON.stringify(params.allowedTools), $now: now } as P)
+    return this.getAgentRun(id)!
+  }
+
+  getAgentRun(id: string): AgentRun | null {
+    const row = this.db.prepare(`SELECT * FROM agent_runs WHERE id = $id`).get({ $id: id } as P) as unknown as AgentRunRow | undefined
+    return row ? rowToAgentRun(row) : null
+  }
+
+  listAgentRuns(opts?: { statuses?: string[] }): AgentRun[] {
+    if (opts?.statuses?.length) {
+      const placeholders = opts.statuses.map((_, i) => `$s${i}`).join(',')
+      const params: Record<string, SQLInputValue> = {}
+      opts.statuses.forEach((s, i) => { params[`$s${i}`] = s })
+      return (this.db.prepare(`SELECT * FROM agent_runs WHERE status IN (${placeholders}) ORDER BY created_at DESC LIMIT 200`).all(params) as unknown as AgentRunRow[]).map(rowToAgentRun)
+    }
+    return (this.db.prepare(`SELECT * FROM agent_runs ORDER BY created_at DESC LIMIT 200`).all() as unknown as AgentRunRow[]).map(rowToAgentRun)
+  }
+
+  updateAgentRun(id: string, patch: Partial<Pick<AgentRun, 'status' | 'error' | 'startedAt' | 'endedAt'>>): boolean {
+    const now = new Date().toISOString()
+    const sets: string[] = ['updated_at = $now']
+    const params: Record<string, SQLInputValue> = { $id: id, $now: now }
+    if (patch.status    !== undefined) { sets.push('status = $status');      params.$status  = patch.status }
+    if (patch.error     !== undefined) { sets.push('error = $error');        params.$error   = patch.error }
+    if (patch.startedAt !== undefined) { sets.push('started_at = $started'); params.$started = patch.startedAt }
+    if (patch.endedAt   !== undefined) { sets.push('ended_at = $ended');     params.$ended   = patch.endedAt }
+    return ((this.db.prepare(`UPDATE agent_runs SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0
   }
 
   close(): void { this.db.close() }

--- a/turbollm/src/chat/generation.ts
+++ b/turbollm/src/chat/generation.ts
@@ -1,0 +1,541 @@
+// Core generation loop — shared by the foreground chat (chat-routes.ts) and the
+// background agent runner (agents/runner.ts). The EventSink abstraction decouples
+// the loop from the transport (SSE stream vs. in-memory ring buffer).
+import type { Deps } from '../deps'
+import { clampMaxTokens } from '../config/config'
+import { engineModelAlias } from '../engines/compat'
+import { feedChunk, flushState, initParseState } from './parser'
+import { needsExtraPass } from './think-utils'
+import { checkReply } from '../tools/research-referee.js'
+import type { ClaimVerdict, Message, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from './db'
+
+/** One event emitted by the generation loop — the sink decides what to do with it. */
+export type EventSink = (ev: { event: string; data: unknown }) => void | Promise<void>
+
+type ManagerStatus = ReturnType<Deps['manager']['status']>
+
+export interface GenerationCtx {
+  convId: string
+  conv: NonNullable<ReturnType<Deps['db']['getConversation']>>
+  engineMessages: { role: string; content: unknown }[]
+  assistantMsg: Message
+  ms: ManagerStatus
+  target: string
+  ac: AbortController
+  disableThinking: boolean
+  /** Hard cap on tool-loop iterations (default 10 for chat, 30 for agents). */
+  maxToolIter?: number
+  /** When set, only these tool names are forwarded to the engine.
+   *  Used by agents to enforce the launch-time tool consent. */
+  allowedTools?: string[]
+  /** Skip the auto-title setTimeout after generation. */
+  skipAutoTitle?: boolean
+  /** Priority for the generation gate — 'fg' (foreground chat) or 'bg' (agent). */
+  gatePriority?: 'fg' | 'bg'
+}
+
+/**
+ * Streams an assistant turn with optional agentic tool-calling loop. Shared by the
+ * messages/continue endpoints (foreground SSE) and the agent runner (background ring
+ * buffer). The gate is acquired per engine call and released before tool execution
+ * so the engine is free between tool iterations.
+ */
+export async function runGeneration(d: Deps, sink: EventSink, ctx: GenerationCtx): Promise<void> {
+  const { db } = d
+  const { convId, conv, assistantMsg, ms, target, ac, disableThinking } = ctx
+
+  const convS = conv.sampling ?? {}
+  const SAMPLING_KEYS: Record<string, string> = {
+    temp: 'temperature', topP: 'top_p', topK: 'top_k', minP: 'min_p',
+    repeatPenalty: 'repeat_penalty', presencePenalty: 'presence_penalty',
+    frequencyPenalty: 'frequency_penalty',
+  }
+  const samplingOverride: Record<string, unknown> = {}
+  for (const [camel, snake] of Object.entries(SAMPLING_KEYS)) {
+    if (camel in convS) samplingOverride[snake] = convS[camel]
+  }
+  for (const [k, v] of Object.entries(convS)) {
+    if (!(k in SAMPLING_KEYS) && k !== 'stop') samplingOverride[k] = v
+  }
+  const stopStrings = convS.stop as string[] | undefined
+  const maxLimit = d.store.snapshot().modelDefaults.maxTokens ?? 0
+  const MAX_TOOL_ITER = ctx.maxToolIter ?? 10
+  const gatePriority = ctx.gatePriority ?? 'fg'
+
+  const iterMessages: { role: string; content: unknown; tool_calls?: unknown; tool_call_id?: string }[] =
+    ctx.engineMessages.map((m) => ({ role: m.role, content: m.content }))
+
+  const CONFIDENCE_INSTRUCTION =
+    '\n\nAfter reviewing the search results, include a confidence assessment on a line by itself before your final answer: `[confidence: 0.XX]` where XX is your confidence (0.0–1.0) that your answer is accurate and current. If your confidence is below 0.8, call web_search again with a more specific query first. Maximum 3 search calls per response.'
+  if (conv.toolPolicy === 'force_web_search') {
+    const sysIdx = iterMessages.findIndex((m) => m.role === 'system')
+    if (sysIdx >= 0) {
+      const existing = typeof iterMessages[sysIdx].content === 'string' ? iterMessages[sysIdx].content : ''
+      iterMessages[sysIdx] = { ...iterMessages[sysIdx], content: existing + CONFIDENCE_INSTRUCTION }
+    } else {
+      iterMessages.unshift({ role: 'system', content: CONFIDENCE_INSTRUCTION.trim() })
+    }
+  }
+
+  let toolIter = 0
+  let searchCallCount = 0
+  const allResearchSources: ResearchSource[] = []
+  let parsedConfidence: number | undefined
+  let fullContent = ''
+  let fullReasoning = ''
+  const allToolCalls: ToolCallRecord[] = []
+
+  const requestStart = Date.now()
+  let ttftMs = 0
+  let thinkStart = 0
+  let thinkEnd = 0
+  let finalUsage: { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } } = {}
+  let finalTimings: Record<string, number> = {}
+  let aborted = false
+  let liveOut = 0
+
+  d.manager.generationStart()
+  // Tracks the active gate lease; always released in the finally block if still held
+  // (catches AbortError mid-fetch or any other early throw).
+  let currentGate: (() => void) | undefined
+
+  try {
+    let toolDefs = d.tools ? await d.tools.buildToolDefinitions() : []
+    if (ctx.allowedTools) {
+      toolDefs = toolDefs.filter((t) => ctx.allowedTools!.includes(t.function.name))
+    }
+
+    outerLoop: while (toolIter <= MAX_TOOL_ITER) {
+      toolIter++
+
+      // Acquire gate per engine call so fg can preempt bg between tool iterations.
+      currentGate = await d.gate?.acquire(gatePriority)
+
+      const reqBody: Record<string, unknown> = {
+        model: engineModelAlias(d.registry.active()?.kind ?? '') ?? ms.model!.key,
+        messages: iterMessages,
+        stream: true,
+        stream_options: { include_usage: true },
+        return_progress: true,
+        ...samplingOverride,
+      }
+      if (stopStrings?.length) reqBody.stop = stopStrings
+      const cappedMax = clampMaxTokens(reqBody.max_tokens as number | undefined, maxLimit)
+      if (cappedMax != null) reqBody.max_tokens = cappedMax
+      else delete reqBody.max_tokens
+      if (disableThinking) {
+        reqBody.reasoning_budget = 0
+        reqBody.chat_template_kwargs = { enable_thinking: false }
+      }
+      const toolsSupported = (d.registry.active()?.kind ?? '') !== 'vllm' && toolDefs.length > 0
+      if (toolsSupported) reqBody.tools = toolDefs
+      if (
+        toolsSupported &&
+        conv.toolPolicy === 'force_web_search' &&
+        toolIter <= 2 &&
+        toolDefs.some((t) => t.function.name === 'web_search')
+      ) {
+        reqBody.tool_choice = { type: 'function', function: { name: 'web_search' } }
+      }
+
+      const res = await fetch(`${target}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reqBody),
+        signal: ac.signal,
+        duplex: 'half',
+      })
+
+      if (!res.ok || !res.body) {
+        currentGate?.(); currentGate = undefined
+        await sink({ event: 'error', data: { code: 'engine_error', message: `Engine returned ${res.status}` } })
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buf = ''
+      const cancelReader = () => void reader.cancel()
+      if (ac.signal.aborted) { cancelReader() }
+      else { ac.signal.addEventListener('abort', cancelReader, { once: true }) }
+
+      let roundContent = ''
+      let parseState = initParseState()
+      let finishReason = ''
+      const pendingToolCalls = new Map<number, { id: string; name: string; argsBuffer: string }>()
+
+      roundLoop: while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const raw = line.slice(6).trim()
+          if (raw === '[DONE]') break roundLoop
+
+          let chunk: Record<string, unknown>
+          try { chunk = JSON.parse(raw) as Record<string, unknown> } catch { continue }
+
+          const pp = chunk.prompt_progress as { processed?: number; total?: number; tps?: number } | undefined
+          if (pp && pp.total) {
+            const pct = Math.round((pp.processed ?? 0) / pp.total * 100)
+            d.manager.setLiveGen({ phase: 'prompt', pct, outputTokens: 0 })
+            await sink({ event: 'progress', data: { phase: 'prompt', processed: pp.processed, total: pp.total, pct, tps: pp.tps ?? 0 } })
+            continue
+          }
+
+          if (chunk.usage) finalUsage = chunk.usage as typeof finalUsage
+          if (chunk.timings) finalTimings = chunk.timings as typeof finalTimings
+
+          const choices = chunk.choices as Array<{
+            delta?: { content?: string; reasoning_content?: string; reasoning?: string; tool_calls?: Array<{ index: number; id?: string; function?: { name?: string; arguments?: string } }> }
+            finish_reason?: string
+          }> | undefined
+          if (!choices?.length) continue
+
+          if (choices[0].finish_reason) finishReason = choices[0].finish_reason
+          const delta = choices[0].delta ?? {}
+
+          if (delta.tool_calls?.length) {
+            for (const tc of delta.tool_calls) {
+              if (!pendingToolCalls.has(tc.index)) pendingToolCalls.set(tc.index, { id: '', name: '', argsBuffer: '' })
+              const entry = pendingToolCalls.get(tc.index)!
+              if (tc.id && !entry.id) entry.id = tc.id
+              if (tc.function?.name && !entry.name) entry.name = tc.function.name
+              if (tc.function?.arguments) entry.argsBuffer += tc.function.arguments
+            }
+            continue
+          }
+
+          const rc = (delta.reasoning_content ?? delta.reasoning) as string | undefined
+          if (rc) {
+            if (!thinkStart) thinkStart = Date.now()
+            thinkEnd = Date.now()
+            fullReasoning += rc
+            await sink({ event: 'reasoning', data: { delta: rc } })
+            continue
+          }
+
+          const raw_content = delta.content ?? ''
+          if (!raw_content) continue
+
+          const { state: nextState, events: parseEvents } = feedChunk(parseState, raw_content)
+          parseState = nextState
+          for (const ev of parseEvents) {
+            if (ev.type === 'reasoning') {
+              if (!thinkStart) thinkStart = Date.now()
+              thinkEnd = Date.now()
+              fullReasoning += ev.text
+              await sink({ event: 'reasoning', data: { delta: ev.text } })
+            } else {
+              fullContent += ev.text
+              roundContent += ev.text
+              if (!ttftMs) ttftMs = Date.now() - requestStart
+              d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut })
+              await sink({ event: 'delta', data: { delta: ev.text } })
+            }
+          }
+        }
+      }
+      ac.signal.removeEventListener('abort', cancelReader)
+
+      for (const ev of flushState(parseState)) {
+        if (ev.type === 'reasoning') {
+          fullReasoning += ev.text
+          await sink({ event: 'reasoning', data: { delta: ev.text } })
+        } else {
+          fullContent += ev.text
+          roundContent += ev.text
+          await sink({ event: 'delta', data: { delta: ev.text } })
+        }
+      }
+
+      // Release gate BEFORE tool execution so fg can preempt between iterations.
+      currentGate?.(); currentGate = undefined
+
+      // ── Tool call execution ──────────────────────────────────────────────
+      if ((finishReason === 'tool_calls' || pendingToolCalls.size > 0) && d.tools && toolIter <= MAX_TOOL_ITER) {
+        const roundToolCalls = Array.from(pendingToolCalls.values())
+        iterMessages.push({
+          role: 'assistant',
+          content: roundContent || null,
+          tool_calls: roundToolCalls.map((tc) => ({
+            id: tc.id, type: 'function',
+            function: { name: tc.name, arguments: tc.argsBuffer },
+          })),
+        })
+
+        for (const tc of roundToolCalls) {
+          let parsedArgs: Record<string, unknown>
+          try { parsedArgs = JSON.parse(tc.argsBuffer || '{}') as Record<string, unknown> }
+          catch { parsedArgs = {} }
+
+          // run_code confirmation: only for foreground chat (agents pre-authorized at launch)
+          const requireConfirm =
+            tc.name === 'run_code' &&
+            ctx.allowedTools === undefined &&
+            d.store.snapshot().tools.requireRunCodeConfirmation !== false
+          if (requireConfirm) {
+            await sink({ event: 'tool_confirmation_required', data: { id: tc.id, name: tc.name, args: parsedArgs } })
+          }
+
+          await sink({ event: 'tool_call', data: { id: tc.id, name: tc.name, args: parsedArgs, status: 'pending' } })
+
+          let result = ''
+          let callError: string | undefined
+          try {
+            result = await d.tools.executeTool({ id: tc.id, name: tc.name, args: parsedArgs })
+          } catch (e) {
+            callError = (e as Error).message
+            result = `Error: ${callError}`
+          }
+
+          if (tc.name === 'web_search' && !callError) {
+            searchCallCount++
+            try {
+              const sourceMatches = [...result.matchAll(/\[(\d+)\] (.+?)\nSource: (\S+)\nDomain: (\S+) \| Relevance: ([\d.]+) \| Freshness: (\w+)\nKey passage: ([\s\S]+?)(?=\n\[|\s*$)/g)]
+              for (const m of sourceMatches) {
+                allResearchSources.push({
+                  title: m[2].trim(), url: m[3].trim(), domain: m[4].trim(),
+                  relevanceScore: parseFloat(m[5]),
+                  freshnessSignal: m[6].trim() as 'recent' | 'dated' | 'unknown',
+                  passage: m[7].trim(),
+                })
+              }
+            } catch { /* best-effort */ }
+          }
+
+          allToolCalls.push({ id: tc.id, name: tc.name, args: parsedArgs, result: callError ? undefined : result, error: callError })
+          await sink({ event: 'tool_call', data: { id: tc.id, name: tc.name, args: parsedArgs, status: callError ? 'error' : 'done', result } })
+          iterMessages.push({ role: 'tool', content: result, tool_call_id: tc.id })
+        }
+
+        continue outerLoop
+      }
+
+      // ── F-021: Confidence loop ───────────────────────────────────────────
+      if (conv.toolPolicy === 'force_web_search' && fullContent && d.tools) {
+        const confMatch = fullContent.match(/\[confidence:\s*([\d.]+)\]/i)
+        if (confMatch) {
+          const conf = parseFloat(confMatch[1])
+          parsedConfidence = conf
+          fullContent = fullContent.replace(/\[confidence:\s*[\d.]+\]\s*/gi, '').trim()
+          if (conf < 0.8 && searchCallCount < 3) {
+            console.log(`[chat] F-021: confidence ${conf} < 0.8 (searches: ${searchCallCount}/3) — re-entering search loop`)
+            const toolDefs2 = await d.tools.buildToolDefinitions()
+            if (toolDefs2.some((t) => t.function.name === 'web_search')) {
+              iterMessages.push({ role: 'assistant', content: fullContent })
+              iterMessages.push({
+                role: 'user',
+                content: `Your confidence is ${conf}. Please search again with a more specific query to improve accuracy, then provide a revised answer with an updated [confidence: X.XX] line.`,
+              })
+              fullContent = ''
+              continue outerLoop
+            }
+          }
+        }
+      }
+
+      break outerLoop
+    }
+
+    // ── BUG-001: Qwen3 empty-reply guard ──────────────────────────────────
+    console.log(`[chat] tool loop finished after ${toolIter} iteration(s); visible content length: ${fullContent.trim().length}`)
+    if (needsExtraPass(fullContent)) {
+      console.log('[chat] BUG-001: final content is empty — making extra pass with tool_choice:none')
+      iterMessages.push({ role: 'user', content: 'Please now write your final answer based on what you found.' })
+      const reqBody: Record<string, unknown> = {
+        model: engineModelAlias(d.registry.active()?.kind ?? '') ?? ms.model!.key,
+        messages: iterMessages,
+        stream: true,
+        stream_options: { include_usage: true },
+        return_progress: true,
+        tool_choice: 'none',
+        ...samplingOverride,
+      }
+      if (stopStrings?.length) reqBody.stop = stopStrings
+      const cappedMax = clampMaxTokens(reqBody.max_tokens as number | undefined, maxLimit)
+      if (cappedMax != null) reqBody.max_tokens = cappedMax
+      else delete reqBody.max_tokens
+      if (disableThinking) {
+        reqBody.reasoning_budget = 0
+        reqBody.chat_template_kwargs = { enable_thinking: false }
+      }
+
+      currentGate = await d.gate?.acquire(gatePriority)
+      const res = await fetch(`${target}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reqBody),
+        signal: ac.signal,
+        duplex: 'half',
+      })
+      if (res.ok && res.body) {
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buf = ''
+        const cancelReader2 = () => void reader.cancel()
+        if (ac.signal.aborted) { cancelReader2() }
+        else { ac.signal.addEventListener('abort', cancelReader2, { once: true }) }
+
+        let parseState = initParseState()
+        roundLoop2: while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buf += decoder.decode(value, { stream: true })
+          const lines = buf.split('\n')
+          buf = lines.pop() ?? ''
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            const raw = line.slice(6).trim()
+            if (raw === '[DONE]') break roundLoop2
+            let chunk: Record<string, unknown>
+            try { chunk = JSON.parse(raw) as Record<string, unknown> } catch { continue }
+            if (chunk.usage) finalUsage = chunk.usage as typeof finalUsage
+            if (chunk.timings) finalTimings = chunk.timings as typeof finalTimings
+            const choices = chunk.choices as Array<{ delta?: { content?: string; reasoning_content?: string; reasoning?: string }; finish_reason?: string }> | undefined
+            if (!choices?.length) continue
+            const delta = choices[0].delta ?? {}
+            const rc = (delta.reasoning_content ?? delta.reasoning) as string | undefined
+            if (rc) { fullReasoning += rc; await sink({ event: 'reasoning', data: { delta: rc } }); continue }
+            const raw_content = delta.content ?? ''
+            if (!raw_content) continue
+            const { state: nextState, events: parseEvents } = feedChunk(parseState, raw_content)
+            parseState = nextState
+            for (const ev of parseEvents) {
+              if (ev.type === 'reasoning') { fullReasoning += ev.text; await sink({ event: 'reasoning', data: { delta: ev.text } }) }
+              else { fullContent += ev.text; if (!ttftMs) ttftMs = Date.now() - requestStart; d.manager.setLiveGen({ phase: 'gen', pct: 0, outputTokens: ++liveOut }); await sink({ event: 'delta', data: { delta: ev.text } }) }
+            }
+          }
+        }
+        ac.signal.removeEventListener('abort', cancelReader2)
+        for (const ev of flushState(parseState)) {
+          if (ev.type === 'reasoning') { fullReasoning += ev.text; await sink({ event: 'reasoning', data: { delta: ev.text } }) }
+          else { fullContent += ev.text; await sink({ event: 'delta', data: { delta: ev.text } }) }
+        }
+      }
+      currentGate?.(); currentGate = undefined
+    }
+  } catch (e: unknown) {
+    const isAbort = (e as Error)?.name === 'AbortError'
+    aborted = isAbort
+    if (!isAbort) await sink({ event: 'error', data: { code: 'engine_stopped', message: (e as Error).message } })
+  } finally {
+    currentGate?.()  // release if thrown mid-fetch or mid-reader
+    d.manager.generationEnd()
+  }
+
+  const totalMs = Date.now() - requestStart
+  const thinkMs = thinkStart && thinkEnd ? thinkEnd - thinkStart : 0
+  const ctxMax = ms.model?.ctx ?? 4096
+
+  const stats: Partial<MessageStats> = {
+    ttftMs, totalMs, thinkMs,
+    ctxUsed: (finalUsage.prompt_tokens ?? 0) + (finalUsage.completion_tokens ?? 0),
+    ctxMax, model: ms.model?.name ?? '', aborted,
+  }
+  const fullPrompt = finalUsage.prompt_tokens ?? 0
+  const cachedExplicit = finalUsage.prompt_tokens_details?.cached_tokens
+  if (finalTimings.prompt_n) {
+    const processed = finalTimings.prompt_n
+    stats.promptTokens = fullPrompt || processed
+    stats.promptMs     = finalTimings.prompt_ms
+    stats.promptTps    = finalTimings.prompt_per_second
+    stats.genTokens    = finalTimings.predicted_n
+    stats.genMs        = finalTimings.predicted_ms
+    stats.tps          = finalTimings.predicted_per_second
+    stats.cachedTokens = cachedExplicit ?? Math.max(0, (fullPrompt || processed) - processed)
+  } else {
+    stats.promptTokens = fullPrompt
+    stats.genTokens    = finalUsage.completion_tokens ?? 0
+    stats.genMs        = totalMs - ttftMs
+    stats.tps          = stats.genMs > 0 ? Math.round((stats.genTokens / stats.genMs) * 1000 * 10) / 10 : 0
+    stats.cachedTokens = cachedExplicit ?? 0
+  }
+
+  let refereeVerdicts: ClaimVerdict[] | undefined
+  if (conv.toolPolicy === 'force_web_search' && fullContent && allResearchSources.length > 0) {
+    try { refereeVerdicts = checkReply(fullContent, allResearchSources) } catch { /* best-effort */ }
+  }
+
+  const researchMeta: ResearchMeta | undefined =
+    conv.toolPolicy === 'force_web_search' && (parsedConfidence !== undefined || allResearchSources.length > 0 || refereeVerdicts !== undefined)
+      ? {
+          confidence: parsedConfidence,
+          sources: allResearchSources.length > 0 ? allResearchSources : undefined,
+          refereeVerdicts: refereeVerdicts && refereeVerdicts.length > 0 ? refereeVerdicts : undefined,
+        }
+      : undefined
+
+  db.updateMessage(assistantMsg.id, { content: fullContent, reasoning: fullReasoning, toolCalls: allToolCalls, stats, researchMeta })
+  db.touchConversation(convId)
+
+  try {
+    d.manager.recordCompletion({
+      inputTokens: stats.promptTokens,
+      outputTokens: stats.genTokens,
+      promptTps: stats.promptTps,
+      genTps: stats.tps,
+    })
+  } catch { /* swallow */ }
+
+  const finalMsg = db.getMessage(assistantMsg.id)!
+  try {
+    await sink({ event: 'done', data: { message: finalMsg } })
+  } catch { /* client gone */ }
+
+  if (!aborted && !ctx.skipAutoTitle && conv.title === 'New chat' && d.store.snapshot().daemon.autoGenerateTitles) {
+    setTimeout(() => { void autoTitle(d, convId, ctx.engineMessages, fullContent, target) }, 1000)
+  }
+}
+
+// ── Auto title generation ──────────────────────────────────────────────────────
+
+export async function autoTitle(
+  d: Deps,
+  convId: string,
+  prevMessages: { role: string; content: unknown }[],
+  assistantReply: string,
+  target: string,
+): Promise<void> {
+  try {
+    const ms = d.manager.status()
+    if (ms.state !== 'running') return
+    const titleMessages = [
+      ...prevMessages.slice(-2),
+      { role: 'assistant', content: assistantReply.slice(0, 500) },
+      { role: 'user', content: 'Generate a concise 3-6 word title for this conversation. Reply with ONLY the title — no quotes, no punctuation, no preamble. /no_think' },
+    ]
+    const res = await fetch(`${target}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: engineModelAlias(d.registry.active()?.kind ?? '') ?? ms.model?.key,
+        messages: titleMessages,
+        stream: false,
+        temperature: 0.3,
+        max_tokens: 32,
+        reasoning_budget: 0,
+        chat_template_kwargs: { enable_thinking: false },
+      }),
+      signal: AbortSignal.timeout(20_000),
+    })
+    if (!res.ok) return
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+    let raw = data.choices?.[0]?.message?.content ?? ''
+    raw = raw.replace(/<think>[\s\S]*?<\/think>/gi, '').trim()
+    let title = raw.replace(/^["'""]+|["'""]+$/g, '').replace(/[.!?]+$/, '').trim().slice(0, 60)
+    if (!title) {
+      const firstUser = prevMessages.find((m) => m.role === 'user')?.content
+      if (typeof firstUser === 'string') {
+        title = firstUser.replace(/\s+/g, ' ').trim().split(' ').slice(0, 6).join(' ').slice(0, 60)
+      }
+    }
+    if (title && d.db.getConversation(convId)?.title === 'New chat') {
+      d.db.updateConversation(convId, { title })
+    }
+  } catch { /* silently ignore */ }
+}

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -26,6 +26,8 @@ import { DownloadManager } from './downloads/downloads'
 import { BenchRunner } from './bench/bench'
 import { ModelRouter } from './gateway/model-router'
 import { ToolRegistry } from './tools/tool-registry'
+import { GenerationGate } from './agents/gate'
+import { AgentRunner } from './agents/runner'
 import { launchCli } from './cli-launch'
 import { writePidfile, removePidfile, stopDaemon } from './daemon-pid'
 import { createApp } from './server'
@@ -197,6 +199,9 @@ const startedAt = Date.now()
 const appUpdates = new AppUpdateChecker(version)
 // `requestRestart` is attached after the server is created (it must close over it).
 const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, build, updates, appUpdates, hf, downloads, bench, modelRouter, comfy, tools: toolRegistry, version, startedAt }
+deps.gate = new GenerationGate()
+deps.agentRunner = new AgentRunner(deps)
+deps.agentRunner.reconcileOnStartup()
 const app = createApp(deps)
 
 // Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -14,6 +14,8 @@ import type { DownloadManager } from './downloads/downloads'
 import type { BenchRunner } from './bench/bench'
 import type { ModelRouter } from './gateway/model-router'
 import type { ToolRegistry } from './tools/tool-registry'
+import type { GenerationGate } from './agents/gate'
+import type { AgentRunner } from './agents/runner'
 
 export interface Deps {
   store: ConfigStore
@@ -43,6 +45,11 @@ export interface Deps {
   /** ComfyUI GPU coordinator (spec: unload/block while ComfyUI renders, reload after).
    *  Optional: only wired in the real `serve()` entrypoint (cli.ts); absent under tests. */
   comfy?: ComfyGuard
+  /** Priority-queue mutex serialising engine calls (fg > bg). Optional — absent under
+   *  tests; only wired in cli.ts where the agent runner co-exists with chat. */
+  gate?: GenerationGate
+  /** Background agent runner. Optional — same wiring conditions as gate. */
+  agentRunner?: AgentRunner
   version: string
   startedAt: number
   /** Re-exec the daemon so config changes (port, LAN bind) take effect (spec 08 §2).

--- a/turbollm/src/server.ts
+++ b/turbollm/src/server.ts
@@ -6,6 +6,7 @@ import { dirname, join, normalize } from 'node:path'
 import { Agent, setGlobalDispatcher } from 'undici'
 import { registerApi } from './api/routes'
 import { registerChatRoutes } from './chat/chat-routes'
+import { registerAgentRoutes } from './agents/agent-routes'
 import type { Deps } from './deps'
 import { registerGateway } from './gateway/gateway'
 import { lanAuth } from './auth'
@@ -43,6 +44,7 @@ export function createApp(d: Deps): Hono {
 
   registerApi(app, d)
   registerChatRoutes(app, d)
+  registerAgentRoutes(app, d)
   registerGateway(app, d)
 
   // Embedded SPA with client-side-routing fallback (spec 08 §1).

--- a/turbollm/web/package-lock.json
+++ b/turbollm/web/package-lock.json
@@ -22,7 +22,9 @@
         "@tanstack/react-query": "^5.101.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "gifenc": "^1.0.3",
         "lucide-react": "^1.17.0",
+        "mermaid": "^11.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -41,6 +43,19 @@
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^7.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -325,6 +340,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -806,6 +833,23 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -854,6 +898,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2410,6 +2463,259 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2433,6 +2739,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2479,6 +2791,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2490,6 +2809,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2684,6 +3013,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2704,10 +3042,526 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2738,6 +3592,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -2778,6 +3641,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.371",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
@@ -2798,6 +3670,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2931,12 +3813,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
@@ -3026,11 +3920,42 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -3130,6 +4055,42 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3392,6 +4353,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -3454,6 +4421,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -3724,6 +4703,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark": {
@@ -4324,6 +5332,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -4349,6 +5363,12 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4368,6 +5388,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -4659,6 +5695,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
@@ -4703,6 +5745,30 @@
         "@rollup/rollup-win32-x64-msvc": "4.61.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -4788,6 +5854,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -4817,6 +5889,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -4854,6 +5935,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -5049,6 +6139,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/turbollm/web/package.json
+++ b/turbollm/web/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query": "^5.101.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "gifenc": "^1.0.3",
     "lucide-react": "^1.17.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -30,6 +31,7 @@
     "react-router-dom": "^7.17.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "mermaid": "^11.0.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.14"

--- a/turbollm/web/src/App.tsx
+++ b/turbollm/web/src/App.tsx
@@ -14,6 +14,7 @@ import { ApiError, setAuthToken } from './lib/api'
 
 // Route-level code splitting: each screen loads only when first navigated to.
 const ChatScreen = lazy(() => import('./screens/ChatScreen').then((m) => ({ default: m.ChatScreen })))
+const AgentsScreen = lazy(() => import('./screens/AgentsScreen').then((m) => ({ default: m.AgentsScreen })))
 const ModelsScreen = lazy(() => import('./screens/ModelsScreen').then((m) => ({ default: m.ModelsScreen })))
 const EnginesScreen = lazy(() => import('./screens/EnginesScreen').then((m) => ({ default: m.EnginesScreen })))
 const DeveloperScreen = lazy(() => import('./screens/DeveloperScreen').then((m) => ({ default: m.DeveloperScreen })))
@@ -63,6 +64,8 @@ export function App() {
           <Routes>
             <Route path="/chat" element={<ChatScreen />} />
             <Route path="/chat/:convId" element={<ChatScreen />} />
+            <Route path="/agents" element={<AgentsScreen />} />
+            <Route path="/agents/:id" element={<AgentsScreen />} />
             <Route path="/models" element={<ModelsScreen />} />
             <Route path="/engines" element={<EnginesScreen />} />
             <Route path="/developer" element={<DeveloperScreen />} />

--- a/turbollm/web/src/components/ArtifactCard.tsx
+++ b/turbollm/web/src/components/ArtifactCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { Code2, Eye, Download, Loader2, ChevronDown, Maximize2, Minimize2 } from 'lucide-react'
-import { CopyButton } from './ui/copy-button'
+import { Download, Loader2, ChevronDown, Maximize2, Minimize2 } from 'lucide-react'
+import { toast } from 'sonner'
 import { cn } from '../lib/utils'
 import { useUiStore, resolveDark } from '../stores/ui'
 
@@ -17,24 +17,20 @@ export function isArtifactLang(lang: string): string | null {
 }
 
 /** Build a sandboxed srcdoc that reports its NATURAL content size ({w,h}). The card
- *  then scales the whole iframe to fit both the height cap and the column width, and
- *  sizes itself to the result (FittedIframe). Injects a CSP (blocks external network)
- *  and (HTML only) self-rasterizers for PNG and GIF export. */
+ *  scales the whole iframe to fit; injects a CSP (blocks external network) and
+ *  (HTML only) self-rasterizers for PNG/JPEG and GIF export. */
 function buildSrcdoc(type: string, code: string): string {
   const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:;">`
-  // HTML: report the document's content box. `norm` forces height:auto so a `100vh`
-  // artifact can't feed back against the auto-sizing iframe.
   const resizeHtml = `<script>(function(){function r(){var h=Math.max(document.documentElement.scrollHeight,document.body?document.body.scrollHeight:0);var w=Math.max(document.documentElement.scrollWidth,document.body?document.body.scrollWidth:0);parent.postMessage({type:'tllm-size',w:w,h:h},'*')}window.addEventListener('load',r);if(document.readyState!=='loading')r();try{new ResizeObserver(r).observe(document.documentElement)}catch(e){}})()</script>`
-  // SVG/mermaid: measure the <svg> itself so the card fits the diagram, not the iframe.
   const resizeSvg = `<script>(function(){function r(){var s=document.querySelector('svg');var b=s?s.getBoundingClientRect():null;var w=b?Math.ceil(b.width):Math.ceil(document.documentElement.scrollWidth);var h=b?Math.ceil(b.height):Math.max(document.documentElement.scrollHeight,document.body?document.body.scrollHeight:0);parent.postMessage({type:'tllm-size',w:w,h:h},'*')}window.addEventListener('load',r);if(document.readyState!=='loading')r();try{new ResizeObserver(r).observe(document.documentElement)}catch(e){}setTimeout(r,60)})()</script>`
   const norm = `<style>html,body{height:auto!important;min-height:0!important}img,svg,canvas,video{max-width:100%}</style>`
-  // Best-effort PNG export via foreignObject (may taint on some browsers → caught).
   const shot = `<script>window.addEventListener('message',function(e){if(!e.data||e.data.type!=='tllm-shot')return;try{var el=document.documentElement;var w=Math.max(el.scrollWidth,document.body?document.body.scrollWidth:0)||800;var h=Math.max(el.scrollHeight,document.body?document.body.scrollHeight:0)||600;var ser=new XMLSerializer().serializeToString(el);var svg='<svg xmlns="http://www.w3.org/2000/svg" width="'+w+'" height="'+h+'"><foreignObject width="100%" height="100%">'+ser+'</foreignObject></svg>';var img=new Image();img.onload=function(){try{var c=document.createElement('canvas');c.width=w;c.height=h;c.getContext('2d').drawImage(img,0,0);parent.postMessage({type:'tllm-shot-result',png:c.toDataURL('image/png')},'*')}catch(err){parent.postMessage({type:'tllm-shot-result',png:null},'*')}};img.onerror=function(){parent.postMessage({type:'tllm-shot-result',png:null},'*')};img.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg)}catch(err){parent.postMessage({type:'tllm-shot-result',png:null},'*')}})</script>`
-  // GIF export: grab frames straight off a <canvas> (same-origin within the iframe).
+  // Single still frame grabbed straight off a <canvas> (no taint, unlike foreignObject).
+  const frame = `<script>window.addEventListener('message',function(e){if(!e.data||e.data.type!=='tllm-frame')return;var s=document.querySelector('canvas');if(!s){parent.postMessage({type:'tllm-frame-result',png:null},'*');return}try{parent.postMessage({type:'tllm-frame-result',png:s.toDataURL('image/png')},'*')}catch(err){parent.postMessage({type:'tllm-frame-result',png:null},'*')}})</script>`
   const gif = `<script>window.addEventListener('message',function(e){if(!e.data||e.data.type!=='tllm-gif')return;var s=document.querySelector('canvas');if(!s){parent.postMessage({type:'tllm-gif-result',frames:null},'*');return}var sw=s.width||s.clientWidth||300,sh=s.height||s.clientHeight||150;var sc=Math.min(1,480/Math.max(sw,sh));var w=Math.max(1,Math.round(sw*sc)),h=Math.max(1,Math.round(sh*sc));var t=document.createElement('canvas');t.width=w;t.height=h;var x=t.getContext('2d');var fr=[],n=0,m=24;var iv=setInterval(function(){try{x.clearRect(0,0,w,h);x.drawImage(s,0,0,w,h);fr.push(x.getImageData(0,0,w,h).data.buffer.slice(0))}catch(err){}if(++n>=m){clearInterval(iv);try{parent.postMessage({type:'tllm-gif-result',w:w,h:h,frames:fr},'*',fr)}catch(err){parent.postMessage({type:'tllm-gif-result',frames:null},'*')}}},70)})</script>`
 
   if (type === 'text/html') {
-    const head = `${csp}\n${resizeHtml}\n${norm}\n${shot}\n${gif}`
+    const head = `${csp}\n${resizeHtml}\n${norm}\n${shot}\n${frame}\n${gif}`
     if (/<head[\s>]/i.test(code)) return code.replace(/(<head[^>]*>)/i, `$1\n${head}`)
     return `<!doctype html><html><head>${head}</head><body>${code}</body></html>`
   }
@@ -44,14 +40,13 @@ function buildSrcdoc(type: string, code: string): string {
   return ''
 }
 
-/** Render an iframe scaled by `scale` (preserving aspect) and sized to the scaled
- *  result, so the card hugs the content. Before the first size report it renders
- *  full-width to measure; the DOM shape is identical in both states (no reload). */
+/** Render an iframe scaled by `scale` and sized to the result, so the card hugs
+ *  the content. Renders full-width to measure first; DOM shape is identical in
+ *  both states (no reload). */
 function FittedIframe({
-  srcDoc, title, frameRef, naturalW, naturalH, scale, cap, ready,
+  srcDoc, frameRef, naturalW, naturalH, scale, cap, ready,
 }: {
   srcDoc: string
-  title: string
   frameRef: React.RefObject<HTMLIFrameElement | null>
   naturalW: number
   naturalH: number
@@ -67,7 +62,7 @@ function FittedIframe({
         ref={frameRef}
         srcDoc={srcDoc}
         sandbox="allow-scripts"
-        title={title}
+        title="Artifact"
         className={cn('block border-0', ready ? '' : 'w-full')}
         style={ready
           ? { width: naturalW, height: naturalH, transform: scale !== 1 ? `scale(${scale})` : undefined, transformOrigin: 'top left' }
@@ -86,8 +81,9 @@ function downloadBlob(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url)
 }
 
-/** Rasterize a self-contained SVG string to a PNG blob (2× for crispness). */
-function svgToPng(svg: string, scale = 2): Promise<Blob | null> {
+/** Rasterize a self-contained SVG string to PNG or JPEG (2× for crispness). JPEG
+ *  has no alpha, so a white background is painted first. */
+function svgToRaster(svg: string, mime: 'image/png' | 'image/jpeg', scale = 2): Promise<Blob | null> {
   return new Promise((resolve) => {
     const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
     const url = URL.createObjectURL(blob)
@@ -104,16 +100,36 @@ function svgToPng(svg: string, scale = 2): Promise<Blob | null> {
       canvas.height = Math.max(1, Math.round(h * scale))
       const ctx = canvas.getContext('2d')
       if (!ctx) { URL.revokeObjectURL(url); return resolve(null) }
+      if (mime === 'image/jpeg') { ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, canvas.width, canvas.height) }
       ctx.scale(scale, scale); ctx.drawImage(img, 0, 0, w, h)
       URL.revokeObjectURL(url)
-      try { canvas.toBlob((b) => resolve(b), 'image/png') } catch { resolve(null) }
+      try { canvas.toBlob((b) => resolve(b), mime, 0.95) } catch { resolve(null) }
     }
     img.onerror = () => { URL.revokeObjectURL(url); resolve(null) }
     img.src = url
   })
 }
 
-/** Ask the sandboxed HTML iframe to rasterize itself to PNG (best-effort). */
+/** Re-encode a (PNG) blob as JPEG on a white background. */
+function blobToJpeg(blob: Blob): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(blob)
+    const img = new Image()
+    img.onload = () => {
+      const c = document.createElement('canvas')
+      c.width = img.naturalWidth || 800; c.height = img.naturalHeight || 600
+      const ctx = c.getContext('2d')
+      if (!ctx) { URL.revokeObjectURL(url); return resolve(null) }
+      ctx.fillStyle = '#ffffff'; ctx.fillRect(0, 0, c.width, c.height); ctx.drawImage(img, 0, 0)
+      URL.revokeObjectURL(url)
+      try { c.toBlob((b) => resolve(b), 'image/jpeg', 0.95) } catch { resolve(null) }
+    }
+    img.onerror = () => { URL.revokeObjectURL(url); resolve(null) }
+    img.src = url
+  })
+}
+
+/** Ask the sandboxed HTML iframe to rasterize itself to a PNG blob (best-effort). */
 function htmlIframeToPng(iframe: HTMLIFrameElement | null): Promise<Blob | null> {
   return new Promise((resolve) => {
     const win = iframe?.contentWindow
@@ -128,6 +144,25 @@ function htmlIframeToPng(iframe: HTMLIFrameElement | null): Promise<Blob | null>
     window.addEventListener('message', onMsg)
     win.postMessage({ type: 'tllm-shot' }, '*')
     setTimeout(() => { window.removeEventListener('message', onMsg); resolve(null) }, 4000)
+  })
+}
+
+/** Grab a single still frame from the iframe's <canvas> as a PNG blob (reliable for
+ *  canvas content, where foreignObject rasterization would taint the canvas). */
+function htmlIframeFrame(iframe: HTMLIFrameElement | null): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const win = iframe?.contentWindow
+    if (!win) return resolve(null)
+    const onMsg = (e: MessageEvent) => {
+      if (e.source !== win) return
+      if (typeof e.data !== 'object' || e.data?.type !== 'tllm-frame-result') return
+      window.removeEventListener('message', onMsg)
+      if (e.data.png) fetch(e.data.png).then((r) => r.blob()).then(resolve).catch(() => resolve(null))
+      else resolve(null)
+    }
+    window.addEventListener('message', onMsg)
+    win.postMessage({ type: 'tllm-frame' }, '*')
+    setTimeout(() => { window.removeEventListener('message', onMsg); resolve(null) }, 3000)
   })
 }
 
@@ -162,9 +197,7 @@ function captureGif(iframe: HTMLIFrameElement | null): Promise<Blob | null> {
 }
 
 const DEFAULT_H = 200
-const MIN_CARD_W = 300 // keep the header (Code/Preview + buttons) usable
-// Debounce window: while a message streams, `code` grows every token. We only
-// (re)render once it settles, so the iframe doesn't reload per token (no blink).
+const MIN_CARD_W = 300
 const SETTLE_MS = 350
 
 /** Cap the preview to ~60% of the visible screen height. */
@@ -173,17 +206,21 @@ function screenCap(): number {
   return Math.max(200, Math.round((v * 0.6) / 10) * 10)
 }
 
+type Fmt = 'png' | 'jpeg' | 'svg' | 'gif' | 'html'
+const FMT_LABEL: Record<Fmt, string> = { png: 'PNG', jpeg: 'JPEG', svg: 'SVG', gif: 'GIF', html: 'HTML' }
+
 interface ArtifactCardProps {
   lang: string
   code: string
 }
 
+/** Renders a code artifact (HTML / SVG / Mermaid) as an IMAGE. The underlying type
+ *  is intentionally hidden — no language tag, no code view — so it reads as a
+ *  rendered result with applicable image-format downloads. */
 export function ArtifactCard({ lang, code }: ArtifactCardProps) {
   const type = ARTIFACT_LANGS[lang.toLowerCase()] ?? 'text/html'
   const theme = useUiStore((s) => s.theme)
-  const [mode, setMode] = useState<'code' | 'preview'>('preview')
-  // 'height' = fit the whole artifact within 60vh (card hugs content). 'width' =
-  // expand to the full column width (taller; the chat scrolls).
+  // 'height' = fit within 60vh (card hugs content). 'width' = full column width.
   const [fitMode, setFitMode] = useState<'height' | 'width'>('height')
   const [naturalH, setNaturalH] = useState(DEFAULT_H)
   const [naturalW, setNaturalW] = useState(0)
@@ -195,15 +232,13 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Debounced code → blink fix (render once the stream settles).
+  // Debounced code (handles any re-render churn; equals code once settled).
   const [stableCode, setStableCode] = useState(code)
   useEffect(() => {
     const t = setTimeout(() => setStableCode(code), SETTLE_MS)
     return () => clearTimeout(t)
   }, [code])
-  const settling = code !== stableCode
 
-  // Track the screen-height cap and the available column width.
   useEffect(() => {
     const onResize = () => setMaxH((prev) => { const n = screenCap(); return n === prev ? prev : n })
     window.addEventListener('resize', onResize)
@@ -219,14 +254,12 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
     return () => ro.disconnect()
   }, [])
 
-  // The iframe reports its NATURAL content size; scoped to THIS card's iframe so
-  // multiple artifacts don't cross-contaminate.
+  // The iframe reports its NATURAL content size (scoped to THIS card). Threshold
+  // updates so animated artifacts don't jitter the card.
   useEffect(() => {
     function onMsg(e: MessageEvent) {
       if (e.source !== iframeRef.current?.contentWindow) return
       if (typeof e.data !== 'object' || e.data?.type !== 'tllm-size') return
-      // Threshold updates: animated artifacts fire ResizeObserver every frame with
-      // sub-pixel deltas — without this the card jitters/resizes continuously.
       const w = Number(e.data.w), h = Number(e.data.h)
       if (!isNaN(h) && h > 0) { const nh = Math.min(Math.ceil(h) + 2, 15000); setNaturalH((p) => Math.abs(nh - p) > 4 ? nh : p) }
       if (!isNaN(w) && w > 0) { const nw = Math.min(Math.ceil(w), 15000); setNaturalW((p) => Math.abs(nw - p) > 4 ? nw : p) }
@@ -235,11 +268,9 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
     return () => window.removeEventListener('message', onMsg)
   }, [])
 
-  const handlePreview = () => setMode('preview')
-
-  // Render mermaid from the SETTLED code; re-renders on app-theme change.
+  // Render mermaid; re-renders on app-theme change.
   useEffect(() => {
-    if (mode !== 'preview' || type !== 'application/vnd.mermaid') return
+    if (type !== 'application/vnd.mermaid') return
     let cancelled = false
     void (async () => {
       setMermaid({ loading: true })
@@ -256,9 +287,8 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
       }
     })()
     return () => { cancelled = true }
-  }, [mode, type, stableCode, theme])
+  }, [type, stableCode, theme])
 
-  // Close the download menu on outside click.
   useEffect(() => {
     if (!menuOpen) return
     const close = () => setMenuOpen(false)
@@ -269,8 +299,7 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
   const srcdoc = type !== 'application/vnd.mermaid' ? buildSrcdoc(type, stableCode) : ''
   const mermaidSrcdoc = mermaid.svg ? buildSrcdoc('image/svg+xml', mermaid.svg) : ''
 
-  // Fit-height: scale to the 60vh cap (and column width), card hugs content.
-  // Fit-width: scale to the full column width, natural height (chat scrolls).
+  // Fit-height: scale to the 60vh cap, card hugs content. Fit-width: full column.
   const cap = maxH
   const fitReady = naturalW > 0 && availW > 0
   let scale = 1
@@ -285,14 +314,12 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
     }
   }
   const displayW = fitReady ? Math.round(naturalW * scale) : 0
-  // Fit-height shrinks the card to the content; fit-width uses the full column.
-  const cardWidth = mode === 'preview' && fitReady && fitMode === 'height' ? `${displayW}px` : '100%'
+  const cardWidth = fitReady && fitMode === 'height' ? `${displayW}px` : '100%'
 
-  // Images first; source as fallback. HTML can also export a GIF (canvas animations).
-  const formats: Array<'gif' | 'png' | 'svg' | 'html'> =
-    type === 'text/html' ? ['gif', 'png', 'html'] : ['png', 'svg']
+  // Applicable image-format downloads — the underlying html/svg/mermaid is abstracted.
+  const formats: Fmt[] = type === 'text/html' ? ['png', 'jpeg', 'gif', 'html'] : ['png', 'jpeg', 'svg']
 
-  async function download(fmt: 'gif' | 'png' | 'svg' | 'html') {
+  async function download(fmt: Fmt) {
     setMenuOpen(false)
     setBusy(true)
     try {
@@ -307,19 +334,46 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
         else {
           const png = await htmlIframeToPng(iframeRef.current)
           if (png) downloadBlob(png, 'artifact.png')
-          else downloadBlob(new Blob([stableCode], { type: 'text/html' }), 'artifact.html')
         }
       } else {
+        // png | jpeg
+        const mime = fmt === 'jpeg' ? 'image/jpeg' : 'image/png'
         let blob: Blob | null = null
-        if (type === 'application/vnd.mermaid') blob = mermaid.svg ? await svgToPng(mermaid.svg) : null
-        else if (type === 'image/svg+xml') blob = await svgToPng(stableCode)
-        else blob = await htmlIframeToPng(iframeRef.current)
-        if (blob) downloadBlob(blob, 'artifact.png')
-        else if (type === 'text/html') downloadBlob(new Blob([stableCode], { type: 'text/html' }), 'artifact.html')
+        if (type === 'application/vnd.mermaid') blob = mermaid.svg ? await svgToRaster(mermaid.svg, mime) : null
+        else if (type === 'image/svg+xml') blob = await svgToRaster(stableCode, mime)
+        else {
+          // Canvas grab is reliable; foreignObject is the fallback (taints on some browsers).
+          const png = (await htmlIframeFrame(iframeRef.current)) ?? (await htmlIframeToPng(iframeRef.current))
+          blob = png ? (fmt === 'jpeg' ? await blobToJpeg(png) : png) : null
+        }
+        if (blob) downloadBlob(blob, fmt === 'jpeg' ? 'artifact.jpg' : 'artifact.png')
+        else toast.error('Couldn’t export this artifact as an image — try GIF or HTML.')
       }
     } finally {
       setBusy(false)
     }
+  }
+
+  // ── Body content ──────────────────────────────────────────────────────────────
+  let body: React.ReactNode
+  if (type === 'application/vnd.mermaid' && mermaid.error) {
+    body = (
+      <div className="flex items-center justify-center px-3 py-6 text-[12px] text-muted" style={{ minHeight: 100 }}>
+        This artifact couldn&apos;t be rendered.
+      </div>
+    )
+  } else if (type === 'application/vnd.mermaid' && (mermaid.loading || !mermaid.svg)) {
+    body = (
+      <div className="flex items-center justify-center" style={{ minHeight: 120 }}>
+        <div className="flex items-center gap-2 text-faint">
+          <Loader2 size={14} className="animate-spin" />
+          <span className="text-[13px]">Rendering artifact…</span>
+        </div>
+      </div>
+    )
+  } else {
+    const doc = type === 'application/vnd.mermaid' ? mermaidSrcdoc : srcdoc
+    body = <FittedIframe frameRef={iframeRef} srcDoc={doc} naturalW={naturalW} naturalH={naturalH} scale={scale} cap={cap} ready={fitReady} />
   }
 
   return (
@@ -329,48 +383,18 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
         className="overflow-hidden rounded-lg border border-border"
         style={{ width: cardWidth, minWidth: 'min(100%, ' + MIN_CARD_W + 'px)' }}
       >
-        {/* Header */}
+        {/* Header — no type tag, no code toggle; just view + download controls */}
         <div className="flex items-center justify-between border-b border-border bg-panel-2 px-3 py-1">
-          <span className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
-            {lang}
-            {settling && mode === 'preview' && <Loader2 size={10} className="animate-spin text-faint" />}
-          </span>
+          <span className="text-[11px] text-faint">Artifact</span>
           <div className="flex items-center gap-0.5">
-            {/* Code / Preview toggle */}
-            <div className="mr-1 flex overflow-hidden rounded border border-border text-[11px]">
-              <button
-                type="button"
-                onClick={() => setMode('code')}
-                className={cn(
-                  'flex items-center gap-1 px-2 py-0.5 transition-colors',
-                  mode === 'code' ? 'bg-accent/15 text-accent' : 'text-muted hover:text-ink',
-                )}
-              >
-                <Code2 size={10} />Code
-              </button>
-              <button
-                type="button"
-                onClick={handlePreview}
-                className={cn(
-                  'flex items-center gap-1 border-l border-border px-2 py-0.5 transition-colors',
-                  mode === 'preview' ? 'bg-accent/15 text-accent' : 'text-muted hover:text-ink',
-                )}
-              >
-                <Eye size={10} />Preview
-              </button>
-            </div>
-            {mode === 'preview' && (
-              <button
-                type="button"
-                title={fitMode === 'height' ? 'Expand to full width' : 'Fit to screen height'}
-                onClick={() => setFitMode((m) => (m === 'height' ? 'width' : 'height'))}
-                className="rounded p-1 text-faint transition-colors hover:text-ink"
-              >
-                {fitMode === 'height' ? <Maximize2 size={12} /> : <Minimize2 size={12} />}
-              </button>
-            )}
-            <CopyButton text={code} size={12} />
-            {/* Download as image / animation — source only as a fallback */}
+            <button
+              type="button"
+              title={fitMode === 'height' ? 'Expand to full width' : 'Fit to screen height'}
+              onClick={() => setFitMode((m) => (m === 'height' ? 'width' : 'height'))}
+              className="rounded p-1 text-faint transition-colors hover:text-ink"
+            >
+              {fitMode === 'height' ? <Maximize2 size={12} /> : <Minimize2 size={12} />}
+            </button>
             <div className="relative" onMouseDown={(e) => e.stopPropagation()}>
               <button
                 type="button"
@@ -390,7 +414,7 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
                       onClick={() => void download(f)}
                       className="block w-full px-3 py-1.5 text-left text-[12px] text-muted hover:bg-panel-2 hover:text-ink"
                     >
-                      {f.toUpperCase()}
+                      {FMT_LABEL[f]}
                       {f === 'gif' && <span className="ml-1 text-[10px] text-faint">animation</span>}
                       {f === 'html' && <span className="ml-1 text-[10px] text-faint">source</span>}
                     </button>
@@ -402,35 +426,7 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
         </div>
 
         {/* Body */}
-        {mode === 'code' ? (
-          <div className="overflow-x-auto overscroll-x-contain" onScroll={(e) => e.stopPropagation()}>
-            <code className={`language-${lang} block p-3 font-mono text-[13px] leading-relaxed whitespace-pre`}>
-              {code}
-            </code>
-          </div>
-        ) : type === 'application/vnd.mermaid' ? (
-          mermaid.error ? (
-            <div className="p-3">
-              <div className="mb-2 text-[12px]" style={{ color: 'var(--err)' }}>
-                Diagram couldn&apos;t render: {mermaid.error}
-              </div>
-              <div className="overflow-x-auto overscroll-x-contain rounded bg-panel-2" onScroll={(e) => e.stopPropagation()}>
-                <code className="block p-3 font-mono text-[12px] leading-relaxed whitespace-pre text-muted">{code}</code>
-              </div>
-            </div>
-          ) : mermaid.loading || !mermaid.svg ? (
-            <div className="flex items-center justify-center" style={{ minHeight: 120 }}>
-              <div className="flex items-center gap-2 text-faint">
-                <Loader2 size={14} className="animate-spin" />
-                <span className="text-[13px]">{settling ? 'Generating…' : 'Rendering diagram…'}</span>
-              </div>
-            </div>
-          ) : (
-            <FittedIframe frameRef={iframeRef} srcDoc={mermaidSrcdoc} title="Mermaid diagram" naturalW={naturalW} naturalH={naturalH} scale={scale} cap={cap} ready={fitReady} />
-          )
-        ) : (
-          <FittedIframe frameRef={iframeRef} srcDoc={srcdoc} title={`${lang} preview`} naturalW={naturalW} naturalH={naturalH} scale={scale} cap={cap} ready={fitReady} />
-        )}
+        {body}
       </div>
     </div>
   )

--- a/turbollm/web/src/components/ArtifactCard.tsx
+++ b/turbollm/web/src/components/ArtifactCard.tsx
@@ -1,0 +1,437 @@
+import { useState, useEffect, useRef } from 'react'
+import { Code2, Eye, Download, Loader2, ChevronDown, Maximize2, Minimize2 } from 'lucide-react'
+import { CopyButton } from './ui/copy-button'
+import { cn } from '../lib/utils'
+import { useUiStore, resolveDark } from '../stores/ui'
+
+// Fenced-block language → artifact MIME type
+const ARTIFACT_LANGS: Record<string, string> = {
+  html: 'text/html',
+  svg: 'image/svg+xml',
+  mermaid: 'application/vnd.mermaid',
+}
+
+/** Returns the artifact MIME type if the language tag is renderable, otherwise null. */
+export function isArtifactLang(lang: string): string | null {
+  return ARTIFACT_LANGS[lang.toLowerCase()] ?? null
+}
+
+/** Build a sandboxed srcdoc that reports its NATURAL content size ({w,h}). The card
+ *  then scales the whole iframe to fit both the height cap and the column width, and
+ *  sizes itself to the result (FittedIframe). Injects a CSP (blocks external network)
+ *  and (HTML only) self-rasterizers for PNG and GIF export. */
+function buildSrcdoc(type: string, code: string): string {
+  const csp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:;">`
+  // HTML: report the document's content box. `norm` forces height:auto so a `100vh`
+  // artifact can't feed back against the auto-sizing iframe.
+  const resizeHtml = `<script>(function(){function r(){var h=Math.max(document.documentElement.scrollHeight,document.body?document.body.scrollHeight:0);var w=Math.max(document.documentElement.scrollWidth,document.body?document.body.scrollWidth:0);parent.postMessage({type:'tllm-size',w:w,h:h},'*')}window.addEventListener('load',r);if(document.readyState!=='loading')r();try{new ResizeObserver(r).observe(document.documentElement)}catch(e){}})()</script>`
+  // SVG/mermaid: measure the <svg> itself so the card fits the diagram, not the iframe.
+  const resizeSvg = `<script>(function(){function r(){var s=document.querySelector('svg');var b=s?s.getBoundingClientRect():null;var w=b?Math.ceil(b.width):Math.ceil(document.documentElement.scrollWidth);var h=b?Math.ceil(b.height):Math.max(document.documentElement.scrollHeight,document.body?document.body.scrollHeight:0);parent.postMessage({type:'tllm-size',w:w,h:h},'*')}window.addEventListener('load',r);if(document.readyState!=='loading')r();try{new ResizeObserver(r).observe(document.documentElement)}catch(e){}setTimeout(r,60)})()</script>`
+  const norm = `<style>html,body{height:auto!important;min-height:0!important}img,svg,canvas,video{max-width:100%}</style>`
+  // Best-effort PNG export via foreignObject (may taint on some browsers → caught).
+  const shot = `<script>window.addEventListener('message',function(e){if(!e.data||e.data.type!=='tllm-shot')return;try{var el=document.documentElement;var w=Math.max(el.scrollWidth,document.body?document.body.scrollWidth:0)||800;var h=Math.max(el.scrollHeight,document.body?document.body.scrollHeight:0)||600;var ser=new XMLSerializer().serializeToString(el);var svg='<svg xmlns="http://www.w3.org/2000/svg" width="'+w+'" height="'+h+'"><foreignObject width="100%" height="100%">'+ser+'</foreignObject></svg>';var img=new Image();img.onload=function(){try{var c=document.createElement('canvas');c.width=w;c.height=h;c.getContext('2d').drawImage(img,0,0);parent.postMessage({type:'tllm-shot-result',png:c.toDataURL('image/png')},'*')}catch(err){parent.postMessage({type:'tllm-shot-result',png:null},'*')}};img.onerror=function(){parent.postMessage({type:'tllm-shot-result',png:null},'*')};img.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg)}catch(err){parent.postMessage({type:'tllm-shot-result',png:null},'*')}})</script>`
+  // GIF export: grab frames straight off a <canvas> (same-origin within the iframe).
+  const gif = `<script>window.addEventListener('message',function(e){if(!e.data||e.data.type!=='tllm-gif')return;var s=document.querySelector('canvas');if(!s){parent.postMessage({type:'tllm-gif-result',frames:null},'*');return}var sw=s.width||s.clientWidth||300,sh=s.height||s.clientHeight||150;var sc=Math.min(1,480/Math.max(sw,sh));var w=Math.max(1,Math.round(sw*sc)),h=Math.max(1,Math.round(sh*sc));var t=document.createElement('canvas');t.width=w;t.height=h;var x=t.getContext('2d');var fr=[],n=0,m=24;var iv=setInterval(function(){try{x.clearRect(0,0,w,h);x.drawImage(s,0,0,w,h);fr.push(x.getImageData(0,0,w,h).data.buffer.slice(0))}catch(err){}if(++n>=m){clearInterval(iv);try{parent.postMessage({type:'tllm-gif-result',w:w,h:h,frames:fr},'*',fr)}catch(err){parent.postMessage({type:'tllm-gif-result',frames:null},'*')}}},70)})</script>`
+
+  if (type === 'text/html') {
+    const head = `${csp}\n${resizeHtml}\n${norm}\n${shot}\n${gif}`
+    if (/<head[\s>]/i.test(code)) return code.replace(/(<head[^>]*>)/i, `$1\n${head}`)
+    return `<!doctype html><html><head>${head}</head><body>${code}</body></html>`
+  }
+  if (type === 'image/svg+xml') {
+    return `<!doctype html><html><head>${csp}${resizeSvg}<style>html,body{height:auto;margin:0}body{display:flex;justify-content:flex-start;align-items:flex-start;background:transparent}svg{max-width:100%;height:auto}</style></head><body>${code}</body></html>`
+  }
+  return ''
+}
+
+/** Render an iframe scaled by `scale` (preserving aspect) and sized to the scaled
+ *  result, so the card hugs the content. Before the first size report it renders
+ *  full-width to measure; the DOM shape is identical in both states (no reload). */
+function FittedIframe({
+  srcDoc, title, frameRef, naturalW, naturalH, scale, cap, ready,
+}: {
+  srcDoc: string
+  title: string
+  frameRef: React.RefObject<HTMLIFrameElement | null>
+  naturalW: number
+  naturalH: number
+  scale: number
+  cap: number
+  ready: boolean
+}) {
+  const boxW = ready ? Math.round(naturalW * scale) : undefined
+  const boxH = ready ? Math.round(naturalH * scale) : Math.min(naturalH, cap)
+  return (
+    <div className={ready ? '' : 'w-full'} style={{ width: boxW, height: boxH, overflow: 'hidden' }}>
+      <iframe
+        ref={frameRef}
+        srcDoc={srcDoc}
+        sandbox="allow-scripts"
+        title={title}
+        className={cn('block border-0', ready ? '' : 'w-full')}
+        style={ready
+          ? { width: naturalW, height: naturalH, transform: scale !== 1 ? `scale(${scale})` : undefined, transformOrigin: 'top left' }
+          : { height: naturalH }}
+      />
+    </div>
+  )
+}
+
+// ── Image / animation export helpers ────────────────────────────────────────────
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url; a.download = filename; a.click()
+  URL.revokeObjectURL(url)
+}
+
+/** Rasterize a self-contained SVG string to a PNG blob (2× for crispness). */
+function svgToPng(svg: string, scale = 2): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const img = new Image()
+    img.onload = () => {
+      let w = img.naturalWidth, h = img.naturalHeight
+      if (!w || !h) {
+        const m = /viewBox="([^"]+)"/.exec(svg)
+        const p = m ? m[1].trim().split(/\s+/).map(Number) : []
+        if (p.length === 4) { w = p[2]; h = p[3] } else { w = 800; h = 600 }
+      }
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.max(1, Math.round(w * scale))
+      canvas.height = Math.max(1, Math.round(h * scale))
+      const ctx = canvas.getContext('2d')
+      if (!ctx) { URL.revokeObjectURL(url); return resolve(null) }
+      ctx.scale(scale, scale); ctx.drawImage(img, 0, 0, w, h)
+      URL.revokeObjectURL(url)
+      try { canvas.toBlob((b) => resolve(b), 'image/png') } catch { resolve(null) }
+    }
+    img.onerror = () => { URL.revokeObjectURL(url); resolve(null) }
+    img.src = url
+  })
+}
+
+/** Ask the sandboxed HTML iframe to rasterize itself to PNG (best-effort). */
+function htmlIframeToPng(iframe: HTMLIFrameElement | null): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const win = iframe?.contentWindow
+    if (!win) return resolve(null)
+    const onMsg = (e: MessageEvent) => {
+      if (e.source !== win) return
+      if (typeof e.data !== 'object' || e.data?.type !== 'tllm-shot-result') return
+      window.removeEventListener('message', onMsg)
+      if (e.data.png) fetch(e.data.png).then((r) => r.blob()).then(resolve).catch(() => resolve(null))
+      else resolve(null)
+    }
+    window.addEventListener('message', onMsg)
+    win.postMessage({ type: 'tllm-shot' }, '*')
+    setTimeout(() => { window.removeEventListener('message', onMsg); resolve(null) }, 4000)
+  })
+}
+
+/** Capture a <canvas> animation from the iframe and encode it to an animated GIF. */
+function captureGif(iframe: HTMLIFrameElement | null): Promise<Blob | null> {
+  return new Promise((resolve) => {
+    const win = iframe?.contentWindow
+    if (!win) return resolve(null)
+    const onMsg = async (e: MessageEvent) => {
+      if (e.source !== win) return
+      if (typeof e.data !== 'object' || e.data?.type !== 'tllm-gif-result') return
+      window.removeEventListener('message', onMsg)
+      const { w, h, frames } = e.data as { w?: number; h?: number; frames?: ArrayBuffer[] | null }
+      if (!frames || !frames.length || !w || !h) return resolve(null)
+      try {
+        const { GIFEncoder, quantize, applyPalette } = await import('gifenc')
+        const enc = GIFEncoder()
+        for (const buf of frames) {
+          const data = new Uint8Array(buf)
+          const palette = quantize(data, 256)
+          const index = applyPalette(data, palette)
+          enc.writeFrame(index, w, h, { palette, delay: 70 })
+        }
+        enc.finish()
+        resolve(new Blob([new Uint8Array(enc.bytes())], { type: 'image/gif' }))
+      } catch { resolve(null) }
+    }
+    window.addEventListener('message', onMsg)
+    win.postMessage({ type: 'tllm-gif' }, '*')
+    setTimeout(() => { window.removeEventListener('message', onMsg); resolve(null) }, 10000)
+  })
+}
+
+const DEFAULT_H = 200
+const MIN_CARD_W = 300 // keep the header (Code/Preview + buttons) usable
+// Debounce window: while a message streams, `code` grows every token. We only
+// (re)render once it settles, so the iframe doesn't reload per token (no blink).
+const SETTLE_MS = 350
+
+/** Cap the preview to ~60% of the visible screen height. */
+function screenCap(): number {
+  const v = typeof window !== 'undefined' ? window.innerHeight : 800
+  return Math.max(200, Math.round((v * 0.6) / 10) * 10)
+}
+
+interface ArtifactCardProps {
+  lang: string
+  code: string
+}
+
+export function ArtifactCard({ lang, code }: ArtifactCardProps) {
+  const type = ARTIFACT_LANGS[lang.toLowerCase()] ?? 'text/html'
+  const theme = useUiStore((s) => s.theme)
+  const [mode, setMode] = useState<'code' | 'preview'>('preview')
+  // 'height' = fit the whole artifact within 60vh (card hugs content). 'width' =
+  // expand to the full column width (taller; the chat scrolls).
+  const [fitMode, setFitMode] = useState<'height' | 'width'>('height')
+  const [naturalH, setNaturalH] = useState(DEFAULT_H)
+  const [naturalW, setNaturalW] = useState(0)
+  const [availW, setAvailW] = useState(0)
+  const [maxH, setMaxH] = useState(screenCap)
+  const [mermaid, setMermaid] = useState<{ svg?: string; error?: string; loading?: boolean }>({})
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Debounced code → blink fix (render once the stream settles).
+  const [stableCode, setStableCode] = useState(code)
+  useEffect(() => {
+    const t = setTimeout(() => setStableCode(code), SETTLE_MS)
+    return () => clearTimeout(t)
+  }, [code])
+  const settling = code !== stableCode
+
+  // Track the screen-height cap and the available column width.
+  useEffect(() => {
+    const onResize = () => setMaxH((prev) => { const n = screenCap(); return n === prev ? prev : n })
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const update = () => setAvailW(el.clientWidth)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  // The iframe reports its NATURAL content size; scoped to THIS card's iframe so
+  // multiple artifacts don't cross-contaminate.
+  useEffect(() => {
+    function onMsg(e: MessageEvent) {
+      if (e.source !== iframeRef.current?.contentWindow) return
+      if (typeof e.data !== 'object' || e.data?.type !== 'tllm-size') return
+      // Threshold updates: animated artifacts fire ResizeObserver every frame with
+      // sub-pixel deltas — without this the card jitters/resizes continuously.
+      const w = Number(e.data.w), h = Number(e.data.h)
+      if (!isNaN(h) && h > 0) { const nh = Math.min(Math.ceil(h) + 2, 15000); setNaturalH((p) => Math.abs(nh - p) > 4 ? nh : p) }
+      if (!isNaN(w) && w > 0) { const nw = Math.min(Math.ceil(w), 15000); setNaturalW((p) => Math.abs(nw - p) > 4 ? nw : p) }
+    }
+    window.addEventListener('message', onMsg)
+    return () => window.removeEventListener('message', onMsg)
+  }, [])
+
+  const handlePreview = () => setMode('preview')
+
+  // Render mermaid from the SETTLED code; re-renders on app-theme change.
+  useEffect(() => {
+    if (mode !== 'preview' || type !== 'application/vnd.mermaid') return
+    let cancelled = false
+    void (async () => {
+      setMermaid({ loading: true })
+      try {
+        const m = (await import('mermaid')).default
+        m.initialize({ startOnLoad: false, theme: resolveDark(theme) ? 'dark' : 'default', suppressErrorRendering: true })
+        await m.parse(stableCode)
+        if (cancelled) return
+        const id = `mmd${Math.random().toString(36).slice(2, 8)}`
+        const { svg } = await m.render(id, stableCode)
+        if (!cancelled) setMermaid({ svg })
+      } catch (e) {
+        if (!cancelled) setMermaid({ error: (e as Error).message })
+      }
+    })()
+    return () => { cancelled = true }
+  }, [mode, type, stableCode, theme])
+
+  // Close the download menu on outside click.
+  useEffect(() => {
+    if (!menuOpen) return
+    const close = () => setMenuOpen(false)
+    document.addEventListener('mousedown', close)
+    return () => document.removeEventListener('mousedown', close)
+  }, [menuOpen])
+
+  const srcdoc = type !== 'application/vnd.mermaid' ? buildSrcdoc(type, stableCode) : ''
+  const mermaidSrcdoc = mermaid.svg ? buildSrcdoc('image/svg+xml', mermaid.svg) : ''
+
+  // Fit-height: scale to the 60vh cap (and column width), card hugs content.
+  // Fit-width: scale to the full column width, natural height (chat scrolls).
+  const cap = maxH
+  const fitReady = naturalW > 0 && availW > 0
+  let scale = 1
+  if (fitReady) {
+    if (fitMode === 'width') {
+      scale = availW / naturalW
+    } else {
+      const heightScale = naturalH > cap ? cap / naturalH : 1
+      const wAfterH = naturalW * heightScale
+      const widthScale = wAfterH > availW ? availW / wAfterH : 1
+      scale = heightScale * widthScale
+    }
+  }
+  const displayW = fitReady ? Math.round(naturalW * scale) : 0
+  // Fit-height shrinks the card to the content; fit-width uses the full column.
+  const cardWidth = mode === 'preview' && fitReady && fitMode === 'height' ? `${displayW}px` : '100%'
+
+  // Images first; source as fallback. HTML can also export a GIF (canvas animations).
+  const formats: Array<'gif' | 'png' | 'svg' | 'html'> =
+    type === 'text/html' ? ['gif', 'png', 'html'] : ['png', 'svg']
+
+  async function download(fmt: 'gif' | 'png' | 'svg' | 'html') {
+    setMenuOpen(false)
+    setBusy(true)
+    try {
+      if (fmt === 'svg') {
+        const svg = type === 'application/vnd.mermaid' ? (mermaid.svg ?? '') : stableCode
+        if (svg) downloadBlob(new Blob([svg], { type: 'image/svg+xml' }), 'artifact.svg')
+      } else if (fmt === 'html') {
+        downloadBlob(new Blob([stableCode], { type: 'text/html' }), 'artifact.html')
+      } else if (fmt === 'gif') {
+        const blob = await captureGif(iframeRef.current)
+        if (blob) downloadBlob(blob, 'artifact.gif')
+        else {
+          const png = await htmlIframeToPng(iframeRef.current)
+          if (png) downloadBlob(png, 'artifact.png')
+          else downloadBlob(new Blob([stableCode], { type: 'text/html' }), 'artifact.html')
+        }
+      } else {
+        let blob: Blob | null = null
+        if (type === 'application/vnd.mermaid') blob = mermaid.svg ? await svgToPng(mermaid.svg) : null
+        else if (type === 'image/svg+xml') blob = await svgToPng(stableCode)
+        else blob = await htmlIframeToPng(iframeRef.current)
+        if (blob) downloadBlob(blob, 'artifact.png')
+        else if (type === 'text/html') downloadBlob(new Blob([stableCode], { type: 'text/html' }), 'artifact.html')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    // Outer container is full-width (measures availW); the card is left-aligned.
+    <div ref={containerRef} className="my-2 flex justify-start">
+      <div
+        className="overflow-hidden rounded-lg border border-border"
+        style={{ width: cardWidth, minWidth: 'min(100%, ' + MIN_CARD_W + 'px)' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border bg-panel-2 px-3 py-1">
+          <span className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
+            {lang}
+            {settling && mode === 'preview' && <Loader2 size={10} className="animate-spin text-faint" />}
+          </span>
+          <div className="flex items-center gap-0.5">
+            {/* Code / Preview toggle */}
+            <div className="mr-1 flex overflow-hidden rounded border border-border text-[11px]">
+              <button
+                type="button"
+                onClick={() => setMode('code')}
+                className={cn(
+                  'flex items-center gap-1 px-2 py-0.5 transition-colors',
+                  mode === 'code' ? 'bg-accent/15 text-accent' : 'text-muted hover:text-ink',
+                )}
+              >
+                <Code2 size={10} />Code
+              </button>
+              <button
+                type="button"
+                onClick={handlePreview}
+                className={cn(
+                  'flex items-center gap-1 border-l border-border px-2 py-0.5 transition-colors',
+                  mode === 'preview' ? 'bg-accent/15 text-accent' : 'text-muted hover:text-ink',
+                )}
+              >
+                <Eye size={10} />Preview
+              </button>
+            </div>
+            {mode === 'preview' && (
+              <button
+                type="button"
+                title={fitMode === 'height' ? 'Expand to full width' : 'Fit to screen height'}
+                onClick={() => setFitMode((m) => (m === 'height' ? 'width' : 'height'))}
+                className="rounded p-1 text-faint transition-colors hover:text-ink"
+              >
+                {fitMode === 'height' ? <Maximize2 size={12} /> : <Minimize2 size={12} />}
+              </button>
+            )}
+            <CopyButton text={code} size={12} />
+            {/* Download as image / animation — source only as a fallback */}
+            <div className="relative" onMouseDown={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                title="Download"
+                onClick={() => setMenuOpen((o) => !o)}
+                className="flex items-center rounded p-1 text-faint transition-colors hover:text-ink"
+              >
+                {busy ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+                <ChevronDown size={9} className="ml-0.5" />
+              </button>
+              {menuOpen && (
+                <div className="absolute right-0 z-10 mt-1 min-w-28 overflow-hidden rounded-md border border-border bg-panel shadow-lg">
+                  {formats.map((f) => (
+                    <button
+                      key={f}
+                      type="button"
+                      onClick={() => void download(f)}
+                      className="block w-full px-3 py-1.5 text-left text-[12px] text-muted hover:bg-panel-2 hover:text-ink"
+                    >
+                      {f.toUpperCase()}
+                      {f === 'gif' && <span className="ml-1 text-[10px] text-faint">animation</span>}
+                      {f === 'html' && <span className="ml-1 text-[10px] text-faint">source</span>}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Body */}
+        {mode === 'code' ? (
+          <div className="overflow-x-auto overscroll-x-contain" onScroll={(e) => e.stopPropagation()}>
+            <code className={`language-${lang} block p-3 font-mono text-[13px] leading-relaxed whitespace-pre`}>
+              {code}
+            </code>
+          </div>
+        ) : type === 'application/vnd.mermaid' ? (
+          mermaid.error ? (
+            <div className="p-3">
+              <div className="mb-2 text-[12px]" style={{ color: 'var(--err)' }}>
+                Diagram couldn&apos;t render: {mermaid.error}
+              </div>
+              <div className="overflow-x-auto overscroll-x-contain rounded bg-panel-2" onScroll={(e) => e.stopPropagation()}>
+                <code className="block p-3 font-mono text-[12px] leading-relaxed whitespace-pre text-muted">{code}</code>
+              </div>
+            </div>
+          ) : mermaid.loading || !mermaid.svg ? (
+            <div className="flex items-center justify-center" style={{ minHeight: 120 }}>
+              <div className="flex items-center gap-2 text-faint">
+                <Loader2 size={14} className="animate-spin" />
+                <span className="text-[13px]">{settling ? 'Generating…' : 'Rendering diagram…'}</span>
+              </div>
+            </div>
+          ) : (
+            <FittedIframe frameRef={iframeRef} srcDoc={mermaidSrcdoc} title="Mermaid diagram" naturalW={naturalW} naturalH={naturalH} scale={scale} cap={cap} ready={fitReady} />
+          )
+        ) : (
+          <FittedIframe frameRef={iframeRef} srcDoc={srcdoc} title={`${lang} preview`} naturalW={naturalW} naturalH={naturalH} scale={scale} cap={cap} ready={fitReady} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
-import { Boxes, Code2, Cpu, MessageSquare, Puzzle, Settings2 } from 'lucide-react'
+import { Bot, Boxes, Code2, Cpu, MessageSquare, Puzzle, Settings2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import type { Status } from '../lib/types'
 import { StateChip } from './StateChip'
@@ -14,6 +14,7 @@ import {
 
 const NAV = [
   { to: '/chat',      label: 'Chat',      icon: MessageSquare },
+  { to: '/agents',    label: 'Agents',    icon: Bot },
   { to: '/models',    label: 'Models',    icon: Boxes },
   { to: '/engines',   label: 'Engines',   icon: Cpu },
   { to: '/customize', label: 'Customize', icon: Puzzle },

--- a/turbollm/web/src/gifenc.d.ts
+++ b/turbollm/web/src/gifenc.d.ts
@@ -1,0 +1,19 @@
+// Minimal types for gifenc (ships no declarations). We use a small subset.
+declare module 'gifenc' {
+  export function GIFEncoder(): {
+    writeFrame(
+      index: Uint8Array | Uint8ClampedArray,
+      width: number,
+      height: number,
+      opts?: { palette?: number[][]; delay?: number; transparent?: boolean; dispose?: number },
+    ): void
+    finish(): void
+    bytes(): Uint8Array
+  }
+  export function quantize(rgba: Uint8Array | Uint8ClampedArray, maxColors: number): number[][]
+  export function applyPalette(
+    rgba: Uint8Array | Uint8ClampedArray,
+    palette: number[][],
+    format?: string,
+  ): Uint8Array
+}

--- a/turbollm/web/src/lib/agent-api.ts
+++ b/turbollm/web/src/lib/agent-api.ts
@@ -1,0 +1,99 @@
+import { authHeaders, ApiError } from './api'
+import type { AgentRun } from './agent-types'
+
+export const agentRunKeys = {
+  all: ['agent-runs'] as const,
+  list: () => [...agentRunKeys.all, 'list'] as const,
+  detail: (id: string) => [...agentRunKeys.all, 'detail', id] as const,
+}
+
+async function req<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...authHeaders(),
+    ...((init?.headers as Record<string, string>) ?? {}),
+  }
+  const res = await fetch(path, { ...init, headers })
+  if (res.status === 204) return undefined as T
+  const text = await res.text()
+  const data = text ? (JSON.parse(text) as unknown) : undefined
+  if (!res.ok) {
+    const env = data as { error?: { code?: string; message?: string } } | undefined
+    throw new ApiError(
+      env?.error?.code ?? 'http_error',
+      env?.error?.message ?? `Request failed with status ${res.status}.`,
+      res.status,
+    )
+  }
+  return data as T
+}
+
+export async function fetchAgentRuns(): Promise<AgentRun[]> {
+  return req<AgentRun[]>('/api/v1/agents/runs')
+}
+
+export async function fetchAgentRun(id: string): Promise<AgentRun> {
+  return req<AgentRun>(`/api/v1/agents/runs/${id}`)
+}
+
+export async function createAgentRun(params: {
+  title?: string
+  systemPrompt?: string
+  userMessage: string
+  allowedTools?: string[]
+}): Promise<AgentRun> {
+  return req<AgentRun>('/api/v1/agents/runs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  })
+}
+
+export async function cancelAgentRun(id: string): Promise<void> {
+  await req<{ ok: boolean }>(`/api/v1/agents/runs/${id}`, { method: 'DELETE' })
+}
+
+/** Async generator that replays buffered events from `fromSeq` then live-tails. */
+export async function* subscribeRunStream(
+  id: string,
+  fromSeq = 0,
+  signal?: AbortSignal,
+): AsyncGenerator<{ event: string; data: unknown }> {
+  const url = `/api/v1/agents/runs/${id}/stream?fromSeq=${fromSeq}`
+  const res = await fetch(url, {
+    headers: { Accept: 'text/event-stream', ...authHeaders() },
+    signal,
+  })
+  if (!res.ok || !res.body) throw new Error(`Stream error: ${res.status}`)
+
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+
+      let currentEvent = 'message'
+      for (const line of lines) {
+        if (line.startsWith('event: ')) { currentEvent = line.slice(7).trim(); continue }
+        if (line.startsWith('data: ')) {
+          const raw = line.slice(6).trim()
+          if (raw === '[DONE]') return
+          try {
+            const data = JSON.parse(raw) as unknown
+            yield { event: currentEvent, data }
+            if (currentEvent === 'done' || currentEvent === 'error') return
+          } catch { /* ignore malformed */ }
+          currentEvent = 'message'
+        }
+      }
+    }
+  } finally {
+    reader.cancel()
+  }
+}

--- a/turbollm/web/src/lib/agent-types.ts
+++ b/turbollm/web/src/lib/agent-types.ts
@@ -1,0 +1,39 @@
+export type AgentRunStatus = 'queued' | 'running' | 'done' | 'failed' | 'cancelled' | 'interrupted'
+
+export interface AgentRun {
+  id: string
+  convId: string
+  title: string
+  status: AgentRunStatus
+  allowedTools: string[]
+  error?: string
+  createdAt: string
+  updatedAt: string
+  startedAt?: string
+  endedAt?: string
+  messages?: AgentMessage[]
+}
+
+export interface AgentToolCall {
+  id: string
+  name: string
+  args: Record<string, unknown>
+  result: string
+}
+
+export interface AgentMessage {
+  id: string
+  convId: string
+  seq: number
+  role: 'user' | 'assistant'
+  content: string
+  reasoning: string
+  toolCalls?: AgentToolCall[]
+  createdAt: string
+}
+
+export interface AgentSseEvent {
+  seq: number
+  event: string
+  data: unknown
+}

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -1,4 +1,4 @@
-export type PersonaId = 'default' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative' | 'research'
+export type PersonaId = 'default' | 'designer' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative' | 'research'
 
 export interface Persona {
   id: PersonaId
@@ -13,6 +13,26 @@ export const PERSONAS: readonly Persona[] = [
     name: 'Default',
     description: "Balanced and helpful with chart, diagram & preview capability and your personalization settings",
     systemPrompt: '',
+  },
+  {
+    id: 'designer',
+    name: 'Designer',
+    description: 'Front-end design expert — turns ideas into beautiful, self-contained artifacts you can preview',
+    systemPrompt:
+      'You are a senior product/front-end designer with exceptional visual taste. Your job is to turn the request into a beautiful, production-quality result delivered as a LIVE ARTIFACT that TurboLLM renders as an image.\n\n' +
+      'Always reply with ONE self-contained fenced block (and nothing competing with it), choosing the right type:\n' +
+      '- ```html — pages, UI components, mockups, dashboards, landing pages, interactive widgets, canvas animations.\n' +
+      '- ```svg — icons, logos, illustrations, badges, and charts you draw by hand.\n' +
+      '- ```mermaid — diagrams: flows, architecture, sequences, journeys, timelines, mind maps.\n' +
+      'Put any explanation BEFORE the block, never inside it.\n\n' +
+      'HARD CONSTRAINT — fully self-contained and OFFLINE. The preview sandbox blocks all network. So: put all CSS in a <style> tag and all JS in a <script> tag; use NO external fonts, stylesheets, CDNs, scripts, or image URLs (no Google Fonts, Font Awesome, Tailwind CDN, Unsplash, etc.). For icons and imagery use INLINE SVG; for type use a refined system font stack; for visuals use CSS gradients, shapes, and inline SVG. A design that needs the network is wrong here.\n\n' +
+      'Design to a high bar — distinctive and intentional, never generic, templated, or "AI default":\n' +
+      '- Typography: clear hierarchy and a tight type scale; generous line-height; subtle letter-spacing on headings; at most one display + one body voice.\n' +
+      '- Color: a small, cohesive palette — neutrals plus one or two accents; tasteful gradients and tints; always meet contrast.\n' +
+      '- Layout: deliberate whitespace, strong alignment, clear rhythm; responsive with flexbox/grid and clamp().\n' +
+      '- Depth & polish: restrained shadows, hairline borders, considered corner radii; real hover/focus states; smooth transitions; small delightful details.\n' +
+      '- Accessibility: semantic HTML, visible focus, adequate contrast, and respect prefers-reduced-motion.\n\n' +
+      'Favor craft and restraint over decoration. Ship something you would be proud to put in a portfolio. If the brief is vague, make confident, tasteful choices rather than asking.',
   },
   {
     id: 'blank',

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -11,7 +11,7 @@ export const PERSONAS: readonly Persona[] = [
   {
     id: 'default',
     name: 'Default',
-    description: "Balanced and helpful with chart capability and your personalization settings",
+    description: "Balanced and helpful with chart, diagram & preview capability and your personalization settings",
     systemPrompt: '',
   },
   {
@@ -163,12 +163,34 @@ When a chart is warranted:
 
 Always include a title, axis/column labels, and the underlying numbers. Keep charts compact — no wider than ~60 characters. Wrap chart output in a plain code block (\`\`\`) so spacing is preserved.`
 
+/** Rendered-artifact capability. TurboLLM live-previews fenced blocks tagged
+ *  html / svg / mermaid, so the model should reach for them when the user wants
+ *  something visual or interactive — and NOT otherwise (no over-rendering). */
+const TURBOLLM_ARTIFACTS_CAPABILITY = `TurboLLM also live-previews three kinds of fenced code block, so you can return RENDERED visuals, not just text. When the user wants something visual or interactive, reply with ONE self-contained fenced block in the right language:
+
+- \`\`\`mermaid — diagrams: flowcharts, sequence/class/ER/state diagrams, gantt, mind maps, pie charts. Reach for this on "diagram", "flowchart", "flow", "architecture", "sequence", "how X works" (visually), "org chart", "timeline".
+- \`\`\`svg — static vector graphics: icons, logos, illustrations, simple scenes, or charts you draw by hand (bar/line/scatter). Reach for this on "draw", "icon", "logo", "illustration", "graphic".
+- \`\`\`html — interactive or animated results: a web page, UI mockup, form, canvas animation, game, calculator — anything needing live CSS/JS. Must be fully self-contained: inline CSS/JS only, NO external URLs, scripts, fonts, images, or network calls (they are blocked).
+
+When to use them:
+- ONLY when a rendered visual or runnable result is genuinely what the user asked for. Pick the simplest type that satisfies it — a flowchart is mermaid, not html; an icon is svg, not html.
+- Put any explanation BEFORE or AFTER the block, never inside it. At most one artifact per response.
+
+Keep the syntax valid (a diagram that fails to parse is worse than a simpler one that renders):
+- mermaid: prefer simple flowcharts/graphs. Wrap any node or message label that contains spaces, parentheses, slashes, or punctuation in double quotes. In sequence diagrams, do NOT use activate/deactivate unless every activate has a matching deactivate — when in doubt, leave them out.
+- svg/html: self-contained only — no external URLs, CDNs, fonts, or images.
+
+When NOT to use them (important — do not over-render):
+- Plain questions, opinions, explanations, or conversation → normal prose.
+- Code meant to be read, copied, or used in a project (a function, a script, a config) → a normal code block in its real language, NOT an artifact. Wrapping ordinary code in html/svg/mermaid is wrong.
+- A 1–2 number comparison → just say the numbers. Small text tables/sparklines → the Unicode style above.`
+
 /** Build the hidden system prompt for a new conversation from a persona + personalization. */
 export function buildSystemPrompt(personaId: PersonaId, p: Personalization): string {
   if (personaId === 'blank') return ''
   const persona = PERSONAS.find((px) => px.id === personaId)
   const today = new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
-  const parts: string[] = [TURBOLLM_BASE_CAPABILITY, `Today's date is ${today}.`]
+  const parts: string[] = [TURBOLLM_BASE_CAPABILITY, TURBOLLM_ARTIFACTS_CAPABILITY, `Today's date is ${today}.`]
   if (persona?.systemPrompt) parts.push(persona.systemPrompt)
   if (p.assistantName.trim()) parts.push(`Your name is ${p.assistantName.trim()}.`)
   if (p.userName.trim()) parts.push(`The user's name is ${p.userName.trim()}.`)

--- a/turbollm/web/src/screens/AgentsScreen.tsx
+++ b/turbollm/web/src/screens/AgentsScreen.tsx
@@ -1,0 +1,392 @@
+import { useState, useEffect, useRef } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Bot, CircleDot, CheckCircle2, XCircle, Clock, Loader2, Plus, X, Wrench } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { agentRunKeys, fetchAgentRuns, fetchAgentRun, createAgentRun, cancelAgentRun, subscribeRunStream } from '../lib/agent-api'
+import type { AgentRun, AgentRunStatus } from '../lib/agent-types'
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+const STATUS_ICON: Record<AgentRunStatus, React.ReactNode> = {
+  queued:      <Clock size={12} />,
+  running:     <Loader2 size={12} className="animate-spin" />,
+  done:        <CheckCircle2 size={12} />,
+  failed:      <XCircle size={12} />,
+  cancelled:   <XCircle size={12} />,
+  interrupted: <XCircle size={12} />,
+}
+const STATUS_COLOR: Record<AgentRunStatus, string> = {
+  queued:      'text-muted',
+  running:     'text-accent',
+  done:        'text-green-500',
+  failed:      'text-red-500',
+  cancelled:   'text-muted',
+  interrupted: 'text-orange-500',
+}
+
+function StatusBadge({ status }: { status: AgentRunStatus }) {
+  return (
+    <span className={cn('flex items-center gap-1 text-[11px] capitalize', STATUS_COLOR[status])}>
+      {STATUS_ICON[status]}{status}
+    </span>
+  )
+}
+
+// ── Time formatter ────────────────────────────────────────────────────────────
+
+function relTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  if (ms < 60_000) return 'just now'
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+// ── New Run Dialog ────────────────────────────────────────────────────────────
+
+const TOOL_OPTIONS = [
+  { id: 'web_search', label: 'Web search', hint: 'Search the web (needs a provider configured in Settings)' },
+  { id: 'fetch_url', label: 'Fetch URL', hint: 'Read the contents of a web page' },
+  { id: 'run_code', label: 'Run code', hint: 'Execute JS in a sandbox — no mid-run confirmation, opt in only if you trust the task' },
+] as const
+
+function NewRunDialog({ onClose, onCreated }: { onClose: () => void; onCreated: (id: string) => void }) {
+  const [task, setTask] = useState('')
+  const [systemPrompt, setSystemPrompt] = useState('')
+  // Research is the primary use case → web_search + fetch_url on by default; run_code off (§3.6).
+  const [tools, setTools] = useState<Record<string, boolean>>({ web_search: true, fetch_url: true, run_code: false })
+  const qc = useQueryClient()
+
+  const toggleTool = (id: string) => setTools((t) => ({ ...t, [id]: !t[id] }))
+
+  const create = useMutation({
+    mutationFn: () =>
+      createAgentRun({
+        title: task.slice(0, 60) || 'Agent run',
+        systemPrompt: systemPrompt || undefined,
+        userMessage: task,
+        allowedTools: Object.entries(tools).filter(([, on]) => on).map(([id]) => id),
+      }),
+    onSuccess: (run) => {
+      void qc.invalidateQueries({ queryKey: agentRunKeys.list() })
+      onCreated(run.id)
+      onClose()
+    },
+  })
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="w-full max-w-lg rounded-xl border border-border bg-panel p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-[15px] font-semibold">New agent run</h2>
+          <button type="button" onClick={onClose} className="text-faint hover:text-ink"><X size={16} /></button>
+        </div>
+
+        <label className="mb-1 block text-[12px] text-muted">Task</label>
+        <textarea
+          autoFocus
+          value={task}
+          onChange={(e) => setTask(e.target.value)}
+          placeholder="Describe what the agent should do…"
+          rows={4}
+          className="mb-3 w-full resize-none rounded-lg border border-border bg-input px-3 py-2 text-[13px] text-ink placeholder:text-faint focus:border-accent focus:outline-none"
+        />
+
+        <label className="mb-1 block text-[12px] text-muted">System prompt <span className="text-faint">(optional)</span></label>
+        <textarea
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          placeholder="You are a helpful assistant…"
+          rows={2}
+          className="mb-4 w-full resize-none rounded-lg border border-border bg-input px-3 py-2 text-[13px] text-ink placeholder:text-faint focus:border-accent focus:outline-none"
+        />
+
+        <label className="mb-1.5 block text-[12px] text-muted">Tools</label>
+        <div className="mb-4 space-y-1.5">
+          {TOOL_OPTIONS.map((t) => (
+            <label
+              key={t.id}
+              className="flex cursor-pointer items-start gap-2 rounded-lg border border-border px-2.5 py-2 hover:bg-panel-2"
+            >
+              <input
+                type="checkbox"
+                checked={tools[t.id]}
+                onChange={() => toggleTool(t.id)}
+                className="mt-0.5 accent-[var(--accent)]"
+              />
+              <span className="min-w-0">
+                <span className="block text-[13px] font-medium text-ink">{t.label}</span>
+                <span className="block text-[11px] leading-snug text-faint">{t.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <button type="button" onClick={onClose} className="rounded-lg px-3 py-1.5 text-[13px] text-muted hover:text-ink">Cancel</button>
+          <button
+            type="button"
+            disabled={!task.trim() || create.isPending}
+            onClick={() => create.mutate()}
+            className="flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[13px] font-medium text-white disabled:opacity-50"
+          >
+            {create.isPending ? <Loader2 size={13} className="animate-spin" /> : <Bot size={13} />}
+            Run agent
+          </button>
+        </div>
+        {create.isError && (
+          <p className="mt-2 text-[12px]" style={{ color: 'var(--err)' }}>
+            {(create.error as Error).message}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Tool-call step (collapsible) ──────────────────────────────────────────────
+
+function ToolCallRow({ call }: { call: import('../lib/agent-types').AgentToolCall }) {
+  const [open, setOpen] = useState(false)
+  const summary =
+    typeof call.args?.query === 'string' ? call.args.query
+    : typeof call.args?.url === 'string' ? call.args.url
+    : JSON.stringify(call.args ?? {})
+  return (
+    <div className="w-full max-w-[85%] rounded-lg border border-border bg-panel px-2.5 py-1.5 text-[12px]">
+      <button type="button" onClick={() => setOpen((o) => !o)} className="flex w-full items-center gap-1.5 text-left text-muted hover:text-ink">
+        <Wrench size={12} className="shrink-0 text-accent" />
+        <span className="font-medium text-ink">{call.name}</span>
+        <span className="truncate text-faint">{summary}</span>
+      </button>
+      {open && (
+        <pre className="mt-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded bg-panel-2 p-2 text-[11px] text-muted">
+          {call.result}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+// ── Run messages view ─────────────────────────────────────────────────────────
+
+function RunDetail({ run }: { run: AgentRun }) {
+  const qc = useQueryClient()
+  const abortRef = useRef<AbortController | null>(null)
+  const [liveContent, setLiveContent] = useState('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const cancel = useMutation({
+    mutationFn: () => cancelAgentRun(run.id),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: agentRunKeys.list() }),
+  })
+
+  // Stream live events when the run is active
+  useEffect(() => {
+    if (run.status !== 'running' && run.status !== 'queued') return
+    const ac = new AbortController()
+    abortRef.current = ac
+    let content = ''
+
+    void (async () => {
+      try {
+        for await (const ev of subscribeRunStream(run.id, 0, ac.signal)) {
+          if (ev.event === 'delta') {
+            content += (ev.data as { delta: string }).delta
+            setLiveContent(content)
+          } else if (ev.event === 'done' || ev.event === 'error') {
+            void qc.invalidateQueries({ queryKey: agentRunKeys.detail(run.id) })
+            void qc.invalidateQueries({ queryKey: agentRunKeys.list() })
+            break
+          }
+        }
+      } catch { /* aborted or connection closed */ }
+    })()
+
+    return () => { ac.abort(); abortRef.current = null }
+  }, [run.id, run.status, qc])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [liveContent, run.messages?.length])
+
+  const messages = run.messages ?? []
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+        <div>
+          <p className="text-[14px] font-medium text-ink">{run.title}</p>
+          <StatusBadge status={run.status} />
+        </div>
+        {(run.status === 'running' || run.status === 'queued') && (
+          <button
+            type="button"
+            onClick={() => cancel.mutate()}
+            className="rounded-lg border border-border px-3 py-1 text-[12px] text-muted transition-colors hover:border-red-400 hover:text-red-500"
+          >
+            {cancel.isPending ? <Loader2 size={12} className="inline animate-spin" /> : 'Cancel'}
+          </button>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 space-y-3 overflow-y-auto p-4">
+        {messages.map((msg) => (
+          <div key={msg.id} className={cn('flex flex-col gap-1.5', msg.role === 'user' ? 'items-end' : 'items-start')}>
+            {/* Tool calls (research steps) shown above the assistant's answer */}
+            {msg.toolCalls?.map((tc) => (
+              <ToolCallRow key={tc.id} call={tc} />
+            ))}
+            {(msg.content || msg.role === 'user' || run.status === 'running') && (
+              <div
+                className={cn(
+                  'max-w-[85%] rounded-xl px-3 py-2 text-[13px] leading-relaxed',
+                  msg.role === 'user' ? 'bg-accent/15 text-ink' : 'bg-panel-2 text-ink',
+                )}
+              >
+                <p className="whitespace-pre-wrap break-words">
+                  {msg.content || (msg.role === 'assistant' && run.status === 'running' ? '…' : '')}
+                </p>
+              </div>
+            )}
+          </div>
+        ))}
+        {/* Live streaming output (replaces empty placeholder) */}
+        {liveContent && (
+          <div className="flex gap-2">
+            <div className="max-w-[85%] rounded-xl bg-panel-2 px-3 py-2 text-[13px] leading-relaxed text-ink">
+              <p className="whitespace-pre-wrap break-words">{liveContent}</p>
+            </div>
+          </div>
+        )}
+        {run.error && (
+          <div className="rounded-lg bg-red-500/10 px-3 py-2 text-[12px] text-red-500">
+            Error: {run.error}
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}
+
+// ── Main screen ───────────────────────────────────────────────────────────────
+
+export function AgentsScreen() {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [showDialog, setShowDialog] = useState(false)
+
+  const runsQ = useQuery({
+    queryKey: agentRunKeys.list(),
+    queryFn: fetchAgentRuns,
+    refetchInterval: (q) => {
+      const runs = q.state.data ?? []
+      const hasActive = runs.some((r) => r.status === 'queued' || r.status === 'running')
+      return hasActive ? 3000 : false
+    },
+  })
+
+  const detailQ = useQuery({
+    queryKey: agentRunKeys.detail(selectedId ?? ''),
+    queryFn: () => fetchAgentRun(selectedId!),
+    enabled: !!selectedId,
+    refetchInterval: (q) => {
+      const run = q.state.data
+      const active = run?.status === 'queued' || run?.status === 'running'
+      return active ? 5000 : false
+    },
+  })
+
+  const runs = runsQ.data ?? []
+  const selected = detailQ.data
+
+  return (
+    <div className="flex h-full">
+      {/* Sidebar */}
+      <div className="flex w-64 shrink-0 flex-col border-r border-border">
+        <div className="flex items-center justify-between border-b border-border px-3 py-2.5">
+          <span className="text-[13px] font-semibold text-ink">Agents</span>
+          <button
+            type="button"
+            title="New agent run"
+            onClick={() => setShowDialog(true)}
+            className="flex items-center gap-1 rounded-lg bg-accent px-2 py-1 text-[11px] font-medium text-white transition-opacity hover:opacity-90"
+          >
+            <Plus size={11} /> New
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {runsQ.isLoading && (
+            <div className="flex h-20 items-center justify-center">
+              <Loader2 size={16} className="animate-spin text-faint" />
+            </div>
+          )}
+          {runs.length === 0 && !runsQ.isLoading && (
+            <div className="px-4 py-8 text-center">
+              <Bot size={28} className="mx-auto mb-2 text-faint" />
+              <p className="text-[12px] text-muted">No agent runs yet.</p>
+              <p className="mt-0.5 text-[11px] text-faint">Click &ldquo;New&rdquo; to start one.</p>
+            </div>
+          )}
+          {runs.map((run) => (
+            <button
+              key={run.id}
+              type="button"
+              onClick={() => setSelectedId(run.id)}
+              className={cn(
+                'w-full border-b border-border px-3 py-2.5 text-left transition-colors hover:bg-panel-2',
+                selectedId === run.id && 'bg-panel-2',
+              )}
+            >
+              <p className="mb-0.5 truncate text-[13px] font-medium text-ink">{run.title}</p>
+              <div className="flex items-center justify-between">
+                <StatusBadge status={run.status} />
+                <span className="text-[10px] text-faint">{relTime(run.createdAt)}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Detail pane */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        {!selectedId ? (
+          <div className="flex h-full flex-col items-center justify-center text-center">
+            <CircleDot size={32} className="mb-3 text-faint" />
+            <p className="text-[14px] font-medium text-ink">Select a run</p>
+            <p className="mt-1 text-[12px] text-muted">or create a new agent run to get started</p>
+            <button
+              type="button"
+              onClick={() => setShowDialog(true)}
+              className="mt-4 flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-[13px] font-medium text-white hover:opacity-90"
+            >
+              <Plus size={13} /> New agent run
+            </button>
+          </div>
+        ) : detailQ.isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 size={20} className="animate-spin text-faint" />
+          </div>
+        ) : selected ? (
+          <RunDetail run={selected} />
+        ) : null}
+      </div>
+
+      {showDialog && (
+        <NewRunDialog
+          onClose={() => setShowDialog(false)}
+          onCreated={(id) => {
+            setSelectedId(id)
+            void runsQ.refetch()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -101,7 +101,7 @@ function childrenToString(node: ReactNode): string {
   return ''
 }
 
-const Markdown = memo(function Markdown({ children }: { children: string }) {
+const Markdown = memo(function Markdown({ children, streaming }: { children: string; streaming?: boolean }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
@@ -123,6 +123,17 @@ const Markdown = memo(function Markdown({ children }: { children: string }) {
           const lang = className?.match(/language-(\S+)/)?.[1] ?? ''
           const artifactType = isArtifactLang(lang)
           if (artifactType) {
+            // While the message is still streaming, the artifact code is partial and
+            // re-parsed every token — rendering the live iframe makes it flicker. Show
+            // a calm placeholder; the real preview mounts once when generation finishes.
+            if (streaming) {
+              return (
+                <div className="my-2 flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2 text-[12px] text-muted">
+                  <Loader2 size={12} className="animate-spin" />
+                  Generating {lang} preview…
+                </div>
+              )
+            }
             return <ArtifactCard lang={lang} code={childrenToString(children).replace(/\n$/, '')} />
           }
           return (
@@ -362,7 +373,7 @@ export function StreamingBubble({
         {reasoning && <ThinkingBlock reasoning={reasoning} streaming />}
         <ToolCallsPanel calls={toolCalls} />
         <div className="prose-tllm text-[15px] leading-[1.7] text-ink">
-          {content ? <Markdown>{content}</Markdown> : (
+          {content ? <Markdown streaming>{content}</Markdown> : (
             <span className="text-muted">
               {isPrefill ? 'Processing prompt…' : reasoning ? 'Generating…' : toolCalls.length ? 'Working…' : 'Thinking…'}
             </span>

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -130,7 +130,7 @@ const Markdown = memo(function Markdown({ children, streaming }: { children: str
               return (
                 <div className="my-2 flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2 text-[12px] text-muted">
                   <Loader2 size={12} className="animate-spin" />
-                  Generating {lang} preview…
+                  Generating artifact…
                 </div>
               )
             }

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -6,6 +6,7 @@ import { CheckCircle2, ChevronDown, ChevronRight, FileText, Loader2, Pencil, Ref
 import type { ClaimVerdict, LiveToolCall, Message, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from '../../lib/chat-types'
 import { Button } from '../../components/ui/button'
 import { CopyButton } from '../../components/ui/copy-button'
+import { ArtifactCard, isArtifactLang } from '../../components/ArtifactCard'
 
 // ── Thinking block ────────────────────────────────────────────────────────────
 
@@ -85,6 +86,21 @@ function StatsRow({ stats }: { stats: Partial<MessageStats> }) {
 
 // ── Markdown renderer ─────────────────────────────────────────────────────────
 
+/** Reconstruct raw text from a markdown code block's children. `rehypeHighlight`
+ *  tokenizes code into nested <span> elements, so `children` is a React node tree,
+ *  not a string — `String(children)` yields "[object Object]". Walk it to get the
+ *  original source back (highlight.js wraps text, never drops characters). */
+function childrenToString(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(childrenToString).join('')
+  if (typeof node === 'object' && 'props' in node) {
+    return childrenToString((node as { props?: { children?: ReactNode } }).props?.children)
+  }
+  return ''
+}
+
 const Markdown = memo(function Markdown({ children }: { children: string }) {
   return (
     <ReactMarkdown
@@ -101,12 +117,19 @@ const Markdown = memo(function Markdown({ children }: { children: string }) {
           const hasLang = !!className?.includes('language-')
           const isBlock = hasLang || (typeof children === 'string' && children.includes('\n'))
           if (!isBlock) return <code className="rounded bg-panel-2 px-1 py-0.5 font-mono text-[0.88em]" {...props}>{children}</code>
-          const lang = className?.replace('language-', '') ?? ''
+          // rehypeHighlight rewrites the class to "hljs language-html", so a plain
+          // `.replace('language-','')` leaves "hljs html" and breaks artifact detection.
+          // Pull just the language token out of whatever classes are present.
+          const lang = className?.match(/language-(\S+)/)?.[1] ?? ''
+          const artifactType = isArtifactLang(lang)
+          if (artifactType) {
+            return <ArtifactCard lang={lang} code={childrenToString(children).replace(/\n$/, '')} />
+          }
           return (
             <div className="relative my-2 overflow-hidden rounded-lg border border-border">
               <div className="flex items-center justify-between border-b border-border bg-panel-2 px-3 py-1 font-mono text-[11px] text-muted">
                 <span>{lang}</span>
-                <CopyButton text={String(children)} size={12} />
+                <CopyButton text={childrenToString(children)} size={12} />
               </div>
               <div className="overflow-x-auto overscroll-x-contain" onScroll={e => e.stopPropagation()}>
                 <code className={`${className ?? ''} block p-3 font-mono text-[13px] leading-relaxed whitespace-pre`} {...props}>{children}</code>


### PR DESCRIPTION
## Summary

- **Background agents (Scope A, ADR-112)** — daemon-owned runner, reconnectable SSE, DB migrations v8/v9, `/agents` screen with run list, launch dialog with tool toggles, and live stream tail
- **Inline artifacts (ADR-113)** — fenced-block detection (`html`/`svg`/`mermaid`) + model system instruction; sandboxed iframe (CSP `default-src 'none'`, offline-first guarantee); fit-to-content 60vh card with Fit-Width/Fit-Height toggle; no streaming flicker (placeholder while generating)
- **Image abstraction** — artifacts presented purely as images: no type tag, no Code/Preview toggle, generic "Generating artifact…" label; download as PNG/JPEG/SVG/GIF/HTML (whichever applies)
- **GIF export** — animated canvas artifacts captured via `gifenc` (bundled, offline)
- **Designer persona** — senior front-end design expert: self-contained artifact every time, HARD offline constraint (no CDNs), typography/color/depth principles, portfolio-quality output

## Commits

1. `8bb6f94` feat(agents): background agent runner with reconnectable SSE (Scope A, ADR-112)
2. `ab6ad56` feat(agents): Agents screen with run list, launch dialog, live stream
3. `9bff90f` feat(artifacts): inline HTML/SVG/Mermaid previews with image export
4. `3840dfe` fix(artifacts): don't render the live preview while streaming
5. `cab6a15` feat(artifacts): present artifacts as images (abstraction over type)
6. `0fa82d8` feat(personas): add Designer persona (front-end design + artifact mastery)

## Test plan

- [ ] Agents screen loads at `/agents`; can create a run with tool toggles; live SSE stream shows tool calls and output
- [ ] Chat: ask for a chart/diagram → model auto-renders an artifact (no `html`/`mermaid` label shown)
- [ ] Artifact card: fit-height default (60vh cap), fit-width toggle, expand/collapse works
- [ ] Multi-artifact in one message: each scales independently (no cross-contamination)
- [ ] Download dropdown: PNG, JPEG, GIF (for animated), HTML; SVG for SVG artifacts
- [ ] While streaming: shows "Generating artifact…" placeholder, no live iframe flicker
- [ ] Mermaid diagrams: correct theme (app dark/light class, not OS preference)
- [ ] Designer persona: select from dropdown → produces a polished self-contained artifact
- [ ] CSP: no external network calls from inside an artifact (offline-first guarantee)