### PR TITLE
fix(models): normalize HF blob URLs to resolve URLs on import

### DIFF
--- a/turbollm/src/downloads/downloads.ts
+++ b/turbollm/src/downloads/downloads.ts
@@ -144,7 +144,7 @@ export class DownloadManager {
     let url: string
     let filename: string
     if (input.url) {
-      const u = input.url.trim()
+      const u = normalizeHfBlobUrl(input.url.trim())
       if (!/^https?:\/\//i.test(u)) throw new DownloadError('invalid_url', 'URL must start with http:// or https://.')
       const path = safePathname(u)
       if (!subdir && !/\.gguf$/i.test(path) && !HF_BLOB_RE.test(u.split('?')[0])) {
@@ -455,6 +455,20 @@ export class DownloadManager {
 
 function gb(bytes: number): string {
   return (bytes / 1e9).toFixed(1)
+}
+
+/** Rewrite HF blob viewer URLs to the direct-download resolve URL so raw HTTP
+ *  clients receive the binary rather than the HTML file-viewer page. */
+function normalizeHfBlobUrl(u: string): string {
+  try {
+    const parsed = new URL(u)
+    if (parsed.hostname === 'huggingface.co') {
+      parsed.pathname = parsed.pathname.replace(/\/blob\//, '/resolve/')
+    }
+    return parsed.toString()
+  } catch {
+    return u
+  }
 }
 
 /** Extract the URL pathname without throwing on a malformed URL. */

--- a/turbollm/web/src/screens/models/ImportUrlDialog.tsx
+++ b/turbollm/web/src/screens/models/ImportUrlDialog.tsx
@@ -39,7 +39,8 @@ function deriveFilename(raw: string): string {
 }
 
 /** Convert non-standard HF URL forms to a direct https resolve URL.
- *  Handles hf://owner/repo/file.gguf and ?show_file_info=file.gguf page URLs.
+ *  Handles hf://owner/repo/file.gguf, ?show_file_info=file.gguf page URLs,
+ *  and /blob/ viewer URLs (rewrites to /resolve/ direct-download).
  *  All other URLs are returned unchanged. */
 function normalizeHfUrl(raw: string): string {
   try {
@@ -56,6 +57,8 @@ function normalizeHfUrl(raw: string): string {
       if (file && file.toLowerCase().endsWith('.gguf')) {
         return `https://huggingface.co${u.pathname}/resolve/main/${file}`
       }
+      u.pathname = u.pathname.replace(/\/blob\//, '/resolve/')
+      return u.toString()
     }
   } catch { /* ignore */ }
   return raw


### PR DESCRIPTION
## Summary

- HuggingFace `/blob/` URLs (e.g. copied from the HF file viewer) passed client-side validation because the path ends in `.gguf`, got enqueued, but resulted in a silent 404 — the blob endpoint serves an HTML page, not the raw binary
- Added `normalizeGgufUrl()` in `ImportUrlDialog` to rewrite `/blob/` → `/resolve/` before calling enqueue
- Added `normalizeHfBlobUrl()` in `DownloadManager.enqueue` as defence-in-depth (catches raw API calls too)
- Non-HF URLs are untouched; resolve URLs pass through unchanged

## Test plan

- [ ] Paste a HF blob URL (e.g. `https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF/blob/main/ornith-1.0-9b-Q4_K_M.gguf`) into Import from URL → download starts successfully
- [ ] Paste a correct resolve URL → still works, passes through unchanged
- [ ] Paste a non-HF URL with `/blob/` in the path → not rewritten
- [ ] Paste an invalid URL → clean error message, no regression