### PR TITLE
v1.6.3 — download folder structure, mmproj, and multipart fixes

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1766,8 +1766,10 @@ export function registerApi(app: Hono, d: Deps): void {
   app.post('/api/v1/downloads', async (c) => {
     const b = await body<{ repo?: string; rfilename?: string; url?: string; size?: number; sha256?: string; subdir?: string }>(c)
     try {
-      const rec = d.downloads.enqueue(b)
-      return c.json(rec, 202)
+      // One request may fan out into several files (split shards + a shared mmproj) —
+      // return every record created so the UI reflects the full queued set.
+      const recs = await d.downloads.enqueue(b)
+      return c.json({ downloads: recs }, 202)
     } catch (e) {
       return dlErr(c, e)
     }

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -198,7 +198,12 @@ const hashes = new HashStore(store.dir())
 const db = new ConversationStore(store.dir())
 const hf = new HfClient(() => store.snapshot().hf.token, version)
 // A completed download triggers a rescan so the new model shows up in the library.
-const downloads = new DownloadManager(store, () => void scanner.rescan(), () => hf.authHeaders())
+const downloads = new DownloadManager(
+  store,
+  () => void scanner.rescan(),
+  () => hf.authHeaders(),
+  (repo, rfilename, rev) => hf.expandModelFiles(repo, rfilename, rev),
+)
 // Auto-benchmark + auto-tune runner (Differentiator #2, spec 09). Owns the engine
 // exclusively for a run; reuses manager/profile control rather than reimplementing it.
 const bench = new BenchRunner(manager, store, scanner, registry, version, hf)

--- a/turbollm/src/downloads/downloads.enqueue.test.ts
+++ b/turbollm/src/downloads/downloads.enqueue.test.ts
@@ -1,0 +1,320 @@
+// Tests for DownloadManager.enqueue fan-out + placement (spec 10 §3, §5):
+//  - HF repo downloads land in a per-repo <owner>/<name>/<model-subdir> folder,
+//  - a chosen GGUF expands into all shards + the mmproj (placed together),
+//  - an HF resolve URL is recognised, its revision honoured, path segments decoded,
+//  - files already in flight (same dest) are never enqueued twice,
+//  - a degenerate repo id is rejected rather than silently mis-placed.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { DownloadManager, DownloadError } from './downloads'
+import type { HfModelFiles } from '../hf/hf'
+
+/** Minimal ConfigStore stand-in: only the two members DownloadManager touches. */
+function fakeStore(modelDir: string, stateDir: string) {
+  return {
+    dir: () => stateDir,
+    snapshot: () => ({ primaryModelDir: modelDir, modelDirs: [modelDir] }),
+  } as unknown as ConstructorParameters<typeof DownloadManager>[0]
+}
+
+/** Freeze the background run(): fetch never resolves, so records stay 'downloading'
+ *  (deterministic for the dedup test) and no network I/O happens. enqueue() returns its
+ *  records before run() ever awaits fetch. A never-resolving promise keeps no OS handle,
+ *  so the test process still exits. */
+function stubFetch(): () => void {
+  const real = globalThis.fetch
+  globalThis.fetch = (() => new Promise(() => {})) as unknown as typeof fetch
+  return () => {
+    globalThis.fetch = real
+  }
+}
+
+function newDirs() {
+  const root = mkdtempSync(join(tmpdir(), 'tllm-dl-'))
+  const modelDir = join(root, 'models')
+  const stateDir = join(root, 'state')
+  mkdirSync(modelDir, { recursive: true })
+  mkdirSync(stateDir, { recursive: true })
+  return { modelDir, stateDir }
+}
+
+/** Poll until a record reaches a terminal status (the background run() finished). */
+async function waitTerminal(dm: DownloadManager, id: string) {
+  for (let i = 0; i < 100; i++) {
+    const r = dm.list().find((x) => x.id === id)
+    if (r && (r.status === 'done' || r.status === 'error' || r.status === 'cancelled')) return r
+    await new Promise((res) => setTimeout(res, 5))
+  }
+  throw new Error('timed out waiting for a terminal download status')
+}
+
+/** An expander that echoes the model's dir from the chosen rfilename (mirrors the real
+ *  one's placement contract) and appends any provided mmproj. */
+function echoExpand(extra: HfModelFiles['files'] = []) {
+  return async (_repo: string, rfilename: string): Promise<HfModelFiles> => ({
+    dir: dirname(rfilename) === '.' ? '' : dirname(rfilename),
+    files: [{ rfilename, size: 10, sha256: 'a', mmproj: false }, ...extra],
+  })
+}
+
+test('enqueue: HF repo file expands into shards + mmproj under <owner>/<name>', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const expand = async (): Promise<HfModelFiles> => ({
+      dir: '',
+      files: [
+        { rfilename: 'model-00001-of-00002.gguf', size: 10, sha256: 's1', mmproj: false },
+        { rfilename: 'model-00002-of-00002.gguf', size: 10, sha256: 's2', mmproj: false },
+        { rfilename: 'mmproj-F16.gguf', size: 5, sha256: 'p', mmproj: true },
+      ],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({ repo: 'unsloth/Qwen3-VL-GGUF', rfilename: 'model-00001-of-00002.gguf' })
+
+    assert.equal(recs.length, 3)
+    for (const r of recs) {
+      assert.equal(r.repo, 'unsloth/Qwen3-VL-GGUF')
+      assert.equal(r.dest, join(modelDir, 'unsloth', 'Qwen3-VL-GGUF', r.name))
+    }
+    assert.deepEqual(recs.map((r) => r.name).sort(), [
+      'mmproj-F16.gguf',
+      'model-00001-of-00002.gguf',
+      'model-00002-of-00002.gguf',
+    ])
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a per-quant subfolder is preserved under <owner>/<name>/<dir>', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const expand = async (): Promise<HfModelFiles> => ({
+      dir: 'Q4_K_M',
+      files: [
+        { rfilename: 'Q4_K_M/model-00001-of-00002.gguf', size: 10, mmproj: false },
+        { rfilename: 'Q4_K_M/model-00002-of-00002.gguf', size: 10, mmproj: false },
+        { rfilename: 'Q4_K_M/mmproj-F16.gguf', size: 5, mmproj: true },
+      ],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model-00001-of-00002.gguf' })
+
+    for (const r of recs) {
+      assert.equal(r.dest, join(modelDir, 'owner', 'repo', 'Q4_K_M', r.name))
+    }
+    // All in the same folder so the scanner groups shards + mmproj together.
+    const dirs = new Set(recs.map((r) => dirname(r.dest)))
+    assert.equal(dirs.size, 1)
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: an HF resolve URL honours the linked revision (not main) + decodes path', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    let seen: { repo: string; rfilename: string; rev?: string } | null = null
+    const expand = async (repo: string, rfilename: string, rev?: string): Promise<HfModelFiles> => {
+      seen = { repo, rfilename, rev }
+      return { dir: dirname(rfilename), files: [{ rfilename, size: 10, mmproj: false }] }
+    }
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({
+      url: 'https://huggingface.co/owner/repo/resolve/v2.0/sub%20dir/model.gguf',
+    })
+
+    assert.deepEqual(seen, { repo: 'owner/repo', rfilename: 'sub dir/model.gguf', rev: 'v2.0' })
+    assert.equal(recs.length, 1)
+    // Revision threaded into the download URL; space re-encoded per segment.
+    assert.equal(recs[0].url, 'https://huggingface.co/owner/repo/resolve/v2.0/sub%20dir/model.gguf')
+    assert.equal(recs[0].dest, join(modelDir, 'owner', 'repo', 'sub dir', 'model.gguf'))
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a /blob/ HF URL normalizes to resolve and gets the repo-download path', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    let called = false
+    const expand = async (repo: string, rfilename: string, rev?: string): Promise<HfModelFiles> => {
+      called = true
+      assert.equal(rev, 'main')
+      return echoExpand()(repo, rfilename)
+    }
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({ url: 'https://huggingface.co/owner/repo/blob/main/model.gguf' })
+
+    assert.ok(called, 'expansion should run for an HF blob URL')
+    assert.equal(recs[0].dest, join(modelDir, 'owner', 'repo', 'model.gguf'))
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a concurrent duplicate (same dest) is not enqueued twice', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), echoExpand())
+    const first = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model.gguf' })
+    assert.equal(first.length, 1)
+    // Second enqueue while the first is still in flight ('downloading') → skipped.
+    const second = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model.gguf' })
+    assert.equal(second.length, 0)
+    // No two live records share a dest.
+    const dests = dm.list().map((r) => r.dest)
+    assert.equal(new Set(dests).size, dests.length)
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: two quants sharing one mmproj do not double-enqueue the projector', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const mmproj = { rfilename: 'mmproj-F16.gguf', size: 5, mmproj: true as const }
+    const expand = async (_r: string, rfilename: string): Promise<HfModelFiles> => ({
+      dir: '',
+      files: [{ rfilename, size: 10, mmproj: false }, mmproj],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    await dm.enqueue({ repo: 'owner/repo', rfilename: 'model-Q4_K_M.gguf' })
+    const second = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model-Q8_0.gguf' })
+
+    // The projector is already in flight from the first download → not re-added.
+    assert.deepEqual(second.map((r) => r.name), ['model-Q8_0.gguf'])
+    const mmprojRecs = dm.list().filter((r) => r.name === 'mmproj-F16.gguf')
+    assert.equal(mmprojRecs.length, 1)
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: an already-present, size-matching mmproj is skipped; a mismatched one re-downloads', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const repoDir = join(modelDir, 'owner', 'repo')
+    mkdirSync(repoDir, { recursive: true })
+    // Complete projector on disk (size 5 matches the tree's size).
+    writeFileSync(join(repoDir, 'mmproj-F16.gguf'), 'xxxxx')
+
+    const expand = async (_r: string, rfilename: string): Promise<HfModelFiles> => ({
+      dir: '',
+      files: [
+        { rfilename, size: 10, mmproj: false },
+        { rfilename: 'mmproj-F16.gguf', size: 5, mmproj: true },
+      ],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model-Q4_K_M.gguf' })
+    assert.deepEqual(recs.map((r) => r.name), ['model-Q4_K_M.gguf'])
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a stale/truncated mmproj (wrong size) is re-downloaded', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const repoDir = join(modelDir, 'owner', 'repo')
+    mkdirSync(repoDir, { recursive: true })
+    writeFileSync(join(repoDir, 'mmproj-F16.gguf'), 'xxx') // 3 bytes, tree says 5
+
+    const expand = async (_r: string, rfilename: string): Promise<HfModelFiles> => ({
+      dir: '',
+      files: [
+        { rfilename, size: 10, mmproj: false },
+        { rfilename: 'mmproj-F16.gguf', size: 5, mmproj: true },
+      ],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    const recs = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model-Q4_K_M.gguf' })
+    assert.deepEqual(recs.map((r) => r.name).sort(), ['mmproj-F16.gguf', 'model-Q4_K_M.gguf'])
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a repo id that is not owner/name is rejected', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), echoExpand())
+    await assert.rejects(() => dm.enqueue({ repo: 'noslash', rfilename: 'x.gguf' }), /repo and rfilename are required/)
+  } finally {
+    restore()
+  }
+})
+
+test('enqueue: a traversal-y repo id is sanitised, never escapes the model dir', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), echoExpand())
+    const recs = await dm.enqueue({ repo: '../../etc', rfilename: 'x.gguf' })
+    // '..' segments are stripped by repoSubdir → lands flat under the model dir, no escape.
+    assert.equal(recs.length, 1)
+    assert.equal(recs[0].dest, join(modelDir, 'etc', 'x.gguf'))
+    assert.ok(recs[0].dest.startsWith(modelDir), 'dest must stay under the model dir')
+  } finally {
+    restore()
+  }
+})
+
+test('run: enforces the disk guard using content-length when the enqueue size was unknown', async () => {
+  const { modelDir, stateDir } = newDirs()
+  const real = globalThis.fetch
+  // Resolving fetch (not frozen): a 200 with a huge content-length and a tiny body.
+  globalThis.fetch = (async () =>
+    new Response('x', { status: 200, headers: { 'content-length': '999999999999' } })) as unknown as typeof fetch
+  try {
+    // Unknown size at enqueue (degraded HF metadata) → the enqueue-time sum check is
+    // skipped; the guard must still fire at download time from content-length.
+    const expand = async (_r: string, rfilename: string): Promise<HfModelFiles> => ({
+      dir: '',
+      files: [{ rfilename, size: 0, mmproj: false }],
+    })
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), expand)
+    let checkedSize = -1
+    ;(dm as unknown as { assertDisk: (d: string, s: number) => void }).assertDisk = (_d, s) => {
+      checkedSize = s
+      throw new DownloadError('insufficient_disk', 'Not enough free disk space (test).')
+    }
+    const recs = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model.gguf' })
+    const rec = await waitTerminal(dm, recs[0].id)
+    assert.equal(checkedSize, 999999999999) // consulted with the real content-length
+    assert.equal(rec.status, 'error')
+    assert.match(rec.error ?? '', /disk/i)
+  } finally {
+    globalThis.fetch = real
+  }
+})
+
+test('enqueue: a non-HF raw URL stays a single flat file', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), async () => {
+      throw new Error('expand should not run for a raw URL')
+    })
+    const recs = await dm.enqueue({ url: 'https://example.com/some/model.Q4_K_M.gguf' })
+
+    assert.equal(recs.length, 1)
+    assert.equal(recs[0].repo, '')
+    assert.equal(recs[0].dest, join(modelDir, 'model.Q4_K_M.gguf'))
+  } finally {
+    restore()
+  }
+})

--- a/turbollm/src/downloads/downloads.ts
+++ b/turbollm/src/downloads/downloads.ts
@@ -15,10 +15,11 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import type { ConfigStore } from '../config/config'
+import type { HfModelFiles } from '../hf/hf'
 
 export type DownloadStatus = 'queued' | 'downloading' | 'paused' | 'done' | 'error' | 'cancelled'
 
@@ -69,7 +70,6 @@ export interface ProvenanceEntry {
 }
 
 const MAX_CONCURRENT = 2
-const HF_BLOB_RE = /^https?:\/\/huggingface\.co\/.+\/resolve\/.+\.gguf$/i
 
 export interface EnqueueInput {
   repo?: string
@@ -105,6 +105,12 @@ export class DownloadManager {
     /** Called after a download completes so the model list picks up the new file. */
     private onComplete: () => void,
     private authHeaders: () => Record<string, string>,
+    /** Expand a chosen HF GGUF into every concrete file to fetch — all split shards +
+     *  the shared mmproj projector, plus the model's repo-relative directory (spec 10 §3).
+     *  Injected from the HfClient so the download layer stays decoupled from HF discovery.
+     *  Absent under tests that don't exercise repo downloads → those take the single-file
+     *  path instead. */
+    private expand?: (repo: string, rfilename: string, rev?: string) => Promise<HfModelFiles>,
   ) {
     const dir = join(store.dir(), 'downloads')
     mkdirSync(dir, { recursive: true })
@@ -132,60 +138,145 @@ export class DownloadManager {
     return [...this.records.values()].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
   }
 
-  /** Enqueue a download. Validates the target + disk space, persists, then kicks
-   *  the queue. Throws DownloadError for caller-actionable failures (no dir set,
-   *  bad URL, insufficient disk). */
-  enqueue(input: EnqueueInput): DownloadRecord {
+  /** Enqueue a download. Validates the target + disk space, persists, then kicks the
+   *  queue. Returns every record created — a single file for a raw non-HF URL, or the
+   *  whole model (all split shards + the shared mmproj) for an HF repo file. Throws
+   *  DownloadError for caller-actionable failures (no dir set, bad URL, insufficient
+   *  disk). */
+  async enqueue(input: EnqueueInput): Promise<DownloadRecord[]> {
     const dir = this.primaryDir()
     if (!dir) throw new DownloadError('no_model_dir', 'Add a model folder in Settings before downloading.')
 
     let repo = (input.repo ?? '').trim()
-    const subdir = (input.subdir ?? '').trim()
-    let url: string
-    let filename: string
+    const explicitSubdir = (input.subdir ?? '').trim()
+    let rfilename = (input.rfilename ?? '').trim()
+    let rev = 'main'
+
     if (input.url) {
       const u = normalizeHfBlobUrl(input.url.trim())
       if (!/^https?:\/\//i.test(u)) throw new DownloadError('invalid_url', 'URL must start with http:// or https://.')
-      const path = safePathname(u)
-      if (!subdir && !/\.gguf$/i.test(path) && !HF_BLOB_RE.test(u.split('?')[0])) {
-        throw new DownloadError('invalid_url', 'URL must point to a .gguf file.')
+      // An HF resolve URL carries a repo + revision + file path — recover them so the
+      // import gets the same subfolder + split-shard + mmproj handling as a Discover
+      // download, and targets the exact revision the user linked (not always `main`).
+      const hf = parseHfResolveUrl(u)
+      if (hf) {
+        repo = hf.repo
+        rfilename = hf.rfilename
+        rev = hf.rev
+      } else {
+        // A non-HF host: a single flat file — its repo structure is unknowable.
+        const path = safePathname(u)
+        if (!explicitSubdir && !/\.gguf$/i.test(path)) throw new DownloadError('invalid_url', 'URL must point to a .gguf file.')
+        const filename = basename(path)
+        if (!explicitSubdir && !/\.gguf$/i.test(filename)) throw new DownloadError('invalid_url', 'Could not derive a .gguf filename from that URL.')
+        const destDir = explicitSubdir ? join(dir, explicitSubdir) : dir
+        mkdirSync(destDir, { recursive: true })
+        if ((input.size ?? 0) > 0) this.assertDisk(dir, input.size!)
+        const dest = join(destDir, filename)
+        if (this.hasLiveDest(dest)) return []
+        return this.commit([{ name: filename, repo: '', url: u, dest, total: input.size ?? 0, sha256: input.sha256 }])
       }
-      filename = basename(path)
-      if (!subdir && !/\.gguf$/i.test(filename)) throw new DownloadError('invalid_url', 'Could not derive a .gguf filename from that URL.')
-      url = u
-      repo = '' // raw-URL import: no provenance
-    } else {
-      const rfilename = (input.rfilename ?? '').trim()
-      if (!repo || !rfilename) throw new DownloadError('invalid_request', 'repo and rfilename are required.')
-      if (!subdir && !/\.gguf$/i.test(rfilename)) throw new DownloadError('invalid_url', 'The file must be a .gguf.')
-      filename = basename(rfilename)
-      url = `https://huggingface.co/${repo}/resolve/main/${rfilename}`
     }
 
-    const total = input.size ?? 0
-    const destDir = subdir ? join(dir, subdir) : dir
-    if (subdir) mkdirSync(destDir, { recursive: true })
-    if (total > 0) this.assertDisk(dir, total)
+    // HF repos are always `owner/name` — reject anything that can't be one (also stops a
+    // degenerate `repo` from sanitising to an empty subfolder that lands in the root).
+    if (!repo.includes('/') || !rfilename) throw new DownloadError('invalid_request', 'repo and rfilename are required.')
+    if (!explicitSubdir && !/\.gguf$/i.test(rfilename)) throw new DownloadError('invalid_url', 'The file must be a .gguf.')
 
-    const id = `dl-${Date.now().toString(36)}-${(this.nextSeq++).toString(36)}`
-    const rec: DownloadRecord = {
-      id,
-      name: filename,
-      repo,
-      url,
-      dest: join(destDir, filename),
-      total,
-      received: 0,
-      status: 'queued',
-      error: null,
-      bytesPerSec: 0,
-      sha256: input.sha256,
-      createdAt: new Date().toISOString(),
+    // Safetensors/MLX pass an explicit subdir and enqueue each component file themselves
+    // — no expansion. Place it (single file) directly under that subdir.
+    if (explicitSubdir || !this.expand) {
+      const filename = basename(rfilename)
+      const destDir = join(dir, explicitSubdir || repoSubdir(repo))
+      mkdirSync(destDir, { recursive: true })
+      const dest = join(destDir, filename)
+      if (this.hasLiveDest(dest)) return []
+      if ((input.size ?? 0) > 0) this.assertDisk(dir, input.size!)
+      return this.commit([
+        { name: filename, repo, url: hfResolveUrl(repo, rev, rfilename), dest, total: input.size ?? 0, sha256: input.sha256 },
+      ])
     }
-    this.records.set(id, rec)
+
+    // Expand a GGUF into every concrete file: all split shards + the shared mmproj. Each
+    // model gets its own <owner>/<repo>/<repo-subdir> folder (mirrors HF's layout and the
+    // primary library's structure), so a model's shards + mmproj sit together for the
+    // scanner to group and two quants that share a shard basename never collide.
+    const { dir: modelDir, files } = await this.expand(repo, rfilename, rev)
+    const destDir = join(dir, repoSubdir(repo), modelDir)
+    mkdirSync(destDir, { recursive: true })
+
+    const targets = files
+      .map((f) => ({ f, dest: join(destDir, basename(f.rfilename)) }))
+      .filter(({ f, dest }) => {
+        // An in-flight/queued job already owns this exact file — never enqueue a second
+        // writer for the same .part (double-click, or two quants sharing one mmproj).
+        if (this.hasLiveDest(dest)) return false
+        // A shared mmproj already on disk: keep it only if it looks incomplete (size
+        // known and mismatched) — otherwise adding a second quant shouldn't re-pull it.
+        if (f.mmproj && existsSync(dest)) {
+          if (f.size <= 0) return false
+          try {
+            return statSync(dest).size !== f.size
+          } catch {
+            return true
+          }
+        }
+        return true
+      })
+    if (targets.length === 0) return []
+
+    const totalBytes = targets.reduce((s, { f }) => s + (f.size || 0), 0)
+    if (totalBytes > 0) this.assertDisk(dir, totalBytes)
+
+    return this.commit(
+      targets.map(({ f, dest }) => ({
+        name: basename(f.rfilename),
+        repo,
+        url: hfResolveUrl(repo, rev, f.rfilename),
+        dest,
+        total: f.size || 0,
+        sha256: f.sha256,
+      })),
+    )
+  }
+
+  /** True when a queued/downloading/paused record already targets this exact dest — the
+   *  guard against two concurrent writers corrupting one file. Terminal records
+   *  (done/cancelled/error) don't block a fresh attempt. */
+  private hasLiveDest(dest: string): boolean {
+    for (const r of this.records.values()) {
+      if (r.dest === dest && (r.status === 'queued' || r.status === 'downloading' || r.status === 'paused')) return true
+    }
+    return false
+  }
+
+  /** Materialise queued records from resolved targets, persist once, and kick the queue. */
+  private commit(
+    targets: Array<{ name: string; repo: string; url: string; dest: string; total: number; sha256?: string }>,
+  ): DownloadRecord[] {
+    const created: DownloadRecord[] = []
+    for (const t of targets) {
+      const id = `dl-${Date.now().toString(36)}-${(this.nextSeq++).toString(36)}`
+      const rec: DownloadRecord = {
+        id,
+        name: t.name,
+        repo: t.repo,
+        url: t.url,
+        dest: t.dest,
+        total: t.total,
+        received: 0,
+        status: 'queued',
+        error: null,
+        bytesPerSec: 0,
+        sha256: t.sha256,
+        createdAt: new Date().toISOString(),
+      }
+      this.records.set(id, rec)
+      created.push(rec)
+    }
     this.persist()
     this.pump()
-    return rec
+    return created
   }
 
   /** Cancel an in-flight or queued job: abort the stream, delete the .part, mark
@@ -296,6 +387,13 @@ export class DownloadManager {
 
       const clen = Number(res.headers.get('content-length') ?? 0)
       if (clen > 0) rec.total = resuming ? startAt + clen : clen
+
+      // Disk guard at download time (spec 10 §6): content-length is often the FIRST real
+      // size we see — a raw URL, or an HF expansion where the tree metadata was
+      // unavailable (sizes 0), both skip the enqueue-time check. Verifying the remaining
+      // bytes here fails a too-large download cleanly (status=error) before writing any,
+      // instead of silently filling the disk.
+      if (clen > 0) this.assertDisk(dirname(part), clen)
 
       const hash = rec.sha256 ? createHash('sha256') : null
       // sha256 can only be verified over the full file; skip it on a partial resume.
@@ -478,4 +576,47 @@ function safePathname(u: string): string {
   } catch {
     return ''
   }
+}
+
+/** Recognise an HF resolve URL and pull out the repo + revision + repo-relative file
+ *  path: `https://huggingface.co/<owner>/<repo>/resolve/<rev>/<path…>.gguf`. Segments are
+ *  URL-decoded (so a `%20` in the path becomes a real space). Returns null for any non-HF
+ *  host or a URL that isn't a .gguf resolve link, so those stay raw imports. */
+function parseHfResolveUrl(u: string): { repo: string; rev: string; rfilename: string } | null {
+  let parsed: URL
+  try {
+    parsed = new URL(u)
+  } catch {
+    return null
+  }
+  if (parsed.hostname !== 'huggingface.co') return null
+  const parts = parsed.pathname.split('/').filter(Boolean)
+  const ri = parts.indexOf('resolve')
+  // Need owner/repo before `resolve`, then a revision, then at least one path segment.
+  if (ri < 2 || parts.length < ri + 3) return null
+  const repo = parts.slice(0, ri).join('/')
+  const rev = decodeURIComponent(parts[ri + 1])
+  const rfilename = parts
+    .slice(ri + 2)
+    .map((s) => decodeURIComponent(s))
+    .join('/')
+  if (!repo.includes('/') || !rev || !rfilename || !/\.gguf$/i.test(rfilename)) return null
+  return { repo, rev, rfilename }
+}
+
+/** Build an HF resolve URL for a repo-relative file, encoding each path segment (so a
+ *  space or `#` in a filename survives) while leaving the `/` separators intact. */
+function hfResolveUrl(repo: string, rev: string, rfilename: string): string {
+  const enc = (p: string) => p.split('/').map(encodeURIComponent).join('/')
+  return `https://huggingface.co/${enc(repo)}/resolve/${encodeURIComponent(rev)}/${enc(rfilename)}`
+}
+
+/** Sanitise an HF repo id (`owner/name`) into a safe relative subdirectory: forward
+ *  slashes only, no absolute/`..`/`.` segments that could escape the model dir. */
+function repoSubdir(repo: string): string {
+  return repo
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((s) => s && s !== '.' && s !== '..')
+    .join('/')
 }

--- a/turbollm/src/hf/hf.expand.test.ts
+++ b/turbollm/src/hf/hf.expand.test.ts
@@ -1,0 +1,201 @@
+// Tests for HfClient.expandModelFiles (spec 10 §3): expanding a chosen GGUF into every
+// concrete file to fetch — all shards of its split group + its mmproj projector — with
+// matching scoped to the chosen file's own repo directory and the targeted revision
+// threaded into the tree query.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { HfClient } from './hf'
+
+interface TreeEntry {
+  type: string
+  path: string
+  size?: number
+  lfs?: { oid?: string; size?: number }
+}
+
+/** Stub global.fetch so getJson returns the given tree for the tree endpoint. Captures
+ *  every requested URL so tests can assert the revision the query targeted. */
+function withTree(tree: TreeEntry[], fn: (urls: string[]) => Promise<void>): Promise<void> {
+  const real = globalThis.fetch
+  const urls: string[] = []
+  globalThis.fetch = (async (url: string | URL) => {
+    const u = String(url)
+    urls.push(u)
+    if (u.includes('/tree/')) {
+      return new Response(JSON.stringify(tree), { status: 200, headers: { 'content-type': 'application/json' } })
+    }
+    return new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } })
+  }) as typeof fetch
+  return fn(urls).finally(() => {
+    globalThis.fetch = real
+  })
+}
+
+function client(): HfClient {
+  return new HfClient(() => '', '0.0.0-test')
+}
+
+test('expandModelFiles: single-file quant pulls the shared mmproj alongside it (root dir)', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'Qwen3-VL-Q4_K_M.gguf', lfs: { oid: 'aaa', size: 100 } },
+    { type: 'file', path: 'mmproj-F16.gguf', lfs: { oid: 'proj', size: 20 } },
+    { type: 'file', path: 'README.md', size: 5 },
+  ]
+  await withTree(tree, async () => {
+    const { dir, files } = await client().expandModelFiles('unsloth/Qwen3-VL-GGUF', 'Qwen3-VL-Q4_K_M.gguf')
+    assert.equal(dir, '')
+    assert.deepEqual(
+      files.map((f) => [f.rfilename, f.mmproj]),
+      [
+        ['Qwen3-VL-Q4_K_M.gguf', false],
+        ['mmproj-F16.gguf', true],
+      ],
+    )
+    assert.equal(files[0].sha256, 'aaa')
+    assert.equal(files[1].size, 20)
+  })
+})
+
+test('expandModelFiles: split quant expands to every shard (by first-shard basename) + mmproj', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'gpt-oss-120b-Q4_K_M-00001-of-00003.gguf', lfs: { oid: 's1', size: 10 } },
+    { type: 'file', path: 'gpt-oss-120b-Q4_K_M-00002-of-00003.gguf', lfs: { oid: 's2', size: 10 } },
+    { type: 'file', path: 'gpt-oss-120b-Q4_K_M-00003-of-00003.gguf', lfs: { oid: 's3', size: 10 } },
+    // A different quant's shards must NOT be pulled in.
+    { type: 'file', path: 'gpt-oss-120b-Q8_0-00001-of-00002.gguf', lfs: { oid: 'x1', size: 99 } },
+    { type: 'file', path: 'mmproj-F16.gguf', lfs: { oid: 'proj', size: 5 } },
+  ]
+  await withTree(tree, async () => {
+    const { files } = await client().expandModelFiles('unsloth/gpt-oss-120b-GGUF', 'gpt-oss-120b-Q4_K_M-00001-of-00003.gguf')
+    assert.deepEqual(files.map((f) => f.rfilename), [
+      'gpt-oss-120b-Q4_K_M-00001-of-00003.gguf',
+      'gpt-oss-120b-Q4_K_M-00002-of-00003.gguf',
+      'gpt-oss-120b-Q4_K_M-00003-of-00003.gguf',
+      'mmproj-F16.gguf',
+    ])
+  })
+})
+
+test('expandModelFiles: recovers the full repo path and reports the model dir for subfoldered GGUFs', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'Q4_K_M/model-00001-of-00002.gguf', lfs: { oid: 'a', size: 10 } },
+    { type: 'file', path: 'Q4_K_M/model-00002-of-00002.gguf', lfs: { oid: 'b', size: 10 } },
+  ]
+  await withTree(tree, async () => {
+    // The UI carries only the basename of the first shard.
+    const { dir, files } = await client().expandModelFiles('owner/repo', 'model-00001-of-00002.gguf')
+    assert.equal(dir, 'Q4_K_M')
+    assert.deepEqual(files.map((f) => f.rfilename), [
+      'Q4_K_M/model-00001-of-00002.gguf',
+      'Q4_K_M/model-00002-of-00002.gguf',
+    ])
+  })
+})
+
+test('expandModelFiles: same-basename shards in two subfolders do NOT cross-match', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'Q4_K_M/model-00001-of-00003.gguf', lfs: { oid: 'a1', size: 10 } },
+    { type: 'file', path: 'Q4_K_M/model-00002-of-00003.gguf', lfs: { oid: 'a2', size: 10 } },
+    { type: 'file', path: 'Q4_K_M/model-00003-of-00003.gguf', lfs: { oid: 'a3', size: 10 } },
+    { type: 'file', path: 'Q8_0/model-00001-of-00003.gguf', lfs: { oid: 'b1', size: 20 } },
+    { type: 'file', path: 'Q8_0/model-00002-of-00003.gguf', lfs: { oid: 'b2', size: 20 } },
+    { type: 'file', path: 'Q8_0/model-00003-of-00003.gguf', lfs: { oid: 'b3', size: 20 } },
+  ]
+  await withTree(tree, async () => {
+    // Chosen file's basename is ambiguous across both folders; the tree's first match is
+    // Q4_K_M — only its three shards may be returned, never all six.
+    const { dir, files } = await client().expandModelFiles('owner/repo', 'model-00001-of-00003.gguf')
+    assert.equal(dir, 'Q4_K_M')
+    assert.deepEqual(files.map((f) => f.rfilename), [
+      'Q4_K_M/model-00001-of-00003.gguf',
+      'Q4_K_M/model-00002-of-00003.gguf',
+      'Q4_K_M/model-00003-of-00003.gguf',
+    ])
+  })
+})
+
+test('expandModelFiles: prefers an mmproj in the model’s own subfolder over a larger sibling', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'Q4_K_M/model-Q4_K_M.gguf', lfs: { oid: 'm', size: 100 } },
+    { type: 'file', path: 'Q4_K_M/mmproj-F16.gguf', lfs: { oid: 'p16', size: 10 } },
+    // Larger, but in a different quant folder — must NOT be chosen.
+    { type: 'file', path: 'BF16/mmproj-BF16.gguf', lfs: { oid: 'pbf', size: 40 } },
+  ]
+  await withTree(tree, async () => {
+    const { files } = await client().expandModelFiles('owner/repo', 'model-Q4_K_M.gguf')
+    const proj = files.find((f) => f.mmproj)
+    assert.equal(proj?.rfilename, 'Q4_K_M/mmproj-F16.gguf')
+  })
+})
+
+test('expandModelFiles: falls back to the largest repo-wide mmproj when none in the model dir', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'Q4_K_M/model-Q4_K_M.gguf', lfs: { oid: 'm', size: 100 } },
+    { type: 'file', path: 'mmproj/mmproj-Q8_0.gguf', lfs: { oid: 'p8', size: 10 } },
+    { type: 'file', path: 'mmproj/mmproj-F16.gguf', lfs: { oid: 'p16', size: 25 } },
+  ]
+  await withTree(tree, async () => {
+    const { files } = await client().expandModelFiles('owner/repo', 'model-Q4_K_M.gguf')
+    const proj = files.find((f) => f.mmproj)
+    assert.equal(proj?.rfilename, 'mmproj/mmproj-F16.gguf')
+    assert.equal(files.filter((f) => f.mmproj).length, 1)
+  })
+})
+
+test('expandModelFiles: threads the revision into the tree query', async () => {
+  const tree: TreeEntry[] = [{ type: 'file', path: 'model.gguf', lfs: { oid: 'm', size: 100 } }]
+  await withTree(tree, async (urls) => {
+    await client().expandModelFiles('owner/repo', 'model.gguf', 'v2.0')
+    assert.ok(
+      urls.some((u) => u.includes('/tree/v2.0?')),
+      `expected a tree query on v2.0, got: ${urls.join(', ')}`,
+    )
+    assert.ok(!urls.some((u) => u.includes('/tree/main')), 'must not query main when a revision is given')
+  })
+})
+
+test('expandModelFiles: split regex only matches exactly 5+5 digits', async () => {
+  // 4-digit and 6-digit "of" patterns are NOT llama.cpp splits — treated as single files.
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'a-0001-of-0003.gguf', lfs: { oid: 'x', size: 5 } },
+    { type: 'file', path: 'a-000001-of-000003.gguf', lfs: { oid: 'y', size: 5 } },
+  ]
+  await withTree(tree, async () => {
+    const four = await client().expandModelFiles('owner/repo', 'a-0001-of-0003.gguf')
+    assert.deepEqual(four.files.map((f) => f.rfilename), ['a-0001-of-0003.gguf'])
+    const six = await client().expandModelFiles('owner/repo', 'a-000001-of-000003.gguf')
+    assert.deepEqual(six.files.map((f) => f.rfilename), ['a-000001-of-000003.gguf'])
+  })
+})
+
+test('expandModelFiles: requested file absent from the tree falls back to the name as given', async () => {
+  const tree: TreeEntry[] = [{ type: 'file', path: 'other.gguf', lfs: { oid: 'o', size: 5 } }]
+  await withTree(tree, async () => {
+    const { files } = await client().expandModelFiles('owner/repo', 'missing.gguf')
+    assert.deepEqual(files.map((f) => [f.rfilename, f.mmproj]), [['missing.gguf', false]])
+  })
+})
+
+test('expandModelFiles: downloading an mmproj directly does not pair another projector', async () => {
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'model-Q4_K_M.gguf', lfs: { oid: 'm', size: 100 } },
+    { type: 'file', path: 'mmproj-F16.gguf', lfs: { oid: 'p16', size: 25 } },
+  ]
+  await withTree(tree, async () => {
+    const { files } = await client().expandModelFiles('owner/repo', 'mmproj-F16.gguf')
+    assert.deepEqual(files.map((f) => [f.rfilename, f.mmproj]), [['mmproj-F16.gguf', false]])
+  })
+})
+
+test('expandModelFiles: HF failure falls back to the single requested file', async () => {
+  const real = globalThis.fetch
+  globalThis.fetch = (async () => {
+    throw new Error('network down')
+  }) as typeof fetch
+  try {
+    const { files } = await client().expandModelFiles('owner/repo', 'sub/model-Q4_K_M.gguf')
+    assert.deepEqual(files.map((f) => f.rfilename), ['sub/model-Q4_K_M.gguf'])
+  } finally {
+    globalThis.fetch = real
+  }
+})

--- a/turbollm/src/hf/hf.ts
+++ b/turbollm/src/hf/hf.ts
@@ -103,6 +103,25 @@ export interface HfRepoDetail {
   safetensors?: boolean
 }
 
+/** One concrete file to fetch for a working GGUF model (spec 10 §3): a shard of a
+ *  split group, or a shared mmproj projector. Repo-relative `rfilename` (the download
+ *  manager builds the resolve URL). */
+export interface HfDownloadFile {
+  rfilename: string
+  size: number
+  sha256?: string
+  /** True for the vision projector companion (mmproj-*.gguf). */
+  mmproj: boolean
+}
+
+/** The result of expanding a chosen GGUF: the repo-relative directory the model lives
+ *  in (`''` = repo root) and every file to fetch. All files are placed together under
+ *  `<modelDir>/<owner>/<repo>/<dir>/` so the scanner groups a model's shards + mmproj. */
+export interface HfModelFiles {
+  dir: string
+  files: HfDownloadFile[]
+}
+
 interface CacheRow {
   at: number
   value: unknown
@@ -197,6 +216,64 @@ export class HfClient {
       files,
       ...(safetensors ? { safetensors } : {}),
     }
+  }
+
+  /** Expand a chosen GGUF into every concrete file needed for a working model
+   *  (spec 10 §3): all shards of its split group (NNNNN-of-NNNNN) plus its mmproj vision
+   *  projector. Matching is scoped to the chosen file's OWN repo directory so a repo
+   *  that organises quants in per-quant subfolders (e.g. `Q4_K_M/…`, `Q8_0/…`) never
+   *  cross-matches another quant's identically-named shards. The mmproj is preferred
+   *  from the same directory (mirrors the scanner's per-directory pairing), falling back
+   *  to the largest anywhere in the repo. `rev` is the git revision (branch/tag/commit)
+   *  the download targets. Best-effort: on any HF failure it returns just the one
+   *  requested file. When the requested file is itself an mmproj, none is paired. */
+  async expandModelFiles(repo: string, rfilename: string, rev = 'main'): Promise<HfModelFiles> {
+    const wantBase = base(rfilename).toLowerCase()
+    let tree: RawTreeEntry[]
+    try {
+      tree = await this.getJson<RawTreeEntry[]>(`${BASE}/api/models/${repo}/tree/${encodeURIComponent(rev)}?recursive=true`)
+    } catch {
+      return { dir: dirOf(rfilename), files: [{ rfilename, size: 0, mmproj: wantBase.includes('mmproj') }] }
+    }
+    const ggufs = tree.filter((e) => e.type === 'file' && /\.gguf$/i.test(e.path))
+
+    // Locate the chosen file by basename (the UI carries a split group's first-shard
+    // basename; the tree recovers its full repo path + siblings).
+    const chosen = ggufs.find((e) => base(e.path).toLowerCase() === wantBase)
+    if (!chosen) {
+      // Requested file not in the tree — fall back to the name as given.
+      return { dir: dirOf(rfilename), files: [{ rfilename, size: 0, mmproj: wantBase.includes('mmproj') }] }
+    }
+
+    const modelDir = dirOf(chosen.path)
+    const inModelDir = (e: RawTreeEntry) => dirOf(e.path) === modelDir
+    const files: HfDownloadFile[] = []
+
+    const split = base(chosen.path).match(SPLIT_RE)
+    if (split) {
+      const prefix = split[1].toLowerCase()
+      const total = split[3]
+      for (const e of ggufs) {
+        if (!inModelDir(e)) continue
+        const sm = base(e.path).match(SPLIT_RE)
+        if (sm && sm[1].toLowerCase() === prefix && sm[3] === total) {
+          files.push({ rfilename: e.path, size: sizeOf(e), sha256: e.lfs?.oid, mmproj: false })
+        }
+      }
+      files.sort((a, b) => a.rfilename.localeCompare(b.rfilename))
+    } else {
+      files.push({ rfilename: chosen.path, size: sizeOf(chosen), sha256: chosen.lfs?.oid, mmproj: false })
+    }
+
+    // Pair an mmproj projector with an actual model download (not with another mmproj):
+    // prefer one in the model's own directory, else the largest anywhere in the repo.
+    if (!wantBase.includes('mmproj')) {
+      const projectors = ggufs.filter((e) => base(e.path).toLowerCase().includes('mmproj'))
+      const sameDir = projectors.filter(inModelDir)
+      const best = (sameDir.length ? sameDir : projectors).sort((a, b) => sizeOf(b) - sizeOf(a))[0]
+      if (best) files.push({ rfilename: best.path, size: sizeOf(best), sha256: best.lfs?.oid, mmproj: true })
+    }
+    return { dir: modelDir, files }
   }
 
   /** Public model-card fetch (ADR-099): the cleaned README for `owner/repo`, or '' when
@@ -407,4 +484,11 @@ function sizeOf(e: RawTreeEntry): number {
 function base(p: string): string {
   const i = p.lastIndexOf('/')
   return i >= 0 ? p.slice(i + 1) : p
+}
+
+/** Repo-relative directory of a path (POSIX '/' — HF tree paths are always '/'-joined);
+ *  '' for a root-level file. */
+function dirOf(p: string): string {
+  const i = p.lastIndexOf('/')
+  return i >= 0 ? p.slice(0, i) : ''
 }

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -668,7 +668,9 @@ export function listDownloads(): Promise<DownloadsList> {
   return request<DownloadsList>('/api/v1/downloads')
 }
 
-/** Enqueue a download: an HF repo file {repo, rfilename} OR a raw {url}. */
+/** Enqueue a download: an HF repo file {repo, rfilename} OR a raw {url}. A single HF
+ *  request can fan out into several files (split shards + a shared mmproj projector), so
+ *  the response carries every record created. */
 export function enqueueDownload(input: {
   repo?: string
   rfilename?: string
@@ -676,8 +678,8 @@ export function enqueueDownload(input: {
   size?: number
   sha256?: string
   subdir?: string
-}): Promise<DownloadRecord> {
-  return request<DownloadRecord>('/api/v1/downloads', { method: 'POST', json: input })
+}): Promise<{ downloads: DownloadRecord[] }> {
+  return request<{ downloads: DownloadRecord[] }>('/api/v1/downloads', { method: 'POST', json: input })
 }
 
 export function cancelDownload(id: string): Promise<{ ok: true }> {

--- a/turbollm/web/src/screens/models/DiscoverTab.tsx
+++ b/turbollm/web/src/screens/models/DiscoverTab.tsx
@@ -175,7 +175,14 @@ export function DiscoverTab({ presetQuery = '' }: { presetQuery?: string }) {
         </div>
       </div>
 
-      <ImportUrlDialog open={importOpen} onClose={() => setImportOpen(false)} />
+      <ImportUrlDialog
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onOpenRepo={(repo) => {
+          setSelectedRepo(repo)
+          setImportOpen(false)
+        }}
+      />
     </div>
   )
 }

--- a/turbollm/web/src/screens/models/ImportUrlDialog.tsx
+++ b/turbollm/web/src/screens/models/ImportUrlDialog.tsx
@@ -11,6 +11,34 @@ import { Button } from '../../components/ui/button'
 import { Input } from '../../components/ui/input'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../../components/ui/sheet'
 
+/** First path segment reserved by HF for non-model routes — never a repo owner. Keeps
+ *  a datasets/spaces/browse URL from being mistaken for an `owner/repo` model repo. */
+const HF_RESERVED_PREFIX = new Set([
+  'datasets', 'spaces', 'models', 'organizations', 'settings', 'collections', 'blog', 'docs', 'join', 'login', 'pricing',
+])
+
+/** Recognise an HF *repo* landing/tree URL (not a single-file link) and return its
+ *  `owner/repo`, else null. A repo has many quants, so pasting one can't download a
+ *  file directly — the dialog routes it to the repo's quant picker instead. */
+function parseHfRepoUrl(raw: string): string | null {
+  let u: URL
+  try {
+    u = new URL(raw)
+  } catch {
+    return null
+  }
+  if (u.hostname !== 'huggingface.co') return null
+  const parts = u.pathname.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  // A file link (resolve/blob) is handled by the .gguf path, not here.
+  if (parts.includes('resolve') || parts.includes('blob')) return null
+  const [owner, repo, third] = parts
+  if (HF_RESERVED_PREFIX.has(owner.toLowerCase())) return null
+  // owner/repo, optionally followed by /tree/<rev>/… — anything else isn't a repo root.
+  if (parts.length === 2 || third === 'tree') return `${owner}/${repo}`
+  return null
+}
+
 /** True when the URL is a plausible GGUF download target (spec 10 §8 step 2):
  *  path ends in `.gguf` OR matches an HF resolve blob URL. */
 function isValidGgufUrl(raw: string): boolean {
@@ -64,7 +92,17 @@ function normalizeHfUrl(raw: string): string {
   return raw
 }
 
-export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function ImportUrlDialog({
+  open,
+  onClose,
+  onOpenRepo,
+}: {
+  open: boolean
+  onClose: () => void
+  /** Called when the pasted URL is a repo (many quants) rather than a single file —
+   *  routes to the repo's quant picker instead of a direct download. */
+  onOpenRepo?: (repo: string) => void
+}) {
   const mut = useDownloadMutations()
   const [url, setUrl] = useState('')
 
@@ -72,7 +110,11 @@ export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () 
   const normalized = useMemo(() => normalizeHfUrl(trimmed), [trimmed])
   const wasNormalized = normalized !== trimmed
   const filename = useMemo(() => deriveFilename(normalized), [normalized])
-  const valid = trimmed.length > 0 && isValidGgufUrl(normalized)
+  // A repo URL (owner/repo, no file) can't download directly — it holds many quants —
+  // so it's routed to the quant picker. A direct .gguf/resolve URL downloads as before.
+  const repoTarget = useMemo(() => parseHfRepoUrl(normalized), [normalized])
+  const validFile = trimmed.length > 0 && isValidGgufUrl(normalized)
+  const valid = validFile || !!repoTarget
   const showInvalid = trimmed.length > 0 && !valid
 
   const enqueueErr = mut.enqueue.error instanceof ApiError ? mut.enqueue.error : null
@@ -86,7 +128,12 @@ export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () 
   }
 
   const submit = () => {
-    if (!valid) return
+    if (repoTarget) {
+      onOpenRepo?.(repoTarget)
+      close()
+      return
+    }
+    if (!validFile) return
     mut.enqueue.mutate(
       { url: normalized },
       {
@@ -113,7 +160,8 @@ export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () 
         <SheetHeader>
           <SheetTitle>Import from URL</SheetTitle>
           <SheetDescription>
-            Paste a direct link to a <span className="font-mono">.gguf</span> file — any HTTPS host, not just Hugging Face.
+            Paste a <span className="font-mono">.gguf</span> link (any HTTPS host) or a Hugging Face model page — a repo
+            link opens its quant list to pick from.
           </SheetDescription>
         </SheetHeader>
 
@@ -123,23 +171,31 @@ export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () 
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && submit()}
-            placeholder="https://huggingface.co/owner/repo/resolve/main/model.Q4_K_M.gguf"
+            placeholder="https://huggingface.co/owner/repo  ·  or …/resolve/main/model.Q4_K_M.gguf"
             className="font-mono text-[12px]"
           />
 
-          {filename && valid && (
+          {repoTarget ? (
             <div className="rounded-md border border-border bg-panel-2 px-3 py-2 text-[12px]">
-              <span className="text-muted">Will save as </span>
-              <span className="font-mono text-ink">{filename}</span>
-              {wasNormalized && (
-                <p className="mt-1 text-faint">URL converted to a direct download link.</p>
-              )}
+              <span className="text-muted">Model repo </span>
+              <span className="font-mono text-ink">{repoTarget}</span>
+              <p className="mt-1 text-faint">Opens its quant list so you can pick which one to download.</p>
             </div>
+          ) : (
+            filename && valid && (
+              <div className="rounded-md border border-border bg-panel-2 px-3 py-2 text-[12px]">
+                <span className="text-muted">Will save as </span>
+                <span className="font-mono text-ink">{filename}</span>
+                {wasNormalized && (
+                  <p className="mt-1 text-faint">URL converted to a direct download link.</p>
+                )}
+              </div>
+            )
           )}
 
           {showInvalid && (
             <p className="text-[12px]" style={{ color: 'var(--err)' }}>
-              Enter a valid http(s) link ending in <span className="font-mono">.gguf</span> (or an HF resolve URL).
+              Enter a Hugging Face model link, or an http(s) link ending in <span className="font-mono">.gguf</span>.
             </p>
           )}
 
@@ -157,7 +213,7 @@ export function ImportUrlDialog({ open, onClose }: { open: boolean; onClose: () 
           <Button variant="outline" onClick={close}>Cancel</Button>
           <Button onClick={submit} disabled={!valid || mut.enqueue.isPending}>
             <Link2 size={14} />
-            {mut.enqueue.isPending ? 'Adding…' : 'Import'}
+            {mut.enqueue.isPending ? 'Adding…' : repoTarget ? 'Open' : 'Import'}
           </Button>
         </div>
       </SheetContent>


### PR DESCRIPTION
## Summary

- **fix(downloads):** HF downloads now land in `<owner>/<repo>/<subdir>` folders (mirroring HF's own layout) instead of flat in the model root.
- **fix(downloads):** downloading a GGUF now also pulls its shared `mmproj-*.gguf` vision projector into the same folder, so vision models load correctly instead of silently missing their projector.
- **fix(downloads):** split/multipart quants (e.g. `unsloth/gpt-oss-120b-GGUF`) now expand to every shard, all placed in one folder, so they load as a single model instead of one orphaned first shard.
- Shard/mmproj matching is scoped to the chosen file's own repo directory, so repos organizing quants into per-quant subfolders never cross-match another quant's identically-named shard.
- Pasted HF `resolve` URLs recover repo + revision + path from the URL and get the same subfolder/shard/mmproj handling as a Discover download (previously hardcoded to `main`).
- **fix(web):** pasting a Hugging Face *model-page* URL into "Import from URL" now opens that repo's quant picker instead of a dead-end "not a .gguf" error.
- Adds a concurrent-duplicate-destination guard (two jobs can no longer write the same `.part`) and a download-time disk-space check derived from `content-length` (covers the case where enqueue-time size metadata was unavailable).

## Test plan

- [x] `npm run typecheck` (server) — clean
- [x] `npm run typecheck` (web) — clean
- [x] `npx tsx --test` — 528 pass / 0 fail / 3 skipped, including 23 new tests covering: subfolder placement, split-shard cross-folder isolation, mmproj same-dir preference, revision threading, concurrent-dedup, disk-guard-at-download-time
- [x] Built + ran the daemon locally; manually verified the "Import from URL" repo-page routing in the browser
- [ ] User to verify a real end-to-end multipart + mmproj download (large downloads, not run in this environment)