### PR TITLE
fix(bench): auto-tune correctly preserves vision (mmproj) after tuning

### DIFF
--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -368,6 +368,11 @@ export class BenchRunner {
         recommended && hasAnySampling(recommended)
           ? { ...best.profile, sampling: { ...best.profile.sampling, ...recommended } }
           : best.profile
+      // Restore the vision (mmproj) toggle to what it was BEFORE tuning forced it off (line ~306).
+      // useMmproj:false there is a sweep-only trick to keep the projector off the GPU while probing
+      // offload — it must not leak into the saved profile, or a vision model silently loses image
+      // support after auto-tune (it's still a separate load-time toggle the user controls).
+      profile.useMmproj = resolved.useMmproj
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
       this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -298,12 +298,14 @@ export class BenchRunner {
     // ~24 with it off) and a load-time VRAM probe can't see that runtime cost. The offload + KV
     // choice here is for the base model; spec stays a separate load-time toggle, best left to the
     // user for when a model fits fully on the GPU.
-    // Also tune TEXT generation only: don't keep a vision projector (mmproj) resident on the GPU.
-    // For a vision model it can be 1–2 GB of VRAM that's idle during text gen but steals room from
-    // model layers — forcing more offload to the CPU and tanking t/s. Vision stays a separate load
-    // toggle; the offload/KV choice here is for the model's weights + KV.
+    // Tune WITH the vision projector (mmproj) exactly as the user has it configured (useMmproj /
+    // mmprojGpu come from `resolved`, untouched here). A vision model always loads with mmproj
+    // resident (see resolveProfile), so the offload search must account for its real VRAM
+    // footprint (~1-2 GB) — searching with it excluded would pick an offload that fits WITHOUT
+    // the projector, then load the projector on top of that afterward, eating into the
+    // VRAM_HEADROOM_MB safety margin the search thought it had (or spilling outright).
     const resolved = resolveProfile(entry, sys, saved, base, defaults)
-    const baseProfile: LoadProfile = { ...resolved, speculative: 'off', mtpHeadPath: '', draftModelPath: '', useMmproj: false }
+    const baseProfile: LoadProfile = { ...resolved, speculative: 'off', mtpHeadPath: '', draftModelPath: '' }
 
     const results: BenchCandidate[] = []
     let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
@@ -368,11 +370,6 @@ export class BenchRunner {
         recommended && hasAnySampling(recommended)
           ? { ...best.profile, sampling: { ...best.profile.sampling, ...recommended } }
           : best.profile
-      // Restore the vision (mmproj) toggle to what it was BEFORE tuning forced it off (line ~306).
-      // useMmproj:false there is a sweep-only trick to keep the projector off the GPU while probing
-      // offload — it must not leak into the saved profile, or a vision model silently loses image
-      // support after auto-tune (it's still a separate load-time toggle the user controls).
-      profile.useMmproj = resolved.useMmproj
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
       this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -95,7 +95,10 @@ async function cacheReadFromTimings(timingsJson: string): Promise<number> {
   const delta = events.find((e) => e.event === 'message_delta')
   assert.ok(delta, 'message_delta event must be emitted')
   const parsed = JSON.parse(delta!.data) as { usage: { input_tokens: number; cache_read_input_tokens: number } }
-  assert.equal(parsed.usage.input_tokens, 100)
+  // input_tokens is the NON-cached remainder (prompt_tokens 100 − cache 20), not the
+  // full prompt — Anthropic's usage fields are disjoint, so the cached prefix must not
+  // be counted in both input_tokens and cache_read_input_tokens.
+  assert.equal(parsed.usage.input_tokens, 80)
   return parsed.usage.cache_read_input_tokens
 }
 

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -378,9 +378,17 @@ export async function* streamToAnthropic(
       yield cbStop(blockIdx)
       blockIdx++
     }
+    // Anthropic usage fields are DISJOINT: the full prompt = input_tokens +
+    // cache_read_input_tokens + cache_creation_input_tokens, and clients (incl.
+    // Claude Code's context meter) sum them to size the context. llama.cpp's
+    // `prompt_tokens` is the WHOLE prompt (cached + uncached), so report only the
+    // non-cached remainder here — otherwise the cached prefix is counted twice and
+    // the meter balloons (e.g. an agentic 100k prompt that's ~95k cached would read
+    // as ~195k). Clamp at 0 in case cache_n ever exceeds prompt_tokens.
+    const nonCachedInput = Math.max(0, inputTokens - cacheReadTokens)
     yield sse('message_delta', {
       delta: { stop_reason: stopReason, stop_sequence: null },
-      usage: { input_tokens: inputTokens, output_tokens: outputTokens, cache_read_input_tokens: cacheReadTokens },
+      usage: { input_tokens: nonCachedInput, output_tokens: outputTokens, cache_read_input_tokens: cacheReadTokens },
     })
     yield sse('message_stop', {})
     // Best-effort session stats (B4): hand off the final usage. Never throws.

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -308,6 +308,14 @@ export function resolveProfile(
     gpu: { ...base.gpu, ...(saved?.gpu ?? {}), ...(overrides?.gpu ?? {}) },
     // vllm deep-merged for the same reason — old/partial profiles keep the defaults.
     vllm: { ...base.vllm, ...(saved?.vllm ?? {}), ...(overrides?.vllm ?? {}) },
+    // useMmproj has no UI control (only mmprojGpu — GPU-vs-CPU placement — is user-facing;
+    // see ModelDetailDialog's "Vision encoder on GPU" toggle), so there is no legitimate way
+    // for a saved profile or draft override to carry a meaningful `false` here. Forcing it to
+    // track the model's own vision capability makes it self-healing: any profile saved with a
+    // stale/incorrect useMmproj (e.g. auto-tune runs prior to the bench.ts fix that persisted
+    // false) is corrected on the very next resolve, for every user, with no reset/migration
+    // needed and no other tuned setting touched.
+    useMmproj: m.vision,
   }
 }
 

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -66,6 +66,11 @@ function NavRail({
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (!e.ctrlKey && !e.metaKey) return
+      // Only handle the digit keys 1–9. Non-digit keys (e.g. Ctrl+C, Ctrl+V)
+      // make parseInt return NaN; without this guard NaN slips past the range
+      // check below, calls preventDefault() (silently killing native copy/paste
+      // everywhere in the app) and then throws on NAV[NaN].
+      if (!/^[1-9]$/.test(e.key)) return
       const idx = parseInt(e.key, 10) - 1
       if (idx < 0 || idx >= NAV.length) return
       // Don't hijack number input in text fields / chat composer.


### PR DESCRIPTION
## Summary
- Auto-tune previously benchmarked vision models with the projector (mmproj) fully excluded, then restored it only on the saved winning profile — so the chosen offload never accounted for the projector's real VRAM footprint. Now the whole sweep runs with mmproj resident exactly as configured, so the picked offload genuinely has room for it.
- `resolveProfile` now forces `useMmproj` to track the model's own vision capability. It has no UI control (only `mmprojGpu`, GPU-vs-CPU placement, is user-facing), so a saved profile can never legitimately carry a meaningful `false` — this self-heals any profile poisoned by a prior (buggy) auto-tune run, for every user, without a reset or migration.
- Also includes two already-committed, previously unpushed fixes carried on this branch: the Anthropic usage double-counting fix (gateway) and the Ctrl+C/native-shortcut nav fix (web).

Fixes #31.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 503/503 passing (3 pre-existing skips)
- [x] Verified live against a real GPU box: auto-tuned a real vision model (Ornith 1.0 35B), confirmed the sweep now runs with mmproj resident, confirmed the saved profile keeps `useMmproj`/`mmprojGpu` correct after tuning, and confirmed a previously-poisoned saved profile (from a prior auto-tune run under the old bug) self-healed without losing any other tuned setting