### PR TITLE
v1.6.0 — MCP marketplace + Mixpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,10 @@ the detail:
 - **Image input** for vision models, and **TurboLLM Expert** — a built-in assistant that knows
   the app and your hardware for onboarding and troubleshooting without leaving the UI.
 - **Agentic tools** — built-in `web_search` (Tavily), `fetch_url`, and sandboxed `run_code`, plus
-  **MCP server support** (stdio / SSE) so any MCP server's tools appear in every chat. A **Research**
-  persona forces multi-step web search and cites sources inline.
+  an **MCP marketplace** in Customize: one-click connect for hosted MCPs (GitHub, Linear, Stripe,
+  Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, Mixpanel) and open-source local MCPs
+  (filesystem, git, postgres, playwright, …), plus your own custom servers. Connected tools appear
+  in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
 
 </details>
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,34 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.6.0] - 2026-06-29
+
+**MCP marketplace — one-click tools in Customize.**
+
+The Customize screen becomes a curated MCP marketplace. A **Cloud** tab lists hosted MCPs you connect with a single API key, a **Local** tab lists open-source stdio MCPs (spawned via `npx`/`uvx`) plus the three built-in web-search providers, and a **Connected** tab shows everything currently active. Every entry carries a brand logo and a one-click connect panel. The guiding rule: a service is only listed if it actually connects with a static key — OAuth-only services are deliberately excluded so nothing ever shows a fake "connected" state.
+
+### Added
+- **MCP marketplace** (ADR-124) in Customize — Cloud / Local / Connected tabs with brand logos (tree-shaken `simple-icons`) and one-click connect.
+- **10 verified hosted (Cloud) MCPs**, each confirmed to connect with a static Bearer/API key against its official endpoint: GitHub, Linear, Stripe, Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, and **Mixpanel** (ADR-125). Mixpanel uses a service-account `Bearer Basic <base64>` token; the card tells you exactly what to paste.
+- **19 open-source local MCPs** (filesystem, memory, git, postgres, sqlite, playwright, puppeteer, docker, kubernetes, and more) plus the three built-in web-search providers surfaced as in-marketplace cards.
+- Hosted-MCP auth: a per-server API key is injected as `Authorization: Bearer …`; the key is **write-only** and never echoed back by the API.
+
+### Changed
+- Web-search provider configuration moved inline into the MCP section's built-in cards — one place to wire up tools.
+- Connected MCP tools now refresh live after any add / edit / delete / toggle — no daemon restart needed.
+
+### Fixed
+- **Hosted MCPs now actually connect**: replaced the legacy SSE handshake with **Streamable HTTP** (MCP 2025-03-26) — the transport every modern hosted MCP (GitHub, Linear, Stripe, …) actually uses.
+- **Local MCPs now spawn on Windows**: `npx`/`uvx` (`.cmd` wrappers) are launched through a shell, and catalog command strings are split into command + args correctly.
+- **Memory MCP works with zero config**: `MEMORY_FILE_PATH` is auto-set to `~/.turbollm/mcp-memory.jsonl`, so the server no longer crashes trying to read a directory as a file.
+- Excluded services that cannot connect with a static key (Notion, Figma, Sentry, Vercel, HubSpot, Amplitude, Slack — OAuth-only; Google Stitch — custom header + OAuth2-only; Motion — no confirmed endpoint) so the catalog never offers a connection that silently fails.
+- Removed a Node `DEP0190` deprecation warning from MCP subprocess spawning.
+
+### Discord
+- **New: a one-click MCP marketplace.** Open **Customize** and connect tools like GitHub, Linear, Stripe, Notion-grade integrations, Mixpanel, and more — most take just an API key. There's also a Local tab for open-source tools (filesystem, git, Postgres, Playwright…) that run on your own machine.
+- **It just works now** — hosted tools connect on the modern MCP transport, local tools launch correctly on Windows, and the Memory tool needs no setup. Connected tools show up in chat instantly, no restart.
+- We only list tools that genuinely connect — if a service needs a browser login we don't yet support, it's left out rather than faking a connection.
+
 ## [1.5.4] - 2026-06-28
 
 **Python engines + pixel-perfect artifact export.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -194,8 +194,10 @@ the detail:
 - **Image input** for vision models, and **TurboLLM Expert** — a built-in assistant that knows
   the app and your hardware for onboarding and troubleshooting without leaving the UI.
 - **Agentic tools** — built-in `web_search` (Tavily), `fetch_url`, and sandboxed `run_code`, plus
-  **MCP server support** (stdio / SSE) so any MCP server's tools appear in every chat. A **Research**
-  persona forces multi-step web search and cites sources inline.
+  an **MCP marketplace** in Customize: one-click connect for hosted MCPs (GitHub, Linear, Stripe,
+  Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, Mixpanel) and open-source local MCPs
+  (filesystem, git, postgres, playwright, …), plus your own custom servers. Connected tools appear
+  in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
 
 </details>
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1514,6 +1514,9 @@ export function registerApi(app: Hono, d: Deps): void {
     // Keep ToolRegistry in sync when tools config changes.
     if (b.tavilyApiKey !== undefined || b.search !== undefined) {
       d.tools?.updateConfig(d.store.snapshot().tools)
+      // Rebuild tool definitions so the engine picks up new/changed search providers
+      // without requiring a full daemon restart.
+      await d.tools?.buildToolDefinitions()
     }
     const after = d.store.snapshot().daemon
 
@@ -1552,8 +1555,15 @@ export function registerApi(app: Hono, d: Deps): void {
         ? { command: b.command!.trim(), args: b.args ?? [], env: b.env ?? {} }
         : { url: b.url!.trim(), ...(b.apiKey ? { apiKey: b.apiKey } : {}) }),
     }
+    // Auto-set MEMORY_FILE_PATH for @modelcontextprotocol/server-memory so users never need to configure it
+    if (server.transport === 'stdio' && server.command?.includes('server-memory') && !server.env?.MEMORY_FILE_PATH) {
+      server.env = { ...server.env, MEMORY_FILE_PATH: join(homedir(), '.turbollm', 'mcp-memory.jsonl') }
+    }
     d.store.update((cfg) => { cfg.mcp.servers.push(server) })
-    if (server.enabled) await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
+    if (server.enabled) {
+      await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
+      await d.tools?.buildToolDefinitions()
+    }
     return c.json(server, 201)
   })
 
@@ -1576,15 +1586,17 @@ export function registerApi(app: Hono, d: Deps): void {
       if (b.apiKey !== undefined) s.apiKey = b.apiKey || undefined
     })
     await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
+    await d.tools?.buildToolDefinitions()
     return c.json(d.store.snapshot().mcp.servers.find((s) => s.id === id))
   })
 
-  app.delete('/api/v1/mcp/servers/:id', (c) => {
+  app.delete('/api/v1/mcp/servers/:id', async (c) => {
     const id = c.req.param('id')
     const cfg = d.store.snapshot()
     if (!cfg.mcp.servers.some((s) => s.id === id)) return err(c, 404, 'not_found', 'MCP server not found.')
     d.store.update((c2) => { c2.mcp.servers = c2.mcp.servers.filter((s) => s.id !== id) })
     void d.tools?.syncMcpServers(d.store.snapshot().mcp.servers)
+    await d.tools?.buildToolDefinitions()
     return c.json({ ok: true })
   })
 

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1555,8 +1555,11 @@ export function registerApi(app: Hono, d: Deps): void {
         ? { command: b.command!.trim(), args: b.args ?? [], env: b.env ?? {} }
         : { url: b.url!.trim(), ...(b.apiKey ? { apiKey: b.apiKey } : {}) }),
     }
-    // Auto-set MEMORY_FILE_PATH for @modelcontextprotocol/server-memory so users never need to configure it
-    if (server.transport === 'stdio' && server.command?.includes('server-memory') && !server.env?.MEMORY_FILE_PATH) {
+    // Auto-set MEMORY_FILE_PATH for @modelcontextprotocol/server-memory so users never need to
+    // configure it. The package name lands in args (command is "npx"), so check both.
+    const isMemoryServer = server.transport === 'stdio' &&
+      (server.command?.includes('server-memory') || server.args?.some((a) => a.includes('server-memory')))
+    if (isMemoryServer && !server.env?.MEMORY_FILE_PATH) {
       server.env = { ...server.env, MEMORY_FILE_PATH: join(homedir(), '.turbollm', 'mcp-memory.jsonl') }
     }
     d.store.update((cfg) => { cfg.mcp.servers.push(server) })

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1564,7 +1564,9 @@ export function registerApi(app: Hono, d: Deps): void {
       await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
       await d.tools?.buildToolDefinitions()
     }
-    return c.json(server, 201)
+    // apiKey is write-only: never echo the Bearer token back, even on the create response.
+    const { apiKey: _created, ...safeServer } = server
+    return c.json(safeServer, 201)
   })
 
   app.put('/api/v1/mcp/servers/:id', async (c) => {
@@ -1587,7 +1589,10 @@ export function registerApi(app: Hono, d: Deps): void {
     })
     await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
     await d.tools?.buildToolDefinitions()
-    return c.json(d.store.snapshot().mcp.servers.find((s) => s.id === id))
+    // apiKey is write-only: strip the Bearer token from the update response too.
+    const updated = d.store.snapshot().mcp.servers.find((s) => s.id === id)!
+    const { apiKey: _updated, ...safeUpdated } = updated
+    return c.json(safeUpdated)
   })
 
   app.delete('/api/v1/mcp/servers/:id', async (c) => {

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1548,7 +1548,9 @@ export function registerApi(app: Hono, d: Deps): void {
       name: b.name.trim(),
       transport,
       enabled: b.enabled !== false,
-      ...(transport === 'stdio' ? { command: b.command!.trim(), args: b.args ?? [], env: b.env ?? {} } : { url: b.url!.trim() }),
+      ...(transport === 'stdio'
+        ? { command: b.command!.trim(), args: b.args ?? [], env: b.env ?? {} }
+        : { url: b.url!.trim(), ...(b.apiKey ? { apiKey: b.apiKey } : {}) }),
     }
     d.store.update((cfg) => { cfg.mcp.servers.push(server) })
     if (server.enabled) await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
@@ -1571,6 +1573,7 @@ export function registerApi(app: Hono, d: Deps): void {
       if (b.args !== undefined) s.args = b.args
       if (b.env !== undefined) s.env = b.env
       if (b.url !== undefined) s.url = b.url
+      if (b.apiKey !== undefined) s.apiKey = b.apiKey || undefined
     })
     await d.tools?.syncMcpServers(d.store.snapshot().mcp.servers).catch(() => {})
     return c.json(d.store.snapshot().mcp.servers.find((s) => s.id === id))
@@ -1928,7 +1931,8 @@ function settingsPayload(d: Deps) {
       kagiKeySet: !!cfg.tools.search?.kagiApiKey,
       searxngUrl: cfg.tools.search?.searxngUrl ?? '',
     },
-    mcp: cfg.mcp,
+    // apiKey is write-only: strip before echoing so Bearer tokens never reach the frontend.
+    mcp: { ...cfg.mcp, servers: cfg.mcp.servers.map(({ apiKey: _k, ...s }) => s) },
     // Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
     // conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back.
     build: { toolchainDirs: cfg.build.toolchainDirs },

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -214,6 +214,7 @@ const toolRegistry = new ToolRegistry(store.snapshot().tools)
 void (async () => {
   const cfg = store.snapshot()
   await toolRegistry.syncMcpServers(cfg.mcp.servers)
+  void toolRegistry.buildToolDefinitions()
 })()
 const startedAt = Date.now()
 // App self-update checker (F-006, ADR-031): is a newer TurboLLM published on npm than

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -112,6 +112,8 @@ export interface McpServer {
   env?: Record<string, string>
   /** sse only — base URL of the MCP server */
   url?: string
+  /** sse only — Bearer token injected as Authorization header on every request (ADR-124) */
+  apiKey?: string
   enabled: boolean
 }
 

--- a/turbollm/src/tools/mcp-client.ts
+++ b/turbollm/src/tools/mcp-client.ts
@@ -70,10 +70,15 @@ export class StdioMcpClient implements IMcpClient {
 
   async connect(): Promise<void> {
     if (this.proc) return
-    this.proc = spawn(this.command, this.args, {
+    // shell:true is required so npx/uvx (.cmd wrappers on Windows) resolve on PATH. With
+    // shell:true the whole invocation must be ONE string — passing a separate args array
+    // is deprecated (DEP0190) and unescaped. Quote any arg containing whitespace.
+    const quote = (a: string) => (/\s/.test(a) ? `"${a}"` : a)
+    const fullCmd = [this.command, ...this.args].map(quote).join(' ')
+    this.proc = spawn(fullCmd, {
       env: { ...process.env, ...this.env },
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: true, // required: npx/uvx are .cmd wrappers on Windows; also handles space-separated cmd strings
+      shell: true,
     })
 
     this.proc.stdout?.on('data', (chunk: Buffer) => {

--- a/turbollm/src/tools/mcp-client.ts
+++ b/turbollm/src/tools/mcp-client.ts
@@ -70,15 +70,18 @@ export class StdioMcpClient implements IMcpClient {
 
   async connect(): Promise<void> {
     if (this.proc) return
-    // shell:true is required so npx/uvx (.cmd wrappers on Windows) resolve on PATH. With
-    // shell:true the whole invocation must be ONE string — passing a separate args array
-    // is deprecated (DEP0190) and unescaped. Quote any arg containing whitespace.
-    const quote = (a: string) => (/\s/.test(a) ? `"${a}"` : a)
-    const fullCmd = [this.command, ...this.args].map(quote).join(' ')
-    this.proc = spawn(fullCmd, {
+    // npx/uvx are .cmd shims on Windows; Node refuses to spawn .cmd directly (CVE-2024-27980)
+    // and won't resolve them via PATHEXT without a shell. Instead of shell:true with a
+    // concatenated string (DEP0190 + shell-injection surface from custom commands), run the
+    // invocation through `cmd.exe /c` with a DISCRETE args array (shell:false). Node escapes
+    // each arg, so whitespace and metacharacters in args are not re-interpreted by a shell.
+    // On POSIX the command is on PATH and runs directly.
+    const isWin = process.platform === 'win32'
+    const file = isWin ? 'cmd.exe' : this.command
+    const args = isWin ? ['/c', this.command, ...this.args] : this.args
+    this.proc = spawn(file, args, {
       env: { ...process.env, ...this.env },
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: true,
     })
 
     this.proc.stdout?.on('data', (chunk: Buffer) => {
@@ -199,6 +202,9 @@ export class SseMcpClient implements IMcpClient {
 
   async connect(): Promise<void> {
     if (this.initialized) return
+    // protocolVersion is the MCP message-protocol version (distinct from the Streamable HTTP
+    // transport). 2024-11-05 is the broadest version every hosted server accepts; servers that
+    // prefer a newer one negotiate down, so this stays maximally compatible.
     await this.sendRequest('initialize', {
       protocolVersion: '2024-11-05',
       capabilities: { tools: {} },
@@ -276,17 +282,22 @@ export class SseMcpClient implements IMcpClient {
         buf = lines.pop() ?? ''
         for (const line of lines) {
           if (!line.startsWith('data:')) continue
+          let msg: JsonRpcResponse
           try {
-            const msg = JSON.parse(line.slice(5).trim()) as JsonRpcResponse
-            if (msg.id === targetId) {
-              if (msg.error) throw new Error(msg.error.message)
-              return msg.result
-            }
-          } catch { /* non-JSON lines (comments, pings) */ }
+            msg = JSON.parse(line.slice(5).trim()) as JsonRpcResponse
+          } catch {
+            continue // non-JSON SSE lines (comments, pings) — skip, don't swallow real errors
+          }
+          if (msg.id === targetId) {
+            if (msg.error) throw new Error(msg.error.message)
+            return msg.result
+          }
         }
       }
     } finally {
-      reader.releaseLock()
+      // Cancel (not just release) so the underlying connection is torn down once we have
+      // our answer — releaseLock alone leaves the body streaming.
+      await reader.cancel().catch(() => {})
     }
     throw new Error(`SSE stream ended without response for id ${targetId}`)
   }

--- a/turbollm/src/tools/mcp-client.ts
+++ b/turbollm/src/tools/mcp-client.ts
@@ -176,16 +176,18 @@ export class SseMcpClient implements IMcpClient {
   readonly serverId: string
   readonly serverName: string
   private baseUrl: string
+  private headers: Record<string, string>
   private msgId = 0
   private sseEndpoint = ''
   private sseAbort: AbortController | null = null
   private emitter = new EventEmitter()
   private initialized = false
 
-  constructor(opts: { id: string; name: string; url: string }) {
+  constructor(opts: { id: string; name: string; url: string; headers?: Record<string, string> }) {
     this.serverId = opts.id
     this.serverName = opts.name
     this.baseUrl = opts.url.replace(/\/$/, '')
+    this.headers = opts.headers ?? {}
   }
 
   async connect(): Promise<void> {
@@ -195,7 +197,7 @@ export class SseMcpClient implements IMcpClient {
     this.sseAbort = new AbortController()
     const endpoint = await new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('SSE connect timeout')), 15_000)
-      fetch(`${this.baseUrl}/sse`, { signal: this.sseAbort!.signal })
+      fetch(`${this.baseUrl}/sse`, { signal: this.sseAbort!.signal, headers: this.headers })
         .then(async (resp) => {
           if (!resp.ok || !resp.body) { clearTimeout(timer); reject(new Error(`SSE connect failed: ${resp.status}`)); return }
           const reader = resp.body.getReader()
@@ -283,7 +285,7 @@ export class SseMcpClient implements IMcpClient {
     const url = this.sseEndpoint || `${this.baseUrl}/messages`
     await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...this.headers },
       body: JSON.stringify(msg),
       signal: AbortSignal.timeout(10_000),
     })
@@ -300,10 +302,12 @@ export function createMcpClient(server: {
   args?: string[]
   env?: Record<string, string>
   url?: string
+  apiKey?: string
 }): IMcpClient {
   if (server.transport === 'sse') {
     if (!server.url) throw new Error(`MCP server "${server.name}" has transport=sse but no url`)
-    return new SseMcpClient({ id: server.id, name: server.name, url: server.url })
+    const headers = server.apiKey ? { Authorization: `Bearer ${server.apiKey}` } : undefined
+    return new SseMcpClient({ id: server.id, name: server.name, url: server.url, headers })
   }
   if (!server.command) throw new Error(`MCP server "${server.name}" has transport=stdio but no command`)
   return new StdioMcpClient({

--- a/turbollm/src/tools/mcp-client.ts
+++ b/turbollm/src/tools/mcp-client.ts
@@ -1,7 +1,6 @@
-// MCP host/client (v0.7.0). Implements stdio (subprocess JSON-RPC) and SSE (HTTP)
-// transports per the MCP 2024-11-05 specification.
+// MCP host/client. Implements stdio (subprocess JSON-RPC) and Streamable HTTP
+// (MCP 2025-03-26) transports. All modern hosted MCPs use Streamable HTTP.
 import { spawn, type ChildProcess } from 'node:child_process'
-import { EventEmitter } from 'node:events'
 
 // ── MCP protocol types ────────────────────────────────────────────────────
 
@@ -74,6 +73,7 @@ export class StdioMcpClient implements IMcpClient {
     this.proc = spawn(this.command, this.args, {
       env: { ...process.env, ...this.env },
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true, // required: npx/uvx are .cmd wrappers on Windows; also handles space-separated cmd strings
     })
 
     this.proc.stdout?.on('data', (chunk: Buffer) => {
@@ -170,7 +170,11 @@ export class StdioMcpClient implements IMcpClient {
   }
 }
 
-// ── SSE client ────────────────────────────────────────────────────────────
+// ── Streamable HTTP client (MCP 2025-03-26) ───────────────────────────────────
+// Modern hosted MCPs (GitHub, Linear, Stripe, Atlassian, Neon, etc.) use this
+// transport: POST every JSON-RPC message directly to the base URL; server
+// replies with plain JSON or an SSE stream. Session ID is tracked via the
+// Mcp-Session-Id response header and echoed on all subsequent requests.
 
 export class SseMcpClient implements IMcpClient {
   readonly serverId: string
@@ -178,9 +182,7 @@ export class SseMcpClient implements IMcpClient {
   private baseUrl: string
   private headers: Record<string, string>
   private msgId = 0
-  private sseEndpoint = ''
-  private sseAbort: AbortController | null = null
-  private emitter = new EventEmitter()
+  private sessionId: string | null = null
   private initialized = false
 
   constructor(opts: { id: string; name: string; url: string; headers?: Record<string, string> }) {
@@ -192,59 +194,17 @@ export class SseMcpClient implements IMcpClient {
 
   async connect(): Promise<void> {
     if (this.initialized) return
-
-    // Connect to the SSE stream to discover the messages endpoint
-    this.sseAbort = new AbortController()
-    const endpoint = await new Promise<string>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('SSE connect timeout')), 15_000)
-      fetch(`${this.baseUrl}/sse`, { signal: this.sseAbort!.signal, headers: this.headers })
-        .then(async (resp) => {
-          if (!resp.ok || !resp.body) { clearTimeout(timer); reject(new Error(`SSE connect failed: ${resp.status}`)); return }
-          const reader = resp.body.getReader()
-          const decoder = new TextDecoder()
-          let buf = ''
-          let resolved = false
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-            buf += decoder.decode(value, { stream: true })
-            const lines = buf.split('\n')
-            buf = lines.pop() ?? ''
-            for (const line of lines) {
-              if (line.startsWith('data:')) {
-                const data = line.slice(5).trim()
-                if (!resolved) {
-                  // First event is the endpoint URL
-                  resolved = true
-                  clearTimeout(timer)
-                  resolve(data)
-                }
-                try {
-                  const msg = JSON.parse(data) as JsonRpcResponse
-                  if (msg.id != null) this.emitter.emit(`rpc:${msg.id}`, msg)
-                } catch { /* non-JSON events (endpoint URL) are fine */ }
-              }
-            }
-          }
-        })
-        .catch((e) => { clearTimeout(timer); if (!this.sseAbort?.signal.aborted) reject(e) })
-    })
-
-    this.sseEndpoint = endpoint.startsWith('http') ? endpoint : `${this.baseUrl}${endpoint}`
-
     await this.sendRequest('initialize', {
       protocolVersion: '2024-11-05',
       capabilities: { tools: {} },
       clientInfo: { name: 'turbollm', version: '0.7.0' },
     })
-    await this.post({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+    void this.postNotification({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
     this.initialized = true
   }
 
   disconnect(): void {
-    this.sseAbort?.abort()
-    this.sseAbort = null
+    this.sessionId = null
     this.initialized = false
   }
 
@@ -267,28 +227,72 @@ export class SseMcpClient implements IMcpClient {
   private async sendRequest(method: string, params: unknown): Promise<unknown> {
     const id = ++this.msgId
     const req: JsonRpcRequest = { jsonrpc: '2.0', id, method, params }
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.emitter.removeAllListeners(`rpc:${id}`)
-        reject(new Error(`MCP SSE request timeout: ${method}`))
-      }, 30_000)
-      this.emitter.once(`rpc:${id}`, (msg: JsonRpcResponse) => {
-        clearTimeout(timer)
-        if (msg.error) reject(new Error(msg.error.message))
-        else resolve(msg.result)
-      })
-      this.post(req).catch((e) => { clearTimeout(timer); reject(e) })
+    const reqHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json, text/event-stream',
+      ...this.headers,
+    }
+    if (this.sessionId) reqHeaders['Mcp-Session-Id'] = this.sessionId
+
+    const resp = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: reqHeaders,
+      body: JSON.stringify(req),
+      signal: AbortSignal.timeout(30_000),
     })
+
+    if (!resp.ok) {
+      const txt = await resp.text().catch(() => '')
+      throw new Error(`MCP HTTP ${resp.status}: ${txt.slice(0, 200)}`)
+    }
+
+    const newSession = resp.headers.get('mcp-session-id')
+    if (newSession) this.sessionId = newSession
+
+    const ct = resp.headers.get('content-type') ?? ''
+    if (ct.includes('text/event-stream')) return this.readSSEResult(resp, id)
+
+    const json = await resp.json() as JsonRpcResponse
+    if (json.error) throw new Error(json.error.message)
+    return json.result
   }
 
-  private async post(msg: unknown): Promise<void> {
-    const url = this.sseEndpoint || `${this.baseUrl}/messages`
-    await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...this.headers },
-      body: JSON.stringify(msg),
+  private async readSSEResult(resp: Response, targetId: string | number): Promise<unknown> {
+    if (!resp.body) throw new Error('SSE response body is null')
+    const reader = resp.body.getReader()
+    const dec = new TextDecoder()
+    let buf = ''
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += dec.decode(value, { stream: true })
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+        for (const line of lines) {
+          if (!line.startsWith('data:')) continue
+          try {
+            const msg = JSON.parse(line.slice(5).trim()) as JsonRpcResponse
+            if (msg.id === targetId) {
+              if (msg.error) throw new Error(msg.error.message)
+              return msg.result
+            }
+          } catch { /* non-JSON lines (comments, pings) */ }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+    throw new Error(`SSE stream ended without response for id ${targetId}`)
+  }
+
+  private async postNotification(msg: JsonRpcNotification): Promise<void> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json', ...this.headers }
+    if (this.sessionId) headers['Mcp-Session-Id'] = this.sessionId
+    await fetch(this.baseUrl, {
+      method: 'POST', headers, body: JSON.stringify(msg),
       signal: AbortSignal.timeout(10_000),
-    })
+    }).catch(() => {})
   }
 }
 

--- a/turbollm/web/package-lock.json
+++ b/turbollm/web/package-lock.json
@@ -32,6 +32,7 @@
         "react-router-dom": "^7.17.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
+        "simple-icons": "^16.24.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "zustand": "^5.0.14"
@@ -5823,6 +5824,25 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/simple-icons": {
+      "version": "16.24.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.24.0.tgz",
+      "integrity": "sha512-lAPW1rqgwPQ4tdIY15TtcKSgSelvJexz8q/B+a7Igg1dJoXR0LPjScLkLMI8UbLSkS41/fLVZWIhsH7HPUwAgQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/sonner": {
       "version": "2.0.7",

--- a/turbollm/web/package.json
+++ b/turbollm/web/package.json
@@ -33,6 +33,7 @@
     "react-router-dom": "^7.17.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
+    "simple-icons": "^16.24.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.14"

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -481,6 +481,8 @@ export type McpServer = {
   args?: string[]
   env?: Record<string, string>
   url?: string
+  /** sse only — Bearer token for Authorization header (ADR-124) */
+  apiKey?: string
   enabled: boolean
 }
 

--- a/turbollm/web/src/lib/brand-icons.ts
+++ b/turbollm/web/src/lib/brand-icons.ts
@@ -1,0 +1,49 @@
+// Tree-shaken brand icon imports from simple-icons.
+// Each exported entry: { path: SVG path for viewBox 0 0 24 24, hex: brand color without # }
+// Fallback to colored initials for brands not in this map.
+
+import {
+  siGithub, siLinear, siNotion, siFigma, siStripe, siAtlassian,
+  siSentry, siSupabase, siNeon, siCloudflare, siZapier, siVercel,
+  siHubspot, siMixpanel, siGoogle,
+  siPostgresql, siGit, siPuppeteer, siGoogledrive, siBrave,
+  siDocker, siRedis, siMongodb, siObsidian, siYoutube, siRss,
+  siKubernetes, siMysql, siKagi, siSearxng,
+} from 'simple-icons'
+
+export type BrandIcon = { path: string; hex: string }
+
+export const BRAND_ICONS: Record<string, BrandIcon> = {
+  // Cloud MCPs
+  github:     { path: siGithub.path,     hex: siGithub.hex },
+  linear:     { path: siLinear.path,     hex: siLinear.hex },
+  notion:     { path: siNotion.path,     hex: siNotion.hex },
+  figma:      { path: siFigma.path,      hex: siFigma.hex },
+  stripe:     { path: siStripe.path,     hex: siStripe.hex },
+  atlassian:  { path: siAtlassian.path,  hex: siAtlassian.hex },
+  sentry:     { path: siSentry.path,     hex: siSentry.hex },
+  supabase:   { path: siSupabase.path,   hex: siSupabase.hex },
+  neon:       { path: siNeon.path,       hex: siNeon.hex },
+  cloudflare: { path: siCloudflare.path, hex: siCloudflare.hex },
+  zapier:     { path: siZapier.path,     hex: siZapier.hex },
+  vercel:     { path: siVercel.path,     hex: siVercel.hex },
+  hubspot:    { path: siHubspot.path,    hex: siHubspot.hex },
+  mixpanel:   { path: siMixpanel.path,   hex: siMixpanel.hex },
+  google:     { path: siGoogle.path,     hex: siGoogle.hex },
+  // Local MCPs
+  postgresql: { path: siPostgresql.path, hex: siPostgresql.hex },
+  git:        { path: siGit.path,        hex: siGit.hex },
+  puppeteer:  { path: siPuppeteer.path,  hex: siPuppeteer.hex },
+  googledrive:{ path: siGoogledrive.path,hex: siGoogledrive.hex },
+  brave:      { path: siBrave.path,      hex: siBrave.hex },
+  docker:     { path: siDocker.path,     hex: siDocker.hex },
+  redis:      { path: siRedis.path,      hex: siRedis.hex },
+  mongodb:    { path: siMongodb.path,    hex: siMongodb.hex },
+  obsidian:   { path: siObsidian.path,   hex: siObsidian.hex },
+  youtube:    { path: siYoutube.path,    hex: siYoutube.hex },
+  rss:        { path: siRss.path,        hex: siRss.hex },
+  kubernetes: { path: siKubernetes.path, hex: siKubernetes.hex },
+  mysql:      { path: siMysql.path,      hex: siMysql.hex },
+  kagi:       { path: siKagi.path,       hex: siKagi.hex },
+  searxng:    { path: siSearxng.path,    hex: siSearxng.hex },
+}

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -43,9 +43,11 @@ export type LocalEntry = {
 }
 
 // Only entries where a static API key / Bearer token is confirmed to work against the
-// official hosted MCP endpoint. Verified 2026-06-28 against official docs for each service.
+// official hosted MCP endpoint. Verified 2026-06-29 against official docs for each service.
 // OAuth-only (Notion, Figma, Sentry, Vercel, HubSpot, Amplitude, Slack) are excluded.
 // Motion excluded: no confirmed official hosted endpoint exists.
+// Stitch (Google) excluded: its MCP needs an X-Goog-Api-Key header (we only inject
+// Authorization: Bearer) and rejects API keys anyway — OAuth2-only in practice.
 export const CLOUD_MCPS: CloudEntry[] = [
   {
     id: 'github',
@@ -144,6 +146,17 @@ export const CLOUD_MCPS: CloudEntry[] = [
     color: '#00c45a',
     url: 'https://mcp.apify.com',
     keyNote: 'Get an API token at console.apify.com → Settings → API & Integrations.',
+  },
+  {
+    id: 'mixpanel',
+    name: 'Mixpanel',
+    cat: 'Analytics',
+    desc: 'Query events, funnels, retention, and user profiles.',
+    auth: 'key',
+    color: '#7856ff',
+    iconSlug: 'mixpanel',
+    url: 'https://mcp.mixpanel.com/mcp',
+    keyNote: 'Create a service account at mixpanel.com → Settings → Service Accounts, then run: echo -n "username:secret" | base64 — and paste "Basic <that-base64>" here (include the word Basic).',
   },
 ]
 

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -1,0 +1,381 @@
+// Curated MCP server catalog (ADR-124). Two categories:
+// - Cloud: hosted/SaaS MCPs connected via SSE (Streamable HTTP) with API key auth
+// - Local: open-source stdio MCPs spawned via npx or uvx
+//
+// Auth kinds for Cloud:
+//   'key'       — API key / Bearer token only
+//   'oauth'     — OAuth only (no token path; note shown in UI)
+//   'oauth-key' — either OAuth OR API key
+//
+// iconSlug: key into BRAND_ICONS from brand-icons.ts; omit to fall back to colored initials
+
+export type AuthKind = 'key' | 'oauth' | 'oauth-key'
+
+export type CloudEntry = {
+  id: string
+  name: string
+  cat: string
+  desc: string
+  auth: AuthKind
+  color: string
+  url: string
+  iconSlug?: string
+  keyNote?: string
+}
+
+export type EnvVar = {
+  key: string
+  desc: string
+  required: boolean
+}
+
+export type LocalEntry = {
+  id: string
+  name: string
+  cat: string
+  desc: string
+  cmd: string
+  envs: EnvVar[]
+  uvx?: boolean
+  iconSlug?: string
+  argNote?: string
+  builtin?: true
+}
+
+// Only entries where a static API key / Bearer token is confirmed to work against the
+// official hosted MCP endpoint. Verified 2026-06-28 against official docs for each service.
+// OAuth-only (Notion, Figma, Sentry, Vercel, HubSpot, Amplitude, Slack) are excluded.
+// Motion excluded: no confirmed official hosted endpoint exists.
+export const CLOUD_MCPS: CloudEntry[] = [
+  {
+    id: 'github',
+    name: 'GitHub',
+    cat: 'Dev Tools',
+    desc: 'Issues, PRs, code search, and repo management.',
+    auth: 'key',
+    color: '#24292e',
+    iconSlug: 'github',
+    url: 'https://api.githubcopilot.com/mcp/',
+    keyNote: 'Use a GitHub Personal Access Token (PAT) from github.com → Settings → Developer settings → PATs.',
+  },
+  {
+    id: 'linear',
+    name: 'Linear',
+    cat: 'Project Mgmt',
+    desc: 'Issues, projects, sprints, and cycles.',
+    auth: 'key',
+    color: '#5e6ad2',
+    iconSlug: 'linear',
+    url: 'https://mcp.linear.app/mcp',
+    keyNote: 'Generate an API key at linear.app → Settings → API.',
+  },
+  {
+    id: 'stripe',
+    name: 'Stripe',
+    cat: 'Payments',
+    desc: 'Charges, customers, and subscriptions.',
+    auth: 'key',
+    color: '#4f46bf',
+    iconSlug: 'stripe',
+    url: 'https://mcp.stripe.com',
+    keyNote: 'Use a restricted key (rk_live_… or rk_test_…) from dashboard.stripe.com → Developers → API keys. Prefer restricted keys over secret keys.',
+  },
+  {
+    id: 'atlassian',
+    name: 'Atlassian',
+    cat: 'Project Mgmt',
+    desc: 'Jira, Confluence, Bitbucket, and Compass.',
+    auth: 'key',
+    color: '#0040a0',
+    iconSlug: 'atlassian',
+    url: 'https://mcp.atlassian.com/v1/mcp',
+    keyNote: 'Requires a service-account API key (Bearer). Personal API tokens use Basic auth and won\'t work here. Generate a service-account key from admin.atlassian.com → API keys.',
+  },
+  {
+    id: 'neon',
+    name: 'Neon',
+    cat: 'Database',
+    desc: 'Serverless Postgres — branches and queries.',
+    auth: 'key',
+    color: '#007a44',
+    iconSlug: 'neon',
+    url: 'https://mcp.neon.tech/mcp',
+    keyNote: 'Generate an API key at console.neon.tech → Account → API Keys.',
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    cat: 'Database',
+    desc: 'Tables, auth, storage, and edge functions.',
+    auth: 'key',
+    color: '#136b46',
+    iconSlug: 'supabase',
+    url: 'https://mcp.supabase.com/mcp',
+    keyNote: 'Generate a personal access token at supabase.com → Account → Access Tokens.',
+  },
+  {
+    id: 'cloudflare',
+    name: 'Cloudflare',
+    cat: 'Cloud',
+    desc: 'Workers, KV, D1, R2, and DNS management.',
+    auth: 'key',
+    color: '#f48120',
+    iconSlug: 'cloudflare',
+    url: 'https://mcp.cloudflare.com/mcp',
+    keyNote: 'Create an API token at dash.cloudflare.com → Profile → API Tokens. Note: tokens with IP address filtering enabled do not work.',
+  },
+  {
+    id: 'zapier',
+    name: 'Zapier',
+    cat: 'Automation',
+    desc: 'Trigger and query 7,000+ app automations.',
+    auth: 'key',
+    color: '#ff4a00',
+    iconSlug: 'zapier',
+    url: 'https://mcp.zapier.com/api/v1/connect',
+    keyNote: 'Get a connection token from zapier.com/mcp — Zapier issues a per-server token that you paste here.',
+  },
+  {
+    id: 'apify',
+    name: 'Apify',
+    cat: 'Automation',
+    desc: 'Run web scrapers, browse the web with RAG, and query Apify datasets.',
+    auth: 'key',
+    color: '#00c45a',
+    url: 'https://mcp.apify.com',
+    keyNote: 'Get an API token at console.apify.com → Settings → API & Integrations.',
+  },
+]
+
+export const LOCAL_MCPS: LocalEntry[] = [
+  {
+    id: 'filesystem',
+    name: 'Filesystem',
+    cat: 'File System',
+    desc: 'Read/write local files with a configurable path allow-list.',
+    cmd: 'npx -y @modelcontextprotocol/server-filesystem',
+    envs: [],
+    argNote: 'Provide the directory path(s) to allow access to as command arguments.',
+  },
+  {
+    id: 'memory',
+    name: 'Memory',
+    cat: 'AI',
+    desc: 'Persistent knowledge graph across sessions.',
+    cmd: 'npx -y @modelcontextprotocol/server-memory',
+    envs: [{ key: 'MEMORY_FILE_PATH', desc: 'Path to store the knowledge graph file', required: false }],
+  },
+  {
+    id: 'brave',
+    name: 'Brave Search',
+    cat: 'Search',
+    desc: 'Web and news search via Brave Search API.',
+    cmd: 'npx -y @modelcontextprotocol/server-brave-search',
+    iconSlug: 'brave',
+    envs: [{ key: 'BRAVE_API_KEY', desc: 'From search.brave.com → API', required: true }],
+  },
+  {
+    id: 'postgres',
+    name: 'PostgreSQL',
+    cat: 'Database',
+    desc: 'Natural-language queries against PostgreSQL.',
+    cmd: 'npx -y @modelcontextprotocol/server-postgres',
+    iconSlug: 'postgresql',
+    envs: [],
+    argNote: 'Provide the connection string as an argument: postgresql://user:pass@host/db',
+  },
+  {
+    id: 'sqlite',
+    name: 'SQLite',
+    cat: 'Database',
+    desc: 'Query and inspect local SQLite databases.',
+    cmd: 'npx -y @modelcontextprotocol/server-sqlite',
+    envs: [],
+    argNote: 'Provide the path to your .sqlite file as an argument.',
+  },
+  {
+    id: 'puppeteer',
+    name: 'Puppeteer',
+    cat: 'Browser',
+    desc: 'Headless Chromium for screenshots and form automation.',
+    cmd: 'npx -y @modelcontextprotocol/server-puppeteer',
+    iconSlug: 'puppeteer',
+    envs: [],
+  },
+  {
+    id: 'playwright',
+    name: 'Playwright',
+    cat: 'Browser',
+    desc: 'DOM-aware browser automation from Microsoft.',
+    cmd: 'npx @playwright/mcp@latest',
+    envs: [],
+  },
+  {
+    id: 'sequential',
+    name: 'Sequential Thinking',
+    cat: 'AI',
+    desc: 'Dynamic step-by-step reasoning scaffold.',
+    cmd: 'npx -y @modelcontextprotocol/server-sequentialthinking',
+    envs: [],
+  },
+  {
+    id: 'fetch',
+    name: 'Fetch',
+    cat: 'Web',
+    desc: 'Fetch any URL and convert to LLM-friendly markdown.',
+    cmd: 'uvx mcp-server-fetch',
+    envs: [],
+    uvx: true,
+  },
+  {
+    id: 'git',
+    name: 'Git',
+    cat: 'Dev Tools',
+    desc: 'Commit, diff, log, branch, and blame operations.',
+    cmd: 'uvx mcp-server-git',
+    iconSlug: 'git',
+    envs: [],
+    uvx: true,
+    argNote: 'Provide --repository /path/to/your/repo as an argument.',
+  },
+  {
+    id: 'gdrive',
+    name: 'Google Drive',
+    cat: 'File System',
+    desc: 'Search and read files from Google Drive.',
+    cmd: 'npx -y @modelcontextprotocol/server-google-drive',
+    iconSlug: 'googledrive',
+    envs: [{ key: 'GDRIVE_CREDENTIALS_JSON', desc: 'Path to your credentials.json file', required: true }],
+  },
+  {
+    id: 'redis',
+    name: 'Redis',
+    cat: 'Database',
+    desc: 'Read and write Redis keys, hashes, lists, and streams.',
+    cmd: 'uvx mcp-server-redis',
+    iconSlug: 'redis',
+    uvx: true,
+    envs: [
+      { key: 'REDIS_HOST', desc: 'Redis host (default: localhost)', required: false },
+      { key: 'REDIS_PORT', desc: 'Redis port (default: 6379)', required: false },
+      { key: 'REDIS_PASSWORD', desc: 'Redis password if auth is enabled', required: false },
+    ],
+  },
+  {
+    id: 'mysql',
+    name: 'MySQL',
+    cat: 'Database',
+    desc: 'Query and manage MySQL databases with natural language.',
+    cmd: 'uvx mcp-server-mysql',
+    iconSlug: 'mysql',
+    uvx: true,
+    envs: [
+      { key: 'MYSQL_HOST', desc: 'MySQL host (default: localhost)', required: false },
+      { key: 'MYSQL_USER', desc: 'Database user', required: true },
+      { key: 'MYSQL_PASSWORD', desc: 'Database password', required: true },
+      { key: 'MYSQL_DATABASE', desc: 'Target database name', required: true },
+    ],
+  },
+  {
+    id: 'docker',
+    name: 'Docker',
+    cat: 'Dev Tools',
+    desc: 'Manage containers, images, volumes, and networks.',
+    cmd: 'uvx docker-mcp',
+    iconSlug: 'docker',
+    uvx: true,
+    envs: [],
+  },
+  {
+    id: 'kubernetes',
+    name: 'Kubernetes',
+    cat: 'Dev Tools',
+    desc: 'Inspect pods, deployments, services, and cluster state.',
+    cmd: 'npx -y mcp-server-kubernetes',
+    iconSlug: 'kubernetes',
+    envs: [],
+  },
+  {
+    id: 'excel',
+    name: 'Excel',
+    cat: 'Productivity',
+    desc: 'Read and write Excel (.xlsx) spreadsheet files.',
+    cmd: 'npx -y @negokaz/excel-mcp-server',
+    envs: [],
+    argNote: 'Set EXCEL_FILE_PATH env var or pass the path as an argument.',
+  },
+  {
+    id: 'pdf',
+    name: 'PDF Reader',
+    cat: 'File System',
+    desc: 'Extract text and metadata from local PDF files.',
+    cmd: 'npx -y @sylphlab/pdf-reader-mcp',
+    envs: [],
+  },
+  {
+    id: 'youtube',
+    name: 'YouTube Transcript',
+    cat: 'Web',
+    desc: 'Fetch full transcripts from any YouTube video.',
+    cmd: 'uvx mcp-youtube-transcript',
+    iconSlug: 'youtube',
+    uvx: true,
+    envs: [],
+  },
+  {
+    id: 'obsidian',
+    name: 'Obsidian',
+    cat: 'Productivity',
+    desc: 'Search and read notes from a local Obsidian vault.',
+    cmd: 'npx -y obsidian-mcp-server@latest',
+    iconSlug: 'obsidian',
+    envs: [
+      { key: 'OBSIDIAN_API_KEY', desc: 'From the Local REST API community plugin settings', required: true },
+      { key: 'OBSIDIAN_HOST', desc: 'Obsidian REST API host (default: localhost)', required: false },
+    ],
+  },
+  {
+    id: 'comfyui',
+    name: 'ComfyUI MCP',
+    cat: 'AI',
+    desc: 'Control a local ComfyUI to generate images/video, run workflows, and download models.',
+    cmd: 'npx -y comfyui-mcp',
+    envs: [
+      { key: 'COMFYUI_URL', desc: 'ComfyUI server URL (default: http://127.0.0.1:8188)', required: false },
+      { key: 'CIVITAI_API_TOKEN', desc: 'For downloading models from CivitAI', required: false },
+      { key: 'HUGGINGFACE_TOKEN', desc: 'For downloading models from Hugging Face', required: false },
+    ],
+  },
+  {
+    id: 'builtin-tavily',
+    name: 'Tavily',
+    cat: 'Built-in',
+    desc: 'AI-search API tuned for LLMs — built in to TurboLLM.',
+    cmd: '',
+    envs: [],
+    builtin: true,
+  },
+  {
+    id: 'builtin-kagi',
+    name: 'Kagi',
+    cat: 'Built-in',
+    desc: 'Premium search with no ads or tracking — built in to TurboLLM.',
+    cmd: '',
+    iconSlug: 'kagi',
+    envs: [],
+    builtin: true,
+  },
+  {
+    id: 'builtin-searxng',
+    name: 'SearXNG',
+    cat: 'Built-in',
+    desc: 'Self-hosted meta-search, fully local — built in to TurboLLM.',
+    cmd: '',
+    iconSlug: 'searxng',
+    envs: [],
+    builtin: true,
+  },
+]
+
+export const CLOUD_CATS: string[] = ['All', ...new Set(CLOUD_MCPS.map((m) => m.cat))]
+export const LOCAL_CATS: string[] = ['All', ...new Set(LOCAL_MCPS.map((m) => m.cat))]

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -163,7 +163,7 @@ export const LOCAL_MCPS: LocalEntry[] = [
     cat: 'AI',
     desc: 'Persistent knowledge graph across sessions.',
     cmd: 'npx -y @modelcontextprotocol/server-memory',
-    envs: [{ key: 'MEMORY_FILE_PATH', desc: 'Path to store the knowledge graph file', required: false }],
+    envs: [],
   },
   {
     id: 'brave',

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -45,8 +45,9 @@ const TURBOLLM_KNOWLEDGE =
   '- Runs persist in the SQLite database (DB v8/v9).\n\n' +
 
   '**Customize** (Puzzle icon in nav):\n' +
-  '- **Search provider**: Tavily (default), Kagi, or SearXNG (self-hosted) — paste API key here. Required for web_search, fetch_url, and the Research persona.\n' +
-  '- **MCP servers**: add/edit/delete MCP servers (stdio subprocess or SSE HTTP). Tools from all connected servers appear automatically as callable tools in chat.\n\n' +
+  '- **MCP marketplace**: a Cloud tab (hosted MCPs connected via Streamable HTTP with an API key — GitHub, Linear, Stripe, Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, Mixpanel), a Local tab (open-source stdio MCPs spawned via npx/uvx — filesystem, git, postgres, playwright, etc., plus the three built-in web-search providers), and a Connected tab listing active servers. One-click connect with brand logos; only services that actually connect via a static key are listed (OAuth-only services are deliberately excluded).\n' +
+  '- **Search provider** (built-in cards in the Local tab): Tavily (default), Kagi, or SearXNG (self-hosted) — paste API key/URL inline. Required for web_search, fetch_url, and the Research persona.\n' +
+  '- **Custom MCP servers**: add/edit/delete your own MCP servers (stdio subprocess or SSE/HTTP). Tools from all connected servers appear automatically as callable tools in chat, with no daemon restart.\n\n' +
 
   '**Settings**:\n' +
   '- Theme: light / dark / system\n' +

--- a/turbollm/web/src/screens/CustomizeScreen.tsx
+++ b/turbollm/web/src/screens/CustomizeScreen.tsx
@@ -370,8 +370,16 @@ function McpSection({ servers, search }: { servers: McpServer[]; search: DaemonS
   }
 
   const connectLocal = (entry: LocalEntry) => {
-    const fullCmd = extraArg.trim() ? `${entry.cmd} ${extraArg.trim()}` : entry.cmd
-    const [command, ...args] = fullCmd.trim().split(/\s+/)
+    // entry.cmd is a curated catalog string (no spaces within tokens) — safe to split on space.
+    const [command, ...baseArgs] = entry.cmd.trim().split(/\s+/)
+    // extraArg is user input that may contain a path with spaces. Tokenize quote-aware so
+    // a quoted path ("C:\My Files") stays one arg, while unquoted multi-token input
+    // (e.g. --repository /path) still splits into separate args.
+    const extra = extraArg.trim()
+    const extraArgs = extra
+      ? (extra.match(/[^\s"]+|"[^"]*"/g) ?? []).map((t) => t.replace(/^"|"$/g, ''))
+      : []
+    const args = [...baseArgs, ...extraArgs]
     const env: Record<string, string> = {}
     for (const [k, v] of Object.entries(localEnvs)) { if (v.trim()) env[k] = v.trim() }
     for (const e of entry.envs) {

--- a/turbollm/web/src/screens/CustomizeScreen.tsx
+++ b/turbollm/web/src/screens/CustomizeScreen.tsx
@@ -1,11 +1,14 @@
-import { useState } from 'react'
-import { Check, Loader2, Pencil, Plus, Trash2 } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { ArrowLeft, Check, ChevronRight, Loader2, Pencil, Trash2, X } from 'lucide-react'
 import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
 import { toast } from '../components/ui/sonner'
 import { useMcpMutations, useSettings } from '../lib/queries'
 import { ApiError } from '../lib/api'
 import type { McpServer, DaemonSettings, DaemonSettingsPatch, SearchProvider } from '../lib/api'
+import { CLOUD_MCPS, LOCAL_MCPS, CLOUD_CATS, LOCAL_CATS } from '../lib/mcp-catalog'
+import type { CloudEntry, LocalEntry } from '../lib/mcp-catalog'
+import { BRAND_ICONS } from '../lib/brand-icons'
 
 export function CustomizeScreen() {
   const { query: settingsQ } = useSettings()
@@ -28,7 +31,7 @@ export function CustomizeScreen() {
   )
 }
 
-// ── Tools — web search provider (Tavily / Kagi / SearXNG, F-020) ─────────────
+// ── Tools — web search provider ───────────────────────────────────────────────
 
 type ProviderMeta = { id: SearchProvider; label: string; blurb: string; getKey?: string }
 const PROVIDERS: ProviderMeta[] = [
@@ -40,32 +43,22 @@ const PROVIDERS: ProviderMeta[] = [
 function ToolsSection({ search, onSaved }: { search: DaemonSettings['search']; onSaved: () => void }) {
   const { save } = useSettings()
   const [provider, setProvider] = useState<SearchProvider>(search.provider)
-  const [secret, setSecret] = useState('') // key (tavily/kagi) or URL (searxng)
+  const [secret, setSecret] = useState('')
 
   const meta = PROVIDERS.find((p) => p.id === provider)!
   const isUrl = provider === 'searxng'
   const configured = provider === 'tavily' ? search.tavilyKeySet : provider === 'kagi' ? search.kagiKeySet : !!search.searxngUrl
 
-  // Switching the segmented control resets the input and pre-fills the SearXNG URL.
-  const pick = (p: SearchProvider) => {
-    setProvider(p)
-    setSecret(p === 'searxng' ? search.searxngUrl : '')
-  }
+  const pick = (p: SearchProvider) => { setProvider(p); setSecret(p === 'searxng' ? search.searxngUrl : '') }
 
   const handleSave = () => {
     const v = secret.trim()
     const patch: DaemonSettingsPatch['search'] = { provider }
-    // Secrets: only send when the user typed something (avoid wiping a stored key on a bare
-    // provider switch). The SearXNG URL is visible/echoed, so an empty box genuinely clears it.
     if (isUrl) patch.searxngUrl = v
     else if (v && provider === 'tavily') patch.tavilyApiKey = v
     else if (v && provider === 'kagi') patch.kagiApiKey = v
     save.mutate({ search: patch }, {
-      onSuccess: () => {
-        toast.success(`Search set to ${meta.label}${v ? ` — ${isUrl ? 'URL' : 'key'} saved` : ''}`)
-        if (!isUrl) setSecret('')
-        onSaved()
-      },
+      onSuccess: () => { toast.success(`Search set to ${meta.label}${v ? ` — ${isUrl ? 'URL' : 'key'} saved` : ''}`); if (!isUrl) setSecret(''); onSaved() },
       onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save search settings.'),
     })
   }
@@ -80,13 +73,8 @@ function ToolsSection({ search, onSaved }: { search: DaemonSettings['search']; o
 
       <div className="mb-3 inline-flex rounded-md border border-border p-0.5">
         {PROVIDERS.map((p) => (
-          <button
-            key={p.id}
-            onClick={() => pick(p.id)}
-            className={`rounded px-3 py-1 text-[13px] transition-colors ${
-              provider === p.id ? 'bg-bg text-ink' : 'text-muted hover:text-ink'
-            }`}
-          >
+          <button key={p.id} onClick={() => pick(p.id)}
+            className={`rounded px-3 py-1 text-[13px] transition-colors ${provider === p.id ? 'bg-bg text-ink' : 'text-muted hover:text-ink'}`}>
             {p.label}
           </button>
         ))}
@@ -118,9 +106,7 @@ function ToolsSection({ search, onSaved }: { search: DaemonSettings['search']; o
           autoComplete="off"
           className="flex-1 rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[13px] text-ink outline-none"
         />
-        <Button size="sm" onClick={handleSave} disabled={save.isPending}>
-          Save
-        </Button>
+        <Button size="sm" onClick={handleSave} disabled={save.isPending}>Save</Button>
       </div>
 
       <p className="mt-3 text-[12px] text-faint">
@@ -134,28 +120,21 @@ function ToolsSection({ search, onSaved }: { search: DaemonSettings['search']; o
 // ── MCP Servers ───────────────────────────────────────────────────────────────
 
 type McpFormState = {
-  name: string
-  transport: 'stdio' | 'sse'
-  command: string
-  argsStr: string
-  envStr: string
-  url: string
-  enabled: boolean
+  name: string; transport: 'stdio' | 'sse'
+  command: string; argsStr: string; envStr: string
+  url: string; apiKey: string; enabled: boolean
 }
 
 const emptyMcpForm = (): McpFormState => ({
-  name: '', transport: 'stdio', command: '', argsStr: '', envStr: '', url: '', enabled: true,
+  name: '', transport: 'stdio', command: '', argsStr: '', envStr: '', url: '', apiKey: '', enabled: true,
 })
 
 function serverToForm(s: McpServer): McpFormState {
   return {
-    name: s.name,
-    transport: s.transport,
-    command: s.command ?? '',
-    argsStr: (s.args ?? []).join(', '),
+    name: s.name, transport: s.transport,
+    command: s.command ?? '', argsStr: (s.args ?? []).join(', '),
     envStr: Object.entries(s.env ?? {}).map(([k, v]) => `${k}=${v}`).join('\n'),
-    url: s.url ?? '',
-    enabled: s.enabled,
+    url: s.url ?? '', apiKey: s.apiKey ?? '', enabled: s.enabled,
   }
 }
 
@@ -167,37 +146,272 @@ function formToPayload(f: McpFormState): Omit<McpServer, 'id'> {
     if (eq > 0) env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim()
   }
   return {
-    name: f.name.trim(),
-    transport: f.transport,
+    name: f.name.trim(), transport: f.transport,
     command: f.transport === 'stdio' ? f.command.trim() || undefined : undefined,
     args: f.transport === 'stdio' && args.length ? args : undefined,
     env: f.transport === 'stdio' && Object.keys(env).length ? env : undefined,
     url: f.transport === 'sse' ? f.url.trim() || undefined : undefined,
+    apiKey: f.transport === 'sse' && f.apiKey.trim() ? f.apiKey.trim() : undefined,
     enabled: f.enabled,
   }
 }
 
+// ── Brand helpers ─────────────────────────────────────────────────────────────
+
+function initials(name: string): string {
+  const parts = name.split(/\s+/)
+  return parts.length >= 2 ? (parts[0][0] + parts[1][0]).toUpperCase() : name.slice(0, 2).toUpperCase()
+}
+
+function nameColor(name: string): string {
+  const palette = ['#2563eb', '#7c3aed', '#db2777', '#dc2626', '#d97706', '#059669', '#0891b2']
+  let h = 0
+  for (const c of name) h = (h * 31 + c.charCodeAt(0)) & 0x7fffffff
+  return palette[h % palette.length]
+}
+
+// ── Card components ───────────────────────────────────────────────────────────
+
+function BrandCircle({ name, color, iconSlug }: { name: string; color: string; iconSlug?: string }) {
+  const icon = iconSlug ? BRAND_ICONS[iconSlug] : undefined
+  if (icon) {
+    return (
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+        style={{ background: `#${icon.hex}` }}>
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="#fff" aria-hidden="true">
+          <path d={icon.path} />
+        </svg>
+      </div>
+    )
+  }
+  return (
+    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-[12px] font-bold text-white"
+      style={{ background: color }}>
+      {initials(name)}
+    </div>
+  )
+}
+
+function AuthBadge({ auth }: { auth: CloudEntry['auth'] }) {
+  const label = auth === 'oauth' ? 'OAuth' : auth === 'key' ? 'API Key' : 'OAuth/Key'
+  const bg = auth === 'oauth'
+    ? 'color-mix(in srgb, #d97706 18%, transparent)'
+    : auth === 'key'
+    ? 'color-mix(in srgb, var(--ok) 18%, transparent)'
+    : 'color-mix(in srgb, var(--accent) 18%, transparent)'
+  const fg = auth === 'oauth' ? '#d97706' : auth === 'key' ? 'var(--ok)' : 'var(--accent)'
+  return (
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-medium" style={{ background: bg, color: fg }}>
+      {label}
+    </span>
+  )
+}
+
+function RuntimeBadge({ uvx }: { uvx?: boolean }) {
+  return (
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+      style={uvx
+        ? { background: 'color-mix(in srgb, #7c3aed 18%, transparent)', color: '#7c3aed' }
+        : { background: 'color-mix(in srgb, var(--accent) 18%, transparent)', color: 'var(--accent)' }}>
+      {uvx ? 'uvx' : 'npx'}
+    </span>
+  )
+}
+
+function BuiltinBadge() {
+  return (
+    <span className="rounded px-1.5 py-0.5 text-[10px] font-medium"
+      style={{ background: 'color-mix(in srgb, var(--ok) 18%, transparent)', color: 'var(--ok)' }}>
+      Built-in
+    </span>
+  )
+}
+
+function McpCard({ entry, tab, isSelected, isConnected, onSelect }: {
+  entry: CloudEntry | LocalEntry; tab: 'cloud' | 'local'; isSelected: boolean; isConnected?: boolean; onSelect: () => void
+}) {
+  const color = tab === 'cloud' ? (entry as CloudEntry).color : nameColor(entry.name)
+  return (
+    <button type="button" onClick={onSelect}
+      className="relative flex flex-col gap-2 rounded-lg border bg-panel-2 p-3 text-left transition-colors hover:bg-bg"
+      style={{ borderColor: isSelected ? 'var(--accent)' : isConnected ? 'color-mix(in srgb, var(--ok) 50%, transparent)' : 'var(--border, #e2e2e2)' }}>
+      {isConnected && (
+        <span className="absolute right-2 top-2 flex items-center gap-0.5 rounded px-1 py-0.5 text-[9px] font-semibold"
+          style={{ background: 'color-mix(in srgb, var(--ok) 15%, transparent)', color: 'var(--ok)' }}>
+          <Check size={8} /> Connected
+        </span>
+      )}
+      <div className="flex items-start gap-2.5">
+        <BrandCircle name={entry.name} color={color} iconSlug={entry.iconSlug} />
+        <div className="min-w-0 flex-1 pr-14">
+          <div className="truncate text-[13px] font-semibold text-ink">{entry.name}</div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-1">
+            <span className="text-[10px] text-faint">{entry.cat}</span>
+            <span className="text-[10px] text-faint">·</span>
+            {tab === 'cloud'
+              ? <AuthBadge auth={(entry as CloudEntry).auth} />
+              : (entry as LocalEntry).builtin
+              ? <BuiltinBadge />
+              : <RuntimeBadge uvx={(entry as LocalEntry).uvx} />}
+          </div>
+        </div>
+      </div>
+      <p className="text-[11px] leading-relaxed text-muted">{entry.desc}</p>
+    </button>
+  )
+}
+
+function McpCloudPanel({ entry, apiKey, onApiKeyChange, onClose, onConnect, busy }: {
+  entry: CloudEntry; apiKey: string; onApiKeyChange: (v: string) => void
+  onClose: () => void; onConnect: () => void; busy: boolean
+}) {
+  const needsKey = entry.auth !== 'oauth'
+  return (
+    <div className="mt-3 flex flex-col gap-3 rounded-lg border bg-panel-2 p-3"
+      style={{ borderColor: 'color-mix(in srgb, var(--accent) 40%, transparent)' }}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <BrandCircle name={entry.name} color={entry.color} iconSlug={entry.iconSlug} />
+          <span className="text-[13px] font-medium text-ink">Connect {entry.name}</span>
+        </div>
+        <button type="button" onClick={onClose} className="rounded p-1 text-faint transition-colors hover:text-ink">
+          <X size={13} />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] text-muted">Server URL</label>
+        <input type="text" value={entry.url} readOnly
+          className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-faint outline-none" />
+      </div>
+
+      {needsKey ? (
+        <div className="flex flex-col gap-1">
+          <label className="text-[12px] text-muted">API Key / Token</label>
+          <input type="password" value={apiKey} onChange={(e) => onApiKeyChange(e.target.value)}
+            placeholder="Paste your token here" autoComplete="off"
+            className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          {entry.keyNote && <p className="text-[11px] text-faint">{entry.keyNote}</p>}
+        </div>
+      ) : (
+        <p className="rounded-md border border-border bg-bg px-3 py-2 text-[12px] text-muted">
+          {entry.name} uses OAuth — add the server and authenticate via the provider developer console.
+          {entry.keyNote && <> {entry.keyNote}</>}
+        </p>
+      )}
+
+      <Button size="sm" onClick={onConnect} disabled={busy || (needsKey && !apiKey.trim())}>
+        {busy && <Loader2 size={13} className="animate-spin" />}
+        Add server
+      </Button>
+    </div>
+  )
+}
+
+function McpLocalPanel({ entry, extraArg, onExtraArgChange, envs, onEnvChange, onClose, onAdd, busy }: {
+  entry: LocalEntry; extraArg: string; onExtraArgChange: (v: string) => void
+  envs: Record<string, string>; onEnvChange: (k: string, v: string) => void
+  onClose: () => void; onAdd: () => void; busy: boolean
+}) {
+  const canAdd = entry.envs.filter((e) => e.required).every((e) => envs[e.key]?.trim())
+  return (
+    <div className="mt-3 flex flex-col gap-3 rounded-lg border bg-panel-2 p-3"
+      style={{ borderColor: 'color-mix(in srgb, var(--accent) 40%, transparent)' }}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <BrandCircle name={entry.name} color={nameColor(entry.name)} iconSlug={entry.iconSlug} />
+          <span className="text-[13px] font-medium text-ink">Add {entry.name}</span>
+        </div>
+        <button type="button" onClick={onClose} className="rounded p-1 text-faint transition-colors hover:text-ink">
+          <X size={13} />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] text-muted">Command</label>
+        <input type="text" value={entry.cmd} readOnly
+          className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-faint outline-none" />
+      </div>
+
+      {entry.argNote && (
+        <div className="flex flex-col gap-1">
+          <label className="text-[12px] text-muted">Argument</label>
+          <input type="text" value={extraArg} onChange={(e) => onExtraArgChange(e.target.value)}
+            placeholder="e.g. /path/to/directory"
+            className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          <p className="text-[11px] text-faint">{entry.argNote}</p>
+        </div>
+      )}
+
+      {entry.envs.map((ev) => (
+        <div key={ev.key} className="flex flex-col gap-1">
+          <label className="flex items-center gap-1 text-[12px] text-muted">
+            <span className="font-mono">{ev.key}</span>
+            {ev.required && <span className="text-[10px]" style={{ color: 'var(--err)' }}>required</span>}
+          </label>
+          <input type={ev.required ? 'password' : 'text'} value={envs[ev.key] ?? ''}
+            onChange={(e) => onEnvChange(ev.key, e.target.value)} placeholder={ev.desc} autoComplete="off"
+            className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+        </div>
+      ))}
+
+      {entry.uvx && (
+        <p className="rounded-md border border-border bg-bg px-3 py-2 text-[11px] text-muted">
+          Requires <span className="font-mono text-ink">uv</span> — install with{' '}
+          <span className="font-mono text-ink">pip install uv</span>.
+        </p>
+      )}
+
+      <Button size="sm" onClick={onAdd} disabled={busy || !canAdd}>
+        {busy && <Loader2 size={13} className="animate-spin" />}
+        Add server
+      </Button>
+    </div>
+  )
+}
+
+// ── McpSection ────────────────────────────────────────────────────────────────
+
 function McpSection({ servers }: { servers: McpServer[] }) {
   const mut = useMcpMutations()
+
   const [editingId, setEditingId] = useState<string | null>(null)
-  const [showForm, setShowForm] = useState(false)
   const [form, setForm] = useState<McpFormState>(emptyMcpForm())
+  const [view, setView] = useState<'marketplace' | 'manual' | 'edit'>('marketplace')
   const set = (patch: Partial<McpFormState>) => setForm((p) => ({ ...p, ...patch }))
 
-  const openAdd = () => { setEditingId(null); setForm(emptyMcpForm()); setShowForm(true) }
-  const openEdit = (s: McpServer) => { setEditingId(s.id); setForm(serverToForm(s)); setShowForm(true) }
-  const closeForm = () => { setShowForm(false); setEditingId(null) }
+  const [tab, setTab] = useState<'cloud' | 'local' | 'connected'>('cloud')
+  const [activeCat, setActiveCat] = useState('All')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [apiKey, setApiKey] = useState('')
+  const [extraArg, setExtraArg] = useState('')
+  const [localEnvs, setLocalEnvs] = useState<Record<string, string>>({})
+
+  const connectedUrls = useMemo(() => new Set(servers.map((s) => s.url).filter(Boolean) as string[]), [servers])
+  const connectedNames = useMemo(() => new Set(servers.map((s) => s.name)), [servers])
+  const isCatalogConnected = (entry: CloudEntry | LocalEntry) =>
+    'url' in entry ? connectedUrls.has((entry as CloudEntry).url) : connectedNames.has(entry.name)
+
+  const selectCard = (id: string | null) => { setSelectedId(id); setApiKey(''); setExtraArg(''); setLocalEnvs({}) }
+  const switchTab = (t: 'cloud' | 'local' | 'connected') => { setTab(t); setActiveCat('All'); selectCard(null) }
+
+  const cats = tab === 'cloud' ? CLOUD_CATS : LOCAL_CATS
+  const filtered = (tab === 'cloud' ? CLOUD_MCPS : LOCAL_MCPS)
+    .filter((e) => activeCat === 'All' || e.cat === activeCat)
+
+  const openEdit = (s: McpServer) => { setEditingId(s.id); setForm(serverToForm(s)); setView('edit') }
 
   const handleSubmit = () => {
     const payload = formToPayload(form)
     if (!payload.name) return void toast.error('Server name is required.')
-    if (payload.transport === 'stdio' && !payload.command) return void toast.error('Command is required for stdio transport.')
-    if (payload.transport === 'sse' && !payload.url) return void toast.error('URL is required for SSE transport.')
+    if (payload.transport === 'stdio' && !payload.command) return void toast.error('Command is required.')
+    if (payload.transport === 'sse' && !payload.url) return void toast.error('URL is required.')
+    const isEdit = view === 'edit' && editingId
     const opts = {
-      onSuccess: () => { toast.success(editingId ? 'MCP server updated' : 'MCP server added'); closeForm() },
+      onSuccess: () => { toast.success(isEdit ? 'MCP server updated' : 'MCP server added'); setView('marketplace'); setEditingId(null) },
       onError: (e: unknown) => toast.error(e instanceof ApiError ? e.message : 'Could not save server.'),
     }
-    if (editingId) mut.update.mutate({ id: editingId, patch: payload }, opts)
+    if (isEdit) mut.update.mutate({ id: editingId, patch: payload }, opts)
     else mut.add.mutate(payload, opts)
   }
 
@@ -213,174 +427,249 @@ function McpSection({ servers }: { servers: McpServer[] }) {
     })
   }
 
-  const f = form
+  const connectCloud = (entry: CloudEntry) => {
+    mut.add.mutate({
+      name: entry.name, transport: 'sse', url: entry.url, enabled: true,
+      ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+    }, {
+      onSuccess: () => { toast.success(`${entry.name} connected`); selectCard(null) },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not add server.'),
+    })
+  }
+
+  const connectLocal = (entry: LocalEntry) => {
+    const cmd = extraArg.trim() ? `${entry.cmd} ${extraArg.trim()}` : entry.cmd
+    const env: Record<string, string> = {}
+    for (const [k, v] of Object.entries(localEnvs)) { if (v.trim()) env[k] = v.trim() }
+    for (const e of entry.envs) {
+      if (e.required && !env[e.key]) return void toast.error(`${e.key} is required.`)
+    }
+    mut.add.mutate({
+      name: entry.name, transport: 'stdio', command: cmd, enabled: true,
+      ...(Object.keys(env).length ? { env } : {}),
+    }, {
+      onSuccess: () => { toast.success(`${entry.name} added`); selectCard(null) },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not add server.'),
+    })
+  }
+
   const busy = mut.add.isPending || mut.update.isPending
+  const f = form
+  const selectedCloud = tab === 'cloud' ? CLOUD_MCPS.find((e) => e.id === selectedId) : undefined
+  const selectedLocal = tab === 'local' ? LOCAL_MCPS.find((e) => e.id === selectedId) : undefined
+
+  const renderFormFields = () => (
+    <>
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] text-muted">Name</label>
+        <input type="text" value={f.name} onChange={(e) => set({ name: e.target.value })}
+          placeholder="My Tool Server"
+          className="rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-ink outline-none" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-[12px] text-muted">Transport</label>
+        <div className="flex gap-4">
+          {(['stdio', 'sse'] as const).map((t) => (
+            <label key={t} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
+              <input type="radio" name="mcp-transport" checked={f.transport === t}
+                onChange={() => set({ transport: t })} className="h-3.5 w-3.5 accent-[var(--accent)]" />
+              <span className="font-mono">{t}</span>
+              <span className="text-[11px] text-faint">{t === 'stdio' ? '(subprocess)' : '(HTTP)'}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {f.transport === 'stdio' ? (
+        <>
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Command</label>
+            <input type="text" value={f.command} onChange={(e) => set({ command: e.target.value })}
+              placeholder="npx -y @modelcontextprotocol/server-filesystem"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Args <span className="text-faint">(comma-separated, optional)</span></label>
+            <input type="text" value={f.argsStr} onChange={(e) => set({ argsStr: e.target.value })}
+              placeholder="--port, 3000"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">Env vars <span className="text-faint">(KEY=VALUE, one per line, optional)</span></label>
+            <textarea rows={2} value={f.envStr} onChange={(e) => set({ envStr: e.target.value })}
+              placeholder={"API_KEY=abc123\nDEBUG=true"}
+              className="resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">URL</label>
+            <input type="text" value={f.url} onChange={(e) => set({ url: e.target.value })}
+              placeholder="http://localhost:3000"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-[12px] text-muted">API Key <span className="text-faint">(optional — Bearer token)</span></label>
+            <input type="password" value={f.apiKey} onChange={(e) => set({ apiKey: e.target.value })}
+              placeholder="sk-…" autoComplete="off"
+              className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+          </div>
+        </>
+      )}
+
+      <label className="flex cursor-pointer items-center gap-2 text-[13px] text-ink">
+        <input type="checkbox" checked={f.enabled} onChange={(e) => set({ enabled: e.target.checked })}
+          className="h-3.5 w-3.5 accent-[var(--accent)]" />
+        Enable immediately
+      </label>
+    </>
+  )
 
   return (
     <section className="rounded-lg border border-border bg-panel p-4">
       <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">MCP Servers</h2>
       <p className="mb-3 text-[12px] text-muted">
-        Connect external tool providers via the Model Context Protocol. Supports stdio (subprocess)
-        and SSE (HTTP) transports per the MCP 2024-11-05 spec.
+        Connect external tool providers via the Model Context Protocol.
       </p>
 
-      {servers.length > 0 && (
-        <div className="mb-3 flex flex-col gap-1.5">
-          {servers.map((s) => (
-            <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
-              <span
-                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
-                style={{
-                  background: s.transport === 'sse'
-                    ? 'color-mix(in srgb, var(--accent) 15%, transparent)'
-                    : 'color-mix(in srgb, var(--muted) 20%, transparent)',
-                  color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
-                }}
-              >
-                {s.transport}
-              </span>
-              <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
-              <span
-                className="hidden shrink-0 max-w-[220px] truncate font-mono text-[11px] text-faint sm:block"
-                title={s.transport === 'stdio' ? s.command : s.url}
-              >
-                {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
-              </span>
-              <input
-                type="checkbox"
-                checked={s.enabled}
-                onChange={() => handleToggle(s)}
-                title={s.enabled ? 'Disable' : 'Enable'}
-                className="h-3.5 w-3.5 accent-[var(--accent)]"
-              />
-              <button
-                type="button"
-                onClick={() => openEdit(s)}
-                title="Edit"
-                className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink"
-              >
-                <Pencil size={12} />
-              </button>
-              <button
-                type="button"
-                onClick={() => handleDelete(s.id, s.name)}
-                title="Delete"
-                className="rounded p-1 transition-colors hover:bg-bg"
-                style={{ color: 'var(--err)' }}
-              >
-                <Trash2 size={12} />
-              </button>
-            </div>
-          ))}
+
+      {view === 'edit' && (
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-panel-2 p-3">
+          <div className="text-[13px] font-medium text-ink">Edit server</div>
+          {renderFormFields()}
+          <div className="flex gap-2">
+            <Button size="sm" onClick={handleSubmit} disabled={busy}>
+              {busy && <Loader2 size={13} className="animate-spin" />}
+              Update
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => { setView('marketplace'); setEditingId(null) }}>Cancel</Button>
+          </div>
         </div>
       )}
 
-      {!showForm ? (
-        <Button variant="outline" size="sm" onClick={openAdd}>
-          <Plus size={13} />
-          Add server
-        </Button>
-      ) : (
+      {view === 'manual' && (
         <div className="flex flex-col gap-3 rounded-lg border border-border bg-panel-2 p-3">
-          <div className="text-[13px] font-medium text-ink">{editingId ? 'Edit server' : 'Add server'}</div>
+          <div className="flex items-center gap-2">
+            <button type="button" onClick={() => setView('marketplace')}
+              className="rounded p-1 text-faint transition-colors hover:text-ink">
+              <ArrowLeft size={13} />
+            </button>
+            <div className="text-[13px] font-medium text-ink">Add server manually</div>
+          </div>
+          {renderFormFields()}
+          <div className="flex gap-2">
+            <Button size="sm" onClick={handleSubmit} disabled={busy}>
+              {busy && <Loader2 size={13} className="animate-spin" />}
+              Add
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => setView('marketplace')}>Cancel</Button>
+          </div>
+        </div>
+      )}
 
-          <div className="flex flex-col gap-1">
-            <label className="text-[12px] text-muted">Name</label>
-            <input
-              type="text"
-              value={f.name}
-              onChange={(e) => set({ name: e.target.value })}
-              placeholder="My Tool Server"
-              className="rounded-md border border-border bg-bg px-2 py-1.5 text-[13px] text-ink outline-none"
-            />
+      {view === 'marketplace' && (
+        <div>
+          <div className="mb-3 inline-flex rounded-md border border-border p-0.5">
+            {(['cloud', 'local', 'connected'] as const).map((t) => (
+              <button key={t} type="button" onClick={() => switchTab(t)}
+                className={`rounded px-3 py-1 text-[13px] capitalize transition-colors ${tab === t ? 'bg-bg text-ink' : 'text-muted hover:text-ink'}`}>
+                {t === 'connected' ? `Connected${servers.length > 0 ? ` (${servers.length})` : ''}` : t === 'cloud' ? 'Cloud' : 'Local'}
+              </button>
+            ))}
           </div>
 
-          <div className="flex flex-col gap-1">
-            <label className="text-[12px] text-muted">Transport</label>
-            <div className="flex gap-4">
-              {(['stdio', 'sse'] as const).map((t) => (
-                <label key={t} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
-                  <input
-                    type="radio"
-                    name="mcp-transport"
-                    checked={f.transport === t}
-                    onChange={() => set({ transport: t })}
-                    className="h-3.5 w-3.5 accent-[var(--accent)]"
-                  />
-                  <span className="font-mono">{t}</span>
-                  <span className="text-[11px] text-faint">{t === 'stdio' ? '(subprocess)' : '(HTTP)'}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {f.transport === 'stdio' ? (
+          {tab !== 'connected' && (
             <>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">Command</label>
-                <input
-                  type="text"
-                  value={f.command}
-                  onChange={(e) => set({ command: e.target.value })}
-                  placeholder="npx -y @modelcontextprotocol/server-filesystem"
-                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
+              <div className="mb-3 flex flex-wrap gap-1.5">
+                {cats.map((cat) => (
+                  <button key={cat} type="button" onClick={() => { setActiveCat(cat); selectCard(null) }}
+                    className="rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors"
+                    style={activeCat === cat
+                      ? { background: 'var(--accent)', color: '#fff' }
+                      : { background: 'color-mix(in srgb, var(--muted) 12%, transparent)', color: 'var(--muted)' }}>
+                    {cat}
+                  </button>
+                ))}
               </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">
-                  Args <span className="text-faint">(comma-separated, optional)</span>
-                </label>
-                <input
-                  type="text"
-                  value={f.argsStr}
-                  onChange={(e) => set({ argsStr: e.target.value })}
-                  placeholder="--port, 3000"
-                  className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
+
+              <div className="grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(185px, 1fr))' }}>
+                {filtered.map((entry) => (
+                  <McpCard key={entry.id} entry={entry} tab={tab as 'cloud' | 'local'}
+                    isSelected={selectedId === entry.id}
+                    isConnected={isCatalogConnected(entry)}
+                    onSelect={() => selectCard(selectedId === entry.id ? null : entry.id)} />
+                ))}
               </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-[12px] text-muted">
-                  Env vars <span className="text-faint">(KEY=VALUE, one per line, optional)</span>
-                </label>
-                <textarea
-                  rows={2}
-                  value={f.envStr}
-                  onChange={(e) => set({ envStr: e.target.value })}
-                  placeholder={"API_KEY=abc123\nDEBUG=true"}
-                  className="resize-none rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-                />
-              </div>
+
+              {selectedCloud && (
+                <McpCloudPanel entry={selectedCloud} apiKey={apiKey} onApiKeyChange={setApiKey}
+                  onClose={() => selectCard(null)} onConnect={() => connectCloud(selectedCloud)} busy={busy} />
+              )}
+              {selectedLocal && !selectedLocal.builtin && (
+                <McpLocalPanel entry={selectedLocal} extraArg={extraArg} onExtraArgChange={setExtraArg}
+                  envs={localEnvs} onEnvChange={(k, v) => setLocalEnvs((p) => ({ ...p, [k]: v }))}
+                  onClose={() => selectCard(null)} onAdd={() => connectLocal(selectedLocal)} busy={busy} />
+              )}
+              {selectedLocal?.builtin && (
+                <div className="mt-3 flex items-start gap-2.5 rounded-lg border bg-panel-2 p-3"
+                  style={{ borderColor: 'color-mix(in srgb, var(--ok) 40%, transparent)' }}>
+                  <Check size={13} className="mt-0.5 shrink-0" style={{ color: 'var(--ok)' }} />
+                  <p className="text-[12px] text-muted">
+                    <span className="font-medium text-ink">{selectedLocal.name}</span> is built in to TurboLLM — no separate server needed.
+                    Configure it in <span className="font-medium text-ink">Web Search</span> settings above.
+                  </p>
+                  <button type="button" onClick={() => selectCard(null)} className="ml-auto rounded p-1 text-faint hover:text-ink">
+                    <X size={13} />
+                  </button>
+                </div>
+              )}
             </>
-          ) : (
-            <div className="flex flex-col gap-1">
-              <label className="text-[12px] text-muted">URL</label>
-              <input
-                type="text"
-                value={f.url}
-                onChange={(e) => set({ url: e.target.value })}
-                placeholder="http://localhost:3000"
-                className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none"
-              />
+          )}
+
+          {tab === 'connected' && (
+            <div className="flex flex-col gap-1.5">
+              {servers.length === 0 ? (
+                <p className="py-8 text-center text-[12px] text-muted">
+                  No MCP servers connected yet. Add one from the Cloud or Local tab.
+                </p>
+              ) : (
+                servers.map((s) => (
+                  <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
+                    <span className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
+                      style={{
+                        background: s.transport === 'sse' ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'color-mix(in srgb, var(--muted) 20%, transparent)',
+                        color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
+                      }}>
+                      {s.transport}
+                    </span>
+                    <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
+                    <span className="hidden max-w-[220px] shrink-0 truncate font-mono text-[11px] text-faint sm:block"
+                      title={s.transport === 'stdio' ? s.command : s.url}>
+                      {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
+                    </span>
+                    <input type="checkbox" checked={s.enabled} onChange={() => handleToggle(s)}
+                      title={s.enabled ? 'Disable' : 'Enable'} className="h-3.5 w-3.5 accent-[var(--accent)]" />
+                    <button type="button" onClick={() => openEdit(s)} title="Edit"
+                      className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink">
+                      <Pencil size={12} />
+                    </button>
+                    <button type="button" onClick={() => handleDelete(s.id, s.name)} title="Delete"
+                      className="rounded p-1 transition-colors hover:bg-bg" style={{ color: 'var(--err)' }}>
+                      <Trash2 size={12} />
+                    </button>
+                  </div>
+                ))
+              )}
             </div>
           )}
 
-          <label className="flex cursor-pointer items-center gap-2 text-[13px] text-ink">
-            <input
-              type="checkbox"
-              checked={f.enabled}
-              onChange={(e) => set({ enabled: e.target.checked })}
-              className="h-3.5 w-3.5 accent-[var(--accent)]"
-            />
-            Enable immediately
-          </label>
-
-          <div className="flex gap-2">
-            <Button size="sm" onClick={handleSubmit} disabled={busy}>
-              {busy ? <Loader2 size={13} className="animate-spin" /> : null}
-              {editingId ? 'Update' : 'Add'}
-            </Button>
-            <Button variant="outline" size="sm" onClick={closeForm}>Cancel</Button>
-          </div>
+          <button type="button"
+            onClick={() => { setView('manual'); setForm(emptyMcpForm()); setEditingId(null) }}
+            className="mt-4 flex items-center gap-1 text-[12px] text-faint transition-colors hover:text-ink">
+            Add server manually <ChevronRight size={11} />
+          </button>
         </div>
       )}
     </section>

--- a/turbollm/web/src/screens/CustomizeScreen.tsx
+++ b/turbollm/web/src/screens/CustomizeScreen.tsx
@@ -5,7 +5,7 @@ import { Button } from '../components/ui/button'
 import { toast } from '../components/ui/sonner'
 import { useMcpMutations, useSettings } from '../lib/queries'
 import { ApiError } from '../lib/api'
-import type { McpServer, DaemonSettings, DaemonSettingsPatch, SearchProvider } from '../lib/api'
+import type { McpServer, DaemonSettings, DaemonSettingsPatch } from '../lib/api'
 import { CLOUD_MCPS, LOCAL_MCPS, CLOUD_CATS, LOCAL_CATS } from '../lib/mcp-catalog'
 import type { CloudEntry, LocalEntry } from '../lib/mcp-catalog'
 import { BRAND_ICONS } from '../lib/brand-icons'
@@ -20,100 +20,11 @@ export function CustomizeScreen() {
         title="Customize"
         description="Add tools and external providers the model can call during conversations."
       />
-      <div className="flex flex-col gap-6">
-        <ToolsSection
-          search={settings?.search ?? { provider: 'tavily', tavilyKeySet: false, kagiKeySet: false, searxngUrl: '' }}
-          onSaved={() => void settingsQ.refetch()}
-        />
-        <McpSection servers={settings?.mcp?.servers ?? []} />
-      </div>
+      <McpSection
+        servers={settings?.mcp?.servers ?? []}
+        search={settings?.search ?? { provider: 'tavily', tavilyKeySet: false, kagiKeySet: false, searxngUrl: '' }}
+      />
     </div>
-  )
-}
-
-// ── Tools — web search provider ───────────────────────────────────────────────
-
-type ProviderMeta = { id: SearchProvider; label: string; blurb: string; getKey?: string }
-const PROVIDERS: ProviderMeta[] = [
-  { id: 'tavily', label: 'Tavily', blurb: 'AI-search API tuned for LLMs. Reliable default.', getKey: 'https://app.tavily.com' },
-  { id: 'kagi', label: 'Kagi', blurb: 'Premium search, no bot-blocking, no tracking ($0.012/query).', getKey: 'https://kagi.com/settings?p=api' },
-  { id: 'searxng', label: 'SearXNG', blurb: 'Your own self-hosted meta-search. Fully local — no key, just a URL.' },
-]
-
-function ToolsSection({ search, onSaved }: { search: DaemonSettings['search']; onSaved: () => void }) {
-  const { save } = useSettings()
-  const [provider, setProvider] = useState<SearchProvider>(search.provider)
-  const [secret, setSecret] = useState('')
-
-  const meta = PROVIDERS.find((p) => p.id === provider)!
-  const isUrl = provider === 'searxng'
-  const configured = provider === 'tavily' ? search.tavilyKeySet : provider === 'kagi' ? search.kagiKeySet : !!search.searxngUrl
-
-  const pick = (p: SearchProvider) => { setProvider(p); setSecret(p === 'searxng' ? search.searxngUrl : '') }
-
-  const handleSave = () => {
-    const v = secret.trim()
-    const patch: DaemonSettingsPatch['search'] = { provider }
-    if (isUrl) patch.searxngUrl = v
-    else if (v && provider === 'tavily') patch.tavilyApiKey = v
-    else if (v && provider === 'kagi') patch.kagiApiKey = v
-    save.mutate({ search: patch }, {
-      onSuccess: () => { toast.success(`Search set to ${meta.label}${v ? ` — ${isUrl ? 'URL' : 'key'} saved` : ''}`); if (!isUrl) setSecret(''); onSaved() },
-      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save search settings.'),
-    })
-  }
-
-  return (
-    <section className="rounded-lg border border-border bg-panel p-4">
-      <h2 className="mb-1 text-[13px] font-semibold uppercase tracking-wide text-faint">Web Search</h2>
-      <p className="mb-3 text-[12px] text-muted">
-        Choose a search provider. When one is configured, the model can call the{' '}
-        <span className="font-mono text-ink">web_search</span> tool automatically.
-      </p>
-
-      <div className="mb-3 inline-flex rounded-md border border-border p-0.5">
-        {PROVIDERS.map((p) => (
-          <button key={p.id} onClick={() => pick(p.id)}
-            className={`rounded px-3 py-1 text-[13px] transition-colors ${provider === p.id ? 'bg-bg text-ink' : 'text-muted hover:text-ink'}`}>
-            {p.label}
-          </button>
-        ))}
-      </div>
-
-      <p className="mb-2 text-[12px] text-muted">
-        {meta.blurb}{' '}
-        {meta.getKey && (
-          <a href={meta.getKey} target="_blank" rel="noopener noreferrer" className="text-ink underline-offset-2 hover:underline">
-            Get a key
-          </a>
-        )}
-      </p>
-
-      <div className="mb-2 text-[13px] text-muted">
-        {configured ? (
-          <span className="inline-flex items-center gap-1.5 text-ink">
-            <Check size={13} style={{ color: 'var(--ok)' }} /> {isUrl ? 'A URL is configured' : 'A key is configured'}
-          </span>
-        ) : isUrl ? 'No URL configured' : 'No key configured'}
-      </div>
-
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <input
-          type={isUrl ? 'text' : 'password'}
-          value={secret}
-          onChange={(e) => setSecret(e.target.value)}
-          placeholder={isUrl ? 'http://localhost:8888' : configured ? 'Enter a new key to replace the current one' : provider === 'tavily' ? 'tvly-…' : 'Kagi API key'}
-          autoComplete="off"
-          className="flex-1 rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[13px] text-ink outline-none"
-        />
-        <Button size="sm" onClick={handleSave} disabled={save.isPending}>Save</Button>
-      </div>
-
-      <p className="mt-3 text-[12px] text-faint">
-        <span className="font-mono text-ink">fetch_url</span> and{' '}
-        <span className="font-mono text-ink">run_code</span> (sandboxed JS) are always available — no key needed.
-      </p>
-    </section>
   )
 }
 
@@ -372,7 +283,7 @@ function McpLocalPanel({ entry, extraArg, onExtraArgChange, envs, onEnvChange, o
 
 // ── McpSection ────────────────────────────────────────────────────────────────
 
-function McpSection({ servers }: { servers: McpServer[] }) {
+function McpSection({ servers, search }: { servers: McpServer[]; search: DaemonSettings['search'] }) {
   const mut = useMcpMutations()
 
   const [editingId, setEditingId] = useState<string | null>(null)
@@ -386,6 +297,11 @@ function McpSection({ servers }: { servers: McpServer[] }) {
   const [apiKey, setApiKey] = useState('')
   const [extraArg, setExtraArg] = useState('')
   const [localEnvs, setLocalEnvs] = useState<Record<string, string>>({})
+  const [searchProvider, setSearchProvider] = useState<NonNullable<DaemonSettings['search']>['provider']>(search.provider)
+  const [searchSecret, setSearchSecret] = useState(() => {
+    const s = search
+    return s.provider === 'tavily' ? '' : s.provider === 'kagi' ? '' : s.searxngUrl
+  })
 
   const connectedUrls = useMemo(() => new Set(servers.map((s) => s.url).filter(Boolean) as string[]), [servers])
   const connectedNames = useMemo(() => new Set(servers.map((s) => s.name)), [servers])
@@ -427,6 +343,22 @@ function McpSection({ servers }: { servers: McpServer[] }) {
     })
   }
 
+  const { save } = useSettings()
+  const saveSearch = (provider: NonNullable<DaemonSettings['search']>['provider'], secret: string) => {
+    const patch: DaemonSettingsPatch['search'] = { provider }
+    if (provider === 'searxng') patch.searxngUrl = secret
+    else if (secret.trim()) patch[provider === 'tavily' ? 'tavilyApiKey' : 'kagiApiKey'] = secret
+    save.mutate({ search: patch }, {
+      onSuccess: () => {
+        const displayName = provider === 'tavily' ? 'Tavily' : provider === 'kagi' ? 'Kagi' : 'SearXNG'
+        toast.success(`Search set to ${displayName}`)
+        setSearchSecret('')
+        selectCard(null)
+      },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save search settings.'),
+    })
+  }
+
   const connectCloud = (entry: CloudEntry) => {
     mut.add.mutate({
       name: entry.name, transport: 'sse', url: entry.url, enabled: true,
@@ -438,14 +370,15 @@ function McpSection({ servers }: { servers: McpServer[] }) {
   }
 
   const connectLocal = (entry: LocalEntry) => {
-    const cmd = extraArg.trim() ? `${entry.cmd} ${extraArg.trim()}` : entry.cmd
+    const fullCmd = extraArg.trim() ? `${entry.cmd} ${extraArg.trim()}` : entry.cmd
+    const [command, ...args] = fullCmd.trim().split(/\s+/)
     const env: Record<string, string> = {}
     for (const [k, v] of Object.entries(localEnvs)) { if (v.trim()) env[k] = v.trim() }
     for (const e of entry.envs) {
       if (e.required && !env[e.key]) return void toast.error(`${e.key} is required.`)
     }
     mut.add.mutate({
-      name: entry.name, transport: 'stdio', command: cmd, enabled: true,
+      name: entry.name, transport: 'stdio', command, args: args.length ? args : undefined, enabled: true,
       ...(Object.keys(env).length ? { env } : {}),
     }, {
       onSuccess: () => { toast.success(`${entry.name} added`); selectCard(null) },
@@ -613,54 +546,104 @@ function McpSection({ servers }: { servers: McpServer[] }) {
                   onClose={() => selectCard(null)} onAdd={() => connectLocal(selectedLocal)} busy={busy} />
               )}
               {selectedLocal?.builtin && (
-                <div className="mt-3 flex items-start gap-2.5 rounded-lg border bg-panel-2 p-3"
-                  style={{ borderColor: 'color-mix(in srgb, var(--ok) 40%, transparent)' }}>
-                  <Check size={13} className="mt-0.5 shrink-0" style={{ color: 'var(--ok)' }} />
-                  <p className="text-[12px] text-muted">
-                    <span className="font-medium text-ink">{selectedLocal.name}</span> is built in to TurboLLM — no separate server needed.
-                    Configure it in <span className="font-medium text-ink">Web Search</span> settings above.
-                  </p>
-                  <button type="button" onClick={() => selectCard(null)} className="ml-auto rounded p-1 text-faint hover:text-ink">
-                    <X size={13} />
-                  </button>
+                <div className="mt-3 flex flex-col gap-3 rounded-lg border bg-panel-2 p-3"
+                  style={{ borderColor: 'color-mix(in srgb, var(--accent) 40%, transparent)' }}>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <BrandCircle name={selectedLocal.name} color={nameColor(selectedLocal.name)} iconSlug={(selectedLocal as LocalEntry).iconSlug} />
+                      <span className="text-[13px] font-medium text-ink">Configure {selectedLocal.name}</span>
+                    </div>
+                    <button type="button" onClick={() => selectCard(null)} className="rounded p-1 text-faint transition-colors hover:text-ink">
+                      <X size={13} />
+                    </button>
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <label className="text-[12px] text-muted">Provider</label>
+                    <div className="flex gap-4">
+                      {(['tavily', 'kagi', 'searxng'] as const).map((p) => (
+                        <label key={p} className="flex cursor-pointer items-center gap-1.5 text-[13px] text-ink">
+                          <input type="radio" name="search-provider" checked={searchProvider === p}
+                            onChange={() => setSearchProvider(p)} className="h-3.5 w-3.5 accent-[var(--accent)]" />
+                          <span className="font-mono">{p === 'tavily' ? 'Tavily' : p === 'kagi' ? 'Kagi' : 'SearXNG'}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  {searchProvider === 'searxng' ? (
+                    <div className="flex flex-col gap-1">
+                      <label className="text-[12px] text-muted">SearXNG URL</label>
+                      <input type="text" value={searchSecret} onChange={(e) => setSearchSecret(e.target.value)}
+                        placeholder="http://localhost:8080"
+                        className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-1">
+                      <label className="text-[12px] text-muted">{searchProvider === 'tavily' ? 'Tavily' : 'Kagi'} API Key</label>
+                      <input type="password" value={searchSecret} onChange={(e) => setSearchSecret(e.target.value)}
+                        placeholder={searchProvider === 'tavily' ? 'tvly-…' : 'kg-…'} autoComplete="off"
+                        className="rounded-md border border-border bg-bg px-2 py-1.5 font-mono text-[12px] text-ink outline-none" />
+                    </div>
+                  )}
+
+                  <Button size="sm" onClick={() => saveSearch(searchProvider, searchSecret)} disabled={!searchSecret.trim()}>
+                    Save search settings
+                  </Button>
                 </div>
               )}
             </>
           )}
 
           {tab === 'connected' && (
-            <div className="flex flex-col gap-1.5">
+            <div>
               {servers.length === 0 ? (
                 <p className="py-8 text-center text-[12px] text-muted">
                   No MCP servers connected yet. Add one from the Cloud or Local tab.
                 </p>
               ) : (
-                servers.map((s) => (
-                  <div key={s.id} className="flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2">
-                    <span className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
-                      style={{
-                        background: s.transport === 'sse' ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'color-mix(in srgb, var(--muted) 20%, transparent)',
-                        color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
-                      }}>
-                      {s.transport}
-                    </span>
-                    <span className="flex-1 truncate text-[13px] font-medium text-ink">{s.name}</span>
-                    <span className="hidden max-w-[220px] shrink-0 truncate font-mono text-[11px] text-faint sm:block"
-                      title={s.transport === 'stdio' ? s.command : s.url}>
-                      {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
-                    </span>
-                    <input type="checkbox" checked={s.enabled} onChange={() => handleToggle(s)}
-                      title={s.enabled ? 'Disable' : 'Enable'} className="h-3.5 w-3.5 accent-[var(--accent)]" />
-                    <button type="button" onClick={() => openEdit(s)} title="Edit"
-                      className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink">
-                      <Pencil size={12} />
-                    </button>
-                    <button type="button" onClick={() => handleDelete(s.id, s.name)} title="Delete"
-                      className="rounded p-1 transition-colors hover:bg-bg" style={{ color: 'var(--err)' }}>
-                      <Trash2 size={12} />
-                    </button>
-                  </div>
-                ))
+                <div className="grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(185px, 1fr))' }}>
+                  {servers.map((s) => (
+                    <div key={s.id} className="relative flex flex-col gap-2 rounded-lg border bg-panel-2 p-3">
+                      <div className="flex items-start gap-2.5">
+                        <BrandCircle name={s.name} color={nameColor(s.name)} />
+                        <div className="min-w-0 flex-1 pr-14">
+                          <div className="truncate text-[13px] font-semibold text-ink">{s.name}</div>
+                          <div className="mt-0.5 flex flex-wrap items-center gap-1">
+                            <span className="rounded px-1.5 py-0.5 font-mono text-[10px] font-medium"
+                              style={{
+                                background: s.transport === 'sse' ? 'color-mix(in srgb, var(--accent) 15%, transparent)' : 'color-mix(in srgb, var(--muted) 20%, transparent)',
+                                color: s.transport === 'sse' ? 'var(--accent)' : 'var(--muted)',
+                              }}>
+                              {s.transport}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <span className="hidden max-w-[220px] shrink-0 truncate font-mono text-[11px] text-faint sm:block"
+                        title={s.transport === 'stdio' ? s.command : s.url}>
+                        {s.transport === 'stdio' ? s.command?.split(/[\\/]/).slice(-1)[0] : s.url}
+                      </span>
+                      <div className="flex items-center gap-2 pt-1">
+                        <label className="flex cursor-pointer items-center gap-1.5 text-[12px] text-ink">
+                          <input type="checkbox" checked={s.enabled} onChange={() => handleToggle(s)}
+                            className="h-3.5 w-3.5 accent-[var(--accent)]" />
+                          <span className="text-[11px]">{s.enabled ? 'Enabled' : 'Disabled'}</span>
+                        </label>
+                        <div className="ml-auto flex gap-1">
+                          <button type="button" onClick={() => openEdit(s)} title="Edit"
+                            className="rounded p-1 text-faint transition-colors hover:bg-bg hover:text-ink">
+                            <Pencil size={12} />
+                          </button>
+                          <button type="button" onClick={() => handleDelete(s.id, s.name)} title="Delete"
+                            className="rounded p-1 transition-colors hover:bg-bg" style={{ color: 'var(--err)' }}>
+                            <Trash2 size={12} />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
## v1.6.0 — MCP marketplace

Turns the Customize screen into a curated, one-click MCP marketplace.

### Added
- **MCP marketplace** (ADR-124): **Cloud** / **Local** / **Connected** tabs with brand logos (tree-shaken `simple-icons`) and one-click connect.
- **10 verified hosted MCPs** — each confirmed to connect with a static Bearer/API key against its official endpoint: GitHub, Linear, Stripe, Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, **Mixpanel** (ADR-125).
- **19 open-source local MCPs** (filesystem, memory, git, postgres, sqlite, playwright, puppeteer, docker, kubernetes, …) + the 3 built-in web-search providers as cards.
- Per-server API key injected as `Authorization: Bearer …`, **write-only** (never echoed by the API).

### Changed
- Web-search provider config moved inline into the MCP section's built-in cards.
- Connected MCP tools refresh **live** after add/edit/delete/toggle — no daemon restart.

### Fixed
- **Hosted MCPs actually connect**: legacy SSE handshake replaced with **Streamable HTTP** (MCP 2025-03-26).
- **Local MCPs spawn on Windows**: `npx`/`uvx` `.cmd` wrappers launched via shell; catalog cmd strings split into command + args.
- **Memory MCP zero-config**: `MEMORY_FILE_PATH` auto-set to `~/.turbollm/mcp-memory.jsonl`.
- Excluded services that can't connect with a static key (Notion, Figma, Sentry, Vercel, HubSpot, Amplitude, Slack — OAuth-only; Google Stitch — custom header + OAuth2-only; Motion — no confirmed endpoint).
- Removed a Node `DEP0190` deprecation warning from MCP subprocess spawning.

### Release prep
- `package.json` → 1.6.0, CHANGELOG dated section, README features + root mirror, Expert persona KB updated.

Verified: `tsc --noEmit` clean, web build clean. Tag + npm publish happen from `main` after merge per the release runbook.