### PR TITLE
v1.5.1 — auto-tune run log, hardware-aware Expert, mermaid export fix

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,23 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.5.1] - 2026-06-25
+
+**Bugfix / polish release — auto-tune run log, TurboLLM Expert persona improvements.**
+
+### Added
+- **Auto-tune run log.** A "Download run log" checkbox (checked by default) appears in the
+  Save Results dialog after an auto-tune completes. Checking it downloads a structured JSON log
+  of every probe — parameters, outcomes, VRAM readings, timestamps, hardware info, and the
+  winning config.
+- **TurboLLM Expert persona.** The Expert is now a first-class persona in the persona picker
+  (alongside Default, Designer, Research, etc.) instead of a hidden launch from Settings. It
+  carries a comprehensive built-in knowledge base covering every screen, load profile parameter,
+  engine, auto-tune algorithm, gateway, built-in tools, and troubleshooting patterns.
+
+### Changed
+- Removed the "Launch TurboLLM Expert" section from Settings — use the persona picker instead.
+
 ## [1.5.0] - 2026-06-25
 
 **Feature release — background agents, inline artifacts, and a Designer persona.** Run agent

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -37,10 +37,17 @@ _Nothing yet._
 - **TurboLLM Expert persona.** The Expert is now a first-class persona in the persona picker
   (alongside Default, Designer, Research, etc.) instead of a hidden launch from Settings. It
   carries a comprehensive built-in knowledge base covering every screen, load profile parameter,
-  engine, auto-tune algorithm, gateway, built-in tools, and troubleshooting patterns.
+  engine, auto-tune algorithm, gateway, built-in tools, and troubleshooting patterns, and is
+  given your actual hardware (GPU, VRAM, RAM, OS) so it can suggest models that fit your machine.
 
 ### Changed
 - Removed the "Launch TurboLLM Expert" section from Settings — use the persona picker instead.
+
+### Fixed
+- **Mermaid artifact image export.** Downloading a Mermaid diagram (e.g. a flowchart the model
+  drew) as PNG or JPEG failed with "Couldn't export this artifact as an image." Mermaid rendered
+  text labels as HTML `<foreignObject>`, which taints the export canvas in the browser. Labels are
+  now rendered as native SVG text, so PNG/JPEG export works.
 
 ## [1.5.0] - 2026-06-25
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1219,6 +1219,14 @@ export function registerApi(app: Hono, d: Deps): void {
     return c.json({ ok: true })
   })
 
+  app.get('/api/v1/bench/log', (c) => {
+    const log = d.bench.getLog()
+    if (!log) return err(c, 404, 'no_bench_log', 'No auto-tune log available.')
+    const slug = log.modelKey.replace(/[^a-z0-9]/gi, '-').replace(/-+/g, '-').slice(0, 60)
+    c.header('Content-Disposition', `attachment; filename="autotune-${slug}-${log.startedAt.slice(0, 10)}.json"`)
+    return c.json(log)
+  })
+
   // ---- models (A3, spec 04) ----
   app.get('/api/v1/models', (c) => {
     const { models, scanning, lastScanAt } = d.scanner.list()

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -46,6 +46,28 @@ export interface BenchCandidate {
   vramAbsMb: number | null
 }
 
+export interface BenchLogEntry {
+  ts: string
+  step: string
+  candidate?: BenchCandidate
+}
+
+export interface BenchLogWinner {
+  params: BenchCandidate['params']
+  tps: number
+  prefillTps?: number | null
+  ttftMs: number
+  vramMb: number | null
+}
+
+export interface BenchLog {
+  modelKey: string
+  startedAt: string
+  hardware: { gpus: Array<{ name: string; vramMb: number }>; ramMb: number; os: string }
+  entries: BenchLogEntry[]
+  winner: BenchLogWinner | null
+}
+
 /** Live state surfaced on GET /status (spec 02 §7 / 09 §1). `running:false` resets
  *  step/best; `done`/`error` linger after a finished run until the next starts. */
 export interface BenchState {
@@ -140,6 +162,9 @@ export class BenchRunner {
   // stop/restart/load (kill switches) interrupts auto-tune immediately rather than
   // waiting out the current candidate's request.
   private abort: AbortController | null = null
+  private runLog: BenchLogEntry[] = []
+  private runLogMeta: { modelKey: string; startedAt: string; sys: SysInfo } | null = null
+  private logWinner: BenchLogWinner | null = null
   // The finished run's winning candidate, held (not persisted) until the user clicks Save.
   private winning:
     | { modelKey: string; profile: LoadProfile; cand: BenchCandidate; entry: ModelEntry; sys: SysInfo; engineVersion: string }
@@ -196,6 +221,26 @@ export class BenchRunner {
     while (this.state.running && Date.now() < deadline) await sleep(150)
   }
 
+  getLog(): BenchLog | null {
+    if (!this.runLogMeta) return null
+    const { modelKey, startedAt, sys } = this.runLogMeta
+    return {
+      modelKey,
+      startedAt,
+      hardware: {
+        gpus: sys.gpus.map((g) => ({ name: g.name, vramMb: g.vramMb })),
+        ramMb: sys.ramMB,
+        os: sys.os,
+      },
+      entries: [...this.runLog],
+      winner: this.logWinner,
+    }
+  }
+
+  private emit(step: string, candidate?: BenchCandidate): void {
+    this.runLog.push({ ts: new Date().toISOString(), step, ...(candidate ? { candidate } : {}) })
+  }
+
   /** Start a run for `modelKey`. Rejects (throws BenchError) when a run is already
    *  active, the engine is busy, or the model isn't a benchmarkable GGUF. The run
    *  itself proceeds in the background; callers get 202 + poll /status. */
@@ -222,6 +267,9 @@ export class BenchRunner {
     this.cancelled = false
     this.abort = new AbortController()
     this.winning = null
+    this.runLog = []
+    this.runLogMeta = null
+    this.logWinner = null
     this.deadline = Date.now() + TOTAL_BUDGET_MS
     this.state = { running: true, modelKey, step: 'Preparing…', candidates: [] }
     void this.run(modelKey, entry, base).catch((e) => {
@@ -236,6 +284,7 @@ export class BenchRunner {
 
   private async run(modelKey: string, entry: ModelEntry, base?: Partial<LoadProfile>): Promise<void> {
     const sys = getSysInfo()
+    this.runLogMeta = { modelKey, startedAt: new Date().toISOString(), sys }
     const active = this.registry.active()
     const caps = active?.capabilities ?? { flags: [], kvTypes: [] }
     const saved = this.store.snapshot().modelProfiles[modelKey] as Partial<LoadProfile> | undefined
@@ -278,6 +327,7 @@ export class BenchRunner {
       kvToTune = decideKvToBench(spread, kvCandidates)
       const swing = spread < 0 ? 'unknown' : spread >= Number.MAX_SAFE_INTEGER ? 'huge' : `${Math.round(spread)} MB`
       this.state = { ...this.state, step: `KV cache swing ${swing} → tuning ${kvToTune.join(' + ')}`, candidates: results }
+      this.emit(`KV spread ${swing} → tuning ${kvToTune.join(' + ')}`)
     }
 
     for (let i = 0; i < kvToTune.length && !this.cancelled && Date.now() <= this.deadline; i++) {
@@ -321,6 +371,7 @@ export class BenchRunner {
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
       this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }
+      this.logWinner = { params: best.cand.params, tps: best.cand.tps ?? 0, prefillTps: best.cand.prefillTps, ttftMs: best.cand.ttftMs ?? 0, vramMb: best.cand.vramMb }
       this.state = {
         running: false,
         modelKey,
@@ -521,7 +572,7 @@ export class BenchRunner {
     value: number,
     probe: { outcome: BenchCandidate['outcome']; vramAbsMb: number | null },
   ): void {
-    results.push({
+    const probeCand: BenchCandidate = {
       label: `probe ${knob}=${value}`,
       params: {
         ctx: base.ctx,
@@ -537,7 +588,9 @@ export class BenchRunner {
       ttftMs: null,
       vramMb: null,
       vramAbsMb: probe.vramAbsMb,
-    })
+    }
+    results.push(probeCand)
+    this.emit(`${probeCand.label} → ${probe.outcome}${probe.vramAbsMb != null ? ` (${probe.vramAbsMb} MB)` : ''}`, probeCand)
     this.state = { ...this.state, candidates: results }
   }
 
@@ -554,6 +607,7 @@ export class BenchRunner {
     this.state = { ...this.state, step: `KV ${profile.kvTypeK}: measuring best (${label})…`, candidates: results }
     const cand = await this.measure(entry, sys, profile, caps, label, `Measuring ${label}`)
     results.push(cand)
+    this.emit(`bench ${label} → ${cand.outcome}${cand.tps != null ? ` (${cand.tps.toFixed(1)} tok/s)` : ''}`, cand)
     this.state = { ...this.state, candidates: results, bestTps: cand.tps ?? this.state.bestTps }
     await this.settleGpu()
     return cand.outcome === 'ok' && cand.tps !== null ? { cand, profile } : null

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -7,7 +7,7 @@ import { clampMaxTokens } from '../config/config'
 import { engineModelAlias } from '../engines/compat'
 import { feedChunk, flushState, initParseState } from './parser'
 import { needsExtraPass } from './think-utils'
-import { getSysInfo } from '../sysinfo/sysinfo'
+
 import type { ClaimVerdict, ConversationStore, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from './db'
 import { checkReply } from '../tools/research-referee.js'
 import { buildSnapshot } from './chat-export'
@@ -24,36 +24,6 @@ export function abortAllInFlightChats(): number {
   for (const ac of inflight.values()) ac.abort()
   inflight.clear()
   return n
-}
-
-// Built-in system prompt for the TurboLLM Expert thread (spec 08 §2). Kept
-// server-side and never sent to the client, so it stays hidden from the UI.
-const EXPERT_SYSTEM_PROMPT = `You are the TurboLLM in-app expert assistant — a knowledgeable, friendly guide built into TurboLLM, a local-first desktop app for running large language models on the user's own machine.
-
-Your job is to help the user get the most out of TurboLLM:
-- Explain what TurboLLM features do and how to use them: chatting with local models, the Models screen (discover, download, load, and tune models), the Engines screen (install and manage inference backends like llama.cpp), and Settings (idle timeout, model defaults such as context length and GPU layers, auto-load, theme, network/LAN exposure, and privacy/telemetry).
-- Help the user configure things: picking and loading a model, adjusting sampling (temperature, top-p, top-k, min-p), setting context length and GPU offload, and managing per-thread system prompts and sampling overrides.
-- Troubleshoot common problems: a model that won't load, slow generation, running out of context, missing or failed engine installs, and GPU/CPU offload questions. Reason from the symptoms the user describes and the hardware they mention.
-
-Guidelines:
-- Keep answers practical, concise, and actionable. Prefer concrete steps ("Open the Models screen, click …") over abstract advice.
-- When something depends on the user's hardware or which model is loaded, say so and ask a brief clarifying question if needed.
-- Everything runs locally and offline; never suggest sending the user's data to external services.
-- If you are unsure or a feature may not exist, say so honestly rather than inventing details.`
-
-function buildExpertPrompt(): string {
-  const sys = getSysInfo()
-  const ramGb = Math.round(sys.ramMB / 1024)
-  const gpuLines = sys.gpus.length
-    ? sys.gpus.map((g) => `- GPU: ${g.name}${g.vramMb ? ` (${Math.round(g.vramMb / 1024)} GB VRAM)` : ''}`).join('\n')
-    : '- GPU: none detected'
-  const hw = [
-    '\n\n## User\'s hardware',
-    `- CPU: ${sys.cpu}${sys.cores ? ` (${sys.cores} cores)` : ''}`,
-    `- RAM: ${ramGb} GB`,
-    gpuLines,
-  ].join('\n')
-  return EXPERT_SYSTEM_PROMPT + hw
 }
 
 type S = 200 | 201 | 202 | 400 | 404 | 409 | 500
@@ -73,20 +43,6 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
   app.post('/api/v1/conversations', async (c) => {
     const b = await body<{ title?: string; systemPrompt?: string; modelKey?: string; toolPolicy?: string }>(c)
     const conv = db.createConversation({ title: b.title, systemPrompt: b.systemPrompt, modelKey: b.modelKey, toolPolicy: b.toolPolicy })
-    return c.json(conv, 201)
-  })
-
-  // Launch the built-in TurboLLM Expert thread (spec 08 §2). The system prompt is
-  // injected server-side and the conversation is flagged expertMode so the client
-  // never sees or edits it.
-  app.post('/api/v1/conversations/expert', async (c) => {
-    const ms = d.manager.status()
-    const conv = db.createConversation({
-      title: 'TurboLLM Expert',
-      systemPrompt: buildExpertPrompt(),
-      modelKey: ms.model?.key ?? '',
-      expertMode: true,
-    })
     return c.json(conv, 201)
   })
 

--- a/turbollm/web/src/components/ArtifactCard.tsx
+++ b/turbollm/web/src/components/ArtifactCard.tsx
@@ -276,7 +276,18 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
       setMermaid({ loading: true })
       try {
         const m = (await import('mermaid')).default
-        m.initialize({ startOnLoad: false, theme: resolveDark(theme) ? 'dark' : 'default', suppressErrorRendering: true })
+        // htmlLabels:false renders labels as native SVG <text> instead of <foreignObject>.
+        // foreignObject taints the canvas when the SVG is rasterized via <img> for PNG/JPEG
+        // export (Chrome SecurityError), so image downloads of mermaid artifacts fail. Native
+        // <text> rasterizes cleanly. securityLevel:'strict' is the default — set explicitly.
+        m.initialize({
+          startOnLoad: false,
+          theme: resolveDark(theme) ? 'dark' : 'default',
+          suppressErrorRendering: true,
+          securityLevel: 'strict',
+          htmlLabels: false,
+          flowchart: { htmlLabels: false },
+        })
         await m.parse(stableCode)
         if (cancelled) return
         const id = `mmd${Math.random().toString(36).slice(2, 8)}`

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -24,11 +24,6 @@ export function createConversation(partial?: Partial<Pick<Conversation, 'title' 
   return req('/api/v1/conversations', { method: 'POST', json: partial ?? {} })
 }
 
-/** Launch the built-in TurboLLM Expert thread (spec 08 §2). The expert system
- *  prompt lives server-side and is never sent from the client. */
-export function createExpertConversation(): Promise<Conversation> {
-  return req('/api/v1/conversations/expert', { method: 'POST', json: {} })
-}
 
 export function getConversation(id: string): Promise<Conversation> {
   return req(`/api/v1/conversations/${encodeURIComponent(id)}`)

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -16,6 +16,10 @@ async function req<T>(path: string, init?: RequestInit & { json?: unknown }): Pr
   return data as T
 }
 
+export interface SysInfoGpu { name: string; vramMb: number }
+export interface SysInfo { gpus: SysInfoGpu[]; ramMB: number; cpu: string; os: string; cores: number }
+export function fetchSysInfo(): Promise<SysInfo> { return req<SysInfo>('/api/v1/sysinfo') }
+
 export function listConversations(q?: string): Promise<{ conversations: Conversation[] }> {
   return req(`/api/v1/conversations${q ? `?q=${encodeURIComponent(q)}` : ''}`)
 }

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  createConversation, createExpertConversation, deleteConversation, deleteMessage, editMessage,
+  createConversation, deleteConversation, deleteMessage, editMessage,
   getConversation, listConversations, regenerate, stopGeneration, updateConversation,
 } from './chat-api'
 import type { Conversation } from './chat-types'
@@ -39,11 +39,7 @@ export function useConversationMutations() {
       mutationFn: (p?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy'>>) => createConversation(p),
       onSuccess: invalidateList,
     }),
-    createExpert: useMutation({
-      mutationFn: () => createExpertConversation(),
-      onSuccess: invalidateList,
-    }),
-    update: useMutation({
+update: useMutation({
       mutationFn: (v: { id: string } & Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling'>>) => updateConversation(v.id, v),
       onSuccess: (_d, v) => { invalidateList(); invalidateDetail(v.id) },
     }),

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -1,4 +1,4 @@
-export type PersonaId = 'default' | 'designer' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative' | 'research'
+export type PersonaId = 'default' | 'designer' | 'blank' | 'blunt' | 'concise' | 'detailed' | 'formal' | 'tutor' | 'creative' | 'research' | 'expert'
 
 export interface Persona {
   id: PersonaId
@@ -6,6 +6,174 @@ export interface Persona {
   description: string
   systemPrompt: string
 }
+
+const TURBOLLM_KNOWLEDGE =
+  'You are the TurboLLM Expert — the authoritative in-app guide for TurboLLM, a local-first AI desktop platform (`npx turbollm`). Everything runs on the user\'s own machine: no cloud, no external data transmission. The daemon listens on port 6996 and serves a React UI plus an OpenAI/Anthropic-compatible gateway. Data is stored in a local SQLite database.\n\n' +
+
+  '## Screens\n\n' +
+
+  '**Chat** — main screen. Sidebar lists all conversations (threads).\n' +
+  '- Pick a **persona** before the first message; it locks after that (per-conversation).\n' +
+  '- Override **sampling** (temperature, top-p, top-k, min-p, repeat/frequency/presence penalty, stop strings) per conversation via conversation settings.\n' +
+  '- Set a custom **system prompt** per conversation.\n' +
+  '- **Artifacts**: HTML/SVG/Mermaid fenced blocks render as sandboxed live previews (shown as images). Download as PNG/JPEG/SVG/GIF/HTML depending on type.\n' +
+  '- **Thinking/reasoning**: models that emit `<think>` blocks get a collapsible fold; visible prose renders normally below.\n' +
+  '- **Tool-call cards**: live inline cards show each tool call (pending → done / error) as it runs.\n' +
+  '- **Web search**: Research persona forces 3–5 `web_search` calls; other personas use it when a search provider key is configured.\n' +
+  '- **Export/Import**: export as `.turbollm-chat.json` or OpenAI-format JSON; re-import resumes the conversation. Share button gives a LAN read-only link and a debug snapshot.\n' +
+  '- Edit messages, delete a message, regenerate the last response.\n\n' +
+
+  '**Models** — discover and manage local models.\n' +
+  '- **All models** view: scans configured local directories for GGUF, MLX safetensors, vLLM safetensors; badges incompatible models for the active engine.\n' +
+  '- **Discover** tab: searches Hugging Face Hub filtered by active engine kind (GGUF for llama.cpp/TurboQuant, MLX tag for MLX, unrestricted for vLLM); download directly from HF.\n' +
+  '- Click a model → **Model Detail** side panel: load profile config, VRAM estimate bar, auto-tune button, per-model saved profile.\n' +
+  '- **Load** button starts the model; progress indicator shows load time.\n\n' +
+
+  '**Engines** — manage inference backends.\n' +
+  '- **Running now** dropdown at top: switch between installed engines (one active at a time).\n' +
+  '- **Install & manage** catalog: all engines with hardware fit verdict (Recommended / Installed / Incompatible + reason). Incompatible engines are greyed out.\n' +
+  '- **Advanced** (collapsible): per-backend llama.cpp variants — CUDA, ROCm, CPU, Vulkan, SYCL. Install, update, or switch here.\n' +
+  '- **Add your own engine**: guided folder scan that probes a binary and registers it as a custom engine.\n' +
+  '- **In-app build**: clone → cmake → compile (CUDA); auto-downloads CUDA toolkit if absent (~490 MB from NVIDIA redist); live phase log + success screen.\n' +
+  '- **Engine updates**: honest check vs GitHub releases/latest; rollback-safe (probe new build before swap, old build kept until success).\n' +
+  '- Per-engine auto-update policy: Off / Notify / Auto (default Notify).\n\n' +
+
+  '**Agents** — background agent runs (v1.5.0+).\n' +
+  '- Detached conversations that run without the UI open.\n' +
+  '- Create via "New agent" form: pick a model, write a prompt, launch.\n' +
+  '- Reconnect any time via the Agents screen to see live or completed output.\n' +
+  '- Runs persist in the SQLite database (DB v8/v9).\n\n' +
+
+  '**Customize** (Puzzle icon in nav):\n' +
+  '- **Search provider**: Tavily (default), Kagi, or SearXNG (self-hosted) — paste API key here. Required for web_search, fetch_url, and the Research persona.\n' +
+  '- **MCP servers**: add/edit/delete MCP servers (stdio subprocess or SSE HTTP). Tools from all connected servers appear automatically as callable tools in chat.\n\n' +
+
+  '**Settings**:\n' +
+  '- Theme: light / dark / system\n' +
+  '- Idle timeout: auto-stops the engine after N minutes of inactivity (frees VRAM)\n' +
+  '- Default context length and default GPU layers: global defaults for new model loads\n' +
+  '- Auto-load last model on start: re-loads the last-used model at daemon start\n' +
+  '- LAN exposure: bind to 0.0.0.0 (LAN) vs 127.0.0.1 (loopback only)\n' +
+  '- ComfyUI integration: URL of a ComfyUI instance; Reverse GPU gate: TurboLLM calls ComfyUI /free before every model load so VRAM is freed first; update banner when installed ComfyUI node is out of date\n' +
+  '- Gateway: auto model-swap toggle + Keep-N pool (1–4 models loaded simultaneously, LRU eviction)\n' +
+  '- Auth / API key: gateway key required from clients\n' +
+  '- Telemetry: Off / Anonymous / Full\n' +
+  '- About: current version, update-available chip (`npm i -g turbollm`), copy install command\n\n' +
+
+  '## Personas\n\n' +
+  'Personas are style presets selected at conversation creation; locked after the first message. All personas except Blank automatically get the text-chart capability, artifact rendering capability, and current date injected into the system prompt.\n\n' +
+  '- **Default**: balanced; Unicode chart/table + artifact rendering capability\n' +
+  '- **Blank**: zero system prompt — raw model output, nothing injected\n' +
+  '- **Concise**: shortest possible answers, bullet points over paragraphs\n' +
+  '- **Detailed**: thorough explanations with context, examples, and reasoning\n' +
+  '- **Blunt**: direct, no preamble, no pleasantries\n' +
+  '- **Formal**: professional polished tone for documents\n' +
+  '- **Tutor**: asks a clarifying question first, then teaches step by step\n' +
+  '- **Research**: forces 3–5 web_search calls before composing; cites all sources (requires a search provider key in Customize)\n' +
+  '- **Creative**: vivid language, unexpected angles\n' +
+  '- **Designer**: one self-contained artifact per response (html/svg/mermaid); optimized for mockups, UI components, diagrams; HARD offline constraint (no CDNs)\n' +
+  '- **TurboLLM Expert**: this persona\n\n' +
+
+  '## Artifacts (v1.5.0+)\n\n' +
+  'TurboLLM detects three fenced block types and renders them as images in chat:\n' +
+  '- ` ```mermaid ` — flowcharts, sequence diagrams, ER/class/state diagrams, Gantt, mind maps, pie charts\n' +
+  '- ` ```svg ` — static vector graphics: icons, logos, illustrations, hand-drawn charts\n' +
+  '- ` ```html ` — interactive pages, UI mockups, canvas animations, games, calculators\n\n' +
+  'Artifacts are sandboxed (`sandbox="allow-scripts"`, CSP `default-src \'none\'`). The network is blocked inside — all CSS/JS/images must be inline. Controls: Fit-Width / Fit-Height toggles; download as PNG / JPEG / SVG (SVG/Mermaid) or PNG / JPEG / GIF / HTML (HTML).\n\n' +
+
+  '## Auto-Tune\n\n' +
+  'Auto-tune finds the best GPU-offload config for a model given available VRAM. It runs a binary search, not a fixed candidate list. Triggered from the Model Detail panel.\n\n' +
+  '**Phase 1 — KV quant sweep** (VRAM probes, no generation):\n' +
+  'Tests quality-preserving KV cache types from best to smaller: f16 → q8_0 → turbo4 (TurboQuant only) / q4_0. Picks the highest-quality type that fits within a 1 GB VRAM headroom buffer. Lower-quality types (q4_0, q4_1) are never auto-selected — quality floor is enforced.\n\n' +
+  '**Phase 2 — Binary search for GPU offload** (~log₂(blockCount) probes, VRAM-only):\n' +
+  '- Dense models: search ngl ∈ [0, blockCount] — finds highest ngl that doesn\'t exceed the VRAM headroom.\n' +
+  '- MoE models: search nCpuMoe ∈ [0, nExpertsTotal] — ngl stays maxed, finds minimum nCpuMoe (router experts on CPU) that fits. Reducing nCpuMoe pushes more MoE routing onto the GPU.\n\n' +
+  '**Phase 3 — Real benchmark at winner config**:\n' +
+  'One real prefill + generation run. Bench prompt: `min(50,000 tokens, ctx × 75%)`. Per-test cap: 3 minutes. Stop/restart/load cancel a running auto-tune. Records prefill t/s, generation t/s, TTFT ms, and VRAM delta.\n\n' +
+  '**Phase 4 — Model card sampling extraction**:\n' +
+  'Fetches the HuggingFace model card and extracts recommended temperature, top_k, top_p, min_p. Falls back to the base model\'s card if the quant card doesn\'t have sampling info. Prefills the Sampling section of the load profile.\n\n' +
+  'Results dialog: Save applies the winner config to the model profile (tunedBy: "bench"). "Download run log" checkbox (default checked) downloads a JSON log of every probe (timestamps, parameters, outcomes, VRAM readings, and the winner).\n\n' +
+
+  '## Load Profile Parameters\n\n' +
+  '**Core**:\n' +
+  '- `ngl` (GPU layers): 0 = CPU only; blockCount = all layers on GPU. Higher = faster inference but more VRAM. Shown as a slider with the real layer count as max.\n' +
+  '- `ctx` (context length): max token window. VRAM scales linearly with ctx (KV cache). Reduce if VRAM is tight; increase for long conversations.\n' +
+  '- `threads`: CPU threads for computation. Defaults to core count.\n\n' +
+  '**MoE models only**:\n' +
+  '- `nCpuMoe` (CPU MoE expert count): number of MoE router experts kept on CPU. Reducing it frees GPU VRAM (moves more routing to GPU). Auto-tune searches this for MoE models.\n\n' +
+  '**KV Cache**:\n' +
+  '- `kvTypeK` / `kvTypeV`: KV cache quantization. `f16` = best quality, most VRAM. `q8_0` = good quality, ~2× smaller. `q4_0` / `q4_1` = smaller, lower quality. `turbo4` = TurboQuant-specific, high-speed specialized quant. Auto-tune picks automatically.\n' +
+  '- `flashAttn`: Flash Attention 2 — reduces KV memory footprint especially at large ctx. Strongly recommended when ctx > 32k.\n\n' +
+  '**Parallelism & speculative**:\n' +
+  '- `parallel`: concurrent request slots (default 1). Increase for gateway multi-client use.\n' +
+  '- Speculative decoding: `specModelPath` (draft model path) + `specAcceptThreshold`. A smaller draft model generates candidate tokens; the main model verifies them in parallel. Can 2–4× throughput for well-matched model pairs.\n\n' +
+  '**Sampling defaults** (per-model; overridden per-conversation):\n' +
+  '- `temperature`: randomness (0 = greedy/deterministic, 1 = full entropy). Typical range: 0.6–1.0.\n' +
+  '- `topK`: keep only top K tokens by probability (0 = disabled).\n' +
+  '- `topP`: nucleus sampling — keep smallest set whose cumulative prob ≥ topP.\n' +
+  '- `minP`: minimum probability relative to the top token; cuts the low-prob tail.\n' +
+  '- `repeatPenalty`: penalize already-seen tokens (1 = none, >1 = reduces repeats).\n' +
+  '- `frequencyPenalty`: penalize proportional to frequency of appearance.\n' +
+  '- `presencePenalty`: penalize any token that has appeared at all.\n' +
+  '- `stop` strings: generation halts when any stop string is produced.\n\n' +
+  '**Context overflow**:\n' +
+  '- `contextOverflow`: `shift` (sliding window — oldest tokens evicted) or `keep` (preserve first nKeep tokens + recent). `shift` suits open-ended chat; `keep` preserves system prompt integrity.\n' +
+  '- `nKeep`: with `keep` mode, how many leading tokens to always preserve (size it to cover your system prompt).\n\n' +
+  '**Advanced**:\n' +
+  '- `grammar` (GBNF): constrain generation to a format (JSON schema, structured output).\n' +
+  '- `ropeScalingType` / `ropeFreqBase` / `ropeFreqScale`: RoPE context extension for models that support it (e.g. YaRN).\n' +
+  '- Multi-GPU (shown only when >1 GPU detected): `splitMode` (row / layer), `tensorSplit` (fraction array), `mainGpu` (output GPU index).\n\n' +
+  '**MLX note**: context and KV parameters are hidden for MLX models — MLX sizes the KV cache dynamically. Only temperature, top-p, top-k, and min-p are available (the only flags mlx-lm.server supports).\n\n' +
+
+  '## Engines\n\n' +
+  '**llama.cpp** (Windows / Linux / macOS — GGUF format):\n' +
+  'Primary recommended engine. Multiple backends: CUDA (NVIDIA), ROCm (AMD), CPU, Vulkan (cross-vendor), SYCL (Intel). Pre-built downloads or one-click in-app build (git + cmake + MSVC/g++ + CUDA). Full support for all load profile parameters. Handles all GGUF quants: Q4_K_M, Q6_K, Q8_0, IQ4_XS, etc.\n\n' +
+  '**TurboQuant** (Windows / Linux / macOS — GGUF):\n' +
+  'Google\'s TurboQuant quantization engine — fork of llama.cpp for turbo-quantized models. Same llama-server interface as llama.cpp. Adds KV types `turbo3` and `turbo4`. On Windows: prebuilt has a UCRT defect; build from source with the in-app build tool.\n\n' +
+  '**MLX** (macOS Apple Silicon only):\n' +
+  'Loads MLX-format safetensors from HuggingFace or local dirs. KV/ctx controls hidden (dynamic sizing). If a model fails to load, TurboLLM detects the traceback instead of hanging and shows `model_load_failed`. Incomplete MLX shards show a re-download button.\n\n' +
+  '**vLLM** (Linux / WSL2 only):\n' +
+  'High-throughput engine for safetensors. Requires the vLLM venv (provisioned in-app). Hard dependency on `uvloop` (POSIX-only) — on Windows it fails immediately with a clear message directing the user to WSL2/Linux.\n\n' +
+  '**KoboldCpp** (Windows / Linux / macOS — GGUF):\n' +
+  'Popular for creative writing. GGUF over OpenAI-compatible API. Install from releases; full load→serve→gateway pipeline verified working.\n\n' +
+  '**llamafile** (Windows / Linux / macOS — GGUF):\n' +
+  'GGUF model bundled into a single self-contained executable. Very easy distribution. Launch flag is `--no-webui` (not `--nobrowser`). Full gateway passthrough verified.\n\n' +
+  '**ik_llama.cpp** (Linux / macOS — GGUF):\n' +
+  'Drop-in fork with additional quantization optimizations. No universal prebuilt — build from source, then register via "Add your own engine."\n\n' +
+
+  '## Gateway\n\n' +
+  'TurboLLM at `http://localhost:6996` exposes:\n' +
+  '- **OpenAI-compatible**: `POST /v1/chat/completions`, `GET /v1/models`, `POST /v1/embeddings`\n' +
+  '- **Anthropic-compatible**: `POST /v1/messages`\n' +
+  '- **Auto model-swap**: request arrives with any model name → fuzzy-matched against available models → loads it automatically (mutex-serialized). Works with Claude Code, Continue, Open WebUI, any compatible client.\n' +
+  '- **Keep-N pool**: 1–4 models simultaneously with LRU eviction (Settings → Gateway).\n' +
+  '- **`turbollm launch claude`**: launches Claude Code pointed at the gateway with proper slow-model timeouts (`ANTHROPIC_TIMEOUT=300000`, `ANTHROPIC_MAX_RETRIES=0`); `--model <name>` auto-loads that model.\n' +
+  '- **Embeddings**: bert-family / filename-pattern models (bge-, nomic-embed, -embed…) auto-detected; embedding models get a separate pool slot and are never LRU-evicted by chat requests.\n' +
+  '- **Structured output**: pass `grammar` (GBNF) in the request body.\n\n' +
+
+  '## Built-in Tools\n\n' +
+  'When a search provider key is configured in Customize, three tools are available in every conversation:\n' +
+  '- `web_search`: searches via Tavily / Kagi / SearXNG. Research persona triggers this automatically.\n' +
+  '- `fetch_url`: fetches a URL, strips HTML to plain text. RFC-1918 / localhost blocked (SSRF protection). Hostile content in fetched pages is isolated — it cannot override the system prompt.\n' +
+  '- `run_code`: executes JavaScript in a sandboxed Node.js `vm`. Always shows a confirmation chip before running; the user can deny without crashing the tool loop.\n\n' +
+  'MCP tools from configured MCP servers also appear automatically.\n\n' +
+
+  '## Troubleshooting\n\n' +
+  '**Model won\'t load**: Check the VRAM estimate bar in the Model Detail panel — if it\'s full, reduce `ngl` or `ctx`, or choose a smaller/more-quantized model. Verify the active engine is compatible with the model format (GGUF → llama.cpp / TurboQuant / KoboldCpp / llamafile; safetensors → vLLM or MLX). On Windows, vLLM doesn\'t work — use llama.cpp or WSL2.\n\n' +
+  '**Slow generation**: Low `ngl` is the most common cause — run Auto-Tune or manually increase GPU layers. Large `ctx` consumes VRAM; reduce if not needed. Enable `flashAttn` for long contexts. CPU inference (`ngl=0`) is expected to be slow.\n\n' +
+  '**Context exhausted**: Increase `ctx` in the load profile (needs more VRAM). Enable `contextOverflow: shift` so old messages slide off. Or start a new conversation.\n\n' +
+  '**MLX hang / silent failure**: Now detected — TurboLLM reads the traceback and shows `model_load_failed` instead of hanging. Ensure the model isn\'t a partial download (check the re-download button for incomplete shards).\n\n' +
+  '**Empty assistant reply after web searches**: TurboLLM detects an empty-body finish and forces one extra generation pass automatically.\n\n' +
+  '**ComfyUI VRAM conflict**: Enable Settings → ComfyUI → Reverse GPU gate. TurboLLM calls ComfyUI `/free` before every model load. Also install/update the TurboLLM ComfyUI node (update banner appears in Settings when outdated).\n\n' +
+  '**Engine update says "up to date" incorrectly**: Fixed in v1.0.0. Update TurboLLM itself if on an older version.\n\n' +
+  '**No Download run log after auto-tune**: The checkbox appears in the Save Results dialog at the end of an auto-tune run (not during). "Download run log" is checked by default.\n\n' +
+  '**`turbollm --stop` doesn\'t work**: Available since v1.4.0. Update via `npm i -g turbollm`.\n\n' +
+
+  '## Guidelines\n\n' +
+  '- Give concrete, actionable steps ("Open the Models screen → click the model → Auto-tune button"). Avoid vague advice.\n' +
+  '- When an answer depends on hardware or the user\'s model, ask one focused clarifying question.\n' +
+  '- Everything is local and offline. Never suggest sending data to external services.\n' +
+  '- If a feature doesn\'t exist or you\'re unsure of a detail, say so honestly rather than guessing.'
 
 export const PERSONAS: readonly Persona[] = [
   {
@@ -103,6 +271,12 @@ export const PERSONAS: readonly Persona[] = [
     description: 'Imaginative, vivid language with unexpected angles',
     systemPrompt:
       'Prioritize imagination and novelty. Use vivid language, explore unexpected angles, and bring a distinct voice. Favor interesting over safe.',
+  },
+  {
+    id: 'expert',
+    name: 'TurboLLM Expert',
+    description: 'Knows TurboLLM inside-out — explains features, helps configure engines and models, and troubleshoots',
+    systemPrompt: TURBOLLM_KNOWLEDGE,
   },
 ]
 

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { ArrowDown, Brain, Copy, Download, Paperclip, SendHorizontal, Share2, SlidersHorizontal, Square, UserRound, X } from 'lucide-react'
-import { continueConversation, sendMessage } from '../lib/chat-api'
+import { continueConversation, fetchSysInfo, sendMessage } from '../lib/chat-api'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
 import { useModelActions, useModels, useStatus } from '../lib/queries'
 import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
@@ -382,7 +382,17 @@ export function ChatScreen() {
       // Create conversation on first message, baking in the selected persona + personalization.
       let convId = activeId
       if (!convId) {
-        const sp = buildSystemPrompt(selectedPersonaId, getPersonalization())
+        let sp = buildSystemPrompt(selectedPersonaId, getPersonalization())
+        if (selectedPersonaId === 'expert') {
+          try {
+            const sys = await fetchSysInfo()
+            const gpuLine = sys.gpus.length > 0
+              ? sys.gpus.map(g => `${g.name} (${Math.round(g.vramMb / 1024)} GB VRAM)`).join(', ')
+              : 'No GPU detected (CPU inference)'
+            const hwSection = `## User's hardware\nGPU: ${gpuLine}\nRAM: ${Math.round(sys.ramMB / 1024)} GB\nOS: ${sys.os}`
+            sp = sp ? `${sp}\n\n${hwSection}` : hwSection
+          } catch { /* non-fatal — proceed without hardware info */ }
+        }
         const newConv = await mut.create.mutateAsync({
           modelKey: model.key,
           systemPrompt: sp || undefined,

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, Sparkles, RefreshCw, Check, X, Loader2, AlertTriangle, ArrowUpCircle } from 'lucide-react'
+import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, RefreshCw, Check, X, Loader2, AlertTriangle, ArrowUpCircle } from 'lucide-react'
 import {
   PERSONAS, getDefaultPersonaId, getPersonalization, savePersonalization,
   setDefaultPersonaId, type PersonaId, type Personalization,
@@ -23,7 +22,7 @@ import {
 } from '../lib/queries'
 import { CopyButton } from '../components/ui/copy-button'
 import { ModelDirs } from './models/ModelDirs'
-import { useConversationMutations } from '../lib/chat-queries'
+
 import { ApiError, type TelemetryLevel } from '../lib/api'
 import { TELEMETRY_UI_ENABLED } from '../lib/flags'
 import { toast } from '../components/ui/sonner'
@@ -216,9 +215,6 @@ export function SettingsScreen() {
       {restartOverlay && <RestartOverlay onDismiss={() => setRestartOverlay(false)} />}
 
       <div className="flex flex-col gap-6">
-
-        {/* TurboLLM Expert (spec 08 §2) */}
-        <ExpertSection />
 
         {/* Theme */}
         <section className="rounded-lg border border-border bg-panel p-4">
@@ -477,64 +473,6 @@ export function SettingsScreen() {
 }
 
 // ── TurboLLM Expert (spec 08 §2): launch an in-app expert chat ─────────────────
-
-function ExpertSection() {
-  const navigate = useNavigate()
-  const { data: status } = useStatus()
-  const mut = useConversationMutations()
-  const setPendingConversationId = useUiStore((s) => s.setPendingConversationId)
-
-  const modelLoaded = status?.engine.state === 'running' && !!status?.model
-
-  const launch = () => {
-    if (!modelLoaded) return
-    mut.createExpert.mutate(undefined, {
-      onSuccess: (conv) => {
-        setPendingConversationId(conv.id)
-        navigate('/chat')
-      },
-      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not launch the Expert assistant.'),
-    })
-  }
-
-  return (
-    <section className="rounded-lg border border-border bg-panel p-4">
-      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">TurboLLM Expert</h2>
-      <p className="mb-3 text-[12px] text-muted">
-        Chat with a built-in assistant that knows TurboLLM — it can explain features, help
-        configure engines, models, and settings, and troubleshoot. Runs on your loaded model.
-      </p>
-
-      {modelLoaded ? (
-        <Button onClick={launch} disabled={mut.createExpert.isPending}>
-          <Sparkles size={14} />
-          {mut.createExpert.isPending ? 'Launching…' : 'Launch Expert'}
-        </Button>
-      ) : (
-        <div
-          className="flex items-start gap-2 rounded-md border p-2.5 text-[12px]"
-          style={{
-            borderColor: 'color-mix(in srgb, var(--accent) 40%, var(--border))',
-            background: 'color-mix(in srgb, var(--accent) 6%, transparent)',
-          }}
-        >
-          <Sparkles size={14} className="mt-0.5 shrink-0" style={{ color: 'var(--accent)' }} />
-          <div className="text-muted">
-            Load a model first to chat with the Expert assistant. Pick one on the{' '}
-            <button
-              type="button"
-              onClick={() => navigate('/models')}
-              className="font-medium text-ink underline-offset-2 hover:underline"
-            >
-              Models
-            </button>{' '}
-            screen.
-          </div>
-        </div>
-      )}
-    </section>
-  )
-}
 
 // ── ComfyUI GPU coordination (push) ───────────────────────────────────────────
 // ComfyUI and the LLM engine both want the GPU's VRAM. A one-time-installed ComfyUI

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -180,9 +180,16 @@ export function ModelDetailDialog({
 
   // Auto-tune results dialog (shown on a finished run). Both buttons close the whole model dialog;
   // Save persists the tuned profile (POST /bench/save), Cancel discards it.
-  const onTuneSave = () => {
+  const onTuneSave = (downloadLog: boolean) => {
     bench.save.mutate(undefined, {
-      onSuccess: () => toast.success('Tuned settings saved'),
+      onSuccess: () => {
+        toast.success('Tuned settings saved')
+        if (downloadLog) {
+          const a = document.createElement('a')
+          a.href = '/api/v1/bench/log'
+          a.click()
+        }
+      },
       onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save tuned settings.'),
     })
     onClose()
@@ -619,9 +626,10 @@ function AutoTuneResultDialog({
     recommendedSampling?: CardSampling
   }
   modelName?: string
-  onSave: () => void
+  onSave: (downloadLog: boolean) => void
   onCancel: () => void
 }) {
+  const [downloadLog, setDownloadLog] = useState(true)
   const rec = result?.recommendedSampling
   const s = result?.sampling
   const fromCard = (k: keyof CardSampling) => rec?.[k] != null
@@ -683,8 +691,12 @@ function AutoTuneResultDialog({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
+          <label className="mr-auto flex cursor-pointer items-center gap-1.5 text-[12px] text-muted">
+            <input type="checkbox" checked={downloadLog} onChange={(e) => setDownloadLog(e.target.checked)} className="h-3.5 w-3.5 accent-[var(--accent)]" />
+            Download run log
+          </label>
           <AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onSave}>Save</AlertDialogAction>
+          <AlertDialogAction onClick={() => onSave(downloadLog)}>Save</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>


### PR DESCRIPTION
Patch release.

### Added
- **Auto-tune run log** — "Download run log" checkbox (default on) in the Save Results dialog downloads a structured JSON log of every probe (params, outcomes, VRAM, timestamps, hardware, winner).
- **TurboLLM Expert persona** — now a first-class persona in the picker (not a hidden Settings launch), with a comprehensive built-in knowledge base (every screen, engine, load-profile param, auto-tune algorithm, gateway, tools, troubleshooting) and given the user's real hardware (GPU/VRAM/RAM/OS) so it can suggest models that fit.

### Changed
- Removed the "Launch TurboLLM Expert" section from Settings.

### Fixed
- **Mermaid artifact image export** — PNG/JPEG download failed ("Couldn't export this artifact as an image") because mermaid rendered labels as HTML `<foreignObject>`, which taints the export canvas. Labels now render as native SVG text. Verified live: PNG+JPEG export succeed.

Tests: 502 total, 499 pass, 0 fail, 3 skip.