### PR TITLE
v1.6.5: per-engine config, chat folders, MTP fix, file types

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 import { GATE_VERSION, gateNodeSource } from '../comfyui/gate-template'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { homedir, networkInterfaces } from 'node:os'
-import { ValueError, type ApiKey, type Engine, type McpServer } from '../config/config'
+import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, type ApiKey, type Engine, type McpServer } from '../config/config'
 import type { Deps } from '../deps'
 import { type ModelInfo, type StartOpts } from '../engines/manager'
 import { abortAllInFlightChats } from '../chat/chat-routes'
@@ -1026,7 +1026,7 @@ export function registerApi(app: Hono, d: Deps): void {
         // MLX honors sampling defaults; vLLM honors its own load controls (F-027,
         // --max-model-len/--gpu-memory-utilization/--dtype/…) built via vllmProfileToArgs,
         // plus the multi-GPU shard count (ADR-054) mapped to --tensor-parallel-size below.
-        const savedProfile = cfg.modelProfiles[entry.key] as Partial<LoadProfile> | undefined
+        const savedProfile = getModelProfile(cfg, entry.key, active.id) as Partial<LoadProfile> | undefined
         const extraArgs =
           active.kind === 'mlx'
             ? mlxSamplingArgs(savedProfile?.sampling)
@@ -1041,7 +1041,7 @@ export function registerApi(app: Hono, d: Deps): void {
           tensorParallelSize: savedProfile?.gpu?.tensorParallelSize,
         }
       } else {
-        const saved = cfg.modelProfiles[entry.key] as Partial<LoadProfile> | undefined
+        const saved = getModelProfile(cfg, entry.key, active.id) as Partial<LoadProfile> | undefined
         const profile = resolveProfile(entry, sys, saved, b.profileOverrides, cfg.modelDefaults)
         // KoboldCpp is a GGUF engine with its OWN flag names — build its arg-map instead of
         // the llama-server profileToArgs. llamafile IS llama.cpp's server, so it keeps the
@@ -1303,7 +1303,10 @@ export function registerApi(app: Hono, d: Deps): void {
     if (!e) return err(c, 404, 'no_such_model', 'No model with that key.')
     const sys = getSysInfo()
     const snap = d.store.snapshot()
-    const saved = snap.modelProfiles[e.key] as Partial<LoadProfile> | undefined
+    // Per-engine profile (issue #35): the detail dialog passes ?engine=<id> for the engine
+    // it's showing; fall back to the active engine, then the '*' migrated/global profile.
+    const engineId = c.req.query('engine') || d.registry.active()?.id || '*'
+    const saved = getModelProfile(snap, e.key, engineId) as Partial<LoadProfile> | undefined
     const profile = resolveProfile(e, sys, saved, undefined, snap.modelDefaults)
     // `gpu` (first GPU) kept for back-compat; `gpus` (full list) drives the multi-GPU
     // split controls (ADR-054).
@@ -1335,16 +1338,22 @@ export function registerApi(app: Hono, d: Deps): void {
         return err(c, 400, 'invalid_profile_value', 'gpu.tensorParallelSize must be an integer ≥ 1.')
       }
     }
+    // Per-engine profile (issue #35): save into the slot for the engine the client is
+    // editing (?engine=<id>), falling back to the active engine, then the '*' fallback.
+    const engineId = c.req.query('engine') || d.registry.active()?.id || '*'
     d.store.update((cfg) => {
-      cfg.modelProfiles[key] = p as unknown as Record<string, unknown>
+      setModelProfile(cfg, key, engineId, p)
     })
     return c.json(p)
   })
 
   app.post('/api/v1/models/:key/profile/reset', (c) => {
     const key = decodeURIComponent(c.req.param('key'))
+    // Per-engine profile (issue #35): reset only the edited engine's slot (?engine=<id>),
+    // falling back to the active engine, then the '*' fallback.
+    const engineId = c.req.query('engine') || d.registry.active()?.id || '*'
     d.store.update((cfg) => {
-      delete cfg.modelProfiles[key]
+      deleteModelProfile(cfg, key, engineId)
     })
     return c.json({ ok: true })
   })
@@ -1897,7 +1906,10 @@ function overlayModel(e: ModelEntry, d: Deps, lastTpsMap?: Map<string, number>) 
   // guess that's wrong simply 404s when opened; it never marks anything downloaded.
   const provRepo = d.downloads.provenance().find((p) => p.dest === e.path && p.repo)?.repo
   const sourceRepo = provRepo ?? inferRepoFromPath(e.path, snap.modelDirs)
-  return { ...e, loaded, hasProfile: e.key in profiles, lastTps, liveTps, benchTps, compatibleWithActiveEngine, sourceRepo }
+  // Per-engine profiles (issue #35): profiles[e.key] is now an { engineId → profile } map;
+  // "has a saved profile" for the model-list badge means it has at least one engine slot.
+  const hasProfile = !!profiles[e.key] && Object.keys(profiles[e.key]).length > 0
+  return { ...e, loaded, hasProfile, lastTps, liveTps, benchTps, compatibleWithActiveEngine, sourceRepo }
 }
 
 // ---- helpers ----

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -11,7 +11,7 @@ import { execFile } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import type { BenchResult, ConfigStore } from '../config/config'
+import { setModelProfile, getModelProfile, type BenchResult, type ConfigStore } from '../config/config'
 import type { Manager, StartOpts } from '../engines/manager'
 import type { Registry } from '../engines/registry'
 import type { Engine } from '../config/config'
@@ -168,7 +168,7 @@ export class BenchRunner {
   private logWinner: BenchLogWinner | null = null
   // The finished run's winning candidate, held (not persisted) until the user clicks Save.
   private winning:
-    | { modelKey: string; profile: LoadProfile; cand: BenchCandidate; entry: ModelEntry; sys: SysInfo; engineVersion: string }
+    | { modelKey: string; profile: LoadProfile; cand: BenchCandidate; entry: ModelEntry; sys: SysInfo; engineVersion: string; engineId: string }
     | null = null
 
   constructor(
@@ -207,7 +207,7 @@ export class BenchRunner {
   saveResult(): boolean {
     const w = this.winning
     if (!w) return false
-    const record = this.persistBest(w.modelKey, w.profile, w.cand)
+    const record = this.persistBest(w.modelKey, w.profile, w.cand, w.engineId)
     this.queueTelemetry(record, w.entry, w.sys, this.version, w.engineVersion)
     this.winning = null
     this.state = { ...this.state, result: undefined } // consumed — don't re-show the dialog
@@ -288,7 +288,9 @@ export class BenchRunner {
     this.runLogMeta = { modelKey, startedAt: new Date().toISOString(), sys }
     const active = this.registry.active()
     const caps = active?.capabilities ?? { flags: [], kvTypes: [] }
-    const saved = this.store.snapshot().modelProfiles[modelKey] as Partial<LoadProfile> | undefined
+    // Per-engine profile (issue #35): tune from the profile saved for the active engine
+    // (falling back to the '*' migrated profile), so a re-tune builds on this engine's own basis.
+    const saved = getModelProfile(this.store.snapshot(), modelKey, active?.id ?? '*') as Partial<LoadProfile> | undefined
     const defaults = this.store.snapshot().modelDefaults
     // Honor the user's CURRENT config (the dialog draft, passed as `base`) as the basis for every
     // candidate — ctx, flash-attn, sampling, etc. `base` overrides the saved profile + global
@@ -373,7 +375,7 @@ export class BenchRunner {
           : best.profile
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
-      this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '' }
+      this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '', engineId: active?.id ?? '' }
       this.logWinner = { params: best.cand.params, tps: best.cand.tps ?? 0, prefillTps: best.cand.prefillTps, ttftMs: best.cand.ttftMs ?? 0, vramMb: best.cand.vramMb }
       this.state = {
         running: false,
@@ -1026,7 +1028,7 @@ export class BenchRunner {
 
   /** Save the winning profile as the model's saved profile (tunedBy:'bench') and
    *  persist a benchResults row. Both via the same ConfigStore the route uses. */
-  private persistBest(modelKey: string, profile: LoadProfile, cand: BenchCandidate): BenchResult {
+  private persistBest(modelKey: string, profile: LoadProfile, cand: BenchCandidate, engineId: string): BenchResult {
     const record: BenchResult = {
       modelKey,
       tps: cand.tps ?? 0,
@@ -1037,7 +1039,9 @@ export class BenchRunner {
     }
     const tuned: LoadProfile = { ...profile, tunedBy: 'bench' }
     this.store.update((cfg) => {
-      cfg.modelProfiles[modelKey] = tuned as unknown as Record<string, unknown>
+      // Per-engine profile (issue #35): a tune is only valid for the engine it ran on, so
+      // persist into that engine's slot only. No active engine (engineId '') → '*' fallback.
+      setModelProfile(cfg, modelKey, engineId || '*', tuned)
       cfg.benchResults[modelKey] = record
     })
     return record

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -33,6 +33,38 @@ async function body<T>(c: Context): Promise<T> { try { return await c.req.json()
 export function registerChatRoutes(app: Hono, d: Deps): void {
   const { db } = d
 
+  // ── folders CRUD (v10) ─────────────────────────────────────────────────────
+  // Flat folders for grouping conversations in the sidebar. Grouping itself is done
+  // client-side; these endpoints only manage folder records + membership moves.
+
+  app.get('/api/v1/folders', (c) => {
+    return c.json({ folders: db.listFolders() })
+  })
+
+  app.post('/api/v1/folders', async (c) => {
+    const b = await body<{ name?: string }>(c)
+    const name = (b.name ?? '').trim()
+    if (!name) return err(c, 400, 'invalid_input', 'Folder name required.')
+    return c.json(db.createFolder(name), 201)
+  })
+
+  app.patch('/api/v1/folders/:id', async (c) => {
+    const b = await body<{ name?: string }>(c)
+    const name = (b.name ?? '').trim()
+    if (!name) return err(c, 400, 'invalid_input', 'Folder name required.')
+    const ok = db.renameFolder(c.req.param('id'), name)
+    if (!ok) return err(c, 404, 'not_found', 'Folder not found.')
+    return c.json(db.getFolder(c.req.param('id'))!)
+  })
+
+  app.delete('/api/v1/folders/:id', (c) => {
+    // Deleting a folder unassigns its member conversations (folder_id → NULL); it never
+    // deletes the conversations themselves.
+    const ok = db.deleteFolder(c.req.param('id'))
+    if (!ok) return err(c, 404, 'not_found', 'Folder not found.')
+    return c.json({ ok: true })
+  })
+
   // ── conversations CRUD ─────────────────────────────────────────────────────
 
   app.get('/api/v1/conversations', (c) => {
@@ -63,6 +95,20 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     const ok = db.deleteConversation(c.req.param('id'))
     if (!ok) return err(c, 404, 'not_found', 'Conversation not found.')
     return c.json({ ok: true })
+  })
+
+  // Dedicated move-to-folder route (v10). Kept separate from the generic conversation
+  // PATCH so that route's patch surface (title/systemPrompt/sampling) stays unchanged.
+  // Body: { folderId: string | null } — null moves the conversation out of any folder.
+  app.patch('/api/v1/conversations/:id/folder', async (c) => {
+    const b = await body<{ folderId?: string | null }>(c)
+    const folderId = b.folderId ?? null
+    const res = db.moveConversationToFolder(c.req.param('id'), folderId)
+    if (!res.ok) {
+      if (res.reason === 'folder_not_found') return err(c, 404, 'not_found', 'Folder not found.')
+      return err(c, 404, 'not_found', 'Conversation not found.')
+    }
+    return c.json(db.getConversation(c.req.param('id'))!)
   })
 
   // ── streaming send (spec 07 §2) ────────────────────────────────────────────

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -19,9 +19,21 @@ export interface Conversation {
   toolPolicy?: string
   /** Conversation kind: 'chat' (default user-facing) or 'agent' (background agent run). */
   kind: 'chat' | 'agent'
+  /** Folder this conversation is filed under (v10). NULL/undefined = uncategorized. */
+  folderId?: string | null
   createdAt: string
   updatedAt: string
   messages?: Message[]
+}
+
+/** A chat folder for grouping conversations in the sidebar (v10 migration). Flat —
+ *  no nesting. Conversations reference it via the nullable conversations.folder_id. */
+export interface Folder {
+  id: string
+  name: string
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
 }
 
 /** A background agent run record (v8 migration). */
@@ -108,8 +120,9 @@ export interface Message {
   createdAt: string
 }
 
-interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; created_at: string; updated_at: string }
+interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; created_at: string; updated_at: string }
 interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null }
+interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
@@ -118,7 +131,11 @@ type P = Record<string, SQLInputValue>
 function safeJson(s: string): unknown { try { return JSON.parse(s) } catch { return {} } }
 
 function rowToConv(r: ConvRow): Conversation {
-  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), createdAt: r.created_at, updatedAt: r.updated_at }
+  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), folderId: r.folder_id ?? null, createdAt: r.created_at, updatedAt: r.updated_at }
+}
+
+function rowToFolder(r: FolderRow): Folder {
+  return { id: r.id, name: r.name, sortOrder: r.sort_order, createdAt: r.created_at, updatedAt: r.updated_at }
 }
 
 function rowToAgentRun(r: AgentRunRow): AgentRun {
@@ -252,6 +269,23 @@ export class ConversationStore {
         PRAGMA user_version = 9;
       `)
     }
+    // v10: chat folders. Flat (no nesting) — conversations reference a folder via the
+    // nullable folder_id column. Deleting a folder UNASSIGNS its members (folder_id set
+    // to NULL in app code — see deleteFolder), it never cascade-deletes conversations,
+    // so no inline REFERENCES/ON DELETE constraint is added here. sort_order is reserved
+    // for a future drag-to-reorder; folders currently list in insertion order.
+    if (v < 10) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS folders (
+          id TEXT PRIMARY KEY, name TEXT NOT NULL,
+          sort_order INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        ALTER TABLE conversations ADD COLUMN folder_id TEXT;
+        CREATE INDEX IF NOT EXISTS idx_conversations_folder ON conversations(folder_id);
+        PRAGMA user_version = 10;
+      `)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -272,11 +306,11 @@ export class ConversationStore {
     return (this.db.prepare(`SELECT * FROM conversations ORDER BY updated_at DESC LIMIT 200`).all() as unknown as ConvRow[]).map(rowToConv)
   }
 
-  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy' | 'kind'>>): Conversation {
+  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy' | 'kind' | 'folderId'>>): Conversation {
     const now = new Date().toISOString()
     const id = randomUUID()
-    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,kind,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$kind,$now,$now)`)
-      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $kind: partial?.kind ?? 'chat', $now: now } as P)
+    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,kind,folder_id,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$kind,$fid,$now,$now)`)
+      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $kind: partial?.kind ?? 'chat', $fid: partial?.folderId ?? null, $now: now } as P)
     return this.getConversation(id)!
   }
 
@@ -378,6 +412,51 @@ export class ConversationStore {
   getLastMessage(convId: string): Message | null {
     const row = this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id ORDER BY seq DESC LIMIT 1`).get({ $id: convId } as P) as unknown as MsgRow | undefined
     return row ? rowToMsg(row) : null
+  }
+
+  // ── Folder methods (v10 migration) ────────────────────────────────────────
+
+  /** All folders in insertion order (sort_order asc, then created_at). */
+  listFolders(): Folder[] {
+    return (this.db.prepare(`SELECT * FROM folders ORDER BY sort_order ASC, created_at ASC`).all() as unknown as FolderRow[]).map(rowToFolder)
+  }
+
+  getFolder(id: string): Folder | null {
+    const row = this.db.prepare(`SELECT * FROM folders WHERE id = $id`).get({ $id: id } as P) as unknown as FolderRow | undefined
+    return row ? rowToFolder(row) : null
+  }
+
+  createFolder(name: string): Folder {
+    const id = randomUUID()
+    const now = new Date().toISOString()
+    this.db.prepare(`INSERT INTO folders (id,name,sort_order,created_at,updated_at) VALUES ($id,$name,0,$now,$now)`)
+      .run({ $id: id, $name: name, $now: now } as P)
+    return this.getFolder(id)!
+  }
+
+  renameFolder(id: string, name: string): boolean {
+    const now = new Date().toISOString()
+    return ((this.db.prepare(`UPDATE folders SET name = $name, updated_at = $now WHERE id = $id`).run({ $id: id, $name: name, $now: now } as P) as unknown) as Changes).changes > 0
+  }
+
+  /** Delete a folder. Member conversations are UNASSIGNED (folder_id → NULL), never
+   *  cascade-deleted. Returns false if the folder did not exist. */
+  deleteFolder(id: string): boolean {
+    // Unassign members explicitly — do not rely on any SQLite ON DELETE behavior
+    // (node:sqlite does not reliably enforce inline FK constraints added via ALTER TABLE).
+    this.db.prepare(`UPDATE conversations SET folder_id = NULL WHERE folder_id = $id`).run({ $id: id } as P)
+    return ((this.db.prepare(`DELETE FROM folders WHERE id = $id`).run({ $id: id } as P) as unknown) as Changes).changes > 0
+  }
+
+  /** Move a conversation into a folder (or out of any folder when folderId is null).
+   *  When folderId is non-null the folder must exist. Returns:
+   *   - { ok: true }             on success,
+   *   - { ok: false, reason }    when the conversation or the target folder is missing. */
+  moveConversationToFolder(convId: string, folderId: string | null): { ok: true } | { ok: false; reason: 'conversation_not_found' | 'folder_not_found' } {
+    if (folderId !== null && !this.getFolder(folderId)) return { ok: false, reason: 'folder_not_found' }
+    const now = new Date().toISOString()
+    const changed = ((this.db.prepare(`UPDATE conversations SET folder_id = $fid, updated_at = $now WHERE id = $id`).run({ $id: convId, $fid: folderId, $now: now } as P) as unknown) as Changes).changes > 0
+    return changed ? { ok: true } : { ok: false, reason: 'conversation_not_found' }
   }
 
   // ── Agent run methods (v8 migration) ──────────────────────────────────────

--- a/turbollm/src/chat/folders.test.ts
+++ b/turbollm/src/chat/folders.test.ts
@@ -1,0 +1,209 @@
+// Folder CRUD + membership tests (v10). Exercises the ConversationStore folder
+// methods directly against a real temp-dir SQLite DB — the folder route handlers in
+// chat-routes.ts are thin pass-throughs to these methods, so this covers the actual
+// create / list / rename / delete / move behavior, including the critical guarantee
+// that deleting a folder UNASSIGNS its member conversations (folder_id → NULL) rather
+// than cascade-deleting them.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ConversationStore } from './db.js'
+
+function makeStore(): { store: ConversationStore; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'turbollm-folders-test-'))
+  const store = new ConversationStore(dir)
+  return { store, cleanup: () => { store.close(); rmSync(dir, { recursive: true, force: true }) } }
+}
+
+// ── create / list ─────────────────────────────────────────────────────────────
+
+test('createFolder returns a folder and listFolders includes it', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Work')
+    assert.ok(f.id)
+    assert.equal(f.name, 'Work')
+    assert.equal(f.sortOrder, 0)
+    assert.ok(f.createdAt)
+    assert.ok(f.updatedAt)
+    const list = store.listFolders()
+    assert.equal(list.length, 1)
+    assert.equal(list[0].id, f.id)
+  } finally {
+    cleanup()
+  }
+})
+
+test('listFolders returns folders in insertion order', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const a = store.createFolder('Alpha')
+    const b = store.createFolder('Beta')
+    const c = store.createFolder('Gamma')
+    const ids = store.listFolders().map((f) => f.id)
+    assert.deepEqual(ids, [a.id, b.id, c.id])
+  } finally {
+    cleanup()
+  }
+})
+
+test('listFolders is empty on a fresh store', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    assert.deepEqual(store.listFolders(), [])
+  } finally {
+    cleanup()
+  }
+})
+
+// ── rename ─────────────────────────────────────────────────────────────────────
+
+test('renameFolder updates the name and returns true', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Old')
+    assert.equal(store.renameFolder(f.id, 'New'), true)
+    assert.equal(store.getFolder(f.id)?.name, 'New')
+  } finally {
+    cleanup()
+  }
+})
+
+test('renameFolder returns false for an unknown folder', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    assert.equal(store.renameFolder('does-not-exist', 'Whatever'), false)
+  } finally {
+    cleanup()
+  }
+})
+
+// ── move membership ─────────────────────────────────────────────────────────────
+
+test('moveConversationToFolder files a conversation under a folder', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Projects')
+    const conv = store.createConversation({ title: 'C1' })
+    const res = store.moveConversationToFolder(conv.id, f.id)
+    assert.deepEqual(res, { ok: true })
+    assert.equal(store.getConversation(conv.id)?.folderId, f.id)
+  } finally {
+    cleanup()
+  }
+})
+
+test('moveConversationToFolder with null unassigns the conversation', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Projects')
+    const conv = store.createConversation({ title: 'C1', folderId: f.id })
+    assert.equal(store.getConversation(conv.id)?.folderId, f.id)
+    const res = store.moveConversationToFolder(conv.id, null)
+    assert.deepEqual(res, { ok: true })
+    assert.equal(store.getConversation(conv.id)?.folderId, null)
+  } finally {
+    cleanup()
+  }
+})
+
+test('moveConversationToFolder rejects a non-existent target folder', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const conv = store.createConversation({ title: 'C1' })
+    const res = store.moveConversationToFolder(conv.id, 'no-such-folder')
+    assert.deepEqual(res, { ok: false, reason: 'folder_not_found' })
+    // Conversation stays uncategorized (unchanged).
+    assert.equal(store.getConversation(conv.id)?.folderId, null)
+  } finally {
+    cleanup()
+  }
+})
+
+test('moveConversationToFolder reports a missing conversation', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Projects')
+    const res = store.moveConversationToFolder('no-such-conv', f.id)
+    assert.deepEqual(res, { ok: false, reason: 'conversation_not_found' })
+  } finally {
+    cleanup()
+  }
+})
+
+// ── delete: unassign, do NOT cascade ────────────────────────────────────────────
+
+test('deleteFolder removes the folder and returns true', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Temp')
+    assert.equal(store.deleteFolder(f.id), true)
+    assert.equal(store.getFolder(f.id), null)
+    assert.deepEqual(store.listFolders(), [])
+  } finally {
+    cleanup()
+  }
+})
+
+test('deleteFolder returns false for an unknown folder', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    assert.equal(store.deleteFolder('nope'), false)
+  } finally {
+    cleanup()
+  }
+})
+
+test('deleteFolder UNASSIGNS member conversations — it does NOT cascade-delete them', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Doomed')
+    const c1 = store.createConversation({ title: 'Keep me 1', folderId: f.id })
+    const c2 = store.createConversation({ title: 'Keep me 2', folderId: f.id })
+    const outside = store.createConversation({ title: 'Unrelated' })
+
+    assert.equal(store.deleteFolder(f.id), true)
+
+    // The conversations must still exist …
+    assert.ok(store.getConversation(c1.id), 'c1 must survive folder deletion')
+    assert.ok(store.getConversation(c2.id), 'c2 must survive folder deletion')
+    // … and be unassigned (folder_id → NULL) …
+    assert.equal(store.getConversation(c1.id)?.folderId, null)
+    assert.equal(store.getConversation(c2.id)?.folderId, null)
+    // … the unrelated conversation is untouched …
+    assert.equal(store.getConversation(outside.id)?.folderId, null)
+    // … and they still show up in the conversation list.
+    const listedIds = store.listConversations().map((c) => c.id)
+    assert.ok(listedIds.includes(c1.id))
+    assert.ok(listedIds.includes(c2.id))
+    assert.ok(listedIds.includes(outside.id))
+  } finally {
+    cleanup()
+  }
+})
+
+// ── createConversation folderId passthrough ─────────────────────────────────────
+
+test('createConversation persists an optional folderId', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const f = store.createFolder('Inbox')
+    const conv = store.createConversation({ title: 'Filed', folderId: f.id })
+    assert.equal(conv.folderId, f.id)
+    assert.equal(store.getConversation(conv.id)?.folderId, f.id)
+  } finally {
+    cleanup()
+  }
+})
+
+test('createConversation defaults folderId to null when omitted', () => {
+  const { store, cleanup } = makeStore()
+  try {
+    const conv = store.createConversation({ title: 'Loose' })
+    assert.equal(conv.folderId, null)
+  } finally {
+    cleanup()
+  }
+})

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -3,7 +3,7 @@ import { openSync, readFileSync } from 'node:fs'
 import { serve } from '@hono/node-server'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { ConfigStore, defaultConfig, defaultConfigPath, migrateLegacyDataDir } from './config/config'
+import { ConfigStore, defaultConfig, defaultConfigPath, getModelProfile, migrateLegacyDataDir } from './config/config'
 import { Manager, killTrackedEnginesSync, reapStaleEngines, type StartOpts } from './engines/manager'
 import { ComfyGuard } from './engines/comfy-guard'
 import { Registry } from './engines/registry'
@@ -509,7 +509,7 @@ void (async () => {
         extraArgs: [],
       }
     } else {
-      const saved = cfg.modelProfiles[entry.key] as Partial<LoadProfile> | undefined
+      const saved = getModelProfile(cfg, entry.key, active.id) as Partial<LoadProfile> | undefined
       const profile = resolveProfile(entry, sys, saved, undefined, cfg.modelDefaults)
       opts = {
         engine: active,

--- a/turbollm/src/config/config.test.ts
+++ b/turbollm/src/config/config.test.ts
@@ -1,0 +1,247 @@
+// Per-engine model profiles (issue #35). Covers:
+//   1. the v2→v3 shape migration (flat { modelKey → profile } → nested
+//      { modelKey → { '*' → ProfileEntry } }), driven through ConfigStore.load on a real
+//      temp file so it exercises migrate() + normalize() exactly as production does,
+//   2. that the migration is idempotent (a second load must NOT re-wrap the already
+//      nested value), and preserves other v2 data (engines/benchResults/etc.),
+//   3. the getModelProfile / setModelProfile / deleteModelProfile semantics — exact-engine
+//      match wins, otherwise fall back to whichever engine's profile for the model was
+//      saved most recently (there is no fixed "default engine"; mainline llama.cpp and
+//      forks like ik_llama.cpp/TurboQuant are indistinguishable in this codebase),
+//   4. the real bug scenario: two engine ids for the same model resolve to independent
+//      profiles, and a model with no engine-specific profile falls back to the last-used one.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ANY_ENGINE,
+  ConfigStore,
+  SCHEMA_VERSION,
+  defaultConfig,
+  deleteModelProfile,
+  getModelProfile,
+  setModelProfile,
+  type Config,
+  type ProfileEntry,
+} from './config'
+
+/** A minimal but LoadProfile-shaped flat profile — the discriminator only needs a
+ *  numeric `ctx` at the top level, but we carry a couple more fields to prove the whole
+ *  object is preserved intact under '*'. */
+function flatProfile(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return { ctx: 8192, ngl: 99, tunedBy: 'user', ...over }
+}
+
+function tmpConfigPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-cfg-'))
+  return join(dir, 'config.json')
+}
+
+function cleanup(path: string): void {
+  rmSync(join(path, '..'), { recursive: true, force: true })
+}
+
+test('v2→v3 migration wraps each flat profile into a single "*" entry', () => {
+  const path = tmpConfigPath()
+  try {
+    // A realistic v2 config on disk: modelProfiles is the OLD flat shape.
+    const v2 = {
+      ...defaultConfig(),
+      version: 2,
+      modelProfiles: {
+        'llama|q4|100': flatProfile({ ctx: 4096 }),
+        'qwen|q8|200': flatProfile({ ctx: 16384 }),
+      },
+    }
+    writeFileSync(path, JSON.stringify(v2))
+
+    const store = ConfigStore.load(path)
+    const cfg = store.snapshot()
+
+    assert.equal(cfg.version, SCHEMA_VERSION)
+    assert.equal(SCHEMA_VERSION, 3)
+    // Each old profile is now a single ProfileEntry under '*', value preserved intact.
+    const llamaEntry = cfg.modelProfiles['llama|q4|100'][ANY_ENGINE] as ProfileEntry
+    assert.deepEqual(llamaEntry.profile, flatProfile({ ctx: 4096 }))
+    assert.equal(typeof llamaEntry.updatedAt, 'string')
+    const qwenEntry = cfg.modelProfiles['qwen|q8|200'][ANY_ENGINE] as ProfileEntry
+    assert.deepEqual(qwenEntry.profile, flatProfile({ ctx: 16384 }))
+  } finally {
+    cleanup(path)
+  }
+})
+
+test('v2→v3 migration is idempotent — a second load does not re-wrap', () => {
+  const path = tmpConfigPath()
+  try {
+    const v2 = {
+      ...defaultConfig(),
+      version: 2,
+      modelProfiles: { 'm|q4|1': flatProfile() },
+    }
+    writeFileSync(path, JSON.stringify(v2))
+
+    // First load migrates + persists.
+    ConfigStore.load(path)
+    const afterFirst = JSON.parse(readFileSync(path, 'utf8')) as Config
+    const firstEntry = afterFirst.modelProfiles['m|q4|1'][ANY_ENGINE] as ProfileEntry
+    assert.deepEqual(firstEntry.profile, flatProfile())
+
+    // Second load must see the already-nested value and leave it alone (no re-wrap into
+    // { '*': { profile: { profile: …, updatedAt: … }, updatedAt: … } }), and must not
+    // stamp a fresh updatedAt over the one written by the first load.
+    const store2 = ConfigStore.load(path)
+    const cfg2 = store2.snapshot()
+    const secondEntry = cfg2.modelProfiles['m|q4|1'][ANY_ENGINE] as ProfileEntry
+    assert.deepEqual(secondEntry.profile, flatProfile())
+    assert.equal(secondEntry.updatedAt, firstEntry.updatedAt)
+  } finally {
+    cleanup(path)
+  }
+})
+
+test('v2→v3 migration preserves other v2 config data (no data loss on version bump)', () => {
+  const path = tmpConfigPath()
+  try {
+    const engineId = '11111111-1111-1111-1111-111111111111'
+    const v2 = {
+      ...defaultConfig(),
+      version: 2,
+      engines: [
+        {
+          id: engineId,
+          name: 'llama.cpp',
+          binPath: '/opt/llama-server',
+          kind: 'llama-server',
+          version: 'b1234',
+          capabilities: { kvTypes: ['f16', 'q8_0'], flags: [] },
+          addedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      activeEngineId: engineId,
+      modelDirs: [process.platform === 'win32' ? 'C:\\models' : '/models'],
+      benchResults: { 'm|q4|1': { modelKey: 'm|q4|1', tps: 42, ttftMs: 100, vramMb: 8000, params: { ctx: 4096, ngl: 99, nCpuMoe: 0, parallel: 1, kvTypeK: 'f16', flashAttn: 'auto' }, ts: '2026-01-01T00:00:00.000Z' } },
+      modelProfiles: { 'm|q4|1': flatProfile() },
+    }
+    writeFileSync(path, JSON.stringify(v2))
+
+    const cfg = ConfigStore.load(path).snapshot()
+    // Engines / active / dirs / benchResults survived the migrate() rebuild.
+    assert.equal(cfg.engines.length, 1)
+    assert.equal(cfg.engines[0].id, engineId)
+    assert.equal(cfg.activeEngineId, engineId)
+    assert.equal(cfg.benchResults['m|q4|1']?.tps, 42)
+    // Profile migrated in place.
+    const entry = cfg.modelProfiles['m|q4|1'][ANY_ENGINE] as ProfileEntry
+    assert.deepEqual(entry.profile, flatProfile())
+  } finally {
+    cleanup(path)
+  }
+})
+
+test('getModelProfile: exact-engine match wins over any fallback', () => {
+  const cfg = defaultConfig()
+  const engineA = 'aaaa'
+  cfg.modelProfiles = {
+    'm|q4|1': {
+      [engineA]: { profile: flatProfile({ ctx: 32768 }), updatedAt: '2026-01-01T00:00:00.000Z' },
+      [ANY_ENGINE]: { profile: flatProfile({ ctx: 4096 }), updatedAt: '2026-06-01T00:00:00.000Z' },
+    },
+  }
+  // Engine A has its own profile → exact match, even though '*' is the more recent entry.
+  assert.equal((getModelProfile(cfg, 'm|q4|1', engineA) as { ctx: number }).ctx, 32768)
+  // An engine with no slot → falls back to whichever is most recently updated ('*' here).
+  assert.equal((getModelProfile(cfg, 'm|q4|1', 'bbbb') as { ctx: number }).ctx, 4096)
+  // Unknown model → undefined.
+  assert.equal(getModelProfile(cfg, 'nope|q4|1', engineA), undefined)
+})
+
+test('getModelProfile: falls back to whichever engine was saved most recently', () => {
+  const cfg = defaultConfig()
+  const cuda = 'cuda-engine-id'
+  const vulkan = 'vulkan-engine-id'
+  cfg.modelProfiles = {
+    'm|q4|1': {
+      [cuda]: { profile: flatProfile({ ctx: 4096 }), updatedAt: '2026-01-01T00:00:00.000Z' },
+      [vulkan]: { profile: flatProfile({ ctx: 16384 }), updatedAt: '2026-06-01T00:00:00.000Z' },
+    },
+  }
+  // A third engine with no slot of its own falls back to vulkan (the more recent save),
+  // not cuda, even though cuda appears first in the object.
+  const mlx = getModelProfile(cfg, 'm|q4|1', 'mlx-engine-id') as { ctx: number }
+  assert.equal(mlx.ctx, 16384)
+
+  // Re-saving cuda AFTER vulkan flips the fallback back to cuda.
+  setModelProfile(cfg, 'm|q4|1', cuda, flatProfile({ ctx: 99999 }))
+  const mlxAfter = getModelProfile(cfg, 'm|q4|1', 'mlx-engine-id') as { ctx: number }
+  assert.equal(mlxAfter.ctx, 99999)
+  // cuda's own exact match is unaffected either way.
+  assert.equal((getModelProfile(cfg, 'm|q4|1', cuda) as { ctx: number }).ctx, 99999)
+  // vulkan's own exact match is untouched by cuda's re-save.
+  assert.equal((getModelProfile(cfg, 'm|q4|1', vulkan) as { ctx: number }).ctx, 16384)
+})
+
+test('getModelProfile: no entries at all for an unknown engine → undefined', () => {
+  const cfg = defaultConfig()
+  cfg.modelProfiles = {}
+  assert.equal(getModelProfile(cfg, 'm|q4|1', 'aaaa'), undefined)
+})
+
+test('setModelProfile writes one engine slot only, leaving other engines untouched', () => {
+  const cfg = defaultConfig()
+  setModelProfile(cfg, 'm|q4|1', 'aaaa', flatProfile({ ctx: 1024 }))
+  setModelProfile(cfg, 'm|q4|1', 'bbbb', flatProfile({ ctx: 2048 }))
+  // Two independent slots under the same model.
+  assert.equal((cfg.modelProfiles['m|q4|1'].aaaa.profile as { ctx: number }).ctx, 1024)
+  assert.equal((cfg.modelProfiles['m|q4|1'].bbbb.profile as { ctx: number }).ctx, 2048)
+  // Each write is stamped with a timestamp for the fallback comparison.
+  assert.equal(typeof cfg.modelProfiles['m|q4|1'].aaaa.updatedAt, 'string')
+  // Overwriting one slot leaves the other alone.
+  setModelProfile(cfg, 'm|q4|1', 'aaaa', flatProfile({ ctx: 4096 }))
+  assert.equal((cfg.modelProfiles['m|q4|1'].aaaa.profile as { ctx: number }).ctx, 4096)
+  assert.equal((cfg.modelProfiles['m|q4|1'].bbbb.profile as { ctx: number }).ctx, 2048)
+})
+
+test('deleteModelProfile removes only the target slot, pruning the model when empty', () => {
+  const cfg = defaultConfig()
+  setModelProfile(cfg, 'm|q4|1', 'aaaa', flatProfile())
+  setModelProfile(cfg, 'm|q4|1', 'bbbb', flatProfile())
+
+  deleteModelProfile(cfg, 'm|q4|1', 'aaaa')
+  assert.equal(cfg.modelProfiles['m|q4|1'].aaaa, undefined)
+  assert.equal(cfg.modelProfiles['m|q4|1'].bbbb !== undefined, true) // sibling survives
+
+  // Removing the last slot prunes the whole model entry (keeps hasProfile checks honest).
+  deleteModelProfile(cfg, 'm|q4|1', 'bbbb')
+  assert.equal(cfg.modelProfiles['m|q4|1'], undefined)
+
+  // Deleting from an unknown model is a no-op (no throw).
+  assert.doesNotThrow(() => deleteModelProfile(cfg, 'gone|q4|1', 'aaaa'))
+})
+
+test('bug #35 scenario: two engines for one model keep independent profiles; unknown falls back to the last-used one', () => {
+  // Start from a migrated model: a single legacy profile lives under '*'.
+  const cfg = defaultConfig()
+  cfg.modelProfiles = {
+    'm|q4|1': { [ANY_ENGINE]: { profile: flatProfile({ ctx: 8192 }), updatedAt: '2026-01-01T00:00:00.000Z' } },
+  }
+
+  const cuda = 'cuda-engine-id'
+  const vulkan = 'vulkan-engine-id'
+
+  // Before any per-engine save, BOTH engines resolve the shared legacy profile.
+  assert.equal((getModelProfile(cfg, 'm|q4|1', cuda) as { ctx: number }).ctx, 8192)
+  assert.equal((getModelProfile(cfg, 'm|q4|1', vulkan) as { ctx: number }).ctx, 8192)
+
+  // Tune the model differently on each engine (vulkan second, so it's the most recent).
+  setModelProfile(cfg, 'm|q4|1', cuda, flatProfile({ ctx: 65536 }))
+  setModelProfile(cfg, 'm|q4|1', vulkan, flatProfile({ ctx: 16384 }))
+
+  // Now each engine resolves its OWN profile — no cross-contamination (the original bug).
+  assert.equal((getModelProfile(cfg, 'm|q4|1', cuda) as { ctx: number }).ctx, 65536)
+  assert.equal((getModelProfile(cfg, 'm|q4|1', vulkan) as { ctx: number }).ctx, 16384)
+  // A third, untuned engine falls back to whichever was saved most recently (vulkan).
+  assert.equal((getModelProfile(cfg, 'm|q4|1', 'mlx-engine-id') as { ctx: number }).ctx, 16384)
+})

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -7,7 +7,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync 
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 
-export const SCHEMA_VERSION = 2
+export const SCHEMA_VERSION = 3
 
 export interface Capabilities {
   kvTypes: string[]
@@ -184,6 +184,13 @@ export interface DevModel {
   extraArgs: string[]
   label: string
 }
+/** One engine's saved profile for a model (issue #35), timestamped so
+ *  {@link getModelProfile} can fall back to whichever engine's profile was saved most
+ *  recently when the requested engine has none of its own. */
+export interface ProfileEntry {
+  profile: unknown
+  updatedAt: string
+}
 export interface Config {
   version: number
   daemon: Daemon
@@ -195,7 +202,17 @@ export interface Config {
   /** The folder downloads/imports land in (spec 01 §3, ADR-035). When '' or not in
    *  modelDirs, the FIRST entry in modelDirs is the effective default. */
   primaryModelDir: string
-  modelProfiles: Record<string, unknown>
+  /** Saved per-model LoadProfiles, nested by (modelKey → engineId → {@link ProfileEntry})
+   *  so two installed engines (even two builds of the same kind, e.g. llama.cpp CUDA vs
+   *  Vulkan, each with its own {@link Engine.id}) keep independent tunes for the same
+   *  model (issue #35). There's no fixed "default engine" to fall back to — the codebase
+   *  has no reliable way to tell mainline llama.cpp apart from a fork like ik_llama.cpp or
+   *  TurboQuant (both share `kind: 'llama-server'`) — so {@link getModelProfile} instead
+   *  falls back to whichever engine's profile for the model was saved most recently
+   *  (each entry carries its own `updatedAt`). The v2→v3 migration wraps each old flat
+   *  profile into a single entry under the reserved engineId `'*'` (see {@link normalize}).
+   *  `profile` values are still `unknown` (validated/shaped elsewhere as {@link LoadProfile}). */
+  modelProfiles: Record<string, Record<string, ProfileEntry>>
   /** Persisted auto-tune results keyed by modelKey (spec 09 §1, 01 §4). Additive;
    *  absent in old configs → normalize seeds {}. Never throws on load. */
   benchResults: Record<string, BenchResult>
@@ -410,9 +427,15 @@ function migrate(raw: Record<string, unknown>, _from: number): Config {
     if (modelPath) cfg.devModel = { modelPath, extraArgs: extra, label: old.name || '' }
   }
   cfg.version = SCHEMA_VERSION
-  // Preserve any unknown top-level keys from the old file.
+  // Carry EVERY top-level key from the old file forward — both unknown keys (ride-along)
+  // and known ones (engines/apiKeys/modelProfiles/benchResults/modelDirs/lastLoaded/…).
+  // Copying known keys too is required now that this runs for v2→v3 (issue #35): the
+  // ancient pre-v1 path only special-cases the legacy engine/host/port keys, so for a
+  // v2 config the rest of migrate() is a no-op and dropping known keys here would wipe
+  // real user data. normalize() reseats/validates each field afterward (including the
+  // shape migration of modelProfiles), so an old value simply gets normalized in place.
   for (const [k, v] of Object.entries(raw)) {
-    if (!(k in cfg) && k !== 'engine' && k !== 'host' && k !== 'port') {
+    if (k !== 'engine' && k !== 'host' && k !== 'port' && k !== 'version') {
       ;(cfg as unknown as Record<string, unknown>)[k] = v
     }
   }
@@ -460,7 +483,24 @@ function normalize(c: Config): void {
   // Primary model dir (spec 01 §3, ADR-035): absent in old files → '' (effective
   // default falls back to the first modelDir). Never throw on an old config.
   c.primaryModelDir ??= ''
+  // Per-engine model profiles (issue #35, schema v3): modelProfiles moved from a flat
+  // { modelKey → profile } map to a nested { modelKey → { engineId → ProfileEntry } } map
+  // so two installed engines keep independent tunes for the same model. Migrate in place,
+  // shape-based and idempotent (runs every load; must not double-wrap an already-nested
+  // value). Discriminator: a v2 flat profile is a LoadProfile, which always carries a
+  // numeric `ctx` at its top level; a v3 nested map is keyed by engineId (UUID or the
+  // reserved '*'), whose VALUES are {@link ProfileEntry} wrappers — so the map itself
+  // never has a top-level numeric `ctx`. Old profiles are wrapped into a single entry
+  // under the reserved fallback key '*', timestamped at migration time — this is fine
+  // even though it's an approximation of "when it was really last used": it's the only
+  // entry that exists yet, so it's trivially the most recent, and any future per-engine
+  // save (necessarily later) naturally outranks it via getModelProfile's fallback.
   c.modelProfiles ??= {}
+  for (const [modelKey, val] of Object.entries(c.modelProfiles)) {
+    if (val && typeof val === 'object' && typeof (val as { ctx?: unknown }).ctx === 'number') {
+      c.modelProfiles[modelKey] = { '*': { profile: val, updatedAt: new Date().toISOString() } }
+    }
+  }
   // Persisted auto-tune results (spec 09 §1): absent in pre-bench configs → {}.
   c.benchResults ??= {}
   c.autoLoadOnStart ??= false
@@ -584,6 +624,52 @@ function isAbsolutePath(p: string): boolean {
 
 export function findEngine(engines: Engine[], id: string): Engine | undefined {
   return engines.find((e) => e.id === id)
+}
+
+/** Reserved engineId the v2→v3 migration parks every pre-existing flat profile under
+ *  (issue #35). Not otherwise special — it's just one more entry in the per-model map,
+ *  and only wins in {@link getModelProfile} when it happens to be the most recent (or
+ *  only) one; a fresher per-engine save on any real engine outranks it. */
+export const ANY_ENGINE = '*'
+
+/** Resolve a model's saved profile for a specific installed engine (issue #35). Returns
+ *  that engine's own profile if one exists; otherwise falls back to whichever engine's
+ *  profile for this model was saved most recently (there's no fixed "default engine" to
+ *  fall back to — mainline llama.cpp and forks like ik_llama.cpp/TurboQuant are
+ *  indistinguishable in this codebase, both `kind: 'llama-server'` — so "last used" is
+ *  the simplest fallback that doesn't require identifying any engine specially). Returns
+ *  undefined if the model has no saved profile on any engine. The single read seam every
+ *  caller routes through instead of indexing `cfg.modelProfiles[key]` directly. */
+export function getModelProfile(cfg: Config, modelKey: string, engineId: string): unknown {
+  const byEngine = cfg.modelProfiles[modelKey]
+  if (!byEngine) return undefined
+  const exact = byEngine[engineId]
+  if (exact) return exact.profile
+  // `>=` (not `>`): object key insertion order matches save order, so on an exact
+  // millisecond tie (two rapid-fire saves) the later-inserted entry — the truly more
+  // recent one — wins instead of whichever key happened to iterate first.
+  let mostRecent: ProfileEntry | undefined
+  for (const entry of Object.values(byEngine)) {
+    if (!mostRecent || entry.updatedAt >= mostRecent.updatedAt) mostRecent = entry
+  }
+  return mostRecent?.profile
+}
+
+/** Write a model's saved profile into one engine's slot only (issue #35), stamped with
+ *  the current time so {@link getModelProfile}'s "last used" fallback can compare across
+ *  engines. Creates the per-model map if absent; never touches other engines' profiles
+ *  for the same model. */
+export function setModelProfile(cfg: Config, modelKey: string, engineId: string, profile: unknown): void {
+  ;(cfg.modelProfiles[modelKey] ??= {})[engineId] = { profile, updatedAt: new Date().toISOString() }
+}
+
+/** Delete a model's saved profile for one engine only (issue #35). Prunes the per-model
+ *  map when its last slot is removed so `hasProfile`-style emptiness checks stay accurate. */
+export function deleteModelProfile(cfg: Config, modelKey: string, engineId: string): void {
+  const byEngine = cfg.modelProfiles[modelKey]
+  if (!byEngine) return
+  delete byEngine[engineId]
+  if (Object.keys(byEngine).length === 0) delete cfg.modelProfiles[modelKey]
 }
 
 /** Apply the global "max response tokens" cap. `limit <= 0` means unlimited (return

--- a/turbollm/src/gateway/model-router.ts
+++ b/turbollm/src/gateway/model-router.ts
@@ -3,7 +3,7 @@
 // the local model library and loads (or swaps to) that model automatically.
 // Inspired by llama-swap; operates on the existing Manager + Scanner primitives.
 import { Manager, type StartOpts } from '../engines/manager'
-import type { ConfigStore, Engine } from '../config/config'
+import { getModelProfile, type ConfigStore, type Engine } from '../config/config'
 import type { Registry } from '../engines/registry'
 import type { Scanner, ModelEntry } from '../models/scanner'
 import type { ComfyGuard } from '../engines/comfy-guard'
@@ -270,7 +270,7 @@ export class ModelRouter {
     const cfg = this.store.snapshot()
     const sys = getSysInfo()
     if (entry.format !== 'gguf') {
-      const savedProfile = cfg.modelProfiles[entry.key] as Partial<LoadProfile> | undefined
+      const savedProfile = getModelProfile(cfg, entry.key, engine.id) as Partial<LoadProfile> | undefined
       return {
         engine,
         model: { key: entry.key, name: entry.name, quant: entry.quant, ctx: entry.nativeCtx, vision: false },
@@ -285,7 +285,7 @@ export class ModelRouter {
         tensorParallelSize: savedProfile?.gpu?.tensorParallelSize,
       }
     }
-    const saved = cfg.modelProfiles[entry.key] as Partial<LoadProfile> | undefined
+    const saved = getModelProfile(cfg, entry.key, engine.id) as Partial<LoadProfile> | undefined
     const profile = resolveProfile(entry, sys, saved, undefined, cfg.modelDefaults)
     // KoboldCpp is a GGUF engine but uses its OWN flag names, so it gets its own small
     // arg-map (ctx/ngl + GPU backend) rather than the llama-server profileToArgs. llamafile

--- a/turbollm/src/models/profile.gen.test.ts
+++ b/turbollm/src/models/profile.gen.test.ts
@@ -278,3 +278,29 @@ test('draftMin 0 is emitted (not treated as unset)', () => {
   const args = profileToArgs(p, model(), caps)
   assert.equal(args[args.indexOf('--draft-min') + 1], '0')
 })
+
+// Regression: the draft window is a property of the speculation mechanism itself
+// (llama.cpp's shared verify loop), not specific to how the draft is produced — it must
+// apply to 'mtp' and 'nextn' modes too, not only the external-draft-model 'draft' mode
+// (this was the actual GitHub #35 ask — "MTP control ... min and max MTP drafts").
+test('mtp mode also honors draftMax/draftMin, not just draft mode', () => {
+  const p = { ...base(), speculative: 'mtp' as const, mtpHeadPath: '/models/gemma4-mtp.gguf', draftMax: 4, draftMin: 0 }
+  const args = profileToArgs(p, model(), caps)
+  assert.ok(args.includes('--mtp-head'))
+  assert.equal(args[args.indexOf('--draft-max') + 1], '4')
+  assert.equal(args[args.indexOf('--draft-min') + 1], '0')
+})
+
+test('nextn mode also honors draftMax/draftMin, defaults to 16/1 when unset', () => {
+  const p = { ...base(), speculative: 'nextn' as const, draftMax: 6 }
+  const args = profileToArgs(p, model({ nextnLayers: 1 }), caps)
+  assert.equal(args[args.indexOf('--draft-max') + 1], '6')
+  assert.equal(args[args.indexOf('--draft-min') + 1], '1')
+})
+
+test('off mode emits no draft-max/draft-min flags', () => {
+  const p = { ...base(), speculative: 'off' as const, draftMax: 4, draftMin: 0 }
+  const args = profileToArgs(p, model(), caps)
+  assert.ok(!args.includes('--draft-max'))
+  assert.ok(!args.includes('--draft-min'))
+})

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -134,11 +134,13 @@ export interface LoadProfile {
   /** llama.cpp --ubatch-size (-ub). Physical micro-batch size for prompt processing. 0 / absent =
    *  engine default (512). Must be ≤ batchSize. Tune alongside batchSize for throughput. */
   uBatchSize?: number
-  /** Speculative-decoding draft window, `draft` mode only (GitHub #35). Max tokens the draft
-   *  model proposes per step (--draft-max). Absent → 16 (the previous hardcoded default). */
+  /** Speculative-decoding draft window (GitHub #35) — applies to every active speculative
+   *  mode (mtp/nextn/draft), not just `draft`. Max tokens the draft head proposes per step
+   *  (--draft-max). Absent → 16 (the previous hardcoded default). */
   draftMax?: number
-  /** Speculative-decoding draft window, `draft` mode only (GitHub #35). Min tokens drafted per
-   *  step before verification (--draft-min). Absent → 1 (the previous hardcoded default). */
+  /** Speculative-decoding draft window (GitHub #35) — applies to every active speculative
+   *  mode (mtp/nextn/draft), not just `draft`. Min tokens drafted per step before
+   *  verification (--draft-min). Absent → 1 (the previous hardcoded default). */
   draftMin?: number
   /** Provenance of a saved profile (spec 05 §3, 09 §1): 'bench' = written by the
    *  auto-tune runner, 'user' = hand-saved. Absent on heuristic/global defaults. */

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -381,20 +381,33 @@ export function profileToArgs(p: LoadProfile, m: ModelEntry, caps: Capabilities,
   // Whether the engine accepts a given `--spec-type` value (captured by the probe
   // as `spec-type:<value>`). Empty flags = unprobed → allow (graceful degrade).
   const specAccepts = (v: string) => caps.flags.length === 0 || caps.flags.includes(`spec-type:${v}`)
+  let specActive = false
   if (p.speculative === 'mtp' && p.mtpHeadPath && has('--mtp-head')) {
     if (specType) a.push('--spec-type', 'mtp')
     a.push('--mtp-head', p.mtpHeadPath)
+    specActive = true
   } else if (p.speculative === 'nextn' && specType && has('--model-draft')) {
     // Qwen3 NextN drives the model's OWN built-in head as the draft. The fork
     // names that spec-type `nextn`; mainline llama.cpp names the same mechanism
     // `draft-mtp`. Use whichever the engine accepts — skip if neither.
     const nextnVal = ['nextn', 'draft-mtp'].find((v) => specAccepts(v))
-    if (nextnVal) a.push('--spec-type', nextnVal, '--model-draft', m.path)
+    if (nextnVal) {
+      a.push('--spec-type', nextnVal, '--model-draft', m.path)
+      specActive = true
+    }
   } else if (p.speculative === 'draft' && p.draftModelPath && has('--model-draft')) {
     if (specType) a.push('--spec-type', 'draft')
-    // Draft window overridable per-model (GitHub #35); absent → the previous 16/1 defaults.
-    a.push('--model-draft', p.draftModelPath, '--draft-max', String(p.draftMax ?? 16), '--draft-min', String(p.draftMin ?? 1))
+    a.push('--model-draft', p.draftModelPath)
+    specActive = true
   }
+  // Draft window (GitHub #35): how many tokens the draft head proposes per step before
+  // the main model verifies them, and the minimum before verification kicks in. This is
+  // a property of the speculation mechanism itself (llama.cpp's shared verify loop), not
+  // specific to how the draft is produced — applies to all three modes above, matching
+  // e.g. LM Studio's MTP "max/min draft tokens" controls. Absent -> the previous
+  // hardcoded 16/1 defaults (unchanged behavior for existing profiles).
+  if (specActive && has('--draft-max')) a.push('--draft-max', String(p.draftMax ?? 16))
+  if (specActive && has('--draft-min')) a.push('--draft-min', String(p.draftMin ?? 1))
   // Sampling startup defaults — become the engine's per-request defaults; can still
   // be overridden in the chat request body. Only emitted when non-default to avoid
   // cluttering the startup command. llama-server built-in defaults match these values.

--- a/turbollm/web/package-lock.json
+++ b/turbollm/web/package-lock.json
@@ -26,6 +26,7 @@
         "html2canvas": "^1.4.1",
         "lucide-react": "^1.17.0",
         "mermaid": "^11.0.0",
+        "pdfjs-dist": "^6.1.200",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
@@ -911,6 +912,256 @@
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.2.tgz",
+      "integrity": "sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-arm64": "1.0.2",
+        "@napi-rs/canvas-darwin-x64": "1.0.2",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.2",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.2",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.2",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.2",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz",
+      "integrity": "sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -5546,6 +5797,18 @@
       "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.1.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
+      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/turbollm/web/package.json
+++ b/turbollm/web/package.json
@@ -27,6 +27,7 @@
     "html2canvas": "^1.4.1",
     "lucide-react": "^1.17.0",
     "mermaid": "^11.0.0",
+    "pdfjs-dist": "^6.1.200",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/turbollm/web/src/components/ModelLoadMenu.tsx
+++ b/turbollm/web/src/components/ModelLoadMenu.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, CircleSlash, Cpu, Loader2 } from 'lucide-react'
+import { Check, ChevronDown, CircleSlash, Cpu, Loader2, SlidersHorizontal } from 'lucide-react'
 import type { ModelEntry } from '../lib/types'
 import {
   DropdownMenu,
@@ -11,7 +11,8 @@ import {
 /**
  * Model selector + eject control. Lists discovered models; selecting one loads it
  * (the engine auto-starts), and "Eject" stops the running engine. Shared by the
- * Chat and Models screens. Alt+click a model row to open its config before loading.
+ * Chat and Models screens. Click the sliders icon (or Alt+click a row) to open its
+ * config before loading.
  */
 export function ModelLoadMenu({
   models,
@@ -72,13 +73,26 @@ export function ModelLoadMenu({
                 {active && <Check size={14} className="text-accent" />}
               </span>
               <span className="min-w-0 flex-1 truncate">{m.name}</span>
+              {onSettings && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onSettings(m.key)
+                  }}
+                  className="grid h-6 w-6 shrink-0 place-items-center rounded text-faint transition-colors hover:bg-panel hover:text-ink"
+                  title="Configure before loading"
+                  aria-label={`Configure ${m.name} before loading`}
+                >
+                  <SlidersHorizontal size={13} />
+                </button>
+              )}
               <span className="shrink-0 text-[11px] uppercase text-faint">
                 {m.quant}
               </span>
             </div>
           )
         })}
-        {onSettings && <div className="px-2 py-1 text-[11px] text-faint">Alt+click to configure</div>}
         {loadedKey && (
           <>
             <DropdownMenuSeparator />

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -248,6 +248,15 @@ html.tllm-resizing .tllm-split-resizer::after {
   background: var(--accent);
 }
 
+/* Chat sidebar column — animates its own collapse/expand toggle, but that transition
+   must not fight the drag-resize handle's per-pixel style mutation while dragging. */
+.tllm-chat-sidebar {
+  transition: width 0.15s;
+}
+html.tllm-resizing .tllm-chat-sidebar {
+  transition: none;
+}
+
 /* App-wide scrollbar — every scrollable element gets the same thin, theme-colored
    scrollbar; the raw OS/browser default never appears anywhere. Applies universally
    (not a per-element opt-in class) so new scrollable regions are styled automatically.

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -386,19 +386,23 @@ export function deleteModel(key: string): Promise<{ ok: true; deleted: string[] 
 }
 
 // ── Load profiles + load flow (A4, spec 05) ──────────────────────────────────
-export function getModelDetail(key: string): Promise<ModelDetail> {
-  return request<ModelDetail>(`/api/v1/models/${encodeURIComponent(key)}`)
+// Profiles are per-engine (issue #35): pass the installed engine's id so reads/writes
+// hit that engine's slot. Omitting engineId on read lets the server fall back to the
+// active engine, then the '*' migrated/global profile.
+export function getModelDetail(key: string, engineId?: string): Promise<ModelDetail> {
+  const q = engineId ? `?engine=${encodeURIComponent(engineId)}` : ''
+  return request<ModelDetail>(`/api/v1/models/${encodeURIComponent(key)}${q}`)
 }
 
-export function saveModelProfile(key: string, profile: LoadProfile): Promise<LoadProfile> {
-  return request<LoadProfile>(`/api/v1/models/${encodeURIComponent(key)}/profile`, {
+export function saveModelProfile(key: string, profile: LoadProfile, engineId: string): Promise<LoadProfile> {
+  return request<LoadProfile>(`/api/v1/models/${encodeURIComponent(key)}/profile?engine=${encodeURIComponent(engineId)}`, {
     method: 'PUT',
     json: profile,
   })
 }
 
-export function resetModelProfile(key: string): Promise<{ ok: true }> {
-  return request<{ ok: true }>(`/api/v1/models/${encodeURIComponent(key)}/profile/reset`, {
+export function resetModelProfile(key: string, engineId: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/v1/models/${encodeURIComponent(key)}/profile/reset?engine=${encodeURIComponent(engineId)}`, {
     method: 'POST',
     json: {},
   })

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -1,4 +1,4 @@
-import type { Conversation, Message, ChatSseEvent } from './chat-types'
+import type { Conversation, Folder, Message, ChatSseEvent } from './chat-types'
 import { ApiError, authHeaders } from './api'
 
 async function req<T>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> {
@@ -43,6 +43,29 @@ export function deleteConversation(id: string): Promise<{ ok: true }> {
 
 export function stopGeneration(conversationId: string): Promise<{ ok: true }> {
   return req('/api/v1/chat/stop', { method: 'POST', json: { conversationId } })
+}
+
+// ── folders (v10) ─────────────────────────────────────────────────────────────
+
+export function listFolders(): Promise<{ folders: Folder[] }> {
+  return req('/api/v1/folders')
+}
+
+export function createFolder(name: string): Promise<Folder> {
+  return req('/api/v1/folders', { method: 'POST', json: { name } })
+}
+
+export function renameFolder(id: string, name: string): Promise<Folder> {
+  return req(`/api/v1/folders/${encodeURIComponent(id)}`, { method: 'PATCH', json: { name } })
+}
+
+export function deleteFolder(id: string): Promise<{ ok: true }> {
+  return req(`/api/v1/folders/${encodeURIComponent(id)}`, { method: 'DELETE' })
+}
+
+/** Move a conversation into a folder, or out of any folder when folderId is null. */
+export function moveConversationToFolder(convId: string, folderId: string | null): Promise<Conversation> {
+  return req(`/api/v1/conversations/${encodeURIComponent(convId)}/folder`, { method: 'PATCH', json: { folderId } })
 }
 
 export function editMessage(convId: string, msgId: string, content: string): Promise<{ messages: Message[] }> {

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -1,19 +1,30 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  createConversation, deleteConversation, deleteMessage, editMessage,
-  getConversation, listConversations, regenerate, stopGeneration, updateConversation,
+  createConversation, createFolder, deleteConversation, deleteFolder, deleteMessage, editMessage,
+  getConversation, listConversations, listFolders, moveConversationToFolder, regenerate,
+  renameFolder, stopGeneration, updateConversation,
 } from './chat-api'
 import type { Conversation } from './chat-types'
 
 export const chatKeys = {
   list: (q?: string) => ['conversations', q ?? ''] as const,
   detail: (id: string | null) => ['conversation', id] as const,
+  folders: ['folders'] as const,
 }
 
 export function useConversations(q?: string) {
   return useQuery({
     queryKey: chatKeys.list(q),
     queryFn: () => listConversations(q),
+    staleTime: 0,
+    retry: false,
+  })
+}
+
+export function useFolders() {
+  return useQuery({
+    queryKey: chatKeys.folders,
+    queryFn: () => listFolders(),
     staleTime: 0,
     retry: false,
   })
@@ -33,6 +44,7 @@ export function useConversationMutations() {
 
   const invalidateList = () => void qc.invalidateQueries({ queryKey: ['conversations'] })
   const invalidateDetail = (id: string) => void qc.invalidateQueries({ queryKey: chatKeys.detail(id) })
+  const invalidateFolders = () => void qc.invalidateQueries({ queryKey: chatKeys.folders })
 
   return {
     create: useMutation({
@@ -61,6 +73,23 @@ update: useMutation({
     regenerate: useMutation({
       mutationFn: (convId: string) => regenerate(convId),
       onSuccess: (_d, convId) => invalidateDetail(convId),
+    }),
+    createFolder: useMutation({
+      mutationFn: (name: string) => createFolder(name),
+      onSuccess: () => { invalidateFolders(); invalidateList() },
+    }),
+    renameFolder: useMutation({
+      mutationFn: (v: { id: string; name: string }) => renameFolder(v.id, v.name),
+      onSuccess: () => { invalidateFolders(); invalidateList() },
+    }),
+    deleteFolder: useMutation({
+      mutationFn: (id: string) => deleteFolder(id),
+      // Deleting a folder unassigns its members, so the conversations list changes too.
+      onSuccess: () => { invalidateFolders(); invalidateList() },
+    }),
+    moveToFolder: useMutation({
+      mutationFn: (v: { convId: string; folderId: string | null }) => moveConversationToFolder(v.convId, v.folderId),
+      onSuccess: (_d, v) => { invalidateFolders(); invalidateList(); invalidateDetail(v.convId) },
     }),
   }
 }

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -84,9 +84,20 @@ export interface Conversation {
   /** When set, the backend enforces a tool_choice policy on the first generation
    *  iteration. 'force_web_search' forces web_search before the model can reply. */
   toolPolicy?: string
+  /** Folder this conversation is filed under (v10). null/undefined = uncategorized. */
+  folderId?: string | null
   createdAt: string
   updatedAt: string
   messages?: Message[]
+}
+
+/** A chat folder for grouping conversations in the sidebar (v10). Flat — no nesting. */
+export interface Folder {
+  id: string
+  name: string
+  sortOrder: number
+  createdAt: string
+  updatedAt: string
 }
 
 // SSE event payloads

--- a/turbollm/web/src/lib/pdf-extract.ts
+++ b/turbollm/web/src/lib/pdf-extract.ts
@@ -1,0 +1,26 @@
+// Client-side PDF text extraction for chat attachments (GitHub issue #35).
+//
+// Uses pdfjs-dist (Mozilla's pure JS/WASM PDF.js) so extraction runs entirely
+// in the browser — no native binaries, no postinstall build step, works the
+// same on Windows/macOS/Linux. The worker script is resolved via Vite's `?url`
+// import so it's bundled as a static asset and resolves correctly in both dev
+// and production builds.
+import * as pdfjsLib from 'pdfjs-dist'
+// eslint-disable-next-line import/no-unresolved -- Vite `?url` asset import
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl
+
+/** Extracts plain text from a PDF file, page by page, joined with blank lines. */
+export async function extractPdfText(file: File): Promise<string> {
+  const buf = await file.arrayBuffer()
+  const doc = await pdfjsLib.getDocument({ data: buf }).promise
+  const pages: string[] = []
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i)
+    const content = await page.getTextContent()
+    const text = content.items.map((it) => ('str' in it ? it.str : '')).join(' ')
+    pages.push(text)
+  }
+  return pages.join('\n\n')
+}

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -501,11 +501,13 @@ export function useDaemonRestart() {
   return useMutation({ mutationFn: () => restartDaemon() })
 }
 
-/** Model detail (entry + resolved profile + VRAM fit). Disabled when key is null. */
-export function useModelDetail(key: string | null): UseQueryResult<ModelDetail> {
+/** Model detail (entry + resolved profile + VRAM fit). Disabled when key is null.
+ *  engineId (issue #35) scopes the resolved profile to a specific installed engine and
+ *  is part of the query key so switching engines refetches that engine's saved profile. */
+export function useModelDetail(key: string | null, engineId?: string): UseQueryResult<ModelDetail> {
   return useQuery({
-    queryKey: ['model', key],
-    queryFn: () => getModelDetail(key as string),
+    queryKey: ['model', key, engineId],
+    queryFn: () => getModelDetail(key as string, engineId),
     enabled: !!key,
     retry: false,
   })
@@ -519,17 +521,18 @@ export function useModelActions() {
   }
   return {
     save: useMutation({
-      mutationFn: (v: { key: string; profile: LoadProfile }) => saveModelProfile(v.key, v.profile),
+      mutationFn: (v: { key: string; profile: LoadProfile; engineId: string }) => saveModelProfile(v.key, v.profile, v.engineId),
       onSuccess: (_d, v) => {
         invalidate()
+        // Prefix-match ['model', key] invalidates every engine variant of the detail query.
         void qc.invalidateQueries({ queryKey: ['model', v.key] })
       },
     }),
     reset: useMutation({
-      mutationFn: (key: string) => resetModelProfile(key),
-      onSuccess: (_d, key) => {
+      mutationFn: (v: { key: string; engineId: string }) => resetModelProfile(v.key, v.engineId),
+      onSuccess: (_d, v) => {
         invalidate()
-        void qc.invalidateQueries({ queryKey: ['model', key] })
+        void qc.invalidateQueries({ queryKey: ['model', v.key] })
       },
     }),
     load: useMutation({

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -411,8 +411,11 @@ export function ChatScreen() {
     if ((!text && attachments.length === 0) || live) return
     if (engineState !== 'running' || !model) { toast.error('Load a model first.'); return }
 
-    const imageAttachments = attachments.filter((a) => a.dataUrl.startsWith('data:image/'))
-    const textAttachments = attachments.filter((a) => !a.dataUrl.startsWith('data:image/'))
+    // Discriminate by file.type (authoritative, same as the preview thumbnail below) rather
+    // than sniffing the extracted dataUrl content — a text/PDF attachment whose content
+    // happens to start with "data:image/" would otherwise get mis-sent as an image.
+    const imageAttachments = attachments.filter((a) => a.file.type.startsWith('image/'))
+    const textAttachments = attachments.filter((a) => !a.file.type.startsWith('image/'))
     const images = imageAttachments.map((a) => a.dataUrl)
     const docContext = textAttachments.map((a) => `[Attached: ${a.file.name}]\n${a.dataUrl}`).join('\n\n')
 

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { ArrowDown, Brain, Copy, Download, Paperclip, SendHorizontal, Share2, SlidersHorizontal, Square, UserRound, X } from 'lucide-react'
 import { continueConversation, fetchSysInfo, sendMessage } from '../lib/chat-api'
@@ -22,6 +22,23 @@ import {
   getPersonalization, setConvPersonaId,
   type PersonaId,
 } from '../lib/personas'
+
+// Sidebar width — persisted like DiscoverTab's list/detail split, an in-flow flex-basis
+// (not a CSS var pinned against the app shell, since the sidebar isn't a docked panel).
+const SIDEBAR_WIDTH_KEY = 'tllm-sidebar-w'
+const SIDEBAR_MIN_W = 200
+/** Largest the sidebar may grow: always leave the thread at least 480px. */
+function sidebarMaxW(): number {
+  return Math.max(SIDEBAR_MIN_W, Math.min(480, window.innerWidth - 480))
+}
+function readSavedSidebarWidth(): number {
+  try {
+    const n = parseInt(localStorage.getItem(SIDEBAR_WIDTH_KEY) ?? '', 10)
+    return Number.isFinite(n) ? n : 224 // 224px matches the prior fixed w-56
+  } catch {
+    return 224
+  }
+}
 
 // Streaming state
 interface LiveState {
@@ -51,6 +68,8 @@ export function ChatScreen() {
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
   const [showScrollBtn, setShowScrollBtn] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(true)
+  const sidebarRef = useRef<HTMLDivElement>(null)
+  const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const [attachments, setAttachments] = useState<{ file: File; dataUrl: string }[]>([])
   // Share menu state
   const [shareMenuOpen, setShareMenuOpen] = useState(false)
@@ -484,8 +503,15 @@ export function ChatScreen() {
 
   return (
     <div className="flex h-full overflow-hidden">
-      {/* Sidebar (collapsible) */}
-      <div className={sidebarOpen ? 'w-56 shrink-0' : 'w-10 shrink-0'} style={{ transition: 'width 0.15s' }}>
+      {/* Sidebar (collapsible, drag-resizable when open). The collapse/expand width
+          transition lives in the `tllm-chat-sidebar` CSS class (index.css), not inline,
+          so it can be disabled globally while dragging (html.tllm-resizing) without
+          fighting the resize handle's own per-pixel style mutation. */}
+      <div
+        ref={sidebarRef}
+        className={sidebarOpen ? 'tllm-chat-sidebar shrink-0' : 'tllm-chat-sidebar w-10 shrink-0'}
+        style={sidebarOpen ? { width: sidebarWidth } : undefined}
+      >
         <ConversationSidebar
           activeId={activeId}
           onSelect={handleSelect}
@@ -497,6 +523,7 @@ export function ChatScreen() {
           onDeleted={handleActiveDeleted}
         />
       </div>
+      {sidebarOpen && <SidebarResizeHandle sidebarRef={sidebarRef} onCommit={setSidebarWidth} />}
 
       {/* Thread */}
       <div className="relative flex min-w-0 flex-1 flex-col">
@@ -797,6 +824,58 @@ export function ChatScreen() {
 
       <ModelDetailDialog modelKey={settingsKey} onClose={() => setSettingsKey(null)} />
     </div>
+  )
+}
+
+// ── Sidebar resize handle ────────────────────────────────────────────────────
+
+/** Thin drag handle between the sidebar and the thread; resizes the sidebar column
+ *  live via direct style mutation (same pattern as DiscoverTab's SplitResizeHandle —
+ *  avoids a React re-render per pointer-move pixel), then commits + persists the
+ *  final width on release. */
+function SidebarResizeHandle({
+  sidebarRef,
+  onCommit,
+}: {
+  sidebarRef: RefObject<HTMLDivElement | null>
+  onCommit: (w: number) => void
+}) {
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = sidebarRef.current?.getBoundingClientRect().width ?? readSavedSidebarWidth()
+    document.documentElement.classList.add('tllm-resizing')
+    const onMove = (ev: PointerEvent) => {
+      const w = Math.min(Math.max(startW + (ev.clientX - startX), SIDEBAR_MIN_W), sidebarMaxW())
+      if (sidebarRef.current) sidebarRef.current.style.width = `${Math.round(w)}px`
+    }
+    const onUp = () => {
+      document.documentElement.classList.remove('tllm-resizing')
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+      const w = sidebarRef.current?.getBoundingClientRect().width
+      if (w) {
+        const rounded = Math.round(w)
+        onCommit(rounded)
+        try {
+          localStorage.setItem(SIDEBAR_WIDTH_KEY, String(rounded))
+        } catch {
+          /* ignore quota / disabled storage */
+        }
+      }
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }
+  return (
+    <div
+      className="tllm-split-resizer"
+      onPointerDown={onPointerDown}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize conversation sidebar"
+    />
   )
 }
 

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { ArrowDown, Brain, Copy, Download, Paperclip, SendHorizontal, Share2, SlidersHorizontal, Square, UserRound, X } from 'lucide-react'
 import { continueConversation, fetchSysInfo, sendMessage } from '../lib/chat-api'
+import { extractPdfText } from '../lib/pdf-extract'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
 import { useModelActions, useModels, useStatus } from '../lib/queries'
 import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
@@ -307,6 +308,12 @@ export function ChatScreen() {
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
     const loaded = await Promise.all(files.map(async (file) => {
+      const isPdf = file.type === 'application/pdf' || /\.pdf$/i.test(file.name)
+      if (isPdf) {
+        // PDFs are binary — extract real text client-side instead of reading raw bytes as text.
+        const text = await extractPdfText(file)
+        return { file, dataUrl: text }
+      }
       const dataUrl = await new Promise<string>((res) => {
         const r = new FileReader()
         r.onload = () => res(r.result as string)
@@ -750,7 +757,7 @@ export function ChatScreen() {
                   ref={fileInputRef}
                   type="file"
                   multiple
-                  accept="image/*,.pdf,.txt,.md,.csv"
+                  accept="image/*,.pdf,.txt,.md,.csv,.json,.yaml,.yml,.log,.ts,.tsx,.js,.jsx,.py,.go,.rs,.java,.c,.cpp,.h,.rb,.php,.sh,.sql,.xml,.toml,.ini"
                   hidden
                   onChange={handleFileSelect}
                 />

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -274,7 +274,14 @@ export function ConversationSidebar({
               />
             ))}
 
-            {/* Ungrouped conversations, rendered exactly as before. */}
+            {/* Explicit "Uncategorized" label so it reads as its own section rather than
+                blending into whichever folder happens to render above it — only shown
+                once folders exist at all (a flat list with no folders needs no label). */}
+            {folders.length > 0 && ungrouped.length > 0 && (
+              <div className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide text-faint">
+                Uncategorized
+              </div>
+            )}
             {ungrouped.map((conv) => (
               <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
             ))}
@@ -427,7 +434,10 @@ function FolderSection({
         )}
       </div>
       <CollapsibleContent>
-        <div className="pl-2">
+        {/* Left guide line brackets exactly which rows belong to this folder — a plain
+            padding indent alone was too subtle to tell folder contents from the flat
+            ungrouped list below. */}
+        <div className="ml-3 border-l border-border pl-2">
           {items.length === 0 ? (
             <p className="px-3 py-1.5 text-[11px] text-faint">Empty folder</p>
           ) : (

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
-import { ChevronLeft, ChevronRight, Download, MessageSquarePlus, Pencil, Search, Trash2 } from 'lucide-react'
-import type { Conversation } from '../../lib/chat-types'
-import { useConversationMutations, useConversations } from '../../lib/chat-queries'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, ChevronLeft, ChevronRight, Download, Folder as FolderIcon, FolderInput, FolderPlus, MessageSquarePlus, MoreHorizontal, Pencil, Search, Trash2 } from 'lucide-react'
+import type { Conversation, Folder } from '../../lib/chat-types'
+import { useConversationMutations, useConversations, useFolders } from '../../lib/chat-queries'
 import { Button } from '../../components/ui/button'
 import { Input } from '../../components/ui/input'
 import { toast } from '../../components/ui/sonner'
@@ -15,6 +15,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../../components/ui/alert-dialog'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../../components/ui/dropdown-menu'
 
 /** localStorage key for the client-only "confirm before deleting a conversation"
  *  preference (mirrors SettingsScreen). Default ON when unset. */
@@ -56,10 +64,41 @@ export function ConversationSidebar({
   const [debouncedQ, setDebouncedQ] = useState('')
   // Conversation queued for a confirmation dialog (null = dialog closed).
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null)
+  // Folder queued for a delete-confirmation dialog (null = dialog closed).
+  const [pendingFolderDelete, setPendingFolderDelete] = useState<Folder | null>(null)
+  // Which folder sections are open. Not persisted — resets on remount.
+  const [openFolders, setOpenFolders] = useState<Set<string>>(new Set())
+  // True while the inline "new folder" name input is showing.
+  const [addingFolder, setAddingFolder] = useState(false)
+  const [newFolderName, setNewFolderName] = useState('')
   const searchRef = useRef<HTMLInputElement>(null)
   const mut = useConversationMutations()
   const convsQ = useConversations(debouncedQ || undefined)
   const convs = convsQ.data?.conversations ?? []
+  const foldersQ = useFolders()
+  const folders = foldersQ.data?.folders ?? []
+
+  const searching = !!debouncedQ
+
+  // Bucket conversations by folderId (only used when not searching). Conversations
+  // whose folderId is null/undefined OR points at a folder that no longer exists fall
+  // into the "ungrouped" bucket.
+  const { byFolder, ungrouped } = useMemo(() => {
+    const known = new Set(folders.map((f) => f.id))
+    const byFolder = new Map<string, Conversation[]>()
+    const ungrouped: Conversation[] = []
+    for (const conv of convs) {
+      const fid = conv.folderId
+      if (fid && known.has(fid)) {
+        const arr = byFolder.get(fid) ?? []
+        arr.push(conv)
+        byFolder.set(fid, arr)
+      } else {
+        ungrouped.push(conv)
+      }
+    }
+    return { byFolder, ungrouped }
+  }, [convs, folders])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQ(q), 200)
@@ -72,6 +111,15 @@ export function ConversationSidebar({
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [])
+
+  const toggleFolder = (id: string) => {
+    setOpenFolders((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   // Actually delete a conversation. If it was the active one, tell the parent so
   // it can close/clear the now-dangling reference.
@@ -91,6 +139,31 @@ export function ConversationSidebar({
     // When confirmation is enabled, queue the dialog; otherwise delete immediately.
     if (confirmDeleteEnabled()) setPendingDelete(conv)
     else doDelete(conv)
+  }
+
+  const onMove = (conv: Conversation, folderId: string | null) => {
+    mut.moveToFolder.mutate(
+      { convId: conv.id, folderId },
+      { onError: () => { toast.error('Could not move conversation.') } },
+    )
+  }
+
+  const commitNewFolder = () => {
+    const name = newFolderName.trim()
+    setAddingFolder(false)
+    setNewFolderName('')
+    if (!name) return
+    mut.createFolder.mutate(name, {
+      onSuccess: (folder) => { setOpenFolders((prev) => new Set(prev).add(folder.id)) },
+      onError: () => { toast.error('Could not create folder.') },
+    })
+  }
+
+  const doDeleteFolder = (folder: Folder) => {
+    mut.deleteFolder.mutate(folder.id, {
+      onSuccess: () => { toast.success('Folder deleted') },
+      onError: () => { toast.error('Could not delete folder.') },
+    })
   }
 
   // Warn that an in-flight generation will be lost only when deleting the active,
@@ -138,6 +211,9 @@ export function ConversationSidebar({
         <Button size="icon" variant="ghost" onClick={onNew} title="New chat (Ctrl+N)" className="h-7 w-7 shrink-0">
           <MessageSquarePlus size={15} />
         </Button>
+        <Button size="icon" variant="ghost" onClick={() => { setAddingFolder(true); setNewFolderName('') }} title="New folder" className="h-7 w-7 shrink-0">
+          <FolderPlus size={15} />
+        </Button>
         {onImport && (
           <Button size="icon" variant="ghost" onClick={onImport} title="Import chat (.turbollm-chat.json or OpenAI JSON)" className="h-7 w-7 shrink-0">
             <Download size={15} />
@@ -145,13 +221,65 @@ export function ConversationSidebar({
         )}
       </div>
 
+      {/* Inline "new folder" name input — mirrors the conversation-rename inline UX. */}
+      {addingFolder && (
+        <div className="flex items-center gap-2 px-3 pb-2">
+          <FolderIcon size={13} className="shrink-0 text-faint" />
+          <input
+            autoFocus
+            className="w-full bg-transparent text-[13px] font-medium text-ink outline-none placeholder:text-faint"
+            value={newFolderName}
+            placeholder="Folder name…"
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onBlur={commitNewFolder}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitNewFolder()
+              if (e.key === 'Escape') { setAddingFolder(false); setNewFolderName('') }
+            }}
+          />
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto px-1 pb-2">
-        {convs.length === 0 && (
-          <p className="px-3 py-4 text-[12px] text-faint">{q ? 'No results.' : 'No conversations yet.'}</p>
+        {/* When searching, keep the flat, ungrouped list exactly as before. */}
+        {searching ? (
+          <>
+            {convs.length === 0 && (
+              <p className="px-3 py-4 text-[12px] text-faint">No results.</p>
+            )}
+            {convs.map((conv) => (
+              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+            ))}
+          </>
+        ) : (
+          <>
+            {convs.length === 0 && folders.length === 0 && (
+              <p className="px-3 py-4 text-[12px] text-faint">No conversations yet.</p>
+            )}
+
+            {/* One collapsible section per folder. */}
+            {folders.map((folder) => (
+              <FolderSection
+                key={folder.id}
+                folder={folder}
+                items={byFolder.get(folder.id) ?? []}
+                open={openFolders.has(folder.id)}
+                onToggle={() => toggleFolder(folder.id)}
+                onRequestDelete={() => setPendingFolderDelete(folder)}
+                activeId={activeId}
+                folders={folders}
+                onSelect={onSelect}
+                onDelete={onDelete}
+                onMove={onMove}
+              />
+            ))}
+
+            {/* Ungrouped conversations, rendered exactly as before. */}
+            {ungrouped.map((conv) => (
+              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+            ))}
+          </>
         )}
-        {convs.map((conv) => (
-          <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} onSelect={onSelect} onDelete={onDelete} />
-        ))}
       </div>
 
       {/* Delete confirmation (only shown when the "confirm before delete" setting is on). */}
@@ -181,20 +309,152 @@ export function ConversationSidebar({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Folder-delete confirmation. Folders can contain conversations, so always confirm. */}
+      <AlertDialog open={!!pendingFolderDelete} onOpenChange={(open) => { if (!open) setPendingFolderDelete(null) }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this folder?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingFolderDelete ? (
+                <>
+                  <span className="font-medium text-ink">{pendingFolderDelete.name}</span>{' '}
+                  will be deleted. Conversations inside it won’t be deleted — they’ll move back to
+                  Uncategorized.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => { if (pendingFolderDelete) doDeleteFolder(pendingFolderDelete); setPendingFolderDelete(null) }}
+            >
+              Delete folder
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
+  )
+}
+
+/** A single collapsible folder section: header (chevron + name + count + actions
+ *  dropdown) plus its member conversations. Rename is done inline, mirroring ConvItem's
+ *  double-click / Enter-to-commit UX. Delete is confirmed by the parent via AlertDialog. */
+function FolderSection({
+  folder,
+  items,
+  open,
+  onToggle,
+  onRequestDelete,
+  activeId,
+  folders,
+  onSelect,
+  onDelete,
+  onMove,
+}: {
+  folder: Folder
+  items: Conversation[]
+  open: boolean
+  onToggle: () => void
+  onRequestDelete: () => void
+  activeId: string | null
+  folders: Folder[]
+  onSelect: (id: string) => void
+  onDelete: (e: React.MouseEvent, conv: Conversation) => void
+  onMove: (conv: Conversation, folderId: string | null) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(folder.name)
+  const mut = useConversationMutations()
+
+  const commitRename = () => {
+    setEditing(false)
+    const name = draft.trim()
+    if (!name || name === folder.name) { setDraft(folder.name); return }
+    mut.renameFolder.mutate(
+      { id: folder.id, name },
+      { onError: () => { setDraft(folder.name); toast.error('Could not rename folder.') } },
+    )
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={onToggle}>
+      <div className="group/folder relative flex items-center rounded-md pr-1">
+        {editing ? (
+          <div className="flex flex-1 items-center gap-1.5 px-2 py-1.5">
+            <FolderIcon size={13} className="shrink-0 text-faint" />
+            <input
+              autoFocus
+              className="w-full bg-transparent text-[12px] font-semibold text-ink outline-none"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => { if (e.key === 'Enter') commitRename(); if (e.key === 'Escape') { setDraft(folder.name); setEditing(false) } }}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+        ) : (
+          <CollapsibleTrigger className="flex flex-1 items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[12px] font-semibold text-ink transition-colors hover:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)]">
+            <ChevronDown size={13} className={`shrink-0 text-faint transition-transform ${open ? '' : '-rotate-90'}`} />
+            <FolderIcon size={13} className="shrink-0 text-faint" />
+            <span className="truncate" onDoubleClick={(e) => { e.stopPropagation(); setDraft(folder.name); setEditing(true) }}>{folder.name}</span>
+            <span className="ml-auto pl-1 text-[11px] font-normal text-faint">{items.length}</span>
+          </CollapsibleTrigger>
+        )}
+        {!editing && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+                className="rounded p-1 text-faint opacity-0 transition-opacity hover:text-ink group-hover/folder:opacity-100 data-[state=open]:opacity-100"
+                title="Folder actions"
+              >
+                <MoreHorizontal size={13} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => { setDraft(folder.name); setEditing(true) }}>
+                <Pencil size={13} /> Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem destructive onSelect={onRequestDelete}>
+                <Trash2 size={13} /> Delete folder
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+      <CollapsibleContent>
+        <div className="pl-2">
+          {items.length === 0 ? (
+            <p className="px-3 py-1.5 text-[11px] text-faint">Empty folder</p>
+          ) : (
+            items.map((conv) => (
+              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+            ))
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 
 function ConvItem({
   conv,
   active,
+  folders,
   onSelect,
   onDelete,
+  onMove,
 }: {
   conv: Conversation
   active: boolean
+  folders: Folder[]
   onSelect: (id: string) => void
   onDelete: (e: React.MouseEvent, conv: Conversation) => void
+  onMove: (conv: Conversation, folderId: string | null) => void
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(conv.title)
@@ -238,6 +498,40 @@ function ConvItem({
       <span className="text-[11px] text-faint">{relTime(conv.updatedAt)}</span>
       {!editing && (
         <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => e.stopPropagation()}
+                className="rounded p-1 text-faint transition-colors hover:text-ink data-[state=open]:text-ink"
+                title="Move to folder"
+              >
+                <FolderInput size={13} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {folders.length === 0 && (
+                <DropdownMenuItem disabled>No folders yet</DropdownMenuItem>
+              )}
+              {folders.map((f) => (
+                <DropdownMenuItem
+                  key={f.id}
+                  disabled={f.id === conv.folderId}
+                  onSelect={() => onMove(conv, f.id)}
+                >
+                  <FolderIcon size={13} /> {f.name}
+                </DropdownMenuItem>
+              ))}
+              {conv.folderId && (
+                <>
+                  {folders.length > 0 && <DropdownMenuSeparator />}
+                  <DropdownMenuItem onSelect={() => onMove(conv, null)}>
+                    Uncategorized
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); setDraft(conv.title); setEditing(true) }}

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -50,8 +50,12 @@ export function ModelDetailDialog({
   /** Open the model's Hugging Face page (card + quants) for the given repo. */
   onViewRepo?: (repo: string) => void
 }) {
-  const detailQ = useModelDetail(modelKey)
+  // Resolve the active engine first: the model detail (resolved profile + VRAM fit) is
+  // per-engine (issue #35), so useModelDetail needs the engine id to fetch that engine's
+  // saved profile. '*' is the server-side fallback when no engine is active.
   const enginesQ = useEngines()
+  const activeEngine = enginesQ.data?.engines.find((e) => e.id === enginesQ.data?.activeEngineId)
+  const detailQ = useModelDetail(modelKey, activeEngine?.id)
   const actions = useModelActions()
   const bench = useBenchActions()
   const benchState = useBenchState()
@@ -95,7 +99,6 @@ export function ModelDetailDialog({
     }
   }, [pendingBenchKey, engineState, bench.start])
 
-  const activeEngine = enginesQ.data?.engines.find((e) => e.id === enginesQ.data?.activeEngineId)
   const kvTypes = activeEngine?.capabilities.kvTypes ?? ['f16']
 
   // Speculative-decoding options: require BOTH engine capability AND model support
@@ -512,7 +515,7 @@ export function ModelDetailDialog({
                       },
                     )
                   if (remember) {
-                    actions.save.mutate({ key: detail.key, profile: draft }, { onSuccess: fireLoad, onError: fireLoad })
+                    actions.save.mutate({ key: detail.key, profile: draft, engineId: activeEngine?.id ?? '*' }, { onSuccess: fireLoad, onError: fireLoad })
                   } else {
                     fireLoad()
                   }
@@ -523,11 +526,11 @@ export function ModelDetailDialog({
                 <Zap size={14} />
                 {detail.loaded ? 'Reload' : 'Load model'}
               </Button>
-              <Button variant="outline" onClick={() => actions.save.mutate({ key: detail.key, profile: draft })} disabled={actions.save.isPending} title="Save without reloading">
+              <Button variant="outline" onClick={() => actions.save.mutate({ key: detail.key, profile: draft, engineId: activeEngine?.id ?? '*' })} disabled={actions.save.isPending} title="Save without reloading">
                 <Save size={14} />
                 Save
               </Button>
-              <Button variant="ghost" onClick={() => actions.reset.mutate(detail.key)} disabled={actions.reset.isPending} title="Reset to defaults">
+              <Button variant="ghost" onClick={() => actions.reset.mutate({ key: detail.key, engineId: activeEngine?.id ?? '*' })} disabled={actions.reset.isPending} title="Reset to defaults">
                 <RotateCcw size={14} />
               </Button>
             </div>

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -404,18 +404,20 @@ export function ModelDetailDialog({
                     <p className="text-[11px] text-faint">Uses this model's built-in NextN head — no extra file needed.</p>
                   )}
                   {draft.speculative === 'draft' && (
+                    <PathField
+                      label="Draft model GGUF"
+                      hint="A small same-family model."
+                      value={draft.draftModelPath}
+                      placeholder="Path to small draft model"
+                      onChange={(v) => set('draftModelPath', v)}
+                    />
+                  )}
+                  {draft.speculative !== 'off' && (
                     <>
-                      <PathField
-                        label="Draft model GGUF"
-                        hint="A small same-family model."
-                        value={draft.draftModelPath}
-                        placeholder="Path to small draft model"
-                        onChange={(v) => set('draftModelPath', v)}
-                      />
-                      <Row label="Max drafts" hint="Tokens drafted per step (--draft-max). Default 16.">
+                      <Row label="Max drafts" hint="Tokens the draft head proposes per step before verification (--draft-max). Default 16.">
                         <DefaultableNumberInput value={draft.draftMax} placeholder="16" min={1} max={64} onChange={(v) => set('draftMax', v)} />
                       </Row>
-                      <Row label="Min drafts" hint="Minimum tokens drafted per step (--draft-min). Default 1.">
+                      <Row label="Min drafts" hint="Minimum tokens drafted per step before the main model verifies (--draft-min). Default 1.">
                         <DefaultableNumberInput value={draft.draftMin} placeholder="1" min={0} max={8} onChange={(v) => set('draftMin', v)} />
                       </Row>
                     </>


### PR DESCRIPTION
## Summary

Bundles the remaining items from #35 (reopened after v1.6.4's "MTP control" and
"per-engine config" fixes were confirmed incomplete on live testing):

- **fix(profile):** `--draft-max`/`--draft-min` now honored for `mtp` and `nextn`
  speculative modes, not just `draft` (v1.6.4 only wired the `draft` mode — the
  actual mode issue #35 asked about was ignored).
- **fix(ui):** model load menu rows now have a visible settings icon (matching the
  Models screen pattern), not just an easy-to-miss "Alt+click to configure" hint.
- **feat(config):** per-engine + per-model saved profiles. Profiles were keyed only
  by model, so switching engines silently reused/overwrote the same profile. Now
  nested `(modelKey -> engineId -> profile)`, with a v2->v3 migration wrapping old
  flat profiles under a reserved `'*'` slot. When the active engine has no saved
  profile for a model, it falls back to whichever engine's profile was saved most
  recently (no fixed "default engine" — there's no reliable way to distinguish
  mainline llama.cpp from forks like ik_llama.cpp/TurboQuant in this codebase).
- **feat(chat):** folders for organizing conversations in the sidebar (create/
  rename/delete/move). Deleting a folder unassigns member conversations rather
  than cascade-deleting them. A v10 chat-db migration adds the `folders` table +
  `conversations.folder_id`.
- **feat(chat):** fixed a real pre-existing bug — PDF attachments were already
  accepted but silently corrupted (`readAsText` on binary data). PDFs now extract
  real text client-side via `pdfjs-dist`. Also widened the plain-text/code
  attachment allowlist.
- **feat(chat):** sidebar width is now drag-resizable (reuses the existing
  in-flow split-resizer pattern from DiscoverTab), and folder contents get a
  clearer visual indent guide + an explicit "Uncategorized" label so it's no
  longer ambiguous which conversations are inside a folder vs. outside it.

## Test plan
- [x] Backend: `npm test` (579/582 passing, 3 pre-existing unrelated skips) + `tsc --noEmit`
- [x] Frontend: `tsc --noEmit` + production build (confirms pdfjs-dist worker asset bundles correctly)
- [x] Per-engine config verified live via real HTTP routes against two real installed
      llama.cpp engines (independent profiles + last-used-engine fallback confirmed)
- [x] Chat folders verified live end-to-end (create/move/reload/delete-unassigns)
- [x] PDF extraction verified to produce real text (not garbled binary) via a hand-built test PDF
- [x] Alt+click discoverability + sidebar resize + folder indent guide verified live in browser

Closes #35 pending final confirmation after this ships.