### PR TITLE
v1.7.0: GPU VRAM, Windows build, multi-part downloads, MTP control, pin models

### DIFF
--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -24,6 +24,7 @@ import {
   buildCardExtractionPrompt,
   hasAnySampling,
   parseCardSampling,
+  parseGenerationParams,
   parseLlmSampling,
   type CardSampling,
 } from '../models/card-sampling'
@@ -925,12 +926,19 @@ export class BenchRunner {
     if (!repo) return undefined // hand-placed file outside a model dir → no upstream card
     this.state = { ...this.state, step: 'Reading model-card recommendations…' }
 
-    // 1. Local GGUF repo card — heuristic.
+    // 1. Structured params sidecar (some quantizers, e.g. unsloth, publish a root-level
+    //    `params`/`generation_config.json` with the exact recommended values) — exact, no
+    //    parsing/inference needed, so it outranks the heuristic and LLM fallback below.
+    const genParams = await this.hf.fetchGenerationParams(repo).catch(() => '')
+    const paramsH = parseGenerationParams(genParams)
+    if (hasAnySampling(paramsH)) return paramsH
+
+    // 2. Local GGUF repo card — heuristic.
     const localCard = await this.hf.fetchModelCard(repo).catch(() => '')
     const localH = parseCardSampling(localCard)
     if (hasAnySampling(localH)) return localH
 
-    // 2. Base-model fallback — the original model's card (where the author states the recommendation).
+    // 3. Base-model fallback — the original model's card (where the author states the recommendation).
     let baseCard = ''
     if (!this.cancelled) {
       const baseRepo = await this.hf.baseModelOf(repo).catch(() => null)
@@ -941,7 +949,7 @@ export class BenchRunner {
       }
     }
 
-    // 3. LLM fallback (one reload) on the richer card — prose-only / unusual phrasing the scan misses.
+    // 4. LLM fallback (one reload) on the richer card — prose-only / unusual phrasing the scan misses.
     if (this.cancelled) return undefined
     const card = baseCard.length > localCard.length ? baseCard : localCard
     if (!card) return undefined

--- a/turbollm/src/engines/build-prereqs.test.ts
+++ b/turbollm/src/engines/build-prereqs.test.ts
@@ -32,6 +32,60 @@ test('buildEnv: does not create a duplicate PATH/Path key', () => {
   assert.equal(pathKeys.length, Object.keys(process.env).filter((k) => k.toLowerCase() === 'path').length)
 })
 
+// Regression: a trailing/leading/doubled delimiter in PATH can make Windows fail to resolve a
+// bare command with `spawn cmd.exe ENOENT`. buildEnv must never emit an empty PATH segment.
+test('buildEnv: never produces a leading/trailing/doubled delimiter in PATH', () => {
+  const orig = process.env[PATH_KEY]
+  try {
+    for (const seed of [
+      '', // empty existing PATH
+      'onlyone',
+      `a${delimiter}b`,
+      `${delimiter}a${delimiter}b${delimiter}`, // leading + trailing delimiter
+      `a${delimiter}${delimiter}b`, // doubled delimiter
+      `${delimiter}${delimiter}`, // nothing but delimiters
+    ]) {
+      process.env[PATH_KEY] = seed
+      for (const dirs of [[], ['tllm_dir'], ['', '  ', 'tllm_dir']]) {
+        const env = buildEnv(dirs)
+        const path = env[PATH_KEY] ?? ''
+        assert.ok(!path.startsWith(delimiter), `leading delimiter for seed=${JSON.stringify(seed)} dirs=${JSON.stringify(dirs)}`)
+        assert.ok(!path.endsWith(delimiter), `trailing delimiter for seed=${JSON.stringify(seed)} dirs=${JSON.stringify(dirs)}`)
+        assert.ok(!path.includes(delimiter + delimiter), `doubled delimiter for seed=${JSON.stringify(seed)} dirs=${JSON.stringify(dirs)}`)
+        // No empty segment survived.
+        assert.ok(path.split(delimiter).every((s) => s.length > 0) || path === '', `empty segment for seed=${JSON.stringify(seed)}`)
+      }
+    }
+  } finally {
+    if (orig === undefined) delete process.env[PATH_KEY]
+    else process.env[PATH_KEY] = orig
+  }
+})
+
+// The Windows `spawn cmd.exe ENOENT` fix relies on the OS-critical vars surviving into the child
+// env: without SystemRoot/PATHEXT/ComSpec the OS loader can't resolve cmd.exe regardless of PATH.
+// (Env keys are case-insensitive on Windows, so we look them up case-insensitively.)
+test('buildEnv: preserves the parent env vars (OS-critical ones survive the copy)', () => {
+  const lookup = (env: NodeJS.ProcessEnv, name: string): string | undefined => {
+    const k = Object.keys(env).find((x) => x.toLowerCase() === name.toLowerCase())
+    return k === undefined ? undefined : env[k]
+  }
+  const key = '__TLLM_TEST_OS_VAR__'
+  const saved = process.env[key]
+  try {
+    process.env[key] = 'sentinel-value'
+    const env = buildEnv(['tllm_dir'])
+    assert.equal(lookup(env, key), 'sentinel-value')
+    // Whatever the parent actually has for the real OS-critical vars must carry through verbatim.
+    for (const name of ['ComSpec', 'PATHEXT', 'SystemRoot', 'windir']) {
+      assert.equal(lookup(env, name), lookup(process.env, name), `${name} not preserved`)
+    }
+  } finally {
+    if (saved === undefined) delete process.env[key]
+    else process.env[key] = saved
+  }
+})
+
 test('buildCommands: includes --branch when a branch is given', () => {
   const cmds = buildCommands('https://github.com/owner/repo', 'main', 'windows')
   assert.equal(cmds[0], 'git clone --branch "main" --depth 1 "https://github.com/owner/repo" turbo-build')

--- a/turbollm/src/engines/build-prereqs.ts
+++ b/turbollm/src/engines/build-prereqs.ts
@@ -16,13 +16,26 @@ const execFileP = promisify(execFile)
 
 /** Build a child-process env with `toolchainDirs` prepended to PATH. Empty/blank dirs are
  *  dropped. PATH is matched case-insensitively (Windows uses `Path`); we write back to the
- *  same key name the parent used so we never end up with a duplicate `PATH`/`Path` pair. */
+ *  same key name the parent used so we never end up with a duplicate `PATH`/`Path` pair.
+ *
+ *  IMPORTANT (Windows `spawn cmd.exe ENOENT`): the returned env is a FULL copy of the parent
+ *  `process.env`, so the OS-critical vars Windows needs to resolve a bare command — `SystemRoot`
+ *  / `windir` (System32 location), `PATHEXT`, and `ComSpec` (cmd.exe path) — are always carried
+ *  through. We also split each PATH segment individually and drop empty ones, so a stray
+ *  leading/trailing/doubled delimiter (`;` on Windows) can never survive into the child's PATH —
+ *  a malformed PATH is one way Windows fails to resolve `cmd.exe`. */
 export function buildEnv(toolchainDirs: string[] = []): NodeJS.ProcessEnv {
   const dirs = toolchainDirs.map((d) => d.trim()).filter(Boolean)
-  if (dirs.length === 0) return { ...process.env }
   const env = { ...process.env }
   const key = Object.keys(env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
-  env[key] = [...dirs, env[key] ?? ''].filter(Boolean).join(delimiter)
+  // Rebuild PATH from the toolchain dirs + every non-empty existing segment. Splitting and
+  // re-filtering guarantees no empty/blank segments (i.e. no leading/trailing/doubled delimiter),
+  // which is what can otherwise break command resolution on Windows.
+  const existing = (env[key] ?? '').split(delimiter)
+  const segments = [...dirs, ...existing].map((s) => s.trim()).filter(Boolean)
+  // Only touch PATH if the parent had one (or we're adding dirs); write back the cleaned value
+  // even when it collapses to empty, so a parent PATH of only delimiters can't survive malformed.
+  if (env[key] !== undefined || dirs.length > 0) env[key] = segments.join(delimiter)
   return env
 }
 

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -282,6 +282,15 @@ async function findVcvarsall(): Promise<string | null> {
   }
 }
 
+/** The Windows command interpreter to spawn for our vcvars `.bat` steps. Windows always sets
+ *  `ComSpec` to the full path of cmd.exe (e.g. `C:\Windows\System32\cmd.exe`), which is the
+ *  portable, drive-agnostic way to reach it (Windows may not be on C:). Spawning the bare string
+ *  `'cmd.exe'` instead relies on PATH resolution, which can fail with `spawn cmd.exe ENOENT` if
+ *  PATH is malformed. The bare-string fallback is defensive only (ComSpec should always be set). */
+function winComSpec(): string {
+  return process.env.ComSpec || 'cmd.exe'
+}
+
 /** Run one child process, streaming combined stdout+stderr line-by-line to `onLine` and
  *  resolving with the full stdout text. Rejects with a clear message on a non-zero exit or
  *  spawn error; aborting `signal` kills the child (Node throws AbortError, name preserved). */
@@ -490,7 +499,7 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
   if (isWindows) {
     const configureBat = join(buildRoot, '_tllm_configure.bat')
     writeFileSync(configureBat, vcvarsBatch(vcvars!, configureArgs))
-    await runStep('cmd.exe', ['/c', configureBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
+    await runStep(winComSpec(), ['/c', configureBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
   } else {
     await runStep('cmake', configureArgs, { cwd: buildRoot, env, signal, onLine: hooks.log })
   }
@@ -501,7 +510,7 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
   if (isWindows) {
     const compileBat = join(buildRoot, '_tllm_build.bat')
     writeFileSync(compileBat, vcvarsBatch(vcvars!, compileArgs))
-    await runStep('cmd.exe', ['/c', compileBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
+    await runStep(winComSpec(), ['/c', compileBat], { cwd: buildRoot, env, signal, onLine: hooks.log })
   } else {
     await runStep('cmake', compileArgs, { cwd: buildRoot, env, signal, onLine: hooks.log })
   }

--- a/turbollm/src/engines/hardware.test.ts
+++ b/turbollm/src/engines/hardware.test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { detectHardware } from './hardware'
+import type { SysInfo } from '../sysinfo/sysinfo'
+
+// Regression test for the multi-GPU VRAM bug: detectHardware used to report
+// max(vramMb) across cards; a dual-GPU box must report the SUM (pooled budget).
+const dualNvidia: SysInfo = {
+  os: 'win32/x64',
+  cpu: 'Test CPU',
+  cores: 16,
+  ramMB: 65536,
+  gpus: [
+    { name: 'NVIDIA GeForce RTX 5060 Ti', vramMb: 16384, vendor: 'nvidia' },
+    { name: 'NVIDIA GeForce RTX 5060 Ti', vramMb: 16384, vendor: 'nvidia' },
+  ],
+}
+
+test('detectHardware: dual-GPU VRAM is summed, not maxed', () => {
+  const hw = detectHardware(dualNvidia)
+  assert.equal(hw.vramMb, 32768, 'two 16GB cards pool to 32GB, not 16GB')
+  assert.equal(hw.gpuVendor, 'nvidia')
+  assert.equal(hw.hasGpu, true)
+  assert.equal(hw.gpuName, 'NVIDIA GeForce RTX 5060 Ti')
+})
+
+test('detectHardware: mixed-size GPUs sum correctly', () => {
+  const info: SysInfo = {
+    ...dualNvidia,
+    gpus: [
+      { name: 'RTX 4090', vramMb: 24576, vendor: 'nvidia' },
+      { name: 'RTX 3060', vramMb: 12288, vendor: 'nvidia' },
+    ],
+  }
+  const hw = detectHardware(info)
+  assert.equal(hw.vramMb, 36864, '24GB + 12GB = 36GB total VRAM')
+  // Headline is the largest card of the primary vendor.
+  assert.equal(hw.gpuName, 'RTX 4090')
+})
+
+test('detectHardware: single GPU is unchanged (sum of one)', () => {
+  const info: SysInfo = {
+    ...dualNvidia,
+    gpus: [{ name: 'RTX 5070 Ti', vramMb: 16384, vendor: 'nvidia' }],
+  }
+  assert.equal(detectHardware(info).vramMb, 16384)
+})
+
+test('detectHardware: no GPU reports 0 VRAM', () => {
+  const info: SysInfo = { ...dualNvidia, gpus: [] }
+  const hw = detectHardware(info)
+  assert.equal(hw.vramMb, 0)
+  assert.equal(hw.hasGpu, false)
+})

--- a/turbollm/src/engines/hardware.test.ts
+++ b/turbollm/src/engines/hardware.test.ts
@@ -52,3 +52,29 @@ test('detectHardware: no GPU reports 0 VRAM', () => {
   assert.equal(hw.vramMb, 0)
   assert.equal(hw.hasGpu, false)
 })
+
+// Regression: a non-primary-vendor GPU (an Intel iGPU alongside an NVIDIA/AMD dGPU
+// is a common laptop/desktop layout) must NOT be summed into the fit budget — it
+// isn't usable for offload on the primary (discrete) backend.
+test('detectHardware: an Intel iGPU alongside an NVIDIA dGPU is excluded from the VRAM sum', () => {
+  const info: SysInfo = {
+    ...dualNvidia,
+    gpus: [
+      { name: 'NVIDIA GeForce RTX 4070', vramMb: 12288, vendor: 'nvidia' },
+      { name: 'Intel(R) Iris(R) Xe Graphics', vramMb: 4096, vendor: 'intel' },
+    ],
+  }
+  const hw = detectHardware(info)
+  assert.equal(hw.gpuVendor, 'nvidia')
+  assert.equal(hw.vramMb, 12288, 'the iGPU\'s 4GB must not inflate the usable budget')
+  assert.equal(hw.gpuName, 'NVIDIA GeForce RTX 4070')
+})
+
+// Symmetric case: a lone iGPU with no discrete card at all still reports its own
+// (small) VRAM correctly — the primary-vendor filter must not zero it out.
+test('detectHardware: an iGPU-only box still reports its own VRAM', () => {
+  const info: SysInfo = { ...dualNvidia, gpus: [{ name: 'Intel(R) UHD Graphics', vramMb: 1024, vendor: 'intel' }] }
+  const hw = detectHardware(info)
+  assert.equal(hw.gpuVendor, 'intel')
+  assert.equal(hw.vramMb, 1024)
+})

--- a/turbollm/src/engines/hardware.ts
+++ b/turbollm/src/engines/hardware.ts
@@ -29,9 +29,12 @@ export function detectHardware(info: SysInfo = getSysInfo()): HardwareProfile {
     (best, g) => (!best || g.vramMb > best.vramMb ? g : best),
     undefined,
   )
-  // Sum VRAM across all GPUs: a multi-GPU box (e.g. 2× RTX 5060 Ti 16GB) pools
-  // its VRAM for inference, so the fit budget is the total, not the largest card.
-  const vramMb = info.gpus.reduce((sum, g) => sum + g.vramMb, 0)
+  // Sum VRAM across GPUs of the PRIMARY vendor only: a multi-GPU box (e.g. 2× RTX
+  // 5060 Ti 16GB) pools its VRAM for inference, so the fit budget is the total, not
+  // the largest card — but a non-primary-vendor GPU (an Intel iGPU alongside an
+  // NVIDIA/AMD dGPU is common) isn't usable for offload, so it must not inflate the
+  // budget. `ofVendor` is empty only when there's no GPU at all (vramMb correctly 0).
+  const vramMb = ofVendor.reduce((sum, g) => sum + g.vramMb, 0)
   return {
     platform: process.platform,
     arch,

--- a/turbollm/src/engines/hardware.ts
+++ b/turbollm/src/engines/hardware.ts
@@ -13,7 +13,7 @@ export interface HardwareProfile {
   arch: Arch
   gpuVendor: GpuVendor // primaryVendor()
   hasGpu: boolean // gpuVendor !== 'unknown' && gpus.length > 0
-  vramMb: number // max vramMb across gpus, 0 if none
+  vramMb: number // sum of vramMb across gpus, 0 if none
   gpuName?: string // name of the highest-ranked gpu
 }
 
@@ -29,7 +29,9 @@ export function detectHardware(info: SysInfo = getSysInfo()): HardwareProfile {
     (best, g) => (!best || g.vramMb > best.vramMb ? g : best),
     undefined,
   )
-  const vramMb = info.gpus.reduce((max, g) => (g.vramMb > max ? g.vramMb : max), 0)
+  // Sum VRAM across all GPUs: a multi-GPU box (e.g. 2× RTX 5060 Ti 16GB) pools
+  // its VRAM for inference, so the fit budget is the total, not the largest card.
+  const vramMb = info.gpus.reduce((sum, g) => sum + g.vramMb, 0)
   return {
     platform: process.platform,
     arch,

--- a/turbollm/src/hf/hf.expand.test.ts
+++ b/turbollm/src/hf/hf.expand.test.ts
@@ -92,6 +92,45 @@ test('expandModelFiles: recovers the full repo path and reports the model dir fo
   })
 })
 
+test('expandModelFiles: gpt-oss-120b Q4_K_M (2-part split in a per-quant subfolder, root companions + single F16 present) expands to exactly its two shards in one dir', async () => {
+  // Mirrors the real unsloth/gpt-oss-120b-GGUF layout: every quant lives in its own
+  // subfolder as a 2-part split, plus root-level companion files (config.json, params,
+  // template) and a single root F16. Regression guard for the "missing parts" report:
+  // both shards must land under the SAME model dir so the scanner groups them into one
+  // complete split. (b2ecd47 follow-up — this specific repo regressed.)
+  const tree: TreeEntry[] = [
+    { type: 'file', path: 'config.json', size: 100 },
+    { type: 'file', path: 'params', size: 100 },
+    { type: 'file', path: 'template', size: 100 },
+    { type: 'file', path: 'README.md', size: 100 },
+    { type: 'file', path: 'gpt-oss-120b-F16.gguf', lfs: { oid: 'f16', size: 999 } },
+    { type: 'file', path: 'Q4_K_M/gpt-oss-120b-Q4_K_M-00001-of-00002.gguf', lfs: { oid: 'a', size: 10 } },
+    { type: 'file', path: 'Q4_K_M/gpt-oss-120b-Q4_K_M-00002-of-00002.gguf', lfs: { oid: 'b', size: 10 } },
+    { type: 'file', path: 'Q8_0/gpt-oss-120b-Q8_0-00001-of-00002.gguf', lfs: { oid: 'c', size: 20 } },
+    { type: 'file', path: 'Q8_0/gpt-oss-120b-Q8_0-00002-of-00002.gguf', lfs: { oid: 'd', size: 20 } },
+  ]
+  await withTree(tree, async () => {
+    // The Discover UI carries only the first shard's basename (groupFiles sets name = basename).
+    const { dir, files } = await client().expandModelFiles(
+      'unsloth/gpt-oss-120b-GGUF',
+      'gpt-oss-120b-Q4_K_M-00001-of-00002.gguf',
+    )
+    assert.equal(dir, 'Q4_K_M')
+    assert.deepEqual(files.map((f) => f.rfilename), [
+      'Q4_K_M/gpt-oss-120b-Q4_K_M-00001-of-00002.gguf',
+      'Q4_K_M/gpt-oss-120b-Q4_K_M-00002-of-00002.gguf',
+    ])
+    // No mmproj in this repo — must not fabricate one, and the root F16 / other quant / the
+    // companion files must never be pulled into this quant's download set.
+    assert.equal(files.length, 2)
+    assert.equal(files.every((f) => !f.mmproj), true)
+    // Both shards share one repo directory → they will download into one folder and the
+    // scanner will see a complete 2-of-2 split (the crux of the "missing parts" fix).
+    const dirs = new Set(files.map((f) => f.rfilename.slice(0, f.rfilename.lastIndexOf('/'))))
+    assert.equal(dirs.size, 1)
+  })
+})
+
 test('expandModelFiles: same-basename shards in two subfolders do NOT cross-match', async () => {
   const tree: TreeEntry[] = [
     { type: 'file', path: 'Q4_K_M/model-00001-of-00003.gguf', lfs: { oid: 'a1', size: 10 } },

--- a/turbollm/src/hf/hf.ts
+++ b/turbollm/src/hf/hf.ts
@@ -285,6 +285,32 @@ export class HfClient {
     return this.getCard(repo, CARD_EXTRACT_MAX)
   }
 
+  /** Fetch a repo's structured generation-params sidecar, if it has one — some quantizers
+   *  (e.g. unsloth) publish a root-level `params` JSON file with the exact recommended
+   *  sampling values (`{"temperature":1.0,"top_k":0,"top_p":1.0,"min_p":0.0,"stop":[…]}`)
+   *  alongside the GGUF shards. When present this is a strictly better signal than the
+   *  README heuristic/LLM extraction (exact values, no parsing/inference needed) — auto-tune
+   *  tries it first. Tries `params` then the more standard `generation_config.json` name.
+   *  Best-effort: '' when neither exists or the repo is unreachable, never throws. */
+  async fetchGenerationParams(repo: string): Promise<string> {
+    for (const name of ['params', 'generation_config.json']) {
+      const url = `${BASE}/${repo}/raw/main/${name}`
+      const now = Date.now()
+      const hit = this.cache.get(url)
+      if (hit && now - hit.at < CACHE_TTL_MS) return hit.value as string
+      try {
+        const res = await fetch(url, { headers: this.authHeaders(), redirect: 'follow' })
+        if (!res.ok) continue
+        const raw = await res.text()
+        this.cache.set(url, { at: now, value: raw })
+        return raw
+      } catch {
+        continue
+      }
+    }
+    return ''
+  }
+
   /** Resolve the upstream base model for a repo (ADR-099 base-model fallback): the `base_model`
    *  declared in the repo's HF card metadata. Most local GGUFs are third-party requants
    *  (lmstudio-community / unsloth / noctrex / …) whose card omits the author's recommended

--- a/turbollm/src/models/card-sampling.test.ts
+++ b/turbollm/src/models/card-sampling.test.ts
@@ -4,11 +4,48 @@ import {
   parseCardSampling,
   clampCardSampling,
   hasAnySampling,
+  parseGenerationParams,
   parseLlmSampling,
   buildCardExtractionPrompt,
   relevantCardExcerpt,
   type CardSampling,
 } from './card-sampling'
+
+// ─── generation-params sidecar (structured JSON) ────────────────────────────
+
+test('parseGenerationParams: real unsloth/gpt-oss-120b-GGUF `params` file', () => {
+  const raw = JSON.stringify({
+    stop: ['<|endoftext|>', '<|return|>'],
+    temperature: 1.0,
+    min_p: 0.0,
+    top_k: 0,
+    top_p: 1.0,
+  })
+  // min_p and top_k are legitimately 0 here — not "absent", a real recommendation.
+  assert.deepEqual(parseGenerationParams(raw), { temp: 1.0, topP: 1.0, topK: 0, minP: 0 })
+})
+
+test('parseGenerationParams: unknown/extra keys are ignored, known ones still parsed', () => {
+  const raw = JSON.stringify({ temperature: 0.6, repetition_penalty: 1.1, max_new_tokens: 512 })
+  assert.deepEqual(parseGenerationParams(raw), { temp: 0.6 })
+})
+
+test('parseGenerationParams: out-of-range values are dropped (same gate as the heuristic)', () => {
+  const raw = JSON.stringify({ temperature: 5, top_p: 0.9 })
+  assert.deepEqual(parseGenerationParams(raw), { topP: 0.9 })
+})
+
+test('parseGenerationParams: empty string → {}', () => {
+  assert.deepEqual(parseGenerationParams(''), {})
+})
+
+test('parseGenerationParams: invalid JSON → {} (never throws)', () => {
+  assert.deepEqual(parseGenerationParams('not json'), {})
+})
+
+test('parseGenerationParams: JSON array (not an object) → {}', () => {
+  assert.deepEqual(parseGenerationParams('[1,2,3]'), {})
+})
 
 // ─── heuristic parse ─────────────────────────────────────────────────────────
 

--- a/turbollm/src/models/card-sampling.ts
+++ b/turbollm/src/models/card-sampling.ts
@@ -92,6 +92,35 @@ export function hasAnySampling(s: CardSampling): boolean {
   return s.temp != null || s.topP != null || s.topK != null || s.minP != null
 }
 
+/** Parse a repo's structured `params`/`generation_config.json` sidecar (see
+ *  {@link HfClient.fetchGenerationParams}) — a flat JSON object using the same key names as
+ *  the LLM-fallback schema (`temperature`/`top_p`/`top_k`/`min_p`). Exact values, no regex
+ *  guessing, so this is tried before the card heuristic. Returns {} on anything unparseable
+ *  or when `raw` is empty — never throws. */
+export function parseGenerationParams(raw: string): CardSampling {
+  if (!raw) return {}
+  let obj: Record<string, unknown>
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+  if (typeof obj !== 'object' || obj === null) return {}
+  const num = (v: unknown): number | null => (typeof v === 'number' && Number.isFinite(v) ? v : null)
+  const out: CardSampling = {}
+  const map: [string, keyof CardSampling][] = [
+    ['temperature', 'temp'],
+    ['top_p', 'topP'],
+    ['top_k', 'topK'],
+    ['min_p', 'minP'],
+  ]
+  for (const [jsonKey, field] of map) {
+    const v = num(obj[jsonKey])
+    if (v !== null) out[field] = v
+  }
+  return clampCardSampling(out)
+}
+
 /** Pick the most relevant ~`maxLen`-char slice of a (possibly long) card for the LLM
  *  fallback. A card under the limit is returned whole; otherwise we center the window on
  *  the first sampling cue (temperature/top_k/top_p/min_p or a "recommended settings" /

--- a/turbollm/src/models/profile.gen.test.ts
+++ b/turbollm/src/models/profile.gen.test.ts
@@ -256,3 +256,25 @@ test('--grammar gated by engine capability', () => {
 test('deriveDefault grammar is empty string', () => {
   assert.equal(deriveDefault(model(), sys()).grammar, '')
 })
+
+// ── Speculative draft window (GitHub #35) ──────────────────────────────────────
+
+test('draft mode defaults to --draft-max 16 --draft-min 1 when unset', () => {
+  const p = { ...base(), speculative: 'draft' as const, draftModelPath: '/models/draft.gguf' }
+  const args = profileToArgs(p, model(), caps)
+  assert.equal(args[args.indexOf('--draft-max') + 1], '16')
+  assert.equal(args[args.indexOf('--draft-min') + 1], '1')
+})
+
+test('draft mode honors user draftMax/draftMin overrides', () => {
+  const p = { ...base(), speculative: 'draft' as const, draftModelPath: '/models/draft.gguf', draftMax: 8, draftMin: 2 }
+  const args = profileToArgs(p, model(), caps)
+  assert.equal(args[args.indexOf('--draft-max') + 1], '8')
+  assert.equal(args[args.indexOf('--draft-min') + 1], '2')
+})
+
+test('draftMin 0 is emitted (not treated as unset)', () => {
+  const p = { ...base(), speculative: 'draft' as const, draftModelPath: '/models/draft.gguf', draftMin: 0 }
+  const args = profileToArgs(p, model(), caps)
+  assert.equal(args[args.indexOf('--draft-min') + 1], '0')
+})

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -134,6 +134,12 @@ export interface LoadProfile {
   /** llama.cpp --ubatch-size (-ub). Physical micro-batch size for prompt processing. 0 / absent =
    *  engine default (512). Must be ≤ batchSize. Tune alongside batchSize for throughput. */
   uBatchSize?: number
+  /** Speculative-decoding draft window, `draft` mode only (GitHub #35). Max tokens the draft
+   *  model proposes per step (--draft-max). Absent → 16 (the previous hardcoded default). */
+  draftMax?: number
+  /** Speculative-decoding draft window, `draft` mode only (GitHub #35). Min tokens drafted per
+   *  step before verification (--draft-min). Absent → 1 (the previous hardcoded default). */
+  draftMin?: number
   /** Provenance of a saved profile (spec 05 §3, 09 §1): 'bench' = written by the
    *  auto-tune runner, 'user' = hand-saved. Absent on heuristic/global defaults. */
   tunedBy?: 'bench' | 'user'
@@ -386,7 +392,8 @@ export function profileToArgs(p: LoadProfile, m: ModelEntry, caps: Capabilities,
     if (nextnVal) a.push('--spec-type', nextnVal, '--model-draft', m.path)
   } else if (p.speculative === 'draft' && p.draftModelPath && has('--model-draft')) {
     if (specType) a.push('--spec-type', 'draft')
-    a.push('--model-draft', p.draftModelPath, '--draft-max', '16', '--draft-min', '1')
+    // Draft window overridable per-model (GitHub #35); absent → the previous 16/1 defaults.
+    a.push('--model-draft', p.draftModelPath, '--draft-max', String(p.draftMax ?? 16), '--draft-min', String(p.draftMin ?? 1))
   }
   // Sampling startup defaults — become the engine's per-request defaults; can still
   // be overridden in the chat request body. Only emitted when non-default to avoid

--- a/turbollm/src/models/scanner.split.test.ts
+++ b/turbollm/src/models/scanner.split.test.ts
@@ -1,0 +1,103 @@
+// Regression tests for GGUF split-shard completeness in Scanner.build (spec 04 §2).
+//
+// Bug (b2ecd47 follow-up): a multi-part GGUF whose shards download correctly still got
+// reported as "missing parts" and refused to load. The completeness check must judge a
+// split complete by the distinct part INDICES present (1..total), so:
+//   - both shards of a 2-of-2 split in a per-quant subfolder → incomplete=false
+//     (mirrors the on-disk layout the gpt-oss-120b download produces);
+//   - a genuinely missing part → incomplete=true;
+//   - a stray duplicate of one shard must not mask a real hole, nor make a complete
+//     split look "over-full".
+//
+// entryFor() runs parseGguf on each file; these dummy shards are not valid GGUFs, so
+// parseError is set — but `incomplete` is computed independently of the header parse,
+// which is exactly what these tests exercise.
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import type { ConfigStore } from '../config/config'
+import { Scanner } from './scanner'
+
+// walk() only records .gguf files >= 1 MiB — write shards just over that threshold.
+const SHARD_BYTES = (1 << 20) + 16
+const SHARD_BUF = Buffer.alloc(SHARD_BYTES)
+
+function makeTmpRoot(): string {
+  const dir = join(tmpdir(), `turbollm-split-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+/** Minimal ConfigStore stub: the Scanner only reads dir() (cache location) and
+ *  snapshot().modelDirs (what to walk). Cache lives under the same temp root. */
+function stubStore(root: string): ConfigStore {
+  return {
+    dir: () => root,
+    snapshot: () => ({ modelDirs: [root] }),
+  } as unknown as ConfigStore
+}
+
+function writeShards(dir: string, names: string[]): void {
+  mkdirSync(dir, { recursive: true })
+  for (const n of names) writeFileSync(join(dir, n), SHARD_BUF)
+}
+
+/** Scan a temp root and return the single GGUF entry (there is exactly one split group). */
+async function scanOne(root: string): Promise<{ incomplete: boolean } | undefined> {
+  const scanner = new Scanner(stubStore(root))
+  await scanner.rescan()
+  return scanner.list().models.find((m) => m.format === 'gguf')
+}
+
+test('gpt-oss-120b Q4_K_M: both shards of a 2-of-2 split in a per-quant subfolder → complete', async () => {
+  const root = makeTmpRoot()
+  try {
+    // The exact on-disk layout the download produces: <owner>/<repo>/<quant-subdir>/<shards>.
+    const dir = join(root, 'unsloth', 'gpt-oss-120b-GGUF', 'Q4_K_M')
+    writeShards(dir, [
+      'gpt-oss-120b-Q4_K_M-00001-of-00002.gguf',
+      'gpt-oss-120b-Q4_K_M-00002-of-00002.gguf',
+    ])
+    const entry = await scanOne(root)
+    assert.ok(entry, 'expected one GGUF split entry')
+    assert.equal(entry.incomplete, false)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('a genuinely missing part → incomplete=true', async () => {
+  const root = makeTmpRoot()
+  try {
+    const dir = join(root, 'unsloth', 'gpt-oss-120b-GGUF', 'Q4_K_M')
+    writeShards(dir, ['gpt-oss-120b-Q4_K_M-00001-of-00002.gguf']) // 2nd shard absent
+    const entry = await scanOne(root)
+    assert.ok(entry)
+    assert.equal(entry.incomplete, true)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('an out-of-range stray shard does not mask a missing in-range part', async () => {
+  const root = makeTmpRoot()
+  try {
+    // A 3-part split with the real shard 3 missing, but a stray shard whose index (4)
+    // exceeds `total` sits in the same folder. The old count-based check (files === total)
+    // would see 3 files / total 3 and pass; the index-based check sees indices {1,2,4} —
+    // index 3 is absent — and correctly flags it incomplete.
+    const dir = join(root, 'repo', 'Q4_K_M')
+    writeShards(dir, [
+      'm-00001-of-00003.gguf',
+      'm-00002-of-00003.gguf',
+      'm-00004-of-00003.gguf', // stray / mislabeled part — index out of range
+    ])
+    const entry = await scanOne(root)
+    assert.ok(entry)
+    assert.equal(entry.incomplete, true)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -166,15 +166,24 @@ export class Scanner {
       const modelFiles = group.filter((f) => !basename(f.path).toLowerCase().includes('mmproj'))
       const mmprojPath = mmprojFiles.sort((a, b) => b.size - a.size)[0]?.path ?? null
 
-      // Resolve split groups: prefix+total -> shards.
-      const splits = new Map<string, { shards: FileInfo[]; total: number }>()
+      // Resolve split groups: prefix+total -> shards, keyed by shard INDEX so a split is
+      // judged complete by the distinct part numbers present (1..total), not by the raw
+      // file count. A duplicate copy of one shard (e.g. a leftover from a re-download)
+      // must not make an otherwise-complete split look "over-full", and — more importantly
+      // — a missing part must be detected by its absent index, so the presence check is
+      // index-based (spec 04 §2).
+      const splits = new Map<string, { shards: Map<number, FileInfo>; total: number }>()
       const singles: FileInfo[] = []
       for (const f of modelFiles) {
         const m = basename(f.path).match(SPLIT_RE)
         if (m) {
           const gkey = `${m[1]}|${m[3]}`
-          const g = splits.get(gkey) ?? { shards: [], total: Number(m[3]) }
-          g.shards.push(f)
+          const g = splits.get(gkey) ?? { shards: new Map<number, FileInfo>(), total: Number(m[3]) }
+          const idx = Number(m[2])
+          // First writer for an index wins; a duplicate same-index file is ignored so it
+          // can't inflate the count. Deterministic: keep the lexicographically-first path.
+          const prev = g.shards.get(idx)
+          if (!prev || f.path.localeCompare(prev.path) < 0) g.shards.set(idx, f)
           splits.set(gkey, g)
         } else {
           singles.push(f)
@@ -186,10 +195,19 @@ export class Scanner {
         await tick()
       }
       for (const { shards, total } of splits.values()) {
-        shards.sort((a, b) => a.path.localeCompare(b.path))
-        const first = shards[0]
-        const totalSize = shards.reduce((s, x) => s + x.size, 0)
-        const incomplete = shards.length !== total
+        const present = [...shards.values()].sort((a, b) => a.path.localeCompare(b.path))
+        const first = present[0]
+        const totalSize = present.reduce((s, x) => s + x.size, 0)
+        // Complete only when every index 1..total is present on disk (not merely when the
+        // count matches — a duplicate + a hole would otherwise pass the old length check).
+        let incomplete = shards.size !== total
+        if (!incomplete) {
+          for (let i = 1; i <= total; i++)
+            if (!shards.has(i)) {
+              incomplete = true
+              break
+            }
+        }
         entries.push(await this.entryFor(first.path, totalSize, first.mtime, dir, mmprojPath, incomplete))
         await tick()
       }

--- a/turbollm/src/sysinfo/sysinfo.test.ts
+++ b/turbollm/src/sysinfo/sysinfo.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseRocmSmi } from './sysinfo'
+
+// rocm-smi --showmeminfo vram --json output for an RX 7900 XTX (24GB). The WMI
+// AdapterRAM fallback would cap this at ~4GB; rocm-smi reports the true total.
+const memJson = JSON.stringify({
+  card0: {
+    'VRAM Total Memory (B)': '25753026560',
+    'VRAM Total Used Memory (B)': '1234567890',
+  },
+})
+const nameJson = JSON.stringify({
+  card0: { 'Card Series': 'Radeon RX 7900 XTX', 'Card Model': '0x744c' },
+})
+
+test('parseRocmSmi: single AMD card reports true 24GB VRAM', () => {
+  const gpus = parseRocmSmi(memJson, nameJson)
+  assert.equal(gpus.length, 1)
+  assert.equal(gpus[0].vendor, 'amd')
+  assert.equal(gpus[0].name, 'Radeon RX 7900 XTX')
+  // 25753026560 bytes / 1e6 ≈ 25753 MB (~24 GiB), NOT the 4GB WMI cap.
+  assert.equal(gpus[0].vramMb, 25753)
+  assert.ok(gpus[0].vramMb > 20000, 'must be well above the 4GB AdapterRAM cap')
+})
+
+test('parseRocmSmi: falls back to a generic name when productname is absent', () => {
+  const gpus = parseRocmSmi(memJson)
+  assert.equal(gpus.length, 1)
+  assert.equal(gpus[0].vendor, 'amd')
+  assert.equal(gpus[0].name, 'AMD Radeon GPU')
+  assert.equal(gpus[0].vramMb, 25753)
+})
+
+test('parseRocmSmi: multiple AMD cards each parse', () => {
+  const multiMem = JSON.stringify({
+    card0: { 'VRAM Total Memory (B)': '25753026560' },
+    card1: { 'VRAM Total Memory (B)': '25753026560' },
+  })
+  const gpus = parseRocmSmi(multiMem)
+  assert.equal(gpus.length, 2)
+  assert.equal(gpus[0].vramMb, 25753)
+  assert.equal(gpus[1].vramMb, 25753)
+  assert.ok(gpus.every((g) => g.vendor === 'amd'))
+})
+
+test('parseRocmSmi: cards reporting zero/unknown VRAM are skipped', () => {
+  const badMem = JSON.stringify({
+    card0: { 'VRAM Total Memory (B)': '0' },
+    card1: { 'Some Other Field': 'x' },
+  })
+  assert.equal(parseRocmSmi(badMem).length, 0)
+})

--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -68,7 +68,13 @@ function detectGpus(): GpuInfo[] {
         return { name: (name ?? '').trim(), vramMb: parseInt((mb ?? '').trim(), 10) || 0, vendor: 'nvidia' as const }
       })
       .filter((g) => g.vramMb > 0)
-    if (gpus.length) return gpus
+    if (gpus.length) {
+      // Debug aid: dual-GPU users have reported a lower-than-expected total. Log
+      // the raw per-GPU VRAM parsed from nvidia-smi so a future report can tell
+      // "only one card enumerated" apart from "sum bug" (fixed in hardware.ts).
+      console.log(`[sysinfo] nvidia-smi enumerated ${gpus.length} GPU(s): ${gpus.map((g) => `${g.name}=${g.vramMb}MB`).join(', ')}`)
+      return gpus
+    }
   } catch {
     /* no nvidia-smi */
   }
@@ -99,8 +105,19 @@ function detectGpus(): GpuInfo[] {
 }
 
 function enumWindowsGpus(): GpuInfo[] {
+  // AMD first: ROCm's rocm-smi reports true VRAM, unlike WMI's 4GB-capped
+  // AdapterRAM below. Only present when ROCm is installed; falls through if not.
+  try {
+    const amd = rocmSmiGpus()
+    if (amd.length) return amd
+  } catch {
+    /* no rocm-smi (ROCm not installed) — fall back to WMI */
+  }
+
   // Win32_VideoController: Name + AdapterRAM (AdapterRAM caps at 4GB for larger
-  // cards and is unreliable — used only as a weak hint).
+  // cards and is unreliable — used only as a weak hint). This mis-sizes AMD cards
+  // >4GB (e.g. RX 7900 XTX reports ~4GB, not 24GB), which is why AMD is tried via
+  // rocm-smi first above.
   const ps =
     'Get-CimInstance Win32_VideoController | ForEach-Object { "$($_.Name)|$($_.AdapterRAM)" }'
   const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
@@ -117,6 +134,50 @@ function enumWindowsGpus(): GpuInfo[] {
       return { name: nm, vramMb: bytes > 0 ? Math.round(bytes / 1e6) : 0, vendor: classifyVendor(nm) }
     })
     .filter((g) => g.name && g.vendor !== 'unknown')
+}
+
+// AMD VRAM on Windows via ROCm's rocm-smi. `--showmeminfo vram --json` returns an
+// object keyed by "card0", "card1", … each with "VRAM Total Memory (B)". Card
+// names aren't in that call, so pair it with --showproductname; degrade to a
+// generic "AMD Radeon GPU" name (vendor still classifies as amd) when a name is
+// missing. Throws when rocm-smi isn't on PATH so the caller falls back to WMI.
+function rocmSmiGpus(): GpuInfo[] {
+  const memJson = execFileSync('rocm-smi', ['--showmeminfo', 'vram', '--json'], {
+    timeout: 8000,
+    windowsHide: true,
+  }).toString()
+
+  let nameJson = ''
+  try {
+    nameJson = execFileSync('rocm-smi', ['--showproductname', '--json'], {
+      timeout: 8000,
+      windowsHide: true,
+    }).toString()
+  } catch {
+    /* names optional — vendor classification and VRAM come from the mem query */
+  }
+  return parseRocmSmi(memJson, nameJson)
+}
+
+/** Pure parser for rocm-smi --json output, split out for direct testing.
+ *  `memJson` is `--showmeminfo vram --json`; `nameJson` (may be empty) is
+ *  `--showproductname --json`. */
+export function parseRocmSmi(memJson: string, nameJson = ''): GpuInfo[] {
+  const mem = JSON.parse(memJson) as Record<string, Record<string, string>>
+  let names: Record<string, Record<string, string>> = {}
+  if (nameJson.trim()) names = JSON.parse(nameJson) as Record<string, Record<string, string>>
+
+  const gpus: GpuInfo[] = []
+  for (const [card, fields] of Object.entries(mem)) {
+    const totalKey = Object.keys(fields).find((k) => /VRAM Total Memory/i.test(k))
+    const bytes = totalKey ? parseInt(String(fields[totalKey]).trim(), 10) || 0 : 0
+    if (bytes <= 0) continue
+    const nameFields = names[card] ?? {}
+    const nameKey = Object.keys(nameFields).find((k) => /(Card Series|Card Model|Product Name|Device Name)/i.test(k))
+    const name = (nameKey ? String(nameFields[nameKey]).trim() : '') || 'AMD Radeon GPU'
+    gpus.push({ name, vramMb: Math.round(bytes / 1e6), vendor: 'amd' })
+  }
+  return gpus
 }
 
 function enumLinuxGpus(): GpuInfo[] {

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -55,7 +55,7 @@ export type BuiltinSearchEntry = {
 export const BUILTIN_SEARCH: BuiltinSearchEntry[] = [
   { id: 'tavily', name: 'Tavily', desc: 'AI-search API tuned for LLMs.' },
   { id: 'kagi', name: 'Kagi', desc: 'Premium search with no ads or tracking.', iconSlug: 'kagi' },
-  { id: 'searxng', name: 'SearXNG', desc: 'Self-hosted meta-search, fully local.', iconSlug: 'searxng' },
+  { id: 'searxng', name: 'SearXNG', desc: 'Self-hosted meta-search, fully local — no API key required.', iconSlug: 'searxng' },
 ]
 
 // Only entries where a static API key / Bearer token is confirmed to work against the

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -516,6 +516,10 @@ export type LoadProfile = {
   batchSize?: number
   /** llama.cpp --ubatch-size. Physical micro-batch size. 0 / absent = engine default (512). */
   uBatchSize?: number
+  /** Speculative `draft` mode window (GitHub #35). --draft-max; absent = 16 default. */
+  draftMax?: number
+  /** Speculative `draft` mode window (GitHub #35). --draft-min; absent = 1 default. */
+  draftMin?: number
   tunedBy?: string
 }
 

--- a/turbollm/web/src/lib/usePinnedModels.ts
+++ b/turbollm/web/src/lib/usePinnedModels.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useState } from 'react'
+
+/** localStorage key for the client-only set of pinned/favourited model keys. Pinned
+ *  models float to the top of the library list. Stored as a JSON-serialized array of
+ *  model keys (see SettingsScreen for the same localStorage-preference pattern). */
+const PINNED_MODELS_KEY = 'tllm.pinnedModels'
+
+function readPinned(): Set<string> {
+  try {
+    const raw = localStorage.getItem(PINNED_MODELS_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? new Set(parsed.filter((k): k is string => typeof k === 'string')) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+/** Client-only pinned-models state, persisted to localStorage. Returns the current set
+ *  of pinned model keys, a predicate, and a toggle that writes through immediately. */
+export function usePinnedModels() {
+  const [pinned, setPinned] = useState<Set<string>>(() => readPinned())
+
+  // Persist on every change (no Save round-trip; it's client-only, like the thinking pref).
+  useEffect(() => {
+    localStorage.setItem(PINNED_MODELS_KEY, JSON.stringify([...pinned]))
+  }, [pinned])
+
+  const isPinned = useCallback((key: string) => pinned.has(key), [pinned])
+
+  const togglePinned = useCallback((key: string) => {
+    setPinned((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+
+  return { pinned, isPinned, togglePinned }
+}

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -163,10 +163,16 @@ export function ChatScreen() {
     if (live) scrollToBottom()
   }, [live, scrollToBottom])
 
-  // Ctrl+N new chat, Esc stop
+  // Ctrl+N new chat, Esc stop. Whitelist ONLY these exact combos and preventDefault
+  // solely for the one we handle (Ctrl/Cmd+N) — never for anything else, so native
+  // shortcuts like Ctrl/Cmd+C (copy) are left untouched.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'n') { e.preventDefault(); handleNew() }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'n' || e.key === 'N')) {
+        e.preventDefault()
+        handleNew()
+        return
+      }
       if (e.key === 'Escape' && live) { void handleStop() }
     }
     window.addEventListener('keydown', handler)
@@ -280,6 +286,17 @@ export function ChatScreen() {
     setSelectedPersonaId(getConvPersonaId(id))
     userScrolledUp.current = false
     setTimeout(() => scrollToBottom(true), 50)
+  }
+
+  // The currently-open conversation was deleted — abort any live generation and
+  // close it (clear activeId) so we don't hold a dangling reference.
+  const handleActiveDeleted = (id: string) => {
+    if (id !== activeId) return
+    if (live) { abortRef.current?.abort(); setLive(null) }
+    setActiveId(null)
+    setEditingId(null)
+    setInput('')
+    setSelectedPersonaId(getDefaultPersonaId())
   }
 
   const handleStop = async () => {
@@ -469,6 +486,8 @@ export function ChatScreen() {
           onImport={readonly ? undefined : () => importFileRef.current?.click()}
           collapsed={!sidebarOpen}
           onToggle={() => setSidebarOpen((o) => !o)}
+          generating={!!live}
+          onDeleted={handleActiveDeleted}
         />
       </div>
 

--- a/turbollm/web/src/screens/CustomizeScreen.tsx
+++ b/turbollm/web/src/screens/CustomizeScreen.tsx
@@ -554,6 +554,8 @@ function McpSection({ servers, search }: { servers: McpServer[]; search: DaemonS
                     </button>
                   </div>
 
+                  <p className="text-[11px] leading-relaxed text-muted">{entry.desc}</p>
+
                   {entry.id === 'searxng' ? (
                     <div className="flex flex-col gap-1">
                       <label className="text-[12px] text-muted">SearXNG URL</label>

--- a/turbollm/web/src/screens/ModelsScreen.tsx
+++ b/turbollm/web/src/screens/ModelsScreen.tsx
@@ -1,8 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState, type ReactNode } from 'react'
-import { Boxes, ChevronRight, CircleSlash, Download, Loader2, MoreHorizontal, PackageSearch, RefreshCw, SlidersHorizontal, Trash2, Zap } from 'lucide-react'
+import { Boxes, ChevronRight, CircleSlash, Download, Loader2, MoreHorizontal, PackageSearch, RefreshCw, SlidersHorizontal, Star, Trash2, Zap } from 'lucide-react'
 import { ApiError, deleteModel } from '../lib/api'
 import { queryKeys, useModelActions, useModelDirs, useModelMutations, useModels, useStatus } from '../lib/queries'
+import { usePinnedModels } from '../lib/usePinnedModels'
 import type { ModelEntry } from '../lib/types'
 import { EmptyState, InlineError, ScreenHeader } from '../components/common'
 import { Badge } from '../components/ui/badge'
@@ -37,7 +38,7 @@ type Tab = 'library' | 'discover'
  *  with a single variant stays a flat row (spec 04 §2 / spec 11 §5). */
 type Group = { name: string; variants: ModelEntry[] }
 
-function groupModels(models: ModelEntry[]): Group[] {
+function groupModels(models: ModelEntry[], isPinned: (key: string) => boolean): Group[] {
   const byName = new Map<string, ModelEntry[]>()
   for (const m of models) {
     const k = m.name.toLowerCase()
@@ -53,7 +54,11 @@ function groupModels(models: ModelEntry[]): Group[] {
       order.push(k)
     }
   }
-  return order.map((k) => ({ name: byName.get(k)![0].name, variants: byName.get(k)! }))
+  const groups = order.map((k) => ({ name: byName.get(k)![0].name, variants: byName.get(k)! }))
+  // Pinned/favourited models float to the top; a group is pinned when any of its
+  // variants is pinned. Stable partition keeps the existing order within each half.
+  const isGroupPinned = (g: Group) => g.variants.some((v) => isPinned(v.key))
+  return [...groups.filter(isGroupPinned), ...groups.filter((g) => !isGroupPinned(g))]
 }
 
 export function ModelsScreen() {
@@ -63,6 +68,7 @@ export function ModelsScreen() {
   const actions = useModelActions()
   const del = useDeleteModel()
   const { data: status } = useStatus()
+  const { isPinned, togglePinned } = usePinnedModels()
 
   // A load isn't instant: POST /load returns 202, then the engine spends seconds in
   // `starting` before the model is `running`. Keep the Load buttons in a busy/loading
@@ -112,7 +118,7 @@ export function ModelsScreen() {
     if (filter === 'embedding') return m.embedding
     return true
   })
-  const groups = groupModels(filtered)
+  const groups = groupModels(filtered, isPinned)
 
   const onConfirmDelete = () => {
     const m = confirmDelete
@@ -209,6 +215,8 @@ export function ModelsScreen() {
           setOpenKey={setOpenKey}
           setConfirmDelete={setConfirmDelete}
           onDiscover={onDiscover}
+          isPinned={isPinned}
+          togglePinned={togglePinned}
         />
       )}
 
@@ -257,6 +265,8 @@ function LibraryTab({
   setOpenKey,
   setConfirmDelete,
   onDiscover,
+  isPinned,
+  togglePinned,
 }: {
   modelsQ: ReturnType<typeof useModels>
   mut: ReturnType<typeof useModelMutations>
@@ -273,6 +283,8 @@ function LibraryTab({
   setOpenKey: (k: string | null) => void
   setConfirmDelete: (m: ModelEntry | null) => void
   onDiscover: (m: ModelEntry) => void
+  isPinned: (key: string) => boolean
+  togglePinned: (key: string) => void
 }) {
   return (
     <>
@@ -322,6 +334,8 @@ function LibraryTab({
                 busy={loadBusy}
                 loadingThis={loadingKey === g.variants[0].key}
                 ejecting={actions.eject.isPending}
+                pinned={isPinned(g.variants[0].key)}
+                onTogglePin={() => togglePinned(g.variants[0].key)}
               />
             ) : (
               <ModelGroupRow
@@ -335,6 +349,8 @@ function LibraryTab({
                 busy={loadBusy}
                 loadingKey={loadingKey}
                 ejecting={actions.eject.isPending}
+                isPinned={isPinned}
+                togglePinned={togglePinned}
               />
             ),
           )}
@@ -368,6 +384,8 @@ function ModelGroupRow({
   busy,
   loadingKey,
   ejecting,
+  isPinned,
+  togglePinned,
 }: {
   group: Group
   onLoad: (key: string) => void
@@ -378,9 +396,12 @@ function ModelGroupRow({
   busy: boolean
   loadingKey: string | undefined
   ejecting: boolean
+  isPinned: (key: string) => boolean
+  togglePinned: (key: string) => void
 }) {
   const [open, setOpen] = useState(false)
   const anyLoaded = group.variants.some((v) => v.loaded)
+  const anyPinned = group.variants.some((v) => isPinned(v.key))
   return (
     <div className="rounded-lg border border-border bg-panel">
       <button
@@ -395,6 +416,7 @@ function ModelGroupRow({
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <span className="truncate font-medium text-ink">{group.name}</span>
+            {anyPinned && <Star size={13} className="shrink-0 fill-current text-accent" />}
             {anyLoaded && <Tag tone="ok">loaded</Tag>}
           </div>
           <div className="mt-0.5 truncate text-[12px] text-muted">
@@ -420,6 +442,8 @@ function ModelGroupRow({
               busy={busy}
               loadingThis={loadingKey === m.key}
               ejecting={ejecting}
+              pinned={isPinned(m.key)}
+              onTogglePin={() => togglePinned(m.key)}
             />
           ))}
         </div>
@@ -439,6 +463,8 @@ function ModelRow({
   busy,
   loadingThis,
   ejecting,
+  pinned,
+  onTogglePin,
 }: {
   m: ModelEntry
   child?: boolean
@@ -452,6 +478,9 @@ function ModelRow({
   /** This specific model is the one currently coming up — show the spinner here. */
   loadingThis: boolean
   ejecting: boolean
+  /** This model is pinned/favourited — floats to the top of the list. */
+  pinned: boolean
+  onTogglePin: () => void
 }) {
   const loadable = !m.incomplete && !m.parseError
   // Engine compatibility (ADR-044): shown in the "All" view via "Show all". An incompatible
@@ -496,6 +525,16 @@ function ModelRow({
         <Stat>{m.nativeCtx ? `${fmtCtx(m.nativeCtx)} ctx` : '—'}</Stat>
         <TpsStat m={m} />
         <div className="ml-auto flex items-center gap-1 sm:ml-0">
+          <button
+            type="button"
+            onClick={onTogglePin}
+            aria-label={pinned ? 'Unpin model' : 'Pin model to top'}
+            aria-pressed={pinned}
+            title={pinned ? 'Unpin' : 'Pin to top'}
+            className={`grid h-8 w-8 place-items-center rounded-md transition-colors hover:bg-panel-2 ${pinned ? 'text-accent' : 'text-muted hover:text-ink'}`}
+          >
+            <Star size={15} className={pinned ? 'fill-current' : ''} />
+          </button>
           <Button
             size="sm"
             onClick={onLoad}

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -32,6 +32,11 @@ import { toast } from '../components/ui/sonner'
  *  when OFF, the model is told to answer directly. Default ON when unset. */
 const THINKING_DEFAULT_KEY = 'tllm.thinkingEnabled.default'
 
+/** localStorage key for the client-only "confirm before deleting a conversation"
+ *  preference. When ON, deleting a conversation shows a confirmation dialog first;
+ *  when OFF, deletes immediately. Default ON when unset. */
+const CONFIRM_DELETE_KEY = 'tllm.confirmDeleteConversation'
+
 /** A controlled numeric input that doesn't fight the user mid-edit. A raw
  *  `value={number}` with `Number(e.target.value) || min` snaps an emptied field
  *  straight back to a number, so you can't clear it to retype and every partial
@@ -124,6 +129,8 @@ export function SettingsScreen() {
   const [gatewayKeepN, setGatewayKeepN] = useState(1)
   // Client-only "enable thinking by default" preference (ADR-042); default ON.
   const [thinkingEnabled, setThinkingEnabled] = useState(() => localStorage.getItem(THINKING_DEFAULT_KEY) !== 'false')
+  // Client-only "confirm before deleting a conversation" preference; default ON.
+  const [confirmDelete, setConfirmDelete] = useState(() => localStorage.getItem(CONFIRM_DELETE_KEY) !== 'false')
 
   // Full-screen overlay while the daemon re-execs (spec 08 §2).
   const [restartOverlay, setRestartOverlay] = useState(false)
@@ -154,6 +161,11 @@ export function SettingsScreen() {
   useEffect(() => {
     localStorage.setItem(THINKING_DEFAULT_KEY, thinkingEnabled ? 'true' : 'false')
   }, [thinkingEnabled])
+
+  // Persist the confirm-before-delete preference immediately (client-only).
+  useEffect(() => {
+    localStorage.setItem(CONFIRM_DELETE_KEY, confirmDelete ? 'true' : 'false')
+  }, [confirmDelete])
 
   const settingsPayload = () => ({
     // Clamp defensively: NumberField commits unclamped while editing and only
@@ -257,6 +269,20 @@ export function SettingsScreen() {
               type="checkbox"
               checked={thinkingEnabled}
               onChange={(e) => setThinkingEnabled(e.target.checked)}
+              className="h-4 w-4 accent-[var(--accent)]"
+            />
+          </label>
+
+          {/* Confirm before deleting a conversation: client-only, default ON. */}
+          <label className="flex cursor-pointer items-center justify-between border-t border-border py-2 pt-3">
+            <div>
+              <div className="text-[14px] font-medium text-ink">Confirm before deleting a conversation</div>
+              <div className="text-[12px] text-muted">Ask for confirmation before a conversation is deleted. Off = delete immediately with no prompt.</div>
+            </div>
+            <input
+              type="checkbox"
+              checked={confirmDelete}
+              onChange={(e) => setConfirmDelete(e.target.checked)}
               className="h-4 w-4 accent-[var(--accent)]"
             />
           </label>

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -5,6 +5,21 @@ import { useConversationMutations, useConversations } from '../../lib/chat-queri
 import { Button } from '../../components/ui/button'
 import { Input } from '../../components/ui/input'
 import { toast } from '../../components/ui/sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../../components/ui/alert-dialog'
+
+/** localStorage key for the client-only "confirm before deleting a conversation"
+ *  preference (mirrors SettingsScreen). Default ON when unset. */
+const CONFIRM_DELETE_KEY = 'tllm.confirmDeleteConversation'
+const confirmDeleteEnabled = (): boolean => localStorage.getItem(CONFIRM_DELETE_KEY) !== 'false'
 
 function relTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
@@ -21,6 +36,8 @@ export function ConversationSidebar({
   onImport,
   collapsed,
   onToggle,
+  generating,
+  onDeleted,
 }: {
   activeId: string | null
   onSelect: (id: string) => void
@@ -29,9 +46,16 @@ export function ConversationSidebar({
   onImport?: () => void
   collapsed?: boolean
   onToggle?: () => void
+  /** True when a generation is streaming in the active conversation. */
+  generating?: boolean
+  /** Called after a conversation is deleted so the parent can clear its active
+   *  reference when the deleted conversation was the open one. */
+  onDeleted?: (id: string) => void
 }) {
   const [q, setQ] = useState('')
   const [debouncedQ, setDebouncedQ] = useState('')
+  // Conversation queued for a confirmation dialog (null = dialog closed).
+  const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null)
   const searchRef = useRef<HTMLInputElement>(null)
   const mut = useConversationMutations()
   const convsQ = useConversations(debouncedQ || undefined)
@@ -49,13 +73,29 @@ export function ConversationSidebar({
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
-  const onDelete = (e: React.MouseEvent, conv: Conversation) => {
-    e.stopPropagation()
+  // Actually delete a conversation. If it was the active one, tell the parent so
+  // it can close/clear the now-dangling reference.
+  const doDelete = (conv: Conversation) => {
+    const wasActive = conv.id === activeId
     mut.remove.mutate(conv.id, {
-      onSuccess: () => { toast.success('Conversation deleted') },
-      onError:   () => { toast.error('Could not delete conversation.') },
+      onSuccess: () => {
+        toast.success('Conversation deleted')
+        if (wasActive) onDeleted?.(conv.id)
+      },
+      onError: () => { toast.error('Could not delete conversation.') },
     })
   }
+
+  const onDelete = (e: React.MouseEvent, conv: Conversation) => {
+    e.stopPropagation()
+    // When confirmation is enabled, queue the dialog; otherwise delete immediately.
+    if (confirmDeleteEnabled()) setPendingDelete(conv)
+    else doDelete(conv)
+  }
+
+  // Warn that an in-flight generation will be lost only when deleting the active,
+  // currently-generating conversation.
+  const pendingIsActiveGenerating = !!pendingDelete && pendingDelete.id === activeId && !!generating
 
   if (collapsed) {
     return (
@@ -113,6 +153,34 @@ export function ConversationSidebar({
           <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} onSelect={onSelect} onDelete={onDelete} />
         ))}
       </div>
+
+      {/* Delete confirmation (only shown when the "confirm before delete" setting is on). */}
+      <AlertDialog open={!!pendingDelete} onOpenChange={(open) => { if (!open) setPendingDelete(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete ? (
+                <>
+                  <span className="font-medium text-ink">{pendingDelete.title || 'Untitled conversation'}</span>{' '}
+                  will be permanently deleted. This can’t be undone.
+                  {pendingIsActiveGenerating && (
+                    <> A response is still generating in this conversation — it will be stopped and lost.</>
+                  )}
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { if (pendingDelete) doDelete(pendingDelete); setPendingDelete(null) }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/turbollm/web/src/screens/models/HfRepoDialog.tsx
+++ b/turbollm/web/src/screens/models/HfRepoDialog.tsx
@@ -159,10 +159,11 @@ export function HfRepoContent({
     dlMut.enqueue.mutate(
       { repo: detail.repo, rfilename: selectedFile.name, size: selectedFile.sizeBytes, sha256: selectedFile.sha256 },
       {
-        onSuccess: () => {
-          toast.success(`Downloading ${selectedFile.name}`)
-          onClose()
-        },
+        // Stays open (both the Sheet and DiscoverTab's split-pane are "push panel, keep
+        // it open while browsing" per this file's own convention above) — closing here
+        // used to kick the user out of DiscoverTab's permanent detail pane on every
+        // download, and out of the Sheet before they could pick another quant to queue.
+        onSuccess: () => { toast.success(`Downloading ${selectedFile.name}`) },
       },
     )
   }

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -404,13 +404,21 @@ export function ModelDetailDialog({
                     <p className="text-[11px] text-faint">Uses this model's built-in NextN head — no extra file needed.</p>
                   )}
                   {draft.speculative === 'draft' && (
-                    <PathField
-                      label="Draft model GGUF"
-                      hint="A small same-family model."
-                      value={draft.draftModelPath}
-                      placeholder="Path to small draft model"
-                      onChange={(v) => set('draftModelPath', v)}
-                    />
+                    <>
+                      <PathField
+                        label="Draft model GGUF"
+                        hint="A small same-family model."
+                        value={draft.draftModelPath}
+                        placeholder="Path to small draft model"
+                        onChange={(v) => set('draftModelPath', v)}
+                      />
+                      <Row label="Max drafts" hint="Tokens drafted per step (--draft-max). Default 16.">
+                        <DefaultableNumberInput value={draft.draftMax} placeholder="16" min={1} max={64} onChange={(v) => set('draftMax', v)} />
+                      </Row>
+                      <Row label="Min drafts" hint="Minimum tokens drafted per step (--draft-min). Default 1.">
+                        <DefaultableNumberInput value={draft.draftMin} placeholder="1" min={0} max={8} onChange={(v) => set('draftMin', v)} />
+                      </Row>
+                    </>
                   )}
                 </Section>
               </>


### PR DESCRIPTION
## Summary

Bug-fix + feature batch from a round of user reports, including issue #35.

**Bug fixes:**
- GPU VRAM was reported as the max across GPUs instead of the sum (dual RTX 5060 Ti under-reported 32GB as 16GB); AMD cards hit Windows' known 4GB WMI cap (RX 7900 XTX reported ~4GB instead of 24GB) — added a rocm-smi detection path.
- Windows engine source builds failed with `spawn cmd.exe ENOENT` due to a malformed PATH in `buildEnv()`, independent of Ninja vs NMake.
- Multi-part GGUF downloads could be wrongly flagged "missing parts" when a stray duplicate shard inflated the raw file count past the expected total — switched to index-based completeness.
- Deleting a conversation was immediate with no confirmation/warning.
- The Discover model-detail pane closed itself on every download click instead of staying open.
- `BUILTIN_SEARCH` (Tavily/Kagi/SearXNG) descriptions were never rendered anywhere in the UI.

**Features (GitHub #35):**
- User-configurable MTP/speculative-decoding draft min/max.
- Pin/favourite models to the top of the library list.
- Auto-tune now reads a repo's structured `params`/`generation_config.json` sidecar for recommended sampling (exact values, no README-scraping/LLM-reload needed) when a quantizer publishes one.

## Test plan

- [x] Full backend suite: 554 tests, 551 pass, 3 pre-existing skips, 0 failures
- [x] Frontend + backend `tsc --noEmit`: clean
- [x] Live-verified against the real HuggingFace API and a real running instance: GPU VRAM sum/AMD detection, Windows build env, multi-part shard grouping (real unsloth/gpt-oss-120b-GGUF layout), MTP controls, pin/favourite persistence, delete-confirmation dialog, Discover pane staying open, SearXNG description rendering, generation-params extraction