### PR TITLE
v1.7.0: VRAM headroom slider, Cloud Launch (--tunnel), tool-call approval gate, CUDA source-build fixes

### DIFF
--- a/.github/workflows/runpod-image.yml
+++ b/.github/workflows/runpod-image.yml
@@ -1,0 +1,43 @@
+name: RunPod image
+
+# Builds + publishes the official TurboLLM RunPod image (deploy/runpod/Dockerfile) to
+# GHCR, so a "Deploy on RunPod" click works for every user out of the box — nobody
+# has to build/push/template it themselves. GHCR is used (not Docker Hub) because it
+# authenticates with the built-in GITHUB_TOKEN — no extra registry account or secret
+# to configure. Runs weekly on top of the Dockerfile-change trigger since the image
+# always installs `turbollm@latest` from npm (no version pin), so a periodic rebuild
+# is what actually picks up new releases.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/runpod/**'
+      - '.github/workflows/runpod-image.yml'
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC — picks up the latest npm release
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./deploy/runpod
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/turbollm-runpod:latest

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ Thumbs.db
 
 # local-only test/marketing notes — never ship in the public repo
 /turbollm/posts/
+
+# Playwright MCP tool artifacts (console logs, page snapshots from browser debugging)
+/turbollm/.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ the detail:
 - **Saved per-model profiles, per engine** — tune once per (model, engine) pair, so
   switching engines (or between two installs of the same engine, e.g. a fork) never
   overwrites another engine's tuning for the same model.
+- **Configurable VRAM headroom** (Settings → Engine, 300 MB–2 GB, default 1 GB) — tell auto-tune
+  how much VRAM to keep free for other GPU workloads instead of a fixed margin.
 
 </details>
 
@@ -210,6 +212,9 @@ the detail:
   Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, Mixpanel) and open-source local MCPs
   (filesystem, git, postgres, playwright, …), plus your own custom servers. Connected tools appear
   in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
+- **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
+  with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
+  composer. Set per-tool defaults globally from Developer → Tool permissions.
 
 </details>
 
@@ -249,6 +254,9 @@ curl http://127.0.0.1:6996/v1/chat/completions \
   Claude Code below. No other local host offers this.
 - **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape).
 - **API-key auth** you can require when sharing over a LAN (Settings → Network).
+- **Cloud Launch (`turbollm --tunnel`)** — share your local instance over the internet with one
+  flag via a cloudflared quick tunnel, no port forwarding or reverse proxy to set up. An access
+  token is auto-provisioned and enforced on all tunneled traffic; local access is unaffected.
 
 **The gateway loads models for you.** Most local hosts make you load a model first, then call it.
 TurboLLM's gateway reads the `model` field of any incoming request, **fuzzy-matches it to your

--- a/README.md
+++ b/README.md
@@ -254,9 +254,6 @@ curl http://127.0.0.1:6996/v1/chat/completions \
   Claude Code below. No other local host offers this.
 - **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape).
 - **API-key auth** you can require when sharing over a LAN (Settings → Network).
-- **Cloud Launch (`turbollm --tunnel`)** — share your local instance over the internet with one
-  flag via a cloudflared quick tunnel, no port forwarding or reverse proxy to set up. An access
-  token is auto-provisioned and enforced on all tunneled traffic; local access is unaffected.
 
 **The gateway loads models for you.** Most local hosts make you load a model first, then call it.
 TurboLLM's gateway reads the `model` field of any incoming request, **fuzzy-matches it to your

--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -1,0 +1,53 @@
+# TurboLLM on RunPod (Cloud Launch, ADR-045/152) — v1 scope: official upstream
+# llama.cpp only (not TurboQuant/vLLM/other forks/engines). "Official llama.cpp" on
+# an NVIDIA Linux box means the **Vulkan** build, not CUDA: upstream llama.cpp
+# publishes no Linux CUDA prebuilt at all (turbollm/src/engines/download.ts), so
+# TurboLLM's own auto-recommendation (ADR-025) picks Vulkan for NVIDIA-on-Linux. This
+# base image is still an NVIDIA CUDA one (matches RunPod's own official-template
+# convention and keeps the door open for CUDA-needing engines like vLLM later) — but
+# it needs the Vulkan loader added explicitly, since Vulkan and CUDA are unrelated
+# APIs and the CUDA runtime image doesn't include one.
+#
+# Runtime-only base (not -devel/full toolkit): this image RUNS a prebuilt binary, it
+# never compiles anything.
+FROM nvidia/cuda:12.6.3-runtime-ubuntu22.04
+
+# Node >= 22 (TurboLLM's own requirement) via NodeSource — Ubuntu 22.04's apt-default
+# Node is far too old. libvulkan1 is the Vulkan loader the Vulkan backend needs (the
+# NVIDIA Vulkan ICD itself comes from the driver RunPod's container runtime mounts in
+# at pod start, not from anything installed here); libgomp1 (GNU OpenMP) is a real
+# runtime dependency of the llama.cpp binaries themselves — without it the server
+# fails to even start ("error while loading shared libraries: libgomp.so.1"),
+# caught by actually building and running this image locally before shipping it.
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates libvulkan1 libgomp1 \
+  && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g turbollm
+
+# Pre-bake the Vulkan engine (TurboLLM's own first-run seed, ADR-024/025) into the
+# image so a per-hour-billed pod doesn't eat that download on its first request.
+# TURBOLLM_SEED_BACKEND forces Vulkan rather than trusting the seed's live GPU
+# detection: `docker build` never has GPU passthrough (true on any machine, not just
+# this one), so live detection here would always see "no GPU" and pre-bake the CPU
+# backend instead — silently defeating the whole point on hardware this image is
+# explicitly built for. Caught by actually running this build and reading its output,
+# not assumed. Still reuses the real startup path (start the daemon, wait for it to
+# self-seed, stop it) rather than reaching into TurboLLM's internals directly.
+ENV TURBOLLM_SEED_BACKEND=vulkan
+RUN (turbollm --no-open --port 6996 &) \
+    && for i in $(seq 1 60); do \
+      node -e "process.exit((()=>{try{return JSON.parse(require('fs').readFileSync(process.env.HOME+'/.turbollm/config.json','utf8')).engines.length>0}catch{return false}})()?0:1)" && break; \
+      sleep 3; \
+    done \
+    && turbollm --stop || true
+
+# Kept only as a secondary/debug path — see README: RunPod's own HTTP proxy has a
+# ~100s idle/response timeout that risks 524s on slow prefill/cold model loads, so
+# --tunnel (cloudflared) is the primary, reliable access method (ENTRYPOINT below).
+# Docker's EXPOSE only takes tcp/udp (not RunPod's own "6996/http" template-port
+# notation, which belongs in the RunPod Template's ports config, not here).
+EXPOSE 6996/tcp
+
+ENTRYPOINT ["npx", "turbollm", "--tunnel", "--no-open"]

--- a/deploy/runpod/README.md
+++ b/deploy/runpod/README.md
@@ -1,0 +1,102 @@
+# TurboLLM on RunPod — one-click deploy (Cloud Launch, ADR-045/152)
+
+Runs TurboLLM on a rented RunPod GPU pod, reachable over the internet via a
+[`--tunnel`](../../docs/decisions/decision-log.md) cloudflared quick tunnel — the
+provider-agnostic "Cloud Launch" mechanism (Colab/Kaggle/Paperspace/Lambda all use the
+same flag; RunPod is the first concrete recipe).
+
+## v1 scope
+
+- **Official upstream llama.cpp only** — not TurboQuant, not vLLM, not any other
+  engine/fork. On an NVIDIA Linux box this means the **Vulkan** build specifically:
+  upstream llama.cpp ships no Linux CUDA prebuilt at all, so TurboLLM's own
+  auto-recommendation (ADR-025) picks Vulkan for NVIDIA-on-Linux. This is expected,
+  not a workaround — it's the same thing TurboLLM would auto-select on any bare Linux
+  box with an NVIDIA GPU.
+- Other engines (vLLM, SGLang, TurboQuant, …) are a natural follow-up template variant
+  once this one is proven — not in scope here.
+
+## What the image does
+
+1. Ubuntu 22.04 + CUDA runtime base (matches RunPod's own official-template
+   convention), Node ≥22, `libvulkan1` (the Vulkan loader the Vulkan backend needs —
+   the actual NVIDIA Vulkan ICD comes from the driver RunPod's container runtime
+   mounts in at pod start).
+2. `npm install -g turbollm`.
+3. **Pre-bakes** the recommended engine at image-build time (starts the daemon
+   briefly, waits for it to self-seed, stops it) so a per-hour-billed pod doesn't eat
+   a download on its first request.
+4. On container start: `npx turbollm --tunnel --no-open` — binds loopback-only,
+   spawns a cloudflared quick tunnel, and prints the public URL + a required access
+   token to the container logs.
+
+## Why `--tunnel` instead of RunPod's own HTTP proxy
+
+RunPod already gives every pod a public proxy URL
+(`https://<pod-id>-<port>.proxy.runpod.net`) with zero setup — but its docs and blog
+both flag a **hard ~100-second idle/response timeout** enforced at Cloudflare's edge in
+front of it. That's a real risk for an LLM server: a cold model load or a long-context
+prefill can easily exceed 100s, and the proxy 524s before the first byte gets out.
+cloudflared's own tunnel (what `--tunnel` uses) has no such ceiling, which is why it
+stays the primary access path here — the image still `EXPOSE`s the port as a
+secondary/debug route via RunPod's proxy, but don't rely on it for chat traffic.
+
+## Who does what (the shared-template model)
+
+Earlier drafts of this doc had every user build + push their own Docker image before
+the "Deploy on RunPod" button did anything — too technical for a normal user, and
+pointless duplicated work. The image build/push is now automated (below); only ONE
+person (the maintainer) does the RunPod Template creation, ONCE, ever. Everyone else
+just clicks a button in Developer → Cloud Deploy that already works.
+
+### Automated (CI) — nobody does this by hand
+
+`.github/workflows/runpod-image.yml` builds this Dockerfile and pushes it to
+`ghcr.io/<repo-owner>/turbollm-runpod:latest` on every change to `deploy/runpod/`,
+weekly (to pick up new `npm install -g turbollm` releases — the image has no version
+pin), and on manual dispatch. Authenticates with GHCR via the workflow's built-in
+`GITHUB_TOKEN` — no separate registry account or secret to configure.
+
+**One-time setup after the workflow's first run**: GHCR packages default to private:
+open the repo's Packages tab → `turbollm-runpod` → Package settings → change
+visibility to Public (RunPod needs to be able to pull it without credentials).
+
+### Maintainer, one-time only — creating the official RunPod Template
+
+1. **Create a RunPod Template** via the console (Manage → Templates → New Template) —
+   not scripted against the REST API, since RunPod's template field names have shifted
+   as they migrated GraphQL → REST and the exact current schema wasn't independently
+   confirmed while writing this:
+   - Container image: `ghcr.io/<repo-owner>/turbollm-runpod:latest`
+   - Exposed ports: `6996/http` (secondary/debug path only, see above)
+   - Container disk: ~30 GB (model weights need real room)
+   - Start command: leave as the image's `ENTRYPOINT` (no override needed)
+   - Visibility: Public (so the deploy link below works for anyone)
+2. **Take the resulting Template ID** and set it as `OFFICIAL_RUNPOD_TEMPLATE_ID` in
+   `turbollm/web/src/screens/DeveloperScreen.tsx` — this is what makes the Developer
+   screen's "Deploy on RunPod" button work with zero setup for every user from then on.
+   (The Settings field there is only for someone deploying their own custom fork —
+   it overrides the official default, it's never required.)
+
+### Everyone else
+
+Just click **Developer → Cloud Deploy → Deploy on RunPod** in the app. It opens:
+```
+https://runpod.io/console/deploy?template=<TEMPLATE_ID>
+```
+with the official template pre-selected — pick a GPU, hit Deploy, TurboLLM starts
+automatically. Open the pod's logs in the RunPod console shortly after it starts —
+TurboLLM prints:
+```
+  Tunnel:  https://xxxx.trycloudflare.com
+  Token:   tllm-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+           (required for anyone using this tunnel URL)
+```
+Open the tunnel URL in a browser; when it asks for a key, paste the printed token.
+
+## Known unknowns worth verifying on a real pod before wide use
+
+- Whether the Vulkan ICD RunPod's container runtime mounts in is picked up correctly
+  by `libvulkan1` out of the box, or needs an extra `VK_ICD_FILENAMES` env var — this
+  couldn't be verified without an actual GPU pod (the dev box this was built on is a
+  single-GPU Windows machine).

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -23,19 +23,48 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.7.0] - 2026-07-04
+
+**Cloud Launch tunneling, a configurable VRAM headroom, and a real tool-call approval gate.**
+
+### Added
+- **Cloud Launch (`turbollm --tunnel`)** — spin up a cloudflared quick tunnel and share your
+  local TurboLLM over the internet with one flag, no port forwarding or reverse proxy to set
+  up. An access token is auto-provisioned and required on all tunneled traffic; local access
+  stays unauthenticated as before.
+- **VRAM headroom slider** (Settings → Engine, 300 MB–2 GB, default 1 GB) — tell auto-tune how
+  much VRAM to keep free for other GPU workloads (ComfyUI, a browser full of tabs, etc.)
+  instead of the previous fixed 1 GB margin.
 - **Tool-call approval gate for chat** — every tool call (web search, fetch URL, run code, MCP
   tools) now asks for your approval by default before it runs. A small bar appears above the
   message box with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow**. Set
   per-tool defaults (Ask / Allow / Deny) globally from Developer → Tool permissions. Replaces the
-  old `run_code`-only confirmation, which didn't actually work (it always ran anyway).
-- Fix source builds (CUDA engines) failing configure with a `-- unsupported Microsoft Visual
+  old `run_code`-only confirmation, which didn't actually work (it always ran anyway). Background
+  agents are unaffected — a tool an agent is configured to use still runs without a prompt, since
+  there's no one there to ask.
+
+### Fixed
+- **Dual-GPU systems no longer show the wrong VRAM total** on the Engines screen — the "Your
+  hardware" hero card fell back to a single un-summed GPU's VRAM instead of the primary-vendor
+  sum whenever the recommendation query hadn't resolved yet, which happened on effectively every
+  page load.
+- Source builds (CUDA engines) no longer fail configure with a `-- unsupported Microsoft Visual
   Studio version!` CMake error on newer VS releases (e.g. VS2026) that CUDA's nvcc doesn't yet
   recognize as a supported host compiler — cmake now passes nvcc's own `-allow-unsupported-
   compiler` escape hatch by default, for both the in-app 1-click build and the manual command
   list in the build guide.
-- Fix the build guide's manual command list producing an engine that silently ran CPU-only:
+- The build guide's manual command list no longer produces an engine that silently runs CPU-only:
   a source build doesn't bundle the CUDA runtime, so the commands now also copy the CUDA
   DLLs/shared libs next to the binary — matching what the 1-click build already does.
+- The opencode connect snippet now uses the correct singular `provider` config key.
+
+### Discord
+- New: `turbollm --tunnel` shares your local TurboLLM over the internet in one command, no port forwarding or reverse proxy setup needed.
+- New: a VRAM headroom slider in Settings → Engine lets you tell auto-tune how much VRAM to keep free for other apps like ComfyUI.
+- Tool calls in chat (web search, fetch, run code, MCP tools) now ask for your approval by default, with Deny, Allow, Allow for this chat, or Always Allow.
+- Fixed dual-GPU systems showing the wrong total VRAM on the Engines screen.
 
 ## [1.6.5] - 2026-07-03
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -23,7 +23,14 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
-_Nothing yet._
+- Fix source builds (CUDA engines) failing configure with a `-- unsupported Microsoft Visual
+  Studio version!` CMake error on newer VS releases (e.g. VS2026) that CUDA's nvcc doesn't yet
+  recognize as a supported host compiler — cmake now passes nvcc's own `-allow-unsupported-
+  compiler` escape hatch by default, for both the in-app 1-click build and the manual command
+  list in the build guide.
+- Fix the build guide's manual command list producing an engine that silently ran CPU-only:
+  a source build doesn't bundle the CUDA runtime, so the commands now also copy the CUDA
+  DLLs/shared libs next to the binary — matching what the 1-click build already does.
 
 ## [1.6.5] - 2026-07-03
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -27,13 +27,9 @@ _Nothing yet._
 
 ## [1.7.0] - 2026-07-04
 
-**Cloud Launch tunneling, a configurable VRAM headroom, and a real tool-call approval gate.**
+**A configurable VRAM headroom, a real tool-call approval gate for chat, and engine build fixes.**
 
 ### Added
-- **Cloud Launch (`turbollm --tunnel`)** — spin up a cloudflared quick tunnel and share your
-  local TurboLLM over the internet with one flag, no port forwarding or reverse proxy to set
-  up. An access token is auto-provisioned and required on all tunneled traffic; local access
-  stays unauthenticated as before.
 - **VRAM headroom slider** (Settings → Engine, 300 MB–2 GB, default 1 GB) — tell auto-tune how
   much VRAM to keep free for other GPU workloads (ComfyUI, a browser full of tabs, etc.)
   instead of the previous fixed 1 GB margin.
@@ -61,7 +57,6 @@ _Nothing yet._
 - The opencode connect snippet now uses the correct singular `provider` config key.
 
 ### Discord
-- New: `turbollm --tunnel` shares your local TurboLLM over the internet in one command, no port forwarding or reverse proxy setup needed.
 - New: a VRAM headroom slider in Settings → Engine lets you tell auto-tune how much VRAM to keep free for other apps like ComfyUI.
 - Tool calls in chat (web search, fetch, run code, MCP tools) now ask for your approval by default, with Deny, Allow, Allow for this chat, or Always Allow.
 - Fixed dual-GPU systems showing the wrong total VRAM on the Engines screen.

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -23,6 +23,11 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
+- **Tool-call approval gate for chat** — every tool call (web search, fetch URL, run code, MCP
+  tools) now asks for your approval by default before it runs. A small bar appears above the
+  message box with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow**. Set
+  per-tool defaults (Ask / Allow / Deny) globally from Developer → Tool permissions. Replaces the
+  old `run_code`-only confirmation, which didn't actually work (it always ran anyway).
 - Fix source builds (CUDA engines) failing configure with a `-- unsupported Microsoft Visual
   Studio version!` CMake error on newer VS releases (e.g. VS2026) that CUDA's nvcc doesn't yet
   recognize as a supported host compiler — cmake now passes nvcc's own `-allow-unsupported-

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -177,6 +177,8 @@ the detail:
 - **Saved per-model profiles, per engine** — tune once per (model, engine) pair, so
   switching engines (or between two installs of the same engine, e.g. a fork) never
   overwrites another engine's tuning for the same model.
+- **Configurable VRAM headroom** (Settings → Engine, 300 MB–2 GB, default 1 GB) — tell auto-tune
+  how much VRAM to keep free for other GPU workloads instead of a fixed margin.
 
 </details>
 
@@ -210,6 +212,9 @@ the detail:
   Atlassian, Neon, Supabase, Cloudflare, Zapier, Apify, Mixpanel) and open-source local MCPs
   (filesystem, git, postgres, playwright, …), plus your own custom servers. Connected tools appear
   in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
+- **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
+  with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
+  composer. Set per-tool defaults globally from Developer → Tool permissions.
 
 </details>
 
@@ -249,6 +254,9 @@ curl http://127.0.0.1:6996/v1/chat/completions \
   Claude Code below. No other local host offers this.
 - **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape).
 - **API-key auth** you can require when sharing over a LAN (Settings → Network).
+- **Cloud Launch (`turbollm --tunnel`)** — share your local instance over the internet with one
+  flag via a cloudflared quick tunnel, no port forwarding or reverse proxy to set up. An access
+  token is auto-provisioned and enforced on all tunneled traffic; local access is unaffected.
 
 **The gateway loads models for you.** Most local hosts make you load a model first, then call it.
 TurboLLM's gateway reads the `model` field of any incoming request, **fuzzy-matches it to your

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -254,9 +254,6 @@ curl http://127.0.0.1:6996/v1/chat/completions \
   Claude Code below. No other local host offers this.
 - **Structured output** — constrain any response to a **GBNF grammar** (or JSON shape).
 - **API-key auth** you can require when sharing over a LAN (Settings → Network).
-- **Cloud Launch (`turbollm --tunnel`)** — share your local instance over the internet with one
-  flag via a cloudflared quick tunnel, no port forwarding or reverse proxy to set up. An access
-  token is auto-provisioned and enforced on all tunneled traffic; local access is unaffected.
 
 **The gateway loads models for you.** Most local hosts make you load a model first, then call it.
 TurboLLM's gateway reads the `model` field of any incoming request, **fuzzy-matches it to your

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1381,6 +1381,7 @@ export function registerApi(app: Hono, d: Deps): void {
       tavilyApiKey?: string
       search?: { provider?: string; tavilyApiKey?: string; kagiApiKey?: string; searxngUrl?: string }
       build?: { toolchainDirs?: string[] }
+      toolPolicies?: Record<string, string>
     }>(c)
 
     const updates: Record<string, unknown> = {}
@@ -1491,6 +1492,24 @@ export function registerApi(app: Hono, d: Deps): void {
       toolchainDirs = dirs
     }
 
+    // Tool-call approval gate: global per-tool policy map. Validate every value is
+    // one of 'ask' | 'allow' | 'deny' so a garbled patch gets a clean 400, not a
+    // silently-dropped/garbage config.
+    let toolPolicies: Record<string, 'ask' | 'allow' | 'deny'> | undefined
+    if (b.toolPolicies !== undefined) {
+      if (typeof b.toolPolicies !== 'object' || b.toolPolicies === null || Array.isArray(b.toolPolicies)) {
+        return err(c, 400, 'invalid_config_value', 'toolPolicies must be an object mapping tool name to ask, allow, or deny.')
+      }
+      const validated: Record<string, 'ask' | 'allow' | 'deny'> = {}
+      for (const [toolName, v] of Object.entries(b.toolPolicies)) {
+        if (v !== 'ask' && v !== 'allow' && v !== 'deny') {
+          return err(c, 400, 'invalid_config_value', `toolPolicies.${toolName} must be ask, allow, or deny.`)
+        }
+        validated[toolName] = v
+      }
+      toolPolicies = validated
+    }
+
     const before = d.store.snapshot().daemon
     d.store.update((cfg) => {
       Object.assign(cfg.daemon, updates)
@@ -1498,6 +1517,7 @@ export function registerApi(app: Hono, d: Deps): void {
       Object.assign(cfg.comfyui, cuUpdates)
       Object.assign(cfg.gateway, gwUpdates)
       if (toolchainDirs !== undefined) cfg.build.toolchainDirs = toolchainDirs
+      if (toolPolicies !== undefined) cfg.tools.toolPolicies = toolPolicies
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
       // HF token (spec 10 §4): write-only. An explicit '' clears it. Never logged.
@@ -1976,6 +1996,9 @@ function settingsPayload(d: Deps) {
     // Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
     // conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back.
     build: { toolchainDirs: cfg.build.toolchainDirs },
+    // Tool-call approval gate: global per-tool policy ('ask' | 'allow' | 'deny').
+    // Not secret — echoed back directly so Settings can render Tool Permissions.
+    toolPolicies: cfg.tools.toolPolicies ?? {},
   }
 }
 

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -2301,7 +2301,7 @@ function buildConnectSnippets(cli: string, base: string, apiKey: string, modelNa
             label: 'Merge into ~/.config/opencode/opencode.json',
             snippet: JSON.stringify(
               {
-                providers: {
+                provider: {
                   turbollm: {
                     npm: '@ai-sdk/openai-compatible',
                     options: {

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -6,7 +6,7 @@ import { basename, dirname, join, resolve, sep } from 'node:path'
 import { GATE_VERSION, gateNodeSource } from '../comfyui/gate-template'
 import { randomUUID } from 'node:crypto'
 import { homedir, networkInterfaces } from 'node:os'
-import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, type ApiKey, type Engine, type McpServer } from '../config/config'
+import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, VRAM_HEADROOM_MIN_MB, VRAM_HEADROOM_MAX_MB, type ApiKey, type Engine, type McpServer } from '../config/config'
 import type { Deps } from '../deps'
 import { type ModelInfo, type StartOpts } from '../engines/manager'
 import { abortAllInFlightChats } from '../chat/chat-routes'
@@ -1377,6 +1377,7 @@ export function registerApi(app: Hono, d: Deps): void {
       autoGenerateTitles?: boolean
       openBrowserOnStart?: boolean
       autoLoadOnStart?: boolean
+      vramHeadroomMb?: number
       lanBind?: boolean
       requireApiKey?: boolean
       telemetryLevel?: string
@@ -1412,6 +1413,17 @@ export function registerApi(app: Hono, d: Deps): void {
     }
     if (b.autoGenerateTitles !== undefined) updates.autoGenerateTitles = !!b.autoGenerateTitles
     if (b.openBrowserOnStart !== undefined) updates.openBrowserOnStart = !!b.openBrowserOnStart
+
+    // VRAM headroom slider for auto-tune (bench.ts's overHeadroom). config.validate() also
+    // enforces this range and would throw on update() otherwise; reject here for a clean 400.
+    let vramHeadroomMb: number | undefined
+    if (b.vramHeadroomMb !== undefined) {
+      const v = Number(b.vramHeadroomMb)
+      if (!Number.isFinite(v) || v < VRAM_HEADROOM_MIN_MB || v > VRAM_HEADROOM_MAX_MB) {
+        return err(c, 400, 'invalid_config_value', `vramHeadroomMb must be ${VRAM_HEADROOM_MIN_MB}–${VRAM_HEADROOM_MAX_MB}.`)
+      }
+      vramHeadroomMb = Math.round(v)
+    }
     // LAN expose toggle (spec 08 §2). Persist only; auto daemon-restart is deferred —
     // the UI tells the user to restart to apply.
     if (b.lanBind !== undefined) updates.lanBind = !!b.lanBind
@@ -1526,6 +1538,7 @@ export function registerApi(app: Hono, d: Deps): void {
       if (toolchainDirs !== undefined) cfg.build.toolchainDirs = toolchainDirs
       if (toolPolicies !== undefined) cfg.tools.toolPolicies = toolPolicies
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
+      if (vramHeadroomMb !== undefined) cfg.vramHeadroomMb = vramHeadroomMb
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
       // Cloud Launch deploy-link settings (ADR-153): the RunPod Template ID the user
       // published themselves (deploy/runpod/README.md) — not a secret, just an id.
@@ -1984,6 +1997,7 @@ function settingsPayload(d: Deps) {
     autoGenerateTitles: cfg.daemon.autoGenerateTitles,
     openBrowserOnStart: cfg.daemon.openBrowserOnStart,
     autoLoadOnStart: cfg.autoLoadOnStart,
+    vramHeadroomMb: cfg.vramHeadroomMb,
     lanBind: cfg.daemon.lanBind,
     requireApiKey: cfg.daemon.requireApiKey,
     telemetryLevel,

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -4,7 +4,7 @@ import { streamSSE } from 'hono/streaming'
 import { existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join, resolve, sep } from 'node:path'
 import { GATE_VERSION, gateNodeSource } from '../comfyui/gate-template'
-import { createHash, randomBytes, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 import { homedir, networkInterfaces } from 'node:os'
 import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, type ApiKey, type Engine, type McpServer } from '../config/config'
 import type { Deps } from '../deps'
@@ -13,7 +13,8 @@ import { abortAllInFlightChats } from '../chat/chat-routes'
 import { NameTakenError, NotFoundError } from '../engines/registry'
 import { ProbeError, probe } from '../engines/probe'
 import { resolveServerBinary, suggestEngineName } from '../engines/scan'
-import { isLocalRequest } from '../auth'
+import { generateApiKey, isLocalRequest } from '../auth'
+import { enabledFeatures } from '../features'
 import {
   LLAMA_BUILD,
   availableBackends,
@@ -121,6 +122,11 @@ export function registerApi(app: Hono, d: Deps): void {
       })(),
       telemetryLevel: d.store.snapshot().telemetry.level,
       uptimeSec: Math.floor((Date.now() - d.startedAt) / 1000),
+      // Cloud Launch tunnel (ADR-045/152): null until --tunnel is active.
+      tunnel: d.tunnel ? d.tunnel.snapshot() : null,
+      // Local feature flags (TURBOLLM_FEATURES env var) — deliberately undocumented
+      // in any user-facing README; see features.ts.
+      features: enabledFeatures(),
     })
   })
 
@@ -1382,6 +1388,7 @@ export function registerApi(app: Hono, d: Deps): void {
       search?: { provider?: string; tavilyApiKey?: string; kagiApiKey?: string; searxngUrl?: string }
       build?: { toolchainDirs?: string[] }
       toolPolicies?: Record<string, string>
+      cloudDeploy?: { runpodTemplateId?: string }
     }>(c)
 
     const updates: Record<string, unknown> = {}
@@ -1520,6 +1527,11 @@ export function registerApi(app: Hono, d: Deps): void {
       if (toolPolicies !== undefined) cfg.tools.toolPolicies = toolPolicies
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
+      // Cloud Launch deploy-link settings (ADR-153): the RunPod Template ID the user
+      // published themselves (deploy/runpod/README.md) — not a secret, just an id.
+      if (b.cloudDeploy?.runpodTemplateId !== undefined) {
+        cfg.cloudDeploy.runpodTemplateId = String(b.cloudDeploy.runpodTemplateId).trim()
+      }
       // HF token (spec 10 §4): write-only. An explicit '' clears it. Never logged.
       if (b.hfToken !== undefined) cfg.hf.token = String(b.hfToken).trim()
       // Search provider config (F-020). All key/URL fields are write-only; '' clears them.
@@ -1996,6 +2008,8 @@ function settingsPayload(d: Deps) {
     // Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
     // conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back.
     build: { toolchainDirs: cfg.build.toolchainDirs },
+    // Cloud Launch deploy-link settings (ADR-153): not secret — echoed back.
+    cloudDeploy: cfg.cloudDeploy,
     // Tool-call approval gate: global per-tool policy ('ask' | 'allow' | 'deny').
     // Not secret — echoed back directly so Settings can render Tool Permissions.
     toolPolicies: cfg.tools.toolPolicies ?? {},
@@ -2201,16 +2215,6 @@ function readTail(path: string, n: number): string[] {
 }
 
 // ── API key helpers ────────────────────────────────────────────────────────
-
-function generateApiKey(): { full: string; hash: string; prefix: string } {
-  const charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-  const buf = randomBytes(60)
-  let key = ''
-  for (let i = 0; i < 40; i++) key += charset[buf[i] % 62]
-  const full = `tllm-${key}`
-  const hash = createHash('sha256').update(full).digest('hex')
-  return { full, hash, prefix: full.slice(0, 12) }
-}
 
 // ── filesystem browser helpers (spec 03 §9) ─────────────────────────────────
 

--- a/turbollm/src/auth.test.ts
+++ b/turbollm/src/auth.test.ts
@@ -1,0 +1,139 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { bypassesAuth, isLocalRequest, provisionTunnelApiKey } from './auth'
+import type { Context } from 'hono'
+import type { Deps } from './deps'
+
+// Regression tests for ADR-152: a Cloud Launch tunnel's local leg connects via
+// 127.0.0.1, same as a genuinely local caller — so a request that actually traversed
+// the tunnel must never bypass auth via the loopback check. `tunneled` below is the
+// per-REQUEST signal (verified against a live cloudflared tunnel: Cloudflare's edge
+// injects cf-ray/cf-connecting-ip on every proxied request; a direct local request has
+// neither) — NOT a whole-daemon "a tunnel is active somewhere" flag, since that
+// broader form would also block the daemon's own local CLI tooling (--stop, launch).
+
+test('bypassesAuth: default state (no LAN, no tunnel) is a pure pass-through', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: false, loopback: true, exempt: false }),
+    true,
+  )
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: false, loopback: null, exempt: false }),
+    true,
+  )
+})
+
+test('bypassesAuth: LAN-exposed + loopback caller still bypasses (today\'s local-browser case)', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: true, requireApiKey: true, tunneled: false, loopback: true, exempt: false }),
+    true,
+  )
+})
+
+test('bypassesAuth: LAN-exposed + remote caller without a key is rejected', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: true, requireApiKey: true, tunneled: false, loopback: false, exempt: false }),
+    false,
+  )
+})
+
+test('bypassesAuth: LAN-exposed with requireApiKey off is open access', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: true, requireApiKey: false, tunneled: false, loopback: false, exempt: false }),
+    true,
+  )
+})
+
+test('bypassesAuth: THE CRITICAL CASE — a tunneled request that looks loopback must NOT bypass', () => {
+  // Exactly what a request arriving through cloudflared's local leg looks like: lanBind
+  // is false (daemon never toggled LAN), the connection appears loopback, but it's
+  // flagged as tunneled (cf-ray was present). Must require a key.
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: true, loopback: true, exempt: false }),
+    false,
+  )
+})
+
+test('bypassesAuth: a genuinely local request (no cf-ray) still bypasses even while a tunnel is active elsewhere', () => {
+  // The daemon's own --stop/launch CLI tooling, or a local curl on the box: no
+  // Cloudflare headers, so `tunneled` is false for THIS request even though the
+  // tunnel itself is running. Must NOT be blocked.
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: false, loopback: true, exempt: false }),
+    true,
+  )
+})
+
+test('bypassesAuth: tunneled request ignores requireApiKey=false — always enforced', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: false, tunneled: true, loopback: true, exempt: false }),
+    false,
+  )
+})
+
+test('bypassesAuth: tunneled request still exempts the SPA shell + healthz', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: true, loopback: true, exempt: true }),
+    true,
+  )
+})
+
+test('bypassesAuth: tunneled + a genuinely remote caller (loopback=false) is still rejected without a key', () => {
+  assert.equal(
+    bypassesAuth({ lanBind: false, requireApiKey: true, tunneled: true, loopback: false, exempt: false }),
+    false,
+  )
+})
+
+// isLocalRequest gates local-admin actions that execute a caller-supplied binary
+// (add/scan engine, build-from-source, CUDA download) — a request that actually
+// traversed the tunnel must not reach these just because it LOOKS loopback, but the
+// daemon's own genuinely-local access (no Cloudflare headers) must be unaffected.
+
+function fakeDeps(overrides: { lanBind?: boolean; tunnelActive?: boolean }): Deps {
+  return {
+    store: { snapshot: () => ({ daemon: { lanBind: overrides.lanBind ?? false } } as ReturnType<Deps['store']['snapshot']>) },
+    tunnel: overrides.tunnelActive !== undefined ? ({ active: () => overrides.tunnelActive } as Deps['tunnel']) : undefined,
+  } as unknown as Deps
+}
+
+function fakeContext(headers: Record<string, string | undefined>): Context {
+  return { req: { header: (name: string) => headers[name.toLowerCase()] } } as unknown as Context
+}
+
+test('isLocalRequest: a tunneled request (cf-ray present) is never local, even though it looks loopback', () => {
+  const d = fakeDeps({ lanBind: false, tunnelActive: true })
+  const c = fakeContext({ 'cf-ray': 'abc123-DEL' })
+  assert.equal(isLocalRequest(c, d), false)
+})
+
+test('isLocalRequest: tunnel active but THIS request carries no Cloudflare headers is still local', () => {
+  // The exact case that broke --stop/launch under the earlier (overbroad) fix: the
+  // tunnel is running, but this particular request is genuinely local.
+  const d = fakeDeps({ lanBind: false, tunnelActive: true })
+  const c = fakeContext({})
+  assert.equal(isLocalRequest(c, d), true)
+})
+
+test('isLocalRequest: loopback-only bind with no tunnel at all is still always local (unchanged behavior)', () => {
+  const d = fakeDeps({ lanBind: false, tunnelActive: false })
+  const c = fakeContext({})
+  assert.equal(isLocalRequest(c, d), true)
+})
+
+test('provisionTunnelApiKey: stores a fresh key and returns its full (unhashed) value', () => {
+  const pushed: Array<{ id: string; name: string; hash: string }> = []
+  const d = {
+    store: {
+      update: (fn: (cfg: { apiKeys: typeof pushed }) => void) => {
+        const cfg = { apiKeys: pushed }
+        fn(cfg)
+      },
+    },
+  } as unknown as Deps
+  const full = provisionTunnelApiKey(d)
+  assert.match(full, /^tllm-[0-9A-Za-z]{40}$/)
+  assert.equal(pushed.length, 1)
+  assert.match(pushed[0].name, /^tunnel-/)
+  assert.notEqual(pushed[0].hash, full) // only the hash is persisted, never the raw key
+})

--- a/turbollm/src/auth.ts
+++ b/turbollm/src/auth.ts
@@ -4,9 +4,22 @@
 // is reachable from other machines and EVERY non-loopback request to the API /
 // gateway surface must carry a valid API key. Loopback is always exempt so the
 // local browser UI and `turbollm launch claude` keep working with no key.
-import { createHash } from 'node:crypto'
+//
+// A Cloud Launch tunnel (ADR-045/152) breaks the loopback-as-trust assumption BY
+// ADDRESS ALONE: cloudflared's local leg connects to 127.0.0.1 too, so a request
+// that arrived over the public tunnel URL LOOKS identical to a trusted local caller
+// by address. The fix is NOT "distrust all loopback whenever a tunnel is merely
+// active" — that would also break the daemon's own local CLI tooling (`--stop`,
+// `launch claude`), which has no way to hold a usable key (only hashes are ever
+// stored). Verified empirically against a live cloudflared quick tunnel: Cloudflare's
+// edge injects `cf-ray`/`cf-connecting-ip` on every request it proxies, and a direct
+// local request carries neither — a remote caller can't spoof these away (Cloudflare's
+// edge controls them, not the client), so `isTunneled` below is a precise per-REQUEST
+// signal, not a whole-daemon flag.
+import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { getConnInfo } from '@hono/node-server/conninfo'
 import type { Context, MiddlewareHandler } from 'hono'
+import type { ApiKey } from './config/config'
 import type { Deps } from './deps'
 
 /** Loopback addresses that never require a key, in the forms Node surfaces them
@@ -14,9 +27,42 @@ import type { Deps } from './deps'
 const LOOPBACK = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1'])
 
 /** SHA-256 hex of the presented key — the SAME derivation used when keys are
- *  created (api/routes.ts generateApiKey). Stored config holds only this hash. */
+ *  created (generateApiKey below). Stored config holds only this hash. */
 function hashKey(raw: string): string {
   return createHash('sha256').update(raw).digest('hex')
+}
+
+/** Generate a new API key: a `tllm-`-prefixed 40-char random token, its SHA-256 hash
+ *  (the only form persisted), and a display prefix. Shared by the `/api/v1/keys`
+ *  create endpoint and the tunnel auto-provisioning below. */
+export function generateApiKey(): { full: string; hash: string; prefix: string } {
+  const charset = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+  const buf = randomBytes(60)
+  let key = ''
+  for (let i = 0; i < 40; i++) key += charset[buf[i] % 62]
+  const full = `tllm-${key}`
+  const hash = createHash('sha256').update(full).digest('hex')
+  return { full, hash, prefix: full.slice(0, 12) }
+}
+
+/** Provision a fresh, dedicated API key for a Cloud Launch tunnel session and return
+ *  its full (unhashed) value — the only moment it's ever available, since the store
+ *  keeps only the hash (same rule as every other key, spec 06 §5). Always generates a
+ *  new one rather than reusing an existing key: an existing key's raw value can never
+ *  be recovered to print it, and a fresh, clearly-named key is easy to find and revoke
+ *  later from Developer → API Keys. */
+export function provisionTunnelApiKey(d: Deps): string {
+  const { full, hash, prefix } = generateApiKey()
+  const key: ApiKey = {
+    id: randomUUID(),
+    name: `tunnel-${new Date().toISOString()}`,
+    hash,
+    prefix,
+    createdAt: new Date().toISOString(),
+    lastUsedAt: null,
+  }
+  d.store.update((cfg) => cfg.apiKeys.push(key))
+  return full
 }
 
 /** Pull the presented key from any of the accepted headers (spec 06 §5):
@@ -54,31 +100,69 @@ function isLoopback(c: Context): boolean | null {
   return LOOPBACK.has(addr)
 }
 
+/** True when THIS request actually traversed the Cloud Launch tunnel, as opposed to
+ *  "a tunnel merely happens to be active elsewhere". Cloudflare's edge injects
+ *  `cf-ray`/`cf-connecting-ip` on every request it proxies (verified empirically
+ *  against a live quick tunnel) — a direct local request carries neither. A local
+ *  caller forging these headers on their own request only makes THAT request MORE
+ *  restricted (still needs a key), never less — it can't be used to impersonate a
+ *  local caller from the remote side, since Cloudflare's edge (not the client)
+ *  controls what a genuinely tunneled request carries. */
+function isTunneled(c: Context, d: Deps): boolean {
+  if (!d.tunnel?.active()) return false
+  return !!(c.req.header('cf-ray') || c.req.header('cf-connecting-ip'))
+}
+
 /** True when a request is local to the daemon host: either the daemon is loopback-only
  *  bound (no LAN listener at all) or the request came from a loopback address. Use to
- *  gate **local-admin actions that execute a caller-supplied binary** (add/scan engine)
- *  so a LAN client can't trigger arbitrary execution even with a valid API key. Fails
- *  closed: an undetermined address while LAN-exposed is treated as remote. */
+ *  gate **local-admin actions that execute a caller-supplied binary** (add/scan engine,
+ *  build-from-source, CUDA download) so a LAN client can't trigger arbitrary execution
+ *  even with a valid API key. Fails closed: an undetermined address while LAN-exposed
+ *  is treated as remote. Also fails closed for any request that actually traversed a
+ *  Cloud Launch tunnel (ADR-152, see isTunneled) — genuinely local access (the box's
+ *  own terminal, `--stop`, `launch claude`) is unaffected. */
 export function isLocalRequest(c: Context, d: Deps): boolean {
+  if (isTunneled(c, d)) return false
   if (!d.store.snapshot().daemon.lanBind) return true // loopback-only bind → always local
   return isLoopback(c) === true
 }
 
-/** LAN auth middleware (spec 06 §5). Register AFTER cors + the Server header and
- *  BEFORE the API/chat/gateway routes. Enforcement only kicks in when the daemon
- *  is LAN-exposed (lanBind=true); with the default loopback-only bind it is a pure
- *  pass-through, so local dev and the UI can never be locked out. */
+/** Pure decision logic behind lanAuth, extracted so it's directly unit-testable —
+ *  a real "this connection really is loopback" signal needs a live TCP socket,
+ *  which isn't cheap to fake in a test, so the boolean combination itself is
+ *  isolated here instead. True means "let the request through with no key check".
+ *  `tunneled` is a per-REQUEST signal (see isTunneled) — when true, it forces
+ *  enforcement UNCONDITIONALLY (ignores requireApiKey, and does NOT treat loopback
+ *  as proof of a local caller), since a tunneled request looks loopback too (ADR-152). */
+export function bypassesAuth(opts: {
+  lanBind: boolean
+  requireApiKey: boolean
+  tunneled: boolean
+  loopback: boolean | null
+  exempt: boolean
+}): boolean {
+  const { lanBind, requireApiKey, tunneled, loopback, exempt } = opts
+  if (!lanBind && !tunneled) return true // loopback-only, not a tunneled request: no enforcement
+  if (!tunneled && !requireApiKey) return true // user opted into open (unauthenticated) LAN access
+  if (loopback === true && !tunneled) return true // local clients never need a key
+  if (exempt) return true // SPA/static assets + /healthz so a user can paste a key
+  return false
+}
+
+/** LAN auth middleware (spec 06 §5, extended by ADR-152 for tunneled traffic).
+ *  Register AFTER cors + the Server header and BEFORE the API/chat/gateway routes.
+ *  See {@link bypassesAuth} for the enforcement decision. */
 export function lanAuth(d: Deps): MiddlewareHandler {
   return async (c, next) => {
     const daemon = d.store.snapshot().daemon
-    if (!daemon.lanBind) return next() // loopback-only bind: no enforcement
-    if (!daemon.requireApiKey) return next() // user opted into open (unauthenticated) LAN access
-
-    const loopback = isLoopback(c)
-    // Unknown address while LAN-exposed → treat as remote (fail closed).
-    if (loopback === true) return next() // local clients never need a key
-
-    if (isExempt(c)) return next() // SPA/static assets + /healthz so a user can paste a key
+    const allow = bypassesAuth({
+      lanBind: daemon.lanBind,
+      requireApiKey: daemon.requireApiKey,
+      tunneled: isTunneled(c, d),
+      loopback: isLoopback(c),
+      exempt: isExempt(c),
+    })
+    if (allow) return next()
 
     const key = presentedKey(c)
     if (key) {

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1,8 +1,9 @@
 // Auto-benchmark + auto-tune runner (Differentiator #2, spec 09 §1). Owns the engine exclusively
 // for the duration of a run. Two-phase per quality-preserving KV-cache type (f16 / q8_0 / turbo4):
 // (1) pin the offload param (ngl for dense, nCpuMoe for MoE) with CHEAP VRAM probes — load, read
-// absolute VRAM, stop, no generation — keeping the most on the GPU while leaving a ≤1 GB headroom
-// (so a later VRAM grab can't tip it into sysmem-spill); (2) run ONE real prefill + tok/s bench at
+// absolute VRAM, stop, no generation — keeping the most on the GPU while leaving a user-configurable
+// VRAM headroom (default 1 GB; Settings → Engine) so a later VRAM grab can't tip it into sysmem-spill;
+// (2) run ONE real prefill + tok/s bench at
 // that config. Picks the overall winner by best prefill AND generation t/s, saves it as the model's
 // profile (tunedBy:'bench'), persists a benchResults row, and — when telemetry is on — queues an
 // anonymized bench_result event. Single active run; additive; fail-safe (a bad candidate is
@@ -130,7 +131,7 @@ const QUALITY_KV = ['f16', 'q8_0', 'turbo4']
 // maximizes t/s in isolation, but then a later desktop / ComfyUI VRAM grab tips the model into
 // "shared GPU memory" (sysmem over PCIe), which silently tanks generation. The search treats a
 // candidate that uses more than (total − headroom) as "too much on GPU" and offloads further.
-const VRAM_HEADROOM_MB = 1024
+// User-configurable (Settings → Engine → VRAM headroom); see Config.vramHeadroomMb.
 // Output-t/s tie band for the speed objective: when two configs are within this relative margin
 // on generation speed, the one with faster prefill wins (best prefill AND t/s, not just t/s).
 const OUTPUT_TIE = 0.05
@@ -306,9 +307,11 @@ export class BenchRunner {
     // resident (see resolveProfile), so the offload search must account for its real VRAM
     // footprint (~1-2 GB) — searching with it excluded would pick an offload that fits WITHOUT
     // the projector, then load the projector on top of that afterward, eating into the
-    // VRAM_HEADROOM_MB safety margin the search thought it had (or spilling outright).
+    // vramHeadroomMb safety margin the search thought it had (or spilling outright).
     const resolved = resolveProfile(entry, sys, saved, base, defaults)
     const baseProfile: LoadProfile = { ...resolved, speculative: 'off', mtpHeadPath: '', draftModelPath: '' }
+    // User-configurable VRAM safety margin for the offload search (Settings → Engine).
+    const headroomMb = this.store.snapshot().vramHeadroomMb
 
     const results: BenchCandidate[] = []
     let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
@@ -339,8 +342,8 @@ export class BenchRunner {
       const kv = kvToTune[i]
       const kvBase: LoadProfile = { ...baseProfile, kvTypeK: kv, kvTypeV: kv }
       const found = entry.moe
-        ? await this.moeSearch(entry, sys, kvBase, caps, results)
-        : await this.denseSearch(entry, sys, kvBase, caps, results)
+        ? await this.moeSearch(entry, sys, kvBase, caps, results, headroomMb)
+        : await this.denseSearch(entry, sys, kvBase, caps, results, headroomMb)
       if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
       if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
     }
@@ -416,7 +419,7 @@ export class BenchRunner {
 
   /** Dense models: pin `ngl` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
    *  More GPU layers = faster, monotonically, up to the no-spill edge — so the best ngl is the
-   *  HIGHEST whose absolute VRAM still leaves the ≤1 GB headroom. Whether a config fits/spills is a
+   *  HIGHEST whose absolute VRAM still leaves the configured headroom. Whether a config fits/spills is a
    *  LOAD-time property, so we find that ngl with cheap load-and-read-VRAM probes (no generation),
    *  and only measure t/s at the winner. CPU-only machines skip straight to ngl=0. */
   private async denseSearch(
@@ -425,11 +428,12 @@ export class BenchRunner {
     base: LoadProfile,
     caps: Engine['capabilities'],
     results: BenchCandidate[],
+    headroomMb: number,
   ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
     let bestNgl: number | null = 0 // CPU-only box → everything on CPU, no probing needed.
 
     if (sys.gpus.length > 0) {
-      // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with ≤1 GB-headroom VRAM.
+      // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with enough headroom VRAM.
       const hi0 = entry.blockCount > 0 ? entry.blockCount : 99
       let lo = 0, hi = hi0
       bestNgl = null
@@ -439,7 +443,7 @@ export class BenchRunner {
         const probe = await this.probeVram(entry, sys, { ...base, ngl: mid }, caps)
         this.pushProbe(results, base, 'ngl', mid, probe)
         await this.settleGpu()
-        if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, sys)) {
+        if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, sys, headroomMb)) {
           bestNgl = mid // fits with headroom → record, try MORE GPU layers
           lo = mid + 1
         } else {
@@ -454,7 +458,7 @@ export class BenchRunner {
 
   /** MoE models: pin `nCpuMoe` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
    *  Fewer CPU experts = more on GPU = faster, so the best is the LOWEST nCpuMoe whose absolute VRAM
-   *  still leaves the ≤1 GB headroom. Found with cheap load-and-read-VRAM probes (no generation);
+   *  still leaves the configured headroom. Found with cheap load-and-read-VRAM probes (no generation);
    *  t/s is measured only at the winner. */
   private async moeSearch(
     entry: ModelEntry,
@@ -462,6 +466,7 @@ export class BenchRunner {
     base: LoadProfile,
     caps: Engine['capabilities'],
     results: BenchCandidate[],
+    headroomMb: number,
   ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
     const derived = deriveDefault(entry, sys)
     const maxN = entry.blockCount > 0 ? entry.blockCount : (derived.nCpuMoe || 0)
@@ -474,7 +479,7 @@ export class BenchRunner {
       const probe = await this.probeVram(entry, sys, { ...base, nCpuMoe: mid }, caps)
       this.pushProbe(results, base, 'nCpuMoe', mid, probe)
       await this.settleGpu()
-      if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, sys)) {
+      if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, sys, headroomMb)) {
         lo = mid + 1 // too much on GPU → more CPU experts to free VRAM / restore the headroom
       } else if (probe.outcome === 'ok') {
         bestN = mid // fits with headroom → record, try FEWER CPU experts (more on GPU)
@@ -1129,13 +1134,13 @@ function totalVramMb(sys: SysInfo): number {
   return sys.gpus.reduce((s, g) => s + (g.vramMb || 0), 0)
 }
 
-/** True when a candidate's ABSOLUTE VRAM use leaves less than VRAM_HEADROOM_MB free — i.e. it's
- *  too close to the spill edge. The search then offloads more so the chosen config keeps a safety
+/** True when a candidate's ABSOLUTE VRAM use leaves less than `headroomMb` free — i.e. it's too
+ *  close to the spill edge. The search then offloads more so the chosen config keeps a safety
  *  margin against a later desktop / ComfyUI VRAM grab. Unknown VRAM (non-NVIDIA) → never blocks. */
-function overHeadroom(vramAbsMb: number | null, sys: SysInfo): boolean {
+function overHeadroom(vramAbsMb: number | null, sys: SysInfo, headroomMb: number): boolean {
   const total = totalVramMb(sys)
   if (!vramAbsMb || total <= 0) return false
-  return vramAbsMb > total - VRAM_HEADROOM_MB
+  return vramAbsMb > total - headroomMb
 }
 
 /** The quality-preserving KV-cache types to try, in search order. The model's current/base type

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -12,6 +12,8 @@ import type { ClaimVerdict, ConversationStore, MessageStats, ResearchMeta, Resea
 import { checkReply } from '../tools/research-referee.js'
 import { buildSnapshot } from './chat-export'
 import type { ExportFormat } from './chat-export'
+import { executeToolCallWithApproval } from '../tools/execute-with-approval'
+import { resolveToolApproval } from '../tools/approval-gate'
 
 // Track in-flight abort controllers per conversation id.
 const inflight = new Map<string, AbortController>()
@@ -109,6 +111,51 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
       return err(c, 404, 'not_found', 'Conversation not found.')
     }
     return c.json(db.getConversation(c.req.param('id'))!)
+  })
+
+  // ── tool-call approval gate ─────────────────────────────────────────────────
+
+  // Lists the tools currently available to the chat loop (name + description only —
+  // no parameters schema; the frontend just needs this to render Tool Permissions).
+  app.get('/api/v1/tools', async (c) => {
+    const defs = d.tools ? await d.tools.buildToolDefinitions() : []
+    return c.json({ tools: defs.map((t) => ({ name: t.function.name, description: t.function.description ?? '' })) })
+  })
+
+  // Resolves a pending tool-call approval created by the shared approval-gate executor
+  // (execute-with-approval.ts) while streaming a foreground chat response.
+  app.post('/api/v1/conversations/:id/tool-calls/:toolCallId/approve', async (c) => {
+    const { id: convId, toolCallId } = c.req.param()
+    const b = await body<{ toolName?: string; decision?: string }>(c)
+    const toolName = (b.toolName ?? '').trim()
+    const decision = b.decision
+    if (!toolName) return err(c, 400, 'invalid_input', 'toolName is required.')
+    if (decision !== 'allow' && decision !== 'deny' && decision !== 'allow_chat' && decision !== 'always_allow') {
+      return err(c, 400, 'invalid_input', 'decision must be one of: allow, deny, allow_chat, always_allow.')
+    }
+
+    const conv = db.getConversation(convId)
+    if (!conv) return err(c, 404, 'not_found', 'Conversation not found.')
+
+    let decisionToApply: 'allow' | 'deny'
+    if (decision === 'always_allow') {
+      d.store.update((cfg) => {
+        cfg.tools.toolPolicies = { ...(cfg.tools.toolPolicies ?? {}), [toolName]: 'allow' }
+      })
+      decisionToApply = 'allow'
+    } else if (decision === 'allow_chat') {
+      db.setToolOverride(convId, toolName, 'allow')
+      decisionToApply = 'allow'
+    } else if (decision === 'allow') {
+      decisionToApply = 'allow'
+    } else {
+      decisionToApply = 'deny'
+    }
+
+    const key = `${convId}:${toolCallId}`
+    const ok = resolveToolApproval(key, decisionToApply)
+    if (!ok) return err(c, 404, 'not_found', 'No pending approval for this tool call (it may have already timed out or been resolved).')
+    return c.json({ ok: true })
   })
 
   // ── streaming send (spec 07 §2) ────────────────────────────────────────────
@@ -740,32 +787,24 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
           try { parsedArgs = JSON.parse(tc.argsBuffer || '{}') as Record<string, unknown> }
           catch { parsedArgs = {} }
 
-          // When run_code confirmation is required, emit a gate event so the
-          // frontend can prompt the user — tool execution is skipped this round (F-019).
-          const requireConfirm =
-            tc.name === 'run_code' &&
-            d.store.snapshot().tools.requireRunCodeConfirmation !== false
-          if (requireConfirm) {
-            await stream.writeSSE({
-              event: 'tool_confirmation_required',
-              data: JSON.stringify({ id: tc.id, name: tc.name, args: parsedArgs }),
-            })
-          }
-
-          // Emit pending event so the frontend can show "calling..."
-          await stream.writeSSE({
-            event: 'tool_call',
-            data: JSON.stringify({ id: tc.id, name: tc.name, args: parsedArgs, status: 'pending' }),
+          // Live foreground chat gets the real approval gate (interactive: true) — an
+          // 'ask'-policy tool prompts the user via 'tool_call'/'awaiting_approval' and
+          // waits for POST .../tool-calls/:toolCallId/approve to resolve it.
+          const { result, error: callError } = await executeToolCallWithApproval({
+            tools: d.tools,
+            sink: (ev) => stream.writeSSE({ event: ev.event, data: JSON.stringify(ev.data) }),
+            convId,
+            id: tc.id,
+            name: tc.name,
+            args: parsedArgs,
+            globalPolicies: d.store.snapshot().tools.toolPolicies ?? {},
+            // Re-read fresh on every iteration (not the `conv` snapshot captured at request
+            // start) — otherwise a same-turn repeat tool call misses an "Allow for this
+            // chat" decision the user just made via POST .../tool-calls/:id/approve.
+            convOverrides: d.db.getToolOverrides(convId),
+            signal: ac.signal,
+            interactive: true,
           })
-
-          let result = ''
-          let callError: string | undefined
-          try {
-            result = await d.tools.executeTool({ id: tc.id, name: tc.name, args: parsedArgs })
-          } catch (e) {
-            callError = (e as Error).message
-            result = `Error: ${callError}`
-          }
 
           // F-021: track web_search calls and accumulate research sources.
           if (tc.name === 'web_search' && !callError) {
@@ -791,12 +830,6 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
           }
 
           allToolCalls.push({ id: tc.id, name: tc.name, args: parsedArgs, result: callError ? undefined : result, error: callError })
-
-          // Emit done event with result
-          await stream.writeSSE({
-            event: 'tool_call',
-            data: JSON.stringify({ id: tc.id, name: tc.name, args: parsedArgs, status: callError ? 'error' : 'done', result }),
-          })
 
           // Inject tool result into iterMessages
           iterMessages.push({ role: 'tool', content: result, tool_call_id: tc.id })

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -152,6 +152,10 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
       decisionToApply = 'deny'
     }
 
+    // Invariant: the policy write above must happen before resolveToolApproval below.
+    // A same-turn repeat tool call re-reads policies fresh on every iteration (generation.ts),
+    // so resolving the gate first would let it observe the stale pre-approval policy and
+    // re-prompt for a tool the user just marked "Always Allow" / "Allow for this chat".
     const key = `${convId}:${toolCallId}`
     const ok = resolveToolApproval(key, decisionToApply)
     if (!ok) return err(c, 404, 'not_found', 'No pending approval for this tool call (it may have already timed out or been resolved).')

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -21,6 +21,11 @@ export interface Conversation {
   kind: 'chat' | 'agent'
   /** Folder this conversation is filed under (v10). NULL/undefined = uncategorized. */
   folderId?: string | null
+  /** Per-conversation tool-approval overrides (v11, tool-call approval gate). Set via
+   *  "Allow for this chat" — persists across restarts. Only 'allow'/'deny' values;
+   *  absence of a key means "fall through to the global toolPolicies default".
+   *  Always populated (defaults to {}) when read via rowToConv/getConversation. */
+  toolOverrides?: Record<string, 'allow' | 'deny'>
   createdAt: string
   updatedAt: string
   messages?: Message[]
@@ -120,7 +125,7 @@ export interface Message {
   createdAt: string
 }
 
-interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; created_at: string; updated_at: string }
+interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; created_at: string; updated_at: string }
 interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null }
 interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string }
@@ -130,8 +135,19 @@ type P = Record<string, SQLInputValue>
 
 function safeJson(s: string): unknown { try { return JSON.parse(s) } catch { return {} } }
 
+function safeToolOverrides(s: string | null): Record<string, 'allow' | 'deny'> {
+  if (!s) return {}
+  const parsed = safeJson(s)
+  if (typeof parsed !== 'object' || parsed === null) return {}
+  const out: Record<string, 'allow' | 'deny'> = {}
+  for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+    if (v === 'allow' || v === 'deny') out[k] = v
+  }
+  return out
+}
+
 function rowToConv(r: ConvRow): Conversation {
-  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), folderId: r.folder_id ?? null, createdAt: r.created_at, updatedAt: r.updated_at }
+  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), folderId: r.folder_id ?? null, toolOverrides: safeToolOverrides(r.tool_overrides), createdAt: r.created_at, updatedAt: r.updated_at }
 }
 
 function rowToFolder(r: FolderRow): Folder {
@@ -286,6 +302,13 @@ export class ConversationStore {
         PRAGMA user_version = 10;
       `)
     }
+    // v11 (tool-call approval gate): per-conversation "Allow for this chat" overrides,
+    // persisted as JSON so they survive a restart. Nullable — existing rows get NULL
+    // and are decoded as {} in rowToConv (non-breaking).
+    if (v < 11) {
+      this.db.exec("ALTER TABLE conversations ADD COLUMN tool_overrides TEXT")
+      this.db.exec("PRAGMA user_version = 11")
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -330,6 +353,22 @@ export class ConversationStore {
     if (patch.systemPrompt !== undefined) { sets.push('system_prompt = $sp'); params.$sp    = patch.systemPrompt }
     if (patch.sampling !== undefined)     { sets.push('sampling = $samp');    params.$samp  = JSON.stringify(patch.sampling) }
     return ((this.db.prepare(`UPDATE conversations SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0
+  }
+
+  /** Per-conversation tool-approval overrides (tool-call approval gate). Empty object
+   *  when unset or the conversation does not exist. */
+  getToolOverrides(id: string): Record<string, 'allow' | 'deny'> {
+    const row = this.db.prepare(`SELECT tool_overrides FROM conversations WHERE id = $id`).get({ $id: id } as P) as unknown as { tool_overrides: string | null } | undefined
+    return safeToolOverrides(row?.tool_overrides ?? null)
+  }
+
+  /** Merges `{[toolName]: decision}` into the conversation's persisted tool overrides
+   *  ("Allow for this chat" — survives a restart). No-op if the conversation is missing. */
+  setToolOverride(id: string, toolName: string, decision: 'allow' | 'deny'): void {
+    const current = this.getToolOverrides(id)
+    current[toolName] = decision
+    this.db.prepare(`UPDATE conversations SET tool_overrides = $json WHERE id = $id`)
+      .run({ $id: id, $json: JSON.stringify(current) } as P)
   }
 
   touchConversation(id: string): void {

--- a/turbollm/src/chat/generation.ts
+++ b/turbollm/src/chat/generation.ts
@@ -7,6 +7,7 @@ import { engineModelAlias } from '../engines/compat'
 import { feedChunk, flushState, initParseState } from './parser'
 import { needsExtraPass } from './think-utils'
 import { checkReply } from '../tools/research-referee.js'
+import { executeToolCallWithApproval } from '../tools/execute-with-approval'
 import type { ClaimVerdict, Message, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from './db'
 
 /** One event emitted by the generation loop — the sink decides what to do with it. */
@@ -273,25 +274,22 @@ export async function runGeneration(d: Deps, sink: EventSink, ctx: GenerationCtx
           try { parsedArgs = JSON.parse(tc.argsBuffer || '{}') as Record<string, unknown> }
           catch { parsedArgs = {} }
 
-          // run_code confirmation: only for foreground chat (agents pre-authorized at launch)
-          const requireConfirm =
-            tc.name === 'run_code' &&
-            ctx.allowedTools === undefined &&
-            d.store.snapshot().tools.requireRunCodeConfirmation !== false
-          if (requireConfirm) {
-            await sink({ event: 'tool_confirmation_required', data: { id: tc.id, name: tc.name, args: parsedArgs } })
-          }
-
-          await sink({ event: 'tool_call', data: { id: tc.id, name: tc.name, args: parsedArgs, status: 'pending' } })
-
-          let result = ''
-          let callError: string | undefined
-          try {
-            result = await d.tools.executeTool({ id: tc.id, name: tc.name, args: parsedArgs })
-          } catch (e) {
-            callError = (e as Error).message
-            result = `Error: ${callError}`
-          }
+          // Background agent runs never block waiting for a human (interactive: false) —
+          // 'ask'-policy tools are denied outright by the shared approval-gate executor.
+          const { result, error: callError } = await executeToolCallWithApproval({
+            tools: d.tools,
+            sink,
+            convId,
+            id: tc.id,
+            name: tc.name,
+            args: parsedArgs,
+            globalPolicies: d.store.snapshot().tools.toolPolicies ?? {},
+            // Re-read fresh on every iteration rather than the `conv` snapshot captured at
+            // request start, so a concurrently-updated override is always seen.
+            convOverrides: d.db.getToolOverrides(convId),
+            signal: ac.signal,
+            interactive: false,
+          })
 
           if (tc.name === 'web_search' && !callError) {
             searchCallCount++
@@ -309,7 +307,6 @@ export async function runGeneration(d: Deps, sink: EventSink, ctx: GenerationCtx
           }
 
           allToolCalls.push({ id: tc.id, name: tc.name, args: parsedArgs, result: callError ? undefined : result, error: callError })
-          await sink({ event: 'tool_call', data: { id: tc.id, name: tc.name, args: parsedArgs, status: callError ? 'error' : 'done', result } })
           iterMessages.push({ role: 'tool', content: result, tool_call_id: tc.id })
         }
 

--- a/turbollm/src/chat/generation.ts
+++ b/turbollm/src/chat/generation.ts
@@ -289,6 +289,7 @@ export async function runGeneration(d: Deps, sink: EventSink, ctx: GenerationCtx
             convOverrides: d.db.getToolOverrides(convId),
             signal: ac.signal,
             interactive: false,
+            agentAllowedTools: ctx.allowedTools,
           })
 
           if (tc.name === 'web_search' && !callError) {

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -31,6 +31,8 @@ import { AgentRunner } from './agents/runner'
 import { launchCli } from './cli-launch'
 import { writePidfile, removePidfile, stopDaemon, resolveDaemonPort } from './daemon-pid'
 import { createApp } from './server'
+import { provisionTunnelApiKey } from './auth'
+import { TunnelManager, reapStaleTunnels, killTrackedTunnelsSync } from './tunnel/manager'
 import type { Deps } from './deps'
 
 // Entrypoint for the TurboLLM daemon (npm bin "turbollm"): wiring + graceful
@@ -137,6 +139,9 @@ if (hasFlag('--help', '-h')) {
     `  --port <n>     Port to listen on / connect to (default: 6996)\n` +
     `  --addr <h:p>   Full host:port override (e.g. 0.0.0.0:6996)\n` +
     `  --no-open      Do not open a browser window on startup\n` +
+    `  --tunnel       Expose this daemon on the internet via a cloudflared quick\n` +
+    `                 tunnel (Cloud Launch) — prints the public URL + a required\n` +
+    `                 access token. For running TurboLLM on a rented cloud GPU box.\n` +
     `  --config <f>   Path to a custom config file\n` +
     `  --stop         Stop a running TurboLLM daemon and exit\n` +
     `  --help, -h     Show this help message\n\n` +
@@ -145,6 +150,7 @@ if (hasFlag('--help', '-h')) {
     `  turbollm --port 9000             # listen on port 9000\n` +
     `  turbollm --no-open               # start without opening a browser\n` +
     `  turbollm --addr 0.0.0.0:6996    # bind to all interfaces (LAN sharing)\n` +
+    `  turbollm --tunnel --no-open      # run on a rented GPU box, reachable via a public URL\n` +
     `  turbollm --stop                  # stop the running daemon\n` +
     `  turbollm launch claude           # open Claude Code on your loaded model\n` +
     `  turbollm launch claude --model qwen3-8b   # load qwen3-8b, then launch\n\n`,
@@ -176,6 +182,12 @@ if (hasFlag('--stop')) {
 // daemon shows "no model loaded". Best-effort; never blocks startup.
 const reaped = await reapStaleEngines(store.dir()).catch(() => 0)
 if (reaped > 0) console.log(`reaped ${reaped} orphaned engine process(es) from a previous run`)
+// Same idea for a cloudflared tunnel orphaned by an unclean previous shutdown — it
+// would otherwise keep a public URL alive pointing at a port nothing still serves.
+try {
+  const reapedTunnels = reapStaleTunnels(store.dir())
+  if (reapedTunnels > 0) console.log(`reaped ${reapedTunnels} orphaned tunnel process(es) from a previous run`)
+} catch { /* best-effort */ }
 
 const registry = new Registry(store)
 const pruned = registry.pruneDeadManagedBuilds()
@@ -231,6 +243,11 @@ const deps: Deps = { store, registry, manager, scanner, hashes, db, provision, b
 deps.gate = new GenerationGate()
 deps.agentRunner = new AgentRunner(deps)
 deps.agentRunner.reconcileOnStartup()
+// Cloud Launch (ADR-045/152): only wired when --tunnel is passed. Its mere presence
+// on Deps is what forces auth enforcement on tunneled traffic (see auth.ts lanAuth) —
+// absent entirely for the vast majority of runs that never asked for a tunnel.
+const tunnelRequested = hasFlag('--tunnel')
+if (tunnelRequested) deps.tunnel = new TunnelManager(store.dir())
 const app = createApp(deps)
 
 // Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the
@@ -299,6 +316,12 @@ function openBrowser(url: string): void {
 // ── Start server ──────────────────────────────────────────────────────────────
 const noOpen = hasFlag('--no-open')
 
+// Cached for this process's lifetime: a raw API key can only ever be shown once
+// (the store keeps only its hash), so a tunnel that restarts in-place (a rebind, or
+// a rebind's retry loop) reprints the SAME token instead of minting — and orphaning —
+// a fresh one every time the port changes.
+let tunnelToken: string | null = null
+
 // Bind with retry. On a self-restart the OLD listener may not have released the port
 // the instant the replacement starts (Windows lingers the socket, and a 127.0.0.1 →
 // 0.0.0.0 LAN switch is a conflicting bind), so retry EADDRINUSE for ~10s instead of
@@ -335,6 +358,25 @@ function listen(attempt = 0): void {
 
     // Keep the legacy one-liner for log parsers that key on it.
     process.stdout.write(`TurboLLM ${version} listening on http://${displayHost}:${info.port}\n`)
+
+    // Cloud Launch (ADR-045/152): (re)start the tunnel pointed at whatever port we
+    // just bound — covers both the initial start AND a later rebind (the tunnel
+    // manager tears down any prior tunnel before spawning the new one). Fire-and-
+    // forget: never blocks the banner or the listener on cloudflared's handshake.
+    if (deps.tunnel) {
+      void deps.tunnel
+        .start(info.port)
+        .then((url) => {
+          console.log(`  Tunnel:  ${url}`)
+          tunnelToken ??= provisionTunnelApiKey(deps)
+          console.log(`  Token:   ${tunnelToken}`)
+          console.log(`           (required for anyone using this tunnel URL)`)
+          console.log(``)
+        })
+        .catch((e) => {
+          console.error(`  Tunnel failed to start: ${e instanceof Error ? e.message : e}`)
+        })
+    }
 
     // Write pidfile so `turbollm --stop` can find and stop this process (F-035). Written
     // on every successful bind: the PID is constant, but an in-place rebind changes the
@@ -457,7 +499,7 @@ deps.requestRestart = () => {
   const watchdog = setTimeout(finish, 14_000)
   watchdog.unref()
   try {
-    void manager.shutdown().finally(() => {
+    void Promise.all([manager.shutdown(), deps.tunnel?.shutdown() ?? Promise.resolve()]).finally(() => {
       try {
         db.close()
       } catch {
@@ -548,7 +590,10 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
     updateScheduler.stop()
     comfy.stop()
     toolRegistry.disconnectAll()
-    void manager.shutdown().finally(() => { db.close(); server.close(() => process.exit(0)) })
+    void Promise.all([manager.shutdown(), deps.tunnel?.shutdown() ?? Promise.resolve()]).finally(() => {
+      db.close()
+      server.close(() => process.exit(0))
+    })
     setTimeout(() => process.exit(0), 12_000).unref()
   })
 }
@@ -560,6 +605,9 @@ for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
 // startup reap is the backstop for the truly abrupt kills that skip 'exit' too.
 process.on('exit', () => {
   try { killTrackedEnginesSync(store.dir()) } catch { /* best-effort */ }
+  // Same last-resort net for a cloudflared tunnel — a leaked one keeps a PUBLIC URL
+  // alive pointing at a port nothing may be serving anymore, worse than a leaked engine.
+  try { killTrackedTunnelsSync(store.dir()) } catch { /* best-effort */ }
   // Best-effort pidfile cleanup — covers exits that bypass the signal handlers
   // (e.g. process.exit() called elsewhere). Graceful SIGTERM/SIGINT already
   // removed it above; this is a second-layer safety net.

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -94,9 +94,10 @@ export interface ToolsConfig {
   tavily?: { apiKey: string }
   /** Pluggable web-search provider config (F-020). */
   search?: SearchConfig
-  /** When true (default), run_code emits a confirmation-required message instead of
-   *  executing immediately, giving the user a chance to approve (F-019). */
-  requireRunCodeConfirmation?: boolean
+  /** Global per-tool approval policy (tool-call approval gate). Every tool defaults
+   *  to 'ask' unless explicitly set here to 'allow' or 'deny'. A per-conversation
+   *  override (Conversation.toolOverrides) takes precedence over this map. */
+  toolPolicies?: Record<string, 'ask' | 'allow' | 'deny'>
 }
 
 /** One MCP server the daemon manages as a tool provider (v0.7.0). */
@@ -543,8 +544,23 @@ function normalize(c: Config): void {
     kagiApiKey: sl.kagiApiKey ?? undefined,
     searxngUrl: typeof sl.searxngUrl === 'string' && sl.searxngUrl.trim() ? sl.searxngUrl.trim() : undefined,
   }
-  // requireRunCodeConfirmation (F-019): absent in pre-F-019 configs → true (safe default).
-  c.tools.requireRunCodeConfirmation = tl.requireRunCodeConfirmation !== false
+  // Tool approval-gate policies (replaces the old F-019 requireRunCodeConfirmation stub):
+  // always a plain object; strip any invalid values rather than crash on a garbled config.
+  const rawPolicies = (tl.toolPolicies ?? {}) as Record<string, unknown>
+  const toolPolicies: Record<string, 'ask' | 'allow' | 'deny'> = {}
+  for (const [toolName, v] of Object.entries(rawPolicies)) {
+    if (v === 'ask' || v === 'allow' || v === 'deny') toolPolicies[toolName] = v
+  }
+  // Migration: users who had explicitly disabled the old run_code confirmation
+  // (requireRunCodeConfirmation === false) get that intent preserved as an explicit
+  // 'allow' policy for run_code — but only if they haven't already set one via the
+  // new toolPolicies map. Everyone else falls through to the new 'ask' default, which
+  // is a strict improvement over the old permanently-broken confirmation stub.
+  const legacyRequireRunCodeConfirmation = (tl as Record<string, unknown>).requireRunCodeConfirmation
+  if (legacyRequireRunCodeConfirmation === false && toolPolicies.run_code === undefined) {
+    toolPolicies.run_code = 'allow'
+  }
+  c.tools.toolPolicies = toolPolicies
   // MCP host (v0.7.0): absent in pre-v0.7.0 configs → empty server list.
   const mc = (c.mcp ?? {}) as Partial<McpConfig>
   c.mcp = {

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -165,6 +165,15 @@ export interface ComfyUI {
 export interface BuildConfig {
   toolchainDirs: string[]
 }
+/** Cloud Launch deploy-link settings (ADR-153, RunPod recipe). RunPod is the only
+ *  provider for now — a user who has published their own RunPod Template (following
+ *  deploy/runpod/README.md) pastes its ID here; the Developer screen's "Deploy on
+ *  RunPod" button just constructs and opens RunPod's own one-click deploy link with
+ *  it. No credentials involved — full API-driven auto-provisioning is a separate,
+ *  bigger, not-yet-built feature (the BYO-cloud orchestration line, ADR-003). */
+export interface CloudDeployConfig {
+  runpodTemplateId: string
+}
 /** Global model defaults (spec 05 §3): the base LoadProfile values applied when a
  *  model is first seen and has no saved per-model profile. Saved profiles and
  *  per-request overrides still take precedence; these only replace the built-in
@@ -228,6 +237,8 @@ export interface Config {
   mcp: McpConfig
   /** Compile-from-source settings (ADR-089/100): toolchain dirs prepended to PATH. */
   build: BuildConfig
+  /** Cloud Launch deploy-link settings (ADR-153). */
+  cloudDeploy: CloudDeployConfig
   devModel?: DevModel
 }
 
@@ -338,6 +349,7 @@ export function defaultConfig(): Config {
     tools: {},
     mcp: { servers: [] },
     build: { toolchainDirs: [] },
+    cloudDeploy: { runpodTemplateId: '' },
   }
 }
 
@@ -579,6 +591,9 @@ function normalize(c: Config): void {
       ? bd.toolchainDirs.filter((p): p is string => typeof p === 'string' && p.trim() !== '').map((p) => p.trim())
       : [],
   }
+  // Cloud Launch deploy-link settings (ADR-153): absent in pre-ADR-153 configs → ''.
+  const cd = (c.cloudDeploy ?? {}) as Partial<CloudDeployConfig>
+  c.cloudDeploy = { runpodTemplateId: typeof cd.runpodTemplateId === 'string' ? cd.runpodTemplateId.trim() : '' }
   // Telemetry level (spec 09 §3): the UI exposes 'off' | 'anon' | 'full'. Migrate
   // legacy/unknown values safely → 'off' (the conservative, opt-in default).
   c.telemetry.level = normalizeTelemetryLevel(c.telemetry.level)

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -9,6 +9,12 @@ import { dirname, join } from 'node:path'
 
 export const SCHEMA_VERSION = 3
 
+/** VRAM headroom slider bounds (MB) for auto-tune's spill-safety margin (see
+ *  {@link Config.vramHeadroomMb} and `bench.ts`'s `overHeadroom`). */
+export const VRAM_HEADROOM_MIN_MB = 300
+export const VRAM_HEADROOM_MAX_MB = 2048
+export const VRAM_HEADROOM_DEFAULT_MB = 1024
+
 export interface Capabilities {
   kvTypes: string[]
   flags: string[]
@@ -226,6 +232,13 @@ export interface Config {
   /** Persisted auto-tune results keyed by modelKey (spec 09 §1, 01 §4). Additive;
    *  absent in old configs → normalize seeds {}. Never throws on load. */
   benchResults: Record<string, BenchResult>
+  /** VRAM to keep free during auto-tune's offload search (MB), so a later desktop /
+   *  ComfyUI VRAM grab can't tip the chosen config into a sysmem spill (bench.ts's
+   *  `overHeadroom`). User-configurable via a Settings slider,
+   *  {@link VRAM_HEADROOM_MIN_MB}–{@link VRAM_HEADROOM_MAX_MB}, default
+   *  {@link VRAM_HEADROOM_DEFAULT_MB}. Absent in pre-this-feature configs → normalize
+   *  seeds the default. */
+  vramHeadroomMb: number
   lastLoaded: LastLoaded
   autoLoadOnStart: boolean
   hf: HF
@@ -339,6 +352,7 @@ export function defaultConfig(): Config {
     primaryModelDir: '',
     modelProfiles: {},
     benchResults: {},
+    vramHeadroomMb: VRAM_HEADROOM_DEFAULT_MB,
     lastLoaded: { modelKey: '', engineId: '' },
     autoLoadOnStart: false,
     hf: { token: '' },
@@ -516,6 +530,12 @@ function normalize(c: Config): void {
   }
   // Persisted auto-tune results (spec 09 §1): absent in pre-bench configs → {}.
   c.benchResults ??= {}
+  // VRAM headroom slider: absent/garbage (pre-feature config, or a stale out-of-range
+  // value) → the default, never thrown on load — mirrors the gateway.keepN clamp below.
+  c.vramHeadroomMb =
+    typeof c.vramHeadroomMb === 'number' && c.vramHeadroomMb >= VRAM_HEADROOM_MIN_MB && c.vramHeadroomMb <= VRAM_HEADROOM_MAX_MB
+      ? c.vramHeadroomMb
+      : VRAM_HEADROOM_DEFAULT_MB
   c.autoLoadOnStart ??= false
   c.featuredOverrideUrl ??= ''
   // ComfyUI coordination (absent in pre-comfyui configs → defaults; never throw on an
@@ -636,6 +656,9 @@ function validate(c: Config): void {
   }
   if (c.activeEngineId && !c.engines.some((e) => e.id === c.activeEngineId)) {
     throw new ValueError('activeEngineId', 'unknown engine id')
+  }
+  if (c.vramHeadroomMb < VRAM_HEADROOM_MIN_MB || c.vramHeadroomMb > VRAM_HEADROOM_MAX_MB) {
+    throw new ValueError('vramHeadroomMb', `must be between ${VRAM_HEADROOM_MIN_MB} and ${VRAM_HEADROOM_MAX_MB} MB`)
   }
   // ComfyUI reverse-gate origin (F-011): empty is allowed (reverse gate just stays off);
   // if set, it must be an http(s):// origin so the `POST {url}/free` call is well-formed.

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -16,6 +16,7 @@ import type { ModelRouter } from './gateway/model-router'
 import type { ToolRegistry } from './tools/tool-registry'
 import type { GenerationGate } from './agents/gate'
 import type { AgentRunner } from './agents/runner'
+import type { TunnelManager } from './tunnel/manager'
 
 export interface Deps {
   store: ConfigStore
@@ -50,6 +51,11 @@ export interface Deps {
   gate?: GenerationGate
   /** Background agent runner. Optional — same wiring conditions as gate. */
   agentRunner?: AgentRunner
+  /** Cloud Launch tunnel (ADR-045/152): owns the cloudflared child when `--tunnel` is
+   *  active. Optional: only wired in the real `serve()` entrypoint (cli.ts); absent
+   *  under tests. Its presence/active() state is what forces auth enforcement on
+   *  tunneled traffic regardless of lanBind (see auth.ts lanAuth). */
+  tunnel?: TunnelManager
   version: string
   startedAt: number
   /** Re-exec the daemon so config changes (port, LAN bind) take effect (spec 08 §2).

--- a/turbollm/src/engines/build-prereqs.test.ts
+++ b/turbollm/src/engines/build-prereqs.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { delimiter } from 'node:path'
-import { buildCommands, buildEnv } from './build-prereqs'
+import { buildCommands, buildEnv, CMAKE_CONFIGURE_ARGS } from './build-prereqs'
 
 const PATH_KEY = Object.keys(process.env).find((k) => k.toLowerCase() === 'path') ?? 'PATH'
 
@@ -104,11 +104,11 @@ test('buildCommands: passes the repo URL through verbatim', () => {
   assert.ok(cmds[0].includes(url))
 })
 
-test('buildCommands: produces the Windows + CUDA cmake steps and the binary-location note', () => {
+test('buildCommands: produces the Windows + CUDA cmake steps (incl. the unsupported-compiler escape hatch) and the binary-location note', () => {
   const cmds = buildCommands('https://github.com/owner/repo', undefined, 'windows')
   assert.deepEqual(cmds.slice(1, 4), [
     'cd turbo-build',
-    'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+    `cmake -B build ${CMAKE_CONFIGURE_ARGS.join(' ')}`,
     'cmake --build build --config Release -j --target llama-server',
   ])
   assert.match(cmds[cmds.length - 1], /llama-server\.exe/)
@@ -119,9 +119,27 @@ test('buildCommands: produces the Linux + CUDA cmake steps (no config flag, no .
   const cmds = buildCommands('https://github.com/owner/repo', undefined, 'linux')
   assert.deepEqual(cmds.slice(1, 4), [
     'cd turbo-build',
-    'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+    `cmake -B build ${CMAKE_CONFIGURE_ARGS.join(' ')}`,
     'cmake --build build -j --target llama-server',
   ])
   assert.match(cmds[cmds.length - 1], /build\/bin\/llama-server/)
   assert.ok(!cmds[cmds.length - 1].includes('.exe'))
+})
+
+// Regression: the manual path used to skip bundling the CUDA runtime — the build succeeded
+// but the produced engine silently ran CPU-only until the DLLs/libs were found by hand.
+test('buildCommands: Windows bundles the CUDA runtime DLLs (both CUDA 12 and 13 layouts) next to the binary', () => {
+  const cmds = buildCommands('https://github.com/owner/repo', undefined, 'windows')
+  const copyStep = cmds[4]
+  assert.match(copyStep, /^for %f in \(.*\) do copy \/y "%f" "build\\bin\\Release\\" >nul 2>&1$/)
+  assert.match(copyStep, /"%CUDA_PATH%\\bin\\cudart64_\*\.dll"/)
+  assert.match(copyStep, /"%CUDA_PATH%\\bin\\x64\\cudart64_\*\.dll"/)
+})
+
+test('buildCommands: Linux bundles the CUDA runtime shared libs next to the binary', () => {
+  const cmds = buildCommands('https://github.com/owner/repo', undefined, 'linux')
+  assert.equal(cmds[4], 'CUDA_ROOT="$(dirname "$(dirname "$(command -v nvcc)")")"')
+  const copyStep = cmds[5]
+  assert.match(copyStep, /^cp .* build\/bin\/ 2>\/dev\/null$/)
+  assert.match(copyStep, /\$CUDA_ROOT\/lib64\/libcudart\.so\*/)
 })

--- a/turbollm/src/engines/build-prereqs.ts
+++ b/turbollm/src/engines/build-prereqs.ts
@@ -206,10 +206,28 @@ export async function checkBuildPrereqs(toolchainDirs: string[] = []): Promise<B
   return { supported: true, os: platform === 'win32' ? 'windows' : 'linux', tools }
 }
 
+/** The cmake CUDA configure flags — shared with the 1-click build (build-runner.ts imports
+ *  this) so the manual path below can never drift from what the in-app builder actually runs.
+ *  `-allow-unsupported-compiler` works around nvcc's hardcoded host-compiler allowlist (e.g.
+ *  CUDA 13.0 only recognizes MSVC toolsets up to VS2022): a new VS/GCC release routinely ships
+ *  before NVIDIA updates that list, and CMake's own CUDA compiler-id trial-compile dies on it
+ *  before any real compilation happens. The flag only skips that version *check* — a no-op when
+ *  the host compiler is already allowlisted — so it's safe to pass unconditionally. */
+export const CMAKE_CONFIGURE_ARGS = ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler']
+
+/** CUDA runtime DLLs (Windows) / shared libs (Linux) a llama.cpp CUDA build links against at
+ *  runtime. A build does NOT bundle these, so without copying them next to the binary the
+ *  engine silently falls back to CPU. Shared with build-runner.ts's 1-click-build copy step. */
+export const CUDA_RUNTIME_DLL_PREFIXES = ['cudart64_', 'cublas64_', 'cublaslt64_', 'nvrtc64_', 'nvrtc-builtins64_', 'nvjitlink_']
+export const CUDA_RUNTIME_SO_PREFIXES = ['libcudart.so', 'libcublas.so', 'libcublasLt.so', 'libnvrtc.so', 'libnvrtc-builtins.so', 'libnvJitLink.so']
+
 /** PURE: the exact build command list for `repoUrl` (optional `branch`) on `os`. Used by
  *  the guide's copy-able command block. The trailing comment notes where the binary lands
  *  so the user knows what to point "Add your own engine" at. Defaults to the host's own
- *  platform when `os` is omitted (matches what the 1-click build actually runs here). */
+ *  platform when `os` is omitted (matches what the 1-click build actually runs here). A
+ *  source build doesn't bundle the CUDA runtime, so — mirroring build-runner.ts's own
+ *  post-build copy — we add a step that bundles it next to the binary; otherwise the built
+ *  engine runs (CPU-only) with no indication it silently skipped the GPU. */
 export function buildCommands(
   repoUrl: string,
   branch?: string,
@@ -221,20 +239,34 @@ export function buildCommands(
   const clone = b
     ? `git clone --branch "${b}" --depth 1 "${repoUrl}" turbo-build`
     : `git clone --depth 1 "${repoUrl}" turbo-build`
+  const configure = `cmake -B build ${CMAKE_CONFIGURE_ARGS.join(' ')}`
   if (os === 'linux') {
+    // CUDA 13 vs 12 lay the runtime libs out differently (lib64 vs lib vs the
+    // targets/x86_64-linux/lib some installers use) — try all three; a glob that matches
+    // nothing just makes cp emit a (silenced) "no such file" for that one literal token.
+    const libGlobs = ['lib64', 'lib', 'targets/x86_64-linux/lib']
+      .flatMap((dir) => CUDA_RUNTIME_SO_PREFIXES.map((p) => `$CUDA_ROOT/${dir}/${p}*`))
+      .join(' ')
     return [
       clone,
       'cd turbo-build',
-      'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+      configure,
       'cmake --build build -j --target llama-server',
-      '# Built binary: build/bin/llama-server — add it via "Add your own engine".',
+      'CUDA_ROOT="$(dirname "$(dirname "$(command -v nvcc)")")"',
+      `cp ${libGlobs} build/bin/ 2>/dev/null`,
+      '# Built binary + its CUDA runtime libs: build/bin/llama-server — add it via "Add your own engine".',
     ]
   }
+  // CUDA 13 ships the runtime DLLs under bin\x64; CUDA 12 puts them in bin itself — check both.
+  const dllGlobs = ['bin', 'bin\\x64']
+    .flatMap((dir) => CUDA_RUNTIME_DLL_PREFIXES.map((p) => `"%CUDA_PATH%\\${dir}\\${p}*.dll"`))
+    .join(' ')
   return [
     clone,
     'cd turbo-build',
-    'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+    configure,
     'cmake --build build --config Release -j --target llama-server',
-    '# Built binary: build\\bin\\Release\\llama-server.exe — add it via "Add your own engine".',
+    `for %f in (${dllGlobs}) do copy /y "%f" "build\\bin\\Release\\" >nul 2>&1`,
+    '# Built binary + its CUDA runtime DLLs: build\\bin\\Release\\llama-server.exe — add it via "Add your own engine".',
   ]
 }

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -21,8 +21,12 @@ test('buildDirName: unparseable URL falls back to "engine"', () => {
   assert.equal(buildDirName('   '), 'engine')
 })
 
-test('CMAKE_CONFIGURE_ARGS: enables CUDA + Release', () => {
-  assert.deepEqual(CMAKE_CONFIGURE_ARGS, ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release'])
+test('CMAKE_CONFIGURE_ARGS: enables CUDA + Release, allows an unrecognized-but-newer host compiler', () => {
+  assert.deepEqual(CMAKE_CONFIGURE_ARGS, [
+    '-DGGML_CUDA=ON',
+    '-DCMAKE_BUILD_TYPE=Release',
+    '-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler',
+  ])
 })
 
 test('pickGenerator: Ninja when available regardless of platform', () => {

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -18,7 +18,7 @@ import { execFile, spawn } from 'node:child_process'
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { delimiter, dirname, join } from 'node:path'
 import { promisify } from 'node:util'
-import { buildEnv, checkBuildPrereqs } from './build-prereqs'
+import { buildEnv, checkBuildPrereqs, CMAKE_CONFIGURE_ARGS, CUDA_RUNTIME_DLL_PREFIXES, CUDA_RUNTIME_SO_PREFIXES } from './build-prereqs'
 import { resolveServerBinary } from './scan'
 import type { BuildPhase } from './build-state'
 
@@ -99,8 +99,9 @@ export function pickGenerator(hasNinja: boolean, isWindows: boolean): 'Ninja' | 
   return isWindows ? 'NMake Makefiles' : 'Unix Makefiles'
 }
 
-/** The cmake CUDA flags (single-config generators honor CMAKE_BUILD_TYPE). */
-export const CMAKE_CONFIGURE_ARGS = ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release']
+// CMAKE_CONFIGURE_ARGS now lives in build-prereqs.ts (re-exported below) — it's shared with
+// that module's `buildCommands`, the manual-build command list, so the two can never drift.
+export { CMAKE_CONFIGURE_ARGS }
 
 /** PURE: a Windows .bat that enters the MSVC dev env (vcvars x64) then runs one cmake step.
  *  All paths are quoted (vcvars/src/build dirs can contain spaces); the cmake exit code is
@@ -131,13 +132,6 @@ function onPath(env: NodeJS.ProcessEnv, exe: string): boolean {
       }
     })
 }
-
-/** CUDA runtime DLLs a llama.cpp CUDA build links against at runtime. A SOURCE build does
- *  NOT bundle these (unlike the prebuilt release zips), so the produced exe can't start —
- *  and our probe (`--version`) fails — unless they sit beside it or on PATH. We copy them
- *  next to the exe so the engine is self-contained + portable (works even after the CUDA
- *  toolkit dir is removed). Versioned names (e.g. cudart64_13.dll) → match by prefix. */
-const CUDA_RUNTIME_DLL_PREFIXES = ['cudart64_', 'cublas64_', 'cublaslt64_', 'nvrtc64_', 'nvrtc-builtins64_', 'nvjitlink_']
 
 /** Find the directories that hold the CUDA toolkit's runtime DLLs, version-matched to the
  *  build by anchoring on the toolkit that owns `nvcc` (NOT a stray cudart from an unrelated
@@ -199,11 +193,6 @@ function copyCudaRuntimeDlls(env: NodeJS.ProcessEnv, destDir: string, log: (l: s
   if (copied > 0) log(`Bundled ${copied} CUDA runtime DLL(s) next to the binary so the engine is self-contained.`)
   return copied
 }
-
-/** Linux equivalent of {@link CUDA_RUNTIME_DLL_PREFIXES} — the `.so` names match by prefix
- *  since the real files carry a version suffix (e.g. `libcudart.so.12.6.20`, often reached
- *  through a `libcudart.so` / `libcudart.so.12` symlink chain in the same directory). */
-const CUDA_RUNTIME_SO_PREFIXES = ['libcudart.so', 'libcublas.so', 'libcublasLt.so', 'libnvrtc.so', 'libnvrtc-builtins.so', 'libnvJitLink.so']
 
 /** Linux equivalent of {@link cudaDllSourceDirs}: anchor on the toolkit that owns `nvcc` on
  *  PATH, then look at the layouts CUDA installs actually use for the runtime libs — `lib64`

--- a/turbollm/src/engines/seed.ts
+++ b/turbollm/src/engines/seed.ts
@@ -5,7 +5,9 @@
 import type { Registry } from './registry'
 import type { ProvisionState } from './provision-state'
 import { getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
-import { LLAMA_BUILD, fallbackChain, provisionBackend, recommendBackendId, type ProvisionProgress } from './download'
+import { LLAMA_BUILD, fallbackChain, provisionBackend, recommendBackendId, type BackendId, type ProvisionProgress } from './download'
+
+const VALID_BACKENDS: BackendId[] = ['cuda', 'rocm', 'sycl', 'vulkan', 'metal', 'cpu']
 
 export async function seedDefaultEngines(
   registry: Registry,
@@ -19,11 +21,22 @@ export async function seedDefaultEngines(
   const vendor = primaryVendor(sys)
   const hasGpu = sys.gpus.length > 0
 
+  // Escape hatch for environments where live GPU detection can't see the real
+  // target hardware — the main case is pre-baking a Docker image at build time
+  // (deploy/runpod/Dockerfile): `docker build` never has GPU passthrough, so
+  // detection always reports "no GPU" and would otherwise always pre-bake the
+  // CPU backend even for an image explicitly built for an NVIDIA GPU box.
+  const forced = process.env.TURBOLLM_SEED_BACKEND as BackendId | undefined
+
   let chain
   try {
-    const recommended = recommendBackendId(vendor, hasGpu, tag)
+    const recommended = forced && VALID_BACKENDS.includes(forced) ? forced : recommendBackendId(vendor, hasGpu, tag)
     chain = fallbackChain(recommended, tag)
-    console.log(`seed: detected GPU vendor=${vendor} (${sys.gpus.map((g) => g.name).join(', ') || 'none'}) → backend ${recommended}`)
+    if (forced) {
+      console.log(`seed: TURBOLLM_SEED_BACKEND=${forced} → backend ${recommended} (skipping live GPU detection)`)
+    } else {
+      console.log(`seed: detected GPU vendor=${vendor} (${sys.gpus.map((g) => g.name).join(', ') || 'none'}) → backend ${recommended}`)
+    }
   } catch (e) {
     console.warn(`seed: ${e instanceof Error ? e.message : e}`)
     return

--- a/turbollm/src/features.test.ts
+++ b/turbollm/src/features.test.ts
@@ -1,0 +1,54 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { enabledFeatures, isFeatureEnabled } from './features'
+
+function withEnv(value: string | undefined, fn: () => void): void {
+  const prev = process.env.TURBOLLM_FEATURES
+  if (value === undefined) delete process.env.TURBOLLM_FEATURES
+  else process.env.TURBOLLM_FEATURES = value
+  try {
+    fn()
+  } finally {
+    if (prev === undefined) delete process.env.TURBOLLM_FEATURES
+    else process.env.TURBOLLM_FEATURES = prev
+  }
+}
+
+test('enabledFeatures: unset env var → no features enabled', () => {
+  withEnv(undefined, () => {
+    assert.deepEqual(enabledFeatures(), [])
+  })
+})
+
+test('enabledFeatures: a known flag turns on', () => {
+  withEnv('cloud-deploy', () => {
+    assert.deepEqual(enabledFeatures(), ['cloud-deploy'])
+  })
+})
+
+test('enabledFeatures: unknown flags are silently ignored, not half-enabled', () => {
+  withEnv('cloud-deploy,totally-made-up-flag', () => {
+    assert.deepEqual(enabledFeatures(), ['cloud-deploy'])
+  })
+})
+
+test('enabledFeatures: whitespace and empty entries are tolerated', () => {
+  withEnv(' cloud-deploy , , ', () => {
+    assert.deepEqual(enabledFeatures(), ['cloud-deploy'])
+  })
+})
+
+test('enabledFeatures: garbage-only value enables nothing', () => {
+  withEnv('nonsense,another-nonsense', () => {
+    assert.deepEqual(enabledFeatures(), [])
+  })
+})
+
+test('isFeatureEnabled: true only when the flag is present', () => {
+  withEnv('cloud-deploy', () => {
+    assert.equal(isFeatureEnabled('cloud-deploy'), true)
+  })
+  withEnv(undefined, () => {
+    assert.equal(isFeatureEnabled('cloud-deploy'), false)
+  })
+})

--- a/turbollm/src/features.ts
+++ b/turbollm/src/features.ts
@@ -1,0 +1,28 @@
+// Local feature-flag manager — internal/dev only, deliberately undocumented in any
+// user-facing README. Lets an experimental feature ship in code without being live for
+// normal users yet: set TURBOLLM_FEATURES to a comma-separated list of flag ids to turn
+// them on (e.g. `TURBOLLM_FEATURES=cloud-deploy npx turbollm`). Discoverable by reading
+// the source, not by reading docs — the point is letting people exploring the codebase
+// find and try what's still in progress, without it being an advertised feature yet.
+//
+// KNOWN_FEATURES is the registry: the one place that lists every flag that currently
+// exists. Anything not listed here is silently ignored even if set in the env var, so a
+// typo can't accidentally "half enable" garbage.
+const KNOWN_FEATURES = ['cloud-deploy'] as const
+
+export type FeatureId = (typeof KNOWN_FEATURES)[number]
+
+/** Feature ids enabled for this process, parsed from TURBOLLM_FEATURES fresh on every
+ *  call (not cached) — cheap enough that testability matters more than the micro-cost
+ *  of re-splitting a short string, and env vars don't change mid-process anyway. */
+export function enabledFeatures(): FeatureId[] {
+  const raw = process.env.TURBOLLM_FEATURES ?? ''
+  const requested = new Set(
+    raw.split(',').map((s) => s.trim()).filter(Boolean),
+  )
+  return KNOWN_FEATURES.filter((f) => requested.has(f))
+}
+
+export function isFeatureEnabled(id: FeatureId): boolean {
+  return enabledFeatures().includes(id)
+}

--- a/turbollm/src/tools/approval-gate.ts
+++ b/turbollm/src/tools/approval-gate.ts
@@ -1,0 +1,55 @@
+// In-memory pending tool-call approval registry (F-019 replacement).
+// Keyed by `${convId}:${toolCallId}` — tool-call ids come from the LLM and are only
+// unique within a single request, so we prefix with convId to avoid any cross-
+// conversation collision. Entries are created by waitForToolApproval() and resolved
+// either by resolveToolApproval() (a human clicked Allow/Deny) or by the caller's
+// AbortSignal firing (generation was stopped/aborted — treated as a deny).
+interface PendingApproval {
+  resolve: (decision: 'allow' | 'deny') => void
+  cleanup: () => void
+}
+
+const pending = new Map<string, PendingApproval>()
+
+/**
+ * Registers a pending approval for `key` and returns a Promise that resolves when
+ * `resolveToolApproval(key, decision)` is called elsewhere, OR resolves to 'deny'
+ * and cleans up if `signal` fires first. The abort listener is always removed and
+ * the pending entry always deleted on every resolution path — no leaks.
+ */
+export function waitForToolApproval(key: string, signal: AbortSignal): Promise<'allow' | 'deny'> {
+  return new Promise<'allow' | 'deny'>((resolvePromise) => {
+    const onAbort = () => {
+      pending.delete(key)
+      resolvePromise('deny')
+    }
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort)
+    }
+    pending.set(key, {
+      resolve: (decision) => {
+        cleanup()
+        resolvePromise(decision)
+      },
+      cleanup,
+    })
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Resolves the pending approval for `key`, if any. Returns true if a pending entry
+ * existed and was resolved; returns false if no pending entry exists (already
+ * resolved, expired, or never existed) — the caller should treat that as a 404.
+ */
+export function resolveToolApproval(key: string, decision: 'allow' | 'deny'): boolean {
+  const entry = pending.get(key)
+  if (!entry) return false
+  pending.delete(key)
+  entry.resolve(decision)
+  return true
+}

--- a/turbollm/src/tools/builtin.ts
+++ b/turbollm/src/tools/builtin.ts
@@ -1,7 +1,7 @@
 // Built-in tool definitions and execution (v0.7.0).
 // Tools: web_search (Tavily), fetch_url, run_code (Node vm sandbox).
 import { runInNewContext } from 'node:vm'
-import { checkSsrf, RUN_CODE_BLOCKED_MSG } from './security.js'
+import { checkSsrf } from './security.js'
 import { type SearchConfig } from './search-providers.js'
 import { research, type ResearchResult } from './research-service.js'
 
@@ -150,10 +150,9 @@ export async function execFetchUrl(args: Record<string, unknown>): Promise<strin
 
 // ── Run code ─────────────────────────────────────────────────────────────
 
-export function execRunCode(args: Record<string, unknown>, requireConfirmation = false): string {
+export function execRunCode(args: Record<string, unknown>): string {
   const code = String(args.code ?? '').trim()
   if (!code) return 'Error: code is required.'
-  if (requireConfirmation) return RUN_CODE_BLOCKED_MSG
 
   const output: string[] = []
   const sandbox = {

--- a/turbollm/src/tools/execute-with-approval.test.ts
+++ b/turbollm/src/tools/execute-with-approval.test.ts
@@ -1,0 +1,111 @@
+// Regression coverage for the F-019 approval-gate executor, in particular the
+// background-agent path: every tool defaults to 'ask' (tool-policy.ts), and a
+// background run can never prompt a human (interactive: false) — so a tool the
+// agent was explicitly configured to use (agentAllowedTools) must still run.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { ToolRegistry, ToolCall } from './tool-registry'
+import { executeToolCallWithApproval } from './execute-with-approval'
+
+function fakeTools(result = 'ok'): ToolRegistry {
+  return {
+    executeTool: async (_call: ToolCall) => result,
+  } as unknown as ToolRegistry
+}
+
+function collectSink() {
+  const events: Array<{ event: string; data: unknown }> = []
+  return { events, sink: (ev: { event: string; data: unknown }) => { events.push(ev) } }
+}
+
+test('background agent run executes an "ask"-default tool that is in agentAllowedTools', async () => {
+  const { sink, events } = collectSink()
+  const { result, error } = await executeToolCallWithApproval({
+    tools: fakeTools('search results'),
+    sink,
+    convId: 'c1',
+    id: 't1',
+    name: 'web_search',
+    args: {},
+    globalPolicies: {}, // no explicit policy -> resolves to 'ask'
+    convOverrides: {},
+    signal: new AbortController().signal,
+    interactive: false,
+    agentAllowedTools: ['web_search'],
+  })
+
+  assert.strictEqual(error, undefined)
+  assert.strictEqual(result, 'search results')
+  assert.ok(events.some((e) => e.event === 'tool_call' && (e.data as { status: string }).status === 'done'))
+})
+
+test('background agent run blocks an "ask"-default tool NOT in agentAllowedTools', async () => {
+  const { result } = await executeToolCallWithApproval({
+    tools: fakeTools(),
+    sink: () => {},
+    convId: 'c1',
+    id: 't2',
+    name: 'fetch_url',
+    args: {},
+    globalPolicies: {},
+    convOverrides: {},
+    signal: new AbortController().signal,
+    interactive: false,
+    agentAllowedTools: ['web_search'], // fetch_url not whitelisted for this agent
+  })
+
+  assert.match(result, /Blocked.*background agent/)
+})
+
+test('background agent run blocks every tool when agentAllowedTools is omitted (unchanged default)', async () => {
+  const { result } = await executeToolCallWithApproval({
+    tools: fakeTools(),
+    sink: () => {},
+    convId: 'c1',
+    id: 't3',
+    name: 'web_search',
+    args: {},
+    globalPolicies: {},
+    convOverrides: {},
+    signal: new AbortController().signal,
+    interactive: false,
+  })
+
+  assert.match(result, /Blocked.*background agent/)
+})
+
+test('explicit global "deny" wins even if the tool is in agentAllowedTools', async () => {
+  const { result } = await executeToolCallWithApproval({
+    tools: fakeTools(),
+    sink: () => {},
+    convId: 'c1',
+    id: 't4',
+    name: 'web_search',
+    args: {},
+    globalPolicies: { web_search: 'deny' },
+    convOverrides: {},
+    signal: new AbortController().signal,
+    interactive: false,
+    agentAllowedTools: ['web_search'],
+  })
+
+  assert.match(result, /Blocked.*Deny/)
+})
+
+test('an "allow"-policy tool still executes for a background run with no agentAllowedTools needed', async () => {
+  const { result, error } = await executeToolCallWithApproval({
+    tools: fakeTools('42'),
+    sink: () => {},
+    convId: 'c1',
+    id: 't5',
+    name: 'run_code',
+    args: {},
+    globalPolicies: { run_code: 'allow' },
+    convOverrides: {},
+    signal: new AbortController().signal,
+    interactive: false,
+  })
+
+  assert.strictEqual(error, undefined)
+  assert.strictEqual(result, '42')
+})

--- a/turbollm/src/tools/execute-with-approval.ts
+++ b/turbollm/src/tools/execute-with-approval.ts
@@ -1,0 +1,71 @@
+// Shared tool-call executor with the real approval gate (F-019 replacement).
+// Both live foreground chat (chat-routes.ts) and the background agent runner
+// (generation.ts) call this single implementation instead of maintaining their
+// own inline per-tool-call blocks.
+import type { ToolRegistry, ToolCall } from './tool-registry'
+import { type ToolPolicy, resolveToolPolicy } from './tool-policy'
+import { waitForToolApproval } from './approval-gate'
+
+export type ToolCallSink = (ev: { event: string; data: unknown }) => void | Promise<void>
+
+export async function executeToolCallWithApproval(params: {
+  tools: ToolRegistry
+  sink: ToolCallSink
+  convId: string
+  id: string
+  name: string
+  args: Record<string, unknown>
+  globalPolicies: Record<string, ToolPolicy>
+  convOverrides: Record<string, 'allow' | 'deny'>
+  signal: AbortSignal
+  /** true for live foreground chat (can prompt a human); false for background agent runs
+   *  (must never hang waiting for a human — 'ask'-policy tools are denied outright). */
+  interactive: boolean
+}): Promise<{ result: string; error?: string }> {
+  const { tools, sink, convId, id, name, args, globalPolicies, convOverrides, signal, interactive } = params
+
+  const policy = resolveToolPolicy(name, globalPolicies, convOverrides)
+
+  if (policy === 'deny') {
+    const result = 'Blocked: this tool is set to Deny in Tool Permissions settings.'
+    await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
+    return { result }
+  }
+
+  let cameFromApprovedAsk = false
+
+  if (policy === 'ask') {
+    if (!interactive) {
+      const result = 'Blocked: this tool requires interactive approval, which is not available for background agent runs.'
+      await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
+      return { result }
+    }
+
+    await sink({ event: 'tool_call', data: { id, name, args, status: 'awaiting_approval' } })
+    const decision = await waitForToolApproval(`${convId}:${id}`, signal)
+    if (decision === 'deny') {
+      const result = 'Denied by user.'
+      await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
+      return { result }
+    }
+    cameFromApprovedAsk = true
+  }
+
+  // policy === 'allow', or fell through from an approved 'ask'.
+  if (!cameFromApprovedAsk) {
+    await sink({ event: 'tool_call', data: { id, name, args, status: 'pending' } })
+  }
+
+  let result = ''
+  let error: string | undefined
+  try {
+    const call: ToolCall = { id, name, args }
+    result = await tools.executeTool(call)
+  } catch (e) {
+    error = (e as Error).message
+    result = `Error: ${error}`
+  }
+
+  await sink({ event: 'tool_call', data: { id, name, args, status: error ? 'error' : 'done', result } })
+  return { result, error }
+}

--- a/turbollm/src/tools/execute-with-approval.ts
+++ b/turbollm/src/tools/execute-with-approval.ts
@@ -19,10 +19,15 @@ export async function executeToolCallWithApproval(params: {
   convOverrides: Record<string, 'allow' | 'deny'>
   signal: AbortSignal
   /** true for live foreground chat (can prompt a human); false for background agent runs
-   *  (must never hang waiting for a human — 'ask'-policy tools are denied outright). */
+   *  (must never hang waiting for a human — 'ask'-policy tools are denied unless
+   *  pre-approved via agentAllowedTools). */
   interactive: boolean
+  /** For background agent runs only: the tool names this agent was explicitly configured
+   *  to use. A human already approved this list when setting up the agent, so it stands
+   *  in for the interactive approval a background run can never get. */
+  agentAllowedTools?: string[]
 }): Promise<{ result: string; error?: string }> {
-  const { tools, sink, convId, id, name, args, globalPolicies, convOverrides, signal, interactive } = params
+  const { tools, sink, convId, id, name, args, globalPolicies, convOverrides, signal, interactive, agentAllowedTools } = params
 
   const policy = resolveToolPolicy(name, globalPolicies, convOverrides)
 
@@ -36,19 +41,23 @@ export async function executeToolCallWithApproval(params: {
 
   if (policy === 'ask') {
     if (!interactive) {
-      const result = 'Blocked: this tool requires interactive approval, which is not available for background agent runs.'
-      await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
-      return { result }
+      if (agentAllowedTools?.includes(name)) {
+        cameFromApprovedAsk = true
+      } else {
+        const result = "Blocked: this tool requires interactive approval, which is not available for background agent runs. Add it to this agent's allowed tools, or set it to Allow in Developer → Tool permissions."
+        await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
+        return { result }
+      }
+    } else {
+      await sink({ event: 'tool_call', data: { id, name, args, status: 'awaiting_approval' } })
+      const decision = await waitForToolApproval(`${convId}:${id}`, signal)
+      if (decision === 'deny') {
+        const result = 'Denied by user.'
+        await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
+        return { result }
+      }
+      cameFromApprovedAsk = true
     }
-
-    await sink({ event: 'tool_call', data: { id, name, args, status: 'awaiting_approval' } })
-    const decision = await waitForToolApproval(`${convId}:${id}`, signal)
-    if (decision === 'deny') {
-      const result = 'Denied by user.'
-      await sink({ event: 'tool_call', data: { id, name, args, status: 'done', result } })
-      return { result }
-    }
-    cameFromApprovedAsk = true
   }
 
   // policy === 'allow', or fell through from an approved 'ask'.

--- a/turbollm/src/tools/security.test.ts
+++ b/turbollm/src/tools/security.test.ts
@@ -1,7 +1,9 @@
-// Security hardening tests (F-019): SSRF block on fetch_url, run_code confirmation gate.
+// Security hardening tests: SSRF block on fetch_url. run_code confirmation is now
+// handled upstream by the tool-call approval gate (execute-with-approval.ts) —
+// execRunCode itself always executes.
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { checkSsrf, RUN_CODE_BLOCKED_MSG } from './security'
+import { checkSsrf } from './security'
 import { execFetchUrl, execRunCode } from './builtin'
 
 // ── SSRF block ────────────────────────────────────────────────────────────────
@@ -59,19 +61,9 @@ test('execFetchUrl blocks localhost end-to-end', async () => {
   assert.match(result, /blocked/)
 })
 
-// ── run_code confirmation gate ─────────────────────────────────────────────────
+// ── run_code always executes (gating happens upstream) ───────────────────────────
 
-test('execRunCode with requireConfirmation=true skips execution and returns confirmation message', () => {
-  const result = execRunCode({ code: 'return 1 + 1' }, true)
-  assert.strictEqual(result, RUN_CODE_BLOCKED_MSG)
-})
-
-test('execRunCode with requireConfirmation=false executes normally', () => {
-  const result = execRunCode({ code: 'return 1 + 1' }, false)
+test('execRunCode executes normally', () => {
+  const result = execRunCode({ code: 'return 1 + 1' })
   assert.strictEqual(result, '2')
-})
-
-test('execRunCode defaults to executing when requireConfirmation not passed', () => {
-  const result = execRunCode({ code: 'return 2 + 2' })
-  assert.strictEqual(result, '4')
 })

--- a/turbollm/src/tools/security.ts
+++ b/turbollm/src/tools/security.ts
@@ -1,12 +1,6 @@
-// Security hardening for built-in tools (F-019).
+// Security hardening for built-in tools.
 // SSRF block: rejects private/loopback destinations before fetch_url executes.
-// run_code gate: returns a confirmation-required message instead of executing
-// when requireRunCodeConfirmation is enabled (default: true).
 import { lookup } from 'node:dns/promises'
-
-/** Message returned to the LLM when run_code is gated pending user confirmation. */
-export const RUN_CODE_BLOCKED_MSG =
-  'Action required: the user must confirm before code can be executed. Please ask the user to approve running this code.'
 
 /** RFC-1918, loopback, and link-local CIDR ranges to block. */
 const PRIVATE_RANGES: Array<(ip: string) => boolean> = [

--- a/turbollm/src/tools/tool-policy.ts
+++ b/turbollm/src/tools/tool-policy.ts
@@ -1,0 +1,18 @@
+// Tool approval-gate policy resolution (F-019 replacement).
+// Every tool defaults to 'ask' (must prompt the user) unless a policy has been
+// explicitly set — either globally (Settings → Tools) or per-conversation
+// (the "Allow for this chat" action). This is a deliberate behavior change:
+// previously nothing prompted except the (broken) run_code confirmation stub.
+export type ToolPolicy = 'ask' | 'allow' | 'deny'
+
+/** Per-conversation override wins over the global default; falling through to 'ask'
+ *  when neither is set (safe-by-default: a brand-new/unclassified tool always prompts). */
+export function resolveToolPolicy(
+  name: string,
+  globalPolicies: Record<string, ToolPolicy>,
+  convOverrides: Record<string, 'allow' | 'deny'>,
+): ToolPolicy {
+  if (convOverrides[name]) return convOverrides[name]
+  if (globalPolicies[name]) return globalPolicies[name]
+  return 'ask'
+}

--- a/turbollm/src/tools/tool-registry.ts
+++ b/turbollm/src/tools/tool-registry.ts
@@ -111,8 +111,9 @@ export class ToolRegistry {
     // Built-in: fetch_url
     if (name === 'fetch_url') return execFetchUrl(args)
 
-    // Built-in: run_code — gated behind user confirmation when enabled (F-019).
-    if (name === 'run_code') return execRunCode(args, this.toolsCfg.requireRunCodeConfirmation !== false)
+    // Built-in: run_code — approval gating happens upstream in execute-with-approval.ts
+    // before executeTool is ever called, so run_code always executes here.
+    if (name === 'run_code') return execRunCode(args)
 
     // MCP tool: mcp__{serverId}__{toolName}
     const mcpMatch = name.match(/^mcp__([^_]+(?:_[^_]+)*)__(.+)$/)

--- a/turbollm/src/tunnel/manager.ts
+++ b/turbollm/src/tunnel/manager.ts
@@ -1,0 +1,235 @@
+// Tunnel process manager (Cloud Launch, ADR-045/152): spawns cloudflared pointed at
+// the daemon's own local port, parses the assigned public URL out of its stderr
+// (verified empirically against a real cloudflared run: it logs everything to
+// stderr, nothing to stdout), and tracks it with the same pidfile-owner pattern
+// engines/manager.ts uses for orphan safety — a leaked cloudflared process is worse
+// than a leaked engine here, since it keeps a PUBLIC URL alive pointing at a port
+// nothing may be serving anymore.
+import { type ChildProcess, execFile, spawn, spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ensureCloudflared } from './provision'
+
+const URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function signalTerm(child: ChildProcess): void {
+  if (!child.pid) return
+  if (process.platform === 'win32') execFile('taskkill', ['/PID', String(child.pid), '/T'], () => {})
+  else child.kill('SIGTERM')
+}
+
+function forceKill(child: ChildProcess): void {
+  if (!child.pid) return
+  if (process.platform === 'win32') execFile('taskkill', ['/PID', String(child.pid), '/F', '/T'], () => {})
+  else child.kill('SIGKILL')
+}
+
+// ── Orphan-safety pidfile (mirrors engines/manager.ts's engine-<pid>.pid pattern) ──
+// Simpler than the engine version: no portAlive cross-check before killing a
+// suspected orphan. The engine check exists because a recycled pid holding a
+// meaningful serving port is worth confirming; a stray non-cloudflared process
+// recycling this exact pid within the same boot is unlikely enough that the
+// simpler owner-only check is the right amount of caution here.
+
+function tunnelPidDir(dataDir: string): string {
+  return join(dataDir, 'run')
+}
+function tunnelPidFile(dataDir: string, pid: number): string {
+  return join(tunnelPidDir(dataDir), `tunnel-${pid}.pid`)
+}
+function writeTunnelPid(dataDir: string, pid: number): void {
+  try {
+    mkdirSync(tunnelPidDir(dataDir), { recursive: true })
+    writeFileSync(tunnelPidFile(dataDir, pid), JSON.stringify({ pid, owner: process.pid }))
+  } catch {
+    /* best-effort — tracking is a safety net, never block a start on it */
+  }
+}
+function clearTunnelPid(dataDir: string, pid: number): void {
+  try {
+    rmSync(tunnelPidFile(dataDir, pid), { force: true })
+  } catch {
+    /* best-effort */
+  }
+}
+function pidAlive(pid: number): boolean {
+  if (!pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+function readTunnelPidFiles(dataDir: string): Array<{ pid: number; owner: number; file: string }> {
+  const dir = tunnelPidDir(dataDir)
+  let names: string[]
+  try {
+    names = readdirSync(dir).filter((n) => /^tunnel-\d+\.pid$/.test(n))
+  } catch {
+    return [] // no run dir yet
+  }
+  const out: Array<{ pid: number; owner: number; file: string }> = []
+  for (const name of names) {
+    const file = join(dir, name)
+    try {
+      const { pid, owner } = JSON.parse(readFileSync(file, 'utf8')) as { pid?: number; owner?: number }
+      if (typeof pid === 'number' && pid > 0) out.push({ pid, owner: typeof owner === 'number' ? owner : 0, file })
+      else rmSync(file, { force: true })
+    } catch {
+      try {
+        rmSync(file, { force: true })
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  return out
+}
+
+/** Reap cloudflared processes left behind by a previous daemon that didn't shut down
+ *  cleanly. Called once at startup, alongside reapStaleEngines. An orphan is one whose
+ *  owner daemon is gone. Returns the number reaped. */
+export function reapStaleTunnels(dataDir: string): number {
+  let killed = 0
+  for (const { pid, owner, file } of readTunnelPidFiles(dataDir)) {
+    if (owner && pidAlive(owner)) continue // still managed by a live daemon
+    try {
+      if (process.platform === 'win32') spawnSync('taskkill', ['/PID', String(pid), '/F', '/T'])
+      else process.kill(pid, 'SIGKILL')
+      killed++
+    } catch {
+      /* already gone */
+    }
+    try {
+      rmSync(file, { force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+  return killed
+}
+
+/** Synchronous best-effort kill of tunnels THIS daemon owns, for a process 'exit'
+ *  handler (which can't await). Mirrors killTrackedEnginesSync. Owner-scoped so a
+ *  daemon exiting during a restart overlap never kills the incoming daemon's tunnel. */
+export function killTrackedTunnelsSync(dataDir: string): void {
+  for (const { pid, owner, file } of readTunnelPidFiles(dataDir)) {
+    if (owner !== process.pid) continue
+    try {
+      if (process.platform === 'win32') spawnSync('taskkill', ['/PID', String(pid), '/F', '/T'])
+      else process.kill(pid, 'SIGKILL')
+    } catch {
+      /* already gone */
+    }
+    try {
+      rmSync(file, { force: true })
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+export interface TunnelSnapshot {
+  active: boolean
+  url: string | null
+  error: string | null
+}
+
+/** Owns the cloudflared child process for the lifetime it's needed: spawn, parse the
+ *  assigned public URL from stderr, and tear down cleanly (or force-kill a stuck
+ *  process) on shutdown/rebind/restart. One instance per daemon process. */
+export class TunnelManager {
+  private child: ChildProcess | null = null
+  private _url: string | null = null
+  private _error: string | null = null
+  private exited: Promise<void> = Promise.resolve()
+
+  constructor(private dataDir: string) {}
+
+  active(): boolean {
+    return this.child !== null
+  }
+  url(): string | null {
+    return this._url
+  }
+  snapshot(): TunnelSnapshot {
+    return { active: this.active(), url: this._url, error: this._error }
+  }
+
+  /** Start cloudflared pointed at the given local port. Resolves once the public URL
+   *  is parsed out of its output, or rejects if it exits first (bad binary, network
+   *  failure) or 30s elapses without a URL appearing. Idempotent: replaces any prior
+   *  tunnel first, so it's safe to call again on a rebind/restart (new port). */
+  async start(localPort: number): Promise<string> {
+    await this.shutdown()
+    this._error = null
+    const { binPath } = await ensureCloudflared(this.dataDir)
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(binPath, ['tunnel', '--url', `http://127.0.0.1:${localPort}`], { windowsHide: true })
+      this.child = child
+      writeTunnelPid(this.dataDir, child.pid ?? 0)
+
+      let settled = false
+      let buf = ''
+      const onData = (chunk: Buffer) => {
+        if (settled) return
+        buf += chunk.toString()
+        const m = URL_RE.exec(buf)
+        if (m) {
+          settled = true
+          this._url = m[0]
+          child.stderr?.off('data', onData)
+          child.stdout?.off('data', onData)
+          resolve(m[0])
+        }
+      }
+      // cloudflared logs to stderr today (verified); also listen on stdout in case a
+      // future version changes that — harmless either way since both feed the same buffer.
+      child.stderr?.on('data', onData)
+      child.stdout?.on('data', onData)
+
+      this.exited = new Promise((res) => {
+        child.on('exit', (code) => {
+          if (this.child === child) this.child = null
+          clearTunnelPid(this.dataDir, child.pid ?? 0)
+          if (!settled) {
+            settled = true
+            this._error = `cloudflared exited before a tunnel URL appeared (code ${code})`
+            reject(new Error(this._error))
+          }
+          res()
+        })
+      })
+
+      const timeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        this._error = 'timed out waiting for cloudflared to report a tunnel URL'
+        forceKill(child)
+        reject(new Error(this._error))
+      }, 30_000)
+      timeout.unref()
+      void this.exited.then(() => clearTimeout(timeout))
+    })
+  }
+
+  /** Graceful stop with a force-kill fallback, mirroring engines/manager.ts's
+   *  gracefulStop. No-op if no tunnel is running. */
+  async shutdown(): Promise<void> {
+    const child = this.child
+    if (!child) return
+    this.child = null
+    this._url = null
+    signalTerm(child)
+    const forced = sleep(8000).then(() => 'timeout' as const)
+    const result = await Promise.race([this.exited.then(() => 'exited' as const), forced])
+    if (result === 'timeout') forceKill(child)
+    clearTunnelPid(this.dataDir, child.pid ?? 0)
+  }
+}

--- a/turbollm/src/tunnel/provision.test.ts
+++ b/turbollm/src/tunnel/provision.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { cloudflaredAssetName, cloudflaredBinName, pickCloudflaredAsset } from './provision'
+
+// Fixture: the real asset list from cloudflare/cloudflared's latest release (tag
+// 2026.6.1), fetched via `gh api repos/cloudflare/cloudflared/releases/latest` while
+// building this feature. Windows/Linux ship raw executables; macOS ships a .tgz —
+// verified live rather than assumed, since every other tool this codebase provisions
+// (KoboldCpp, TurboQuant, llama.cpp) ships a single consistent shape per release.
+const REAL_ASSETS = [
+  { name: 'cloudflared-amd64.pkg', browser_download_url: 'x' },
+  { name: 'cloudflared-arm64.pkg', browser_download_url: 'x' },
+  { name: 'cloudflared-darwin-amd64.tgz', browser_download_url: 'https://darwin-amd64.tgz' },
+  { name: 'cloudflared-darwin-arm64.tgz', browser_download_url: 'https://darwin-arm64.tgz' },
+  { name: 'cloudflared-fips-linux-amd64', browser_download_url: 'x' },
+  { name: 'cloudflared-fips-linux-amd64.deb', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-386', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-386.deb', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-amd64', browser_download_url: 'https://linux-amd64' },
+  { name: 'cloudflared-linux-amd64.deb', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-arm', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-arm64', browser_download_url: 'https://linux-arm64' },
+  { name: 'cloudflared-linux-arm64.deb', browser_download_url: 'x' },
+  { name: 'cloudflared-linux-armhf', browser_download_url: 'x' },
+  { name: 'cloudflared-windows-386.exe', browser_download_url: 'x' },
+  { name: 'cloudflared-windows-386.msi', browser_download_url: 'x' },
+  { name: 'cloudflared-windows-amd64.exe', browser_download_url: 'https://windows-amd64.exe' },
+  { name: 'cloudflared-windows-amd64.msi', browser_download_url: 'x' },
+]
+
+test('cloudflaredAssetName: win32/x64 picks the raw exe', () => {
+  assert.equal(cloudflaredAssetName('win32', 'x64'), 'cloudflared-windows-amd64.exe')
+})
+
+test('cloudflaredAssetName: win32/arm64 has no published asset', () => {
+  assert.equal(cloudflaredAssetName('win32', 'arm64'), null)
+})
+
+test('cloudflaredAssetName: linux/x64 and linux/arm64 pick the raw binaries', () => {
+  assert.equal(cloudflaredAssetName('linux', 'x64'), 'cloudflared-linux-amd64')
+  assert.equal(cloudflaredAssetName('linux', 'arm64'), 'cloudflared-linux-arm64')
+})
+
+test('cloudflaredAssetName: darwin picks the .tgz archive for both arches', () => {
+  assert.equal(cloudflaredAssetName('darwin', 'x64'), 'cloudflared-darwin-amd64.tgz')
+  assert.equal(cloudflaredAssetName('darwin', 'arm64'), 'cloudflared-darwin-arm64.tgz')
+})
+
+test('pickCloudflaredAsset: finds the exact-name match in a real release asset list', () => {
+  assert.equal(pickCloudflaredAsset(REAL_ASSETS, 'win32', 'x64')?.name, 'cloudflared-windows-amd64.exe')
+  assert.equal(pickCloudflaredAsset(REAL_ASSETS, 'linux', 'x64')?.name, 'cloudflared-linux-amd64')
+  assert.equal(pickCloudflaredAsset(REAL_ASSETS, 'linux', 'arm64')?.name, 'cloudflared-linux-arm64')
+  assert.equal(pickCloudflaredAsset(REAL_ASSETS, 'darwin', 'arm64')?.name, 'cloudflared-darwin-arm64.tgz')
+})
+
+test('pickCloudflaredAsset: null when the platform/arch has no asset at all', () => {
+  assert.equal(pickCloudflaredAsset(REAL_ASSETS, 'win32', 'arm64'), null)
+})
+
+test('cloudflaredBinName: platform-correct extension, no hardcoded .exe', () => {
+  assert.equal(cloudflaredBinName('win32'), 'cloudflared.exe')
+  assert.equal(cloudflaredBinName('linux'), 'cloudflared')
+  assert.equal(cloudflaredBinName('darwin'), 'cloudflared')
+})

--- a/turbollm/src/tunnel/provision.ts
+++ b/turbollm/src/tunnel/provision.ts
@@ -1,0 +1,119 @@
+// cloudflared provisioning (Cloud Launch, ADR-045/152). cloudflared ships raw
+// executables on Windows/Linux but a .tgz archive on macOS (verified against the
+// live `cloudflare/cloudflared` GitHub release — not a fixed shape across
+// platforms like KoboldCpp), so provisioning branches on that instead of
+// assuming one shape everywhere.
+import { chmodSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { downloadFile, extractArchive, findFile, latestGithubRelease, type ProvisionProgress, type ReleaseAsset } from '../engines/download'
+
+export const CLOUDFLARED_REPO = 'cloudflare/cloudflared'
+
+/** The dir cloudflared is provisioned into (own top-level dir under the data dir —
+ *  it isn't an inference engine, so it doesn't live under engines/). */
+export function cloudflaredDir(dataDir: string): string {
+  return join(dataDir, 'cloudflared')
+}
+
+/** Local filename for the provisioned cloudflared binary. */
+export function cloudflaredBinName(platform = process.platform): string {
+  return platform === 'win32' ? 'cloudflared.exe' : 'cloudflared'
+}
+
+export function cloudflaredBinPath(dataDir: string, platform = process.platform): string {
+  return join(cloudflaredDir(dataDir), cloudflaredBinName(platform))
+}
+
+/** The release asset name for this OS/arch, or null when cloudflared publishes none
+ *  (e.g. Windows arm64). Windows/Linux assets are raw executables; macOS ships a
+ *  .tgz archive (verified against the live release — the one real platform split
+ *  in this repo's otherwise-single-binary tools). */
+export function cloudflaredAssetName(platform = process.platform, archStr = process.arch): string | null {
+  if (platform === 'win32') {
+    return archStr === 'x64' ? 'cloudflared-windows-amd64.exe' : null
+  }
+  if (platform === 'linux') {
+    if (archStr === 'arm64') return 'cloudflared-linux-arm64'
+    if (archStr === 'x64') return 'cloudflared-linux-amd64'
+    return null
+  }
+  if (platform === 'darwin') {
+    return archStr === 'arm64' ? 'cloudflared-darwin-arm64.tgz' : 'cloudflared-darwin-amd64.tgz'
+  }
+  return null
+}
+
+/** Pick the cloudflared asset for this box out of a release's asset list, by exact
+ *  name match against {@link cloudflaredAssetName}. Null when unpublished for this
+ *  OS/arch, or the asset isn't present in this particular release. */
+export function pickCloudflaredAsset(
+  assets: ReleaseAsset[],
+  platform = process.platform,
+  archStr = process.arch,
+): ReleaseAsset | null {
+  const want = cloudflaredAssetName(platform, archStr)
+  if (!want) return null
+  return assets.find((a) => a.name === want) ?? null
+}
+
+export interface CloudflaredRuntime {
+  binPath: string
+  version: string
+}
+
+/**
+ * Provision cloudflared: resolve the latest GitHub release, pick the asset for this
+ * OS/arch, download it, and (macOS) extract the .tgz — or (Windows/Linux) use the
+ * raw executable directly — then (POSIX) mark it executable. Cache-checked: a
+ * prior successful provision is reused as-is.
+ */
+export async function ensureCloudflared(
+  dataDir: string,
+  onProgress?: (p: ProvisionProgress) => void,
+  signal?: AbortSignal,
+): Promise<CloudflaredRuntime> {
+  const dir = cloudflaredDir(dataDir)
+  const binPath = cloudflaredBinPath(dataDir)
+
+  const rel = await latestGithubRelease(CLOUDFLARED_REPO, signal)
+  const version = rel.tag_name ?? ''
+
+  if (existsSync(binPath)) return { binPath, version }
+
+  const asset = pickCloudflaredAsset(rel.assets ?? [])
+  if (!asset) throw new Error('no_release_asset')
+
+  mkdirSync(dir, { recursive: true })
+  onProgress?.({ phase: 'downloading', pct: 0 })
+
+  if (asset.name.endsWith('.tgz')) {
+    // macOS: download the archive to a temp file, extract into the final dir, then
+    // locate the binary inside (extractArchive also strips the quarantine xattr).
+    const tmp = join(dir, asset.name)
+    try {
+      await downloadFile(asset.browser_download_url, tmp, onProgress, signal)
+      onProgress?.({ phase: 'extracting', pct: -1 })
+      await extractArchive(tmp, dir)
+      rmSync(tmp, { force: true })
+    } catch (e) {
+      rmSync(tmp, { force: true })
+      rmSync(dir, { recursive: true, force: true })
+      throw e
+    }
+    const found = findFile(dir, 'cloudflared')
+    if (!found) throw new Error('cloudflared not found in extracted archive')
+    chmodSync(found, 0o755)
+    return { binPath: found, version }
+  }
+
+  // Windows/Linux: raw executable, download straight to the final path.
+  await downloadFile(asset.browser_download_url, binPath, onProgress, signal)
+  if (process.platform !== 'win32') {
+    try {
+      chmodSync(binPath, 0o755)
+    } catch {
+      /* best-effort — a non-executable file fails loudly at spawn instead */
+    }
+  }
+  return { binPath, version }
+}

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -499,6 +499,10 @@ export type DaemonSettings = {
   autoGenerateTitles: boolean
   openBrowserOnStart: boolean
   autoLoadOnStart: boolean
+  /** VRAM to keep free during auto-tune's offload search, MB (300–2048, default 1024). A
+   *  later desktop / ComfyUI VRAM grab can't tip a config tuned with less headroom into a
+   *  sysmem spill. */
+  vramHeadroomMb: number
   /** Expose the API on the local network (spec 08 §2). Changing this requires a
    *  daemon restart to take effect (POST /api/v1/daemon/restart). */
   lanBind: boolean

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -532,6 +532,9 @@ export type DaemonSettings = {
   /** Tool-call approval gate (F-025): per-tool default policy. Missing tools default
    *  to 'ask'. Keyed by tool name (e.g. 'run_code', 'mcp__server__tool'). */
   toolPolicies: Record<string, ToolPolicy>
+  /** Cloud Launch deploy-link settings (ADR-153). The RunPod Template ID the user
+   *  published themselves — not a secret, just an id, echoed back as-is. */
+  cloudDeploy: { runpodTemplateId: string }
 }
 
 /** Tool-call approval gate policy (mirrors turbollm/src/tools/tool-policy.ts). */

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -529,7 +529,13 @@ export type DaemonSettings = {
   /** Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
    *  conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back. */
   build: { toolchainDirs: string[] }
+  /** Tool-call approval gate (F-025): per-tool default policy. Missing tools default
+   *  to 'ask'. Keyed by tool name (e.g. 'run_code', 'mcp__server__tool'). */
+  toolPolicies: Record<string, ToolPolicy>
 }
+
+/** Tool-call approval gate policy (mirrors turbollm/src/tools/tool-policy.ts). */
+export type ToolPolicy = 'ask' | 'allow' | 'deny'
 
 export type SearchProvider = 'tavily' | 'kagi' | 'searxng'
 

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -80,6 +80,28 @@ export function regenerate(convId: string): Promise<{ ok: true }> {
   return req(`/api/v1/conversations/${encodeURIComponent(convId)}/regenerate`, { method: 'POST', json: {} })
 }
 
+// ── Tool-call approval gate ───────────────────────────────────────────────────
+
+/** Respond to a tool call awaiting interactive approval. Throws (via `req`'s
+ *  ApiError convention) on non-2xx — e.g. 404 if the approval already timed out
+ *  or was resolved by another client. */
+export function respondToolApproval(
+  convId: string,
+  toolCallId: string,
+  toolName: string,
+  decision: 'allow' | 'deny' | 'allow_chat' | 'always_allow',
+): Promise<void> {
+  return req(`/api/v1/conversations/${encodeURIComponent(convId)}/tool-calls/${encodeURIComponent(toolCallId)}/approve`, {
+    method: 'POST',
+    json: { toolName, decision },
+  })
+}
+
+/** The tool catalog available to the model, for the Tool Permissions settings UI. */
+export function fetchAvailableTools(): Promise<Array<{ name: string; description: string }>> {
+  return req<{ tools: Array<{ name: string; description: string }> }>('/api/v1/tools').then((r) => r.tools)
+}
+
 /** Streaming send — returns an async generator that yields typed SSE events. */
 export async function* sendMessage(
   convId: string,

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -27,9 +27,12 @@ export interface LiveToolCall {
   id: string
   name: string
   args: Record<string, unknown>
-  status: 'pending' | 'done' | 'error'
+  status: 'pending' | 'done' | 'error' | 'awaiting_approval'
   result?: string
 }
+
+/** Tool-call approval gate policy (mirrors turbollm/src/tools/tool-policy.ts). */
+export type ToolPolicy = 'ask' | 'allow' | 'deny'
 
 /** F-021: a single ranked research result from the retrieval service. */
 export interface ResearchSource {
@@ -106,6 +109,6 @@ export type ChatSseEvent =
   | { event: 'progress';  data: { phase: string; processed: number; total: number; pct: number; tps: number } }
   | { event: 'reasoning'; data: { delta: string } }
   | { event: 'delta';     data: { delta: string } }
-  | { event: 'tool_call'; data: { id: string; name: string; args: Record<string, unknown>; status: 'pending' | 'done' | 'error'; result?: string } }
+  | { event: 'tool_call'; data: { id: string; name: string; args: Record<string, unknown>; status: 'pending' | 'done' | 'error' | 'awaiting_approval'; result?: string } }
   | { event: 'done';      data: { message: Message } }
   | { event: 'error';     data: { code: string; message: string } }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -65,7 +65,6 @@ const TURBOLLM_KNOWLEDGE =
   '- ComfyUI integration: URL of a ComfyUI instance; Reverse GPU gate: TurboLLM calls ComfyUI /free before every model load so VRAM is freed first; update banner when installed ComfyUI node is out of date\n' +
   '- Gateway: auto model-swap toggle + Keep-N pool (1–4 models loaded simultaneously, LRU eviction)\n' +
   '- Auth / API key: gateway key required from clients\n' +
-  '- Cloud Launch: start with `turbollm --tunnel` for a cloudflared quick tunnel that shares this instance over the internet (not a Settings toggle — a launch flag); an access token is auto-provisioned and enforced on all tunneled traffic, local access is unaffected\n' +
   '- Telemetry: Off / Anonymous / Full\n' +
   '- About: current version, update-available chip (`npm i -g turbollm`), copy install command\n\n' +
 

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -21,7 +21,7 @@ const TURBOLLM_KNOWLEDGE =
   '- Set a custom **system prompt** per conversation.\n' +
   '- **Artifacts**: HTML/SVG/Mermaid fenced blocks render as sandboxed live previews (shown as images). Download as PNG/JPEG/SVG/GIF/HTML depending on type.\n' +
   '- **Thinking/reasoning**: models that emit `<think>` blocks get a collapsible fold; visible prose renders normally below.\n' +
-  '- **Tool-call cards**: live inline cards show each tool call (pending → done / error) as it runs.\n' +
+  '- **Tool-call approval gate**: every tool call (web search, fetch URL, run code, MCP tools) asks for approval by default before it runs — an inline bar above the composer offers Deny, Allow, Allow for this chat, or Always Allow. Live cards still show each call\'s status (awaiting approval → pending → done / error). Per-tool defaults (Ask / Allow / Deny) are set globally in Developer → Tool permissions. Background agent runs never see this prompt (no one there to answer it) — a tool the agent is configured to use runs without asking.\n' +
   '- **Web search**: Research persona forces 3–5 `web_search` calls; other personas use it when a search provider key is configured.\n' +
   '- **Export/Import**: export as `.turbollm-chat.json` or OpenAI-format JSON; re-import resumes the conversation. Share button gives a LAN read-only link and a debug snapshot.\n' +
   '- **Attachments** (paperclip): images (vision models), PDFs (real extracted text via pdf.js, not raw bytes), and plain-text/code files (`.txt`/`.md`/`.csv`/`.json`/`.yaml`/`.log` and common source extensions).\n' +
@@ -61,9 +61,11 @@ const TURBOLLM_KNOWLEDGE =
   '- Default context length and default GPU layers: global defaults for new model loads\n' +
   '- Auto-load last model on start: re-loads the last-used model at daemon start\n' +
   '- LAN exposure: bind to 0.0.0.0 (LAN) vs 127.0.0.1 (loopback only)\n' +
+  '- VRAM headroom (Settings → Engine): how much VRAM auto-tune keeps free for other GPU workloads — 300 MB to 2 GB, default 1 GB\n' +
   '- ComfyUI integration: URL of a ComfyUI instance; Reverse GPU gate: TurboLLM calls ComfyUI /free before every model load so VRAM is freed first; update banner when installed ComfyUI node is out of date\n' +
   '- Gateway: auto model-swap toggle + Keep-N pool (1–4 models loaded simultaneously, LRU eviction)\n' +
   '- Auth / API key: gateway key required from clients\n' +
+  '- Cloud Launch: start with `turbollm --tunnel` for a cloudflared quick tunnel that shares this instance over the internet (not a Settings toggle — a launch flag); an access token is auto-provisioned and enforced on all tunneled traffic, local access is unaffected\n' +
   '- Telemetry: Off / Anonymous / Full\n' +
   '- About: current version, update-available chip (`npm i -g turbollm`), copy install command\n\n' +
 
@@ -91,7 +93,7 @@ const TURBOLLM_KNOWLEDGE =
   '## Auto-Tune\n\n' +
   'Auto-tune finds the best GPU-offload config for a model given available VRAM. It runs a binary search, not a fixed candidate list. Triggered from the Model Detail panel.\n\n' +
   '**Phase 1 — KV quant sweep** (VRAM probes, no generation):\n' +
-  'Tests quality-preserving KV cache types from best to smaller: f16 → q8_0 → turbo4 (TurboQuant only) / q4_0. Picks the highest-quality type that fits within a 1 GB VRAM headroom buffer. Lower-quality types (q4_0, q4_1) are never auto-selected — quality floor is enforced.\n\n' +
+  'Tests quality-preserving KV cache types from best to smaller: f16 → q8_0 → turbo4 (TurboQuant only) / q4_0. Picks the highest-quality type that fits within the configured VRAM headroom buffer (Settings → Engine, default 1 GB, adjustable 300 MB–2 GB). Lower-quality types (q4_0, q4_1) are never auto-selected — quality floor is enforced.\n\n' +
   '**Phase 2 — Binary search for GPU offload** (~log₂(blockCount) probes, VRAM-only):\n' +
   '- Dense models: search ngl ∈ [0, blockCount] — finds highest ngl that doesn\'t exceed the VRAM headroom.\n' +
   '- MoE models: search nCpuMoe ∈ [0, nExpertsTotal] — ngl stays maxed, finds minimum nCpuMoe (router experts on CPU) that fits. Reducing nCpuMoe pushes more MoE routing onto the GPU.\n\n' +

--- a/turbollm/web/src/lib/tool-explain.ts
+++ b/turbollm/web/src/lib/tool-explain.ts
@@ -1,0 +1,18 @@
+import { friendlyName } from '../screens/chat/MessageBubble'
+
+/** Short, one-line human-readable summary of what a tool call is about to run.
+ *  Used in the approval bar (and optionally as a tool-call card tooltip). */
+export function describeToolCall(name: string, args: Record<string, unknown>): string {
+  if (name === 'web_search') return `Search the web for "${String(args.query)}"`
+  if (name === 'fetch_url') return `Fetch ${String(args.url)}`
+  if (name === 'run_code') {
+    const code = String(args.code)
+    return `Run JavaScript: ${code.slice(0, 80)}${code.length > 80 ? '…' : ''}`
+  }
+  if (name.startsWith('mcp__')) {
+    const match = name.match(/^mcp__([^_]+(?:_[^_]+)*)__/)
+    const server = match?.[1] ?? 'server'
+    return `Call "${friendlyName(name)}" on ${server}`
+  }
+  return `Run "${name}"`
+}

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -142,6 +142,9 @@ export type Status = {
   comfyui?: ComfyRuntime | null
   telemetryLevel: string
   uptimeSec: number
+  /** Locally-enabled feature flags (TURBOLLM_FEATURES env var) — internal/dev only,
+   *  deliberately undocumented; see turbollm/src/features.ts. */
+  features?: string[]
 }
 
 /** App self-update check (F-006, GET /api/v1/app/update). Is a newer TurboLLM published

--- a/turbollm/web/src/lib/vram.test.ts
+++ b/turbollm/web/src/lib/vram.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { primaryVendorSummary } from './vram'
+
+// Regression test for the Engines-screen fallback bug: before the /recommendation query
+// resolves (or if it errors — that query never retries), the hero used sys.gpus[0] alone,
+// showing one card's VRAM on a multi-GPU box. Mirrors turbollm/src/engines/hardware.test.ts's
+// dual-GPU fixture so the two summaries can never drift apart.
+test('primaryVendorSummary: dual-GPU VRAM is summed, not just gpus[0]', () => {
+  const gpus = [
+    { name: 'NVIDIA GeForce RTX 5060 Ti', vramMb: 16384, vendor: 'nvidia' },
+    { name: 'NVIDIA GeForce RTX 5060 Ti', vramMb: 16384, vendor: 'nvidia' },
+  ]
+  const summary = primaryVendorSummary(gpus)
+  assert.equal(summary.vramMb, 32768, 'two 16GB cards pool to 32GB, not one card\'s 16GB')
+  assert.equal(summary.gpuName, 'NVIDIA GeForce RTX 5060 Ti')
+})
+
+test('primaryVendorSummary: an Intel iGPU alongside an NVIDIA dGPU is excluded from the sum', () => {
+  const gpus = [
+    { name: 'NVIDIA GeForce RTX 4070', vramMb: 12288, vendor: 'nvidia' },
+    { name: 'Intel(R) Iris(R) Xe Graphics', vramMb: 4096, vendor: 'intel' },
+  ]
+  const summary = primaryVendorSummary(gpus)
+  assert.equal(summary.vramMb, 12288, 'the iGPU\'s 4GB must not inflate the usable budget')
+  assert.equal(summary.gpuName, 'NVIDIA GeForce RTX 4070')
+})
+
+test('primaryVendorSummary: no GPUs reports null name and 0 VRAM', () => {
+  const summary = primaryVendorSummary([])
+  assert.equal(summary.gpuName, null)
+  assert.equal(summary.vramMb, 0)
+})

--- a/turbollm/web/src/lib/vram.ts
+++ b/turbollm/web/src/lib/vram.ts
@@ -16,6 +16,25 @@ export function gpuBudgetMb(gpus: SysGpu[], gpu?: LoadProfile['gpu']): number {
   return gpus.reduce((sum, g) => sum + (g.vramMb || 0), 0)
 }
 
+const VENDOR_RANK: Record<string, number> = { nvidia: 4, amd: 3, apple: 3, intel: 2, unknown: 1 }
+
+type VendorGpu = { name: string; vramMb: number; vendor: string }
+
+/** Mirror of the daemon's `detectHardware` primary-vendor VRAM sum (`turbollm/src/engines/
+ *  hardware.ts`) for use as the raw-sysinfo fallback on the Engines screen: before the
+ *  `/recommendation` query resolves (or if it errors, since that query never retries), the
+ *  hero must not regress to a single un-summed card's VRAM on a multi-GPU box. */
+export function primaryVendorSummary(gpus: VendorGpu[]): { gpuName: string | null; vramMb: number } {
+  if (!gpus.length) return { gpuName: null, vramMb: 0 }
+  let vendor = 'unknown'
+  for (const g of gpus) if ((VENDOR_RANK[g.vendor] ?? 1) > (VENDOR_RANK[vendor] ?? 1)) vendor = g.vendor
+  const ofVendor = gpus.filter((g) => g.vendor === vendor)
+  const pool = ofVendor.length ? ofVendor : gpus
+  const headline = pool.reduce<VendorGpu | undefined>((best, g) => (!best || g.vramMb > best.vramMb ? g : best), undefined)
+  const vramMb = ofVendor.reduce((sum, g) => sum + g.vramMb, 0)
+  return { gpuName: headline?.name ?? null, vramMb }
+}
+
 function kvBytesPerElem(t: string): number {
   switch (t) {
     case 'f16': return 2

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -11,6 +11,7 @@ import { Button } from '../components/ui/button'
 import { toast } from '../components/ui/sonner'
 import { useQueryClient } from '@tanstack/react-query'
 import { MessageBubble, StreamingBubble } from './chat/MessageBubble'
+import { ToolApprovalBar } from './chat/ToolApprovalBar'
 import { ContextMeter } from './chat/ContextMeter'
 import { ConversationSidebar } from './chat/ConversationSidebar'
 import { ModelLoadMenu } from '../components/ModelLoadMenu'
@@ -504,6 +505,9 @@ export function ChatScreen() {
 
   const ready = engineState === 'running' && !!model
 
+  // At most one tool call awaits interactive approval at a time (the tool loop is sequential).
+  const pendingApproval = live?.toolCalls.find((tc) => tc.status === 'awaiting_approval')
+
   return (
     <div className="flex h-full overflow-hidden">
       {/* Sidebar (collapsible, drag-resizable when open). The collapse/expand width
@@ -750,6 +754,13 @@ export function ChatScreen() {
               <p className="mt-1 text-[11px] text-faint">Select all and copy (Ctrl+C / Cmd+C)</p>
             </div>
           </div>
+        )}
+
+        {/* Tool-call approval gate (inline banner, not a modal — coexists with reading
+            the transcript). Rendered just above the composer while a background tool
+            call awaits interactive approval. */}
+        {!readonly && activeId && pendingApproval && (
+          <ToolApprovalBar key={pendingApproval.id} pending={pendingApproval} convId={activeId} onResolved={() => {}} />
         )}
 
         {/* Composer area (always visible; disabled when no model; hidden in readonly) */}

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
-import { ChevronRight, Globe, Key, Plus, ShieldCheck, Terminal, Trash2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { ChevronRight, Cloud, ExternalLink, Globe, Key, Plus, Rocket, ShieldCheck, Terminal, Trash2 } from 'lucide-react'
 import { CopyButton } from '../components/ui/copy-button'
 import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
-import { useApiKeys, useSettings } from '../lib/queries'
+import { useApiKeys, useSettings, useStatus } from '../lib/queries'
 import { ApiError, getConnect, type ConnectInfo, type ConnectStep, type ToolPolicy } from '../lib/api'
 import { fetchAvailableTools } from '../lib/chat-api'
 import { friendlyName } from './chat/MessageBubble'
@@ -32,11 +32,19 @@ const CLI_LIST = [
 ]
 
 export function DeveloperScreen() {
+  const { data: status } = useStatus()
+  // Cloud Deploy is behind a local, undocumented feature flag (TURBOLLM_FEATURES=
+  // cloud-deploy) while the RunPod side of it is paused — the tunnel/backend work
+  // is finished and stays shipped, but there's no official RunPod Template yet, so
+  // the button isn't ready for normal users. See turbollm/src/features.ts.
+  const cloudDeployEnabled = !!status?.features?.includes('cloud-deploy')
+
   return (
     <div className="w-full px-6 py-6">
       <ScreenHeader title="Developer" description="Server URLs, API endpoints, keys, and CLI setup." />
       <div className="flex flex-col gap-6">
         <ServerSection />
+        {cloudDeployEnabled && <CloudDeploySection />}
         <ApiKeysSection />
         <ToolPermissionsSection />
         <ApisSection />
@@ -62,6 +70,90 @@ function ServerSection() {
           <CopyButton text={BASE} />
         </div>
       </div>
+    </section>
+  )
+}
+
+// ── Cloud Deploy (ADR-153, RunPod recipe) ──────────────────────────────────────
+
+// The official, maintainer-published RunPod Template (built + pushed to GHCR by
+// .github/workflows/runpod-image.yml, then turned into ONE public RunPod Template by
+// hand — RunPod has no API-less way to automate template creation itself). Empty
+// until that one-time setup is done; users are never expected to publish their own —
+// the Settings field below is an ADVANCED override for people running a custom fork.
+const OFFICIAL_RUNPOD_TEMPLATE_ID = ''
+
+function CloudDeploySection() {
+  const { query: settingsQ, save } = useSettings()
+  const [templateId, setTemplateId] = useState('')
+
+  // Sync the editable draft from the loaded/saved value (same pattern as the other
+  // controlled-input settings fields in SettingsScreen.tsx).
+  useEffect(() => {
+    if (settingsQ.data) setTemplateId(settingsQ.data.cloudDeploy?.runpodTemplateId ?? '')
+  }, [settingsQ.data])
+
+  const savedOverride = (settingsQ.data?.cloudDeploy?.runpodTemplateId ?? '').trim()
+  const dirty = templateId.trim() !== savedOverride
+  // The override (if the user set one) always wins; otherwise fall back to the
+  // official shared template — this is what makes the button work with ZERO setup
+  // for a normal user, unlike the earlier design that required everyone to publish
+  // their own image/template first.
+  const effectiveId = savedOverride || OFFICIAL_RUNPOD_TEMPLATE_ID
+
+  const handleSave = () => {
+    save.mutate(
+      { cloudDeploy: { runpodTemplateId: templateId.trim() } },
+      { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save the template id.') },
+    )
+  }
+
+  const deploy = () => {
+    if (!effectiveId) return
+    window.open(`https://runpod.io/console/deploy?template=${encodeURIComponent(effectiveId)}`, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Cloud size={15} className="text-accent" />
+        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Cloud Deploy</h2>
+      </div>
+      <p className="mb-3 text-[12px] text-muted">
+        Run TurboLLM on a rented GPU box, reachable over the internet via{' '}
+        <code className="font-mono text-[11px] text-ink">--tunnel</code>. RunPod is the only
+        provider for now — click below to deploy the official TurboLLM template, no setup
+        required. Running a custom fork? Paste your own RunPod Template ID to override it
+        (see <code className="font-mono text-[11px] text-ink">deploy/runpod/README.md</code>).
+      </p>
+      <div className="flex gap-2">
+        <input
+          value={templateId}
+          onChange={(e) => setTemplateId(e.target.value)}
+          placeholder={OFFICIAL_RUNPOD_TEMPLATE_ID ? 'Custom Template ID (optional — leave blank for the official one)' : 'Custom Template ID (optional)'}
+          className="flex-1 rounded-md border border-border bg-bg px-2.5 py-1.5 font-mono text-[13px] text-ink outline-none placeholder:text-faint focus:border-[color:var(--accent)]"
+          onKeyDown={(e) => e.key === 'Enter' && dirty && handleSave()}
+        />
+        <Button size="sm" variant="outline" onClick={handleSave} disabled={!dirty || save.isPending}>
+          {save.isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+      <Button
+        className="mt-3 w-full"
+        onClick={deploy}
+        disabled={!effectiveId || dirty}
+        title={
+          !effectiveId
+            ? 'No template configured yet'
+            : dirty
+              ? 'Save your changes first'
+              : `Opens RunPod's console in a new tab${savedOverride ? ' (using your custom template)' : ''}`
+        }
+      >
+        <Rocket size={14} />
+        Deploy on RunPod
+        <ExternalLink size={12} />
+      </Button>
     </section>
   )
 }
@@ -165,7 +257,7 @@ const POLICY_OPTIONS: { value: ToolPolicy; label: string }[] = [
 ]
 
 function ToolPermissionsSection() {
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(false)
   const toolsQ = useQuery({ queryKey: ['available-tools'], queryFn: fetchAvailableTools })
   const { query: settingsQ, save } = useSettings()
   const tools = toolsQ.data ?? []

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -1,11 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
-import { Globe, Key, Plus, Terminal, Trash2 } from 'lucide-react'
+import { ChevronRight, Globe, Key, Plus, ShieldCheck, Terminal, Trash2 } from 'lucide-react'
 import { CopyButton } from '../components/ui/copy-button'
 import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
-import { useApiKeys } from '../lib/queries'
-import { ApiError, getConnect, type ConnectInfo, type ConnectStep } from '../lib/api'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
+import { useApiKeys, useSettings } from '../lib/queries'
+import { ApiError, getConnect, type ConnectInfo, type ConnectStep, type ToolPolicy } from '../lib/api'
+import { fetchAvailableTools } from '../lib/chat-api'
+import { friendlyName } from './chat/MessageBubble'
 import { toast } from '../components/ui/sonner'
+import { cn } from '../lib/utils'
 
 const BASE = window.location.origin
 
@@ -33,6 +38,7 @@ export function DeveloperScreen() {
       <div className="flex flex-col gap-6">
         <ServerSection />
         <ApiKeysSection />
+        <ToolPermissionsSection />
         <ApisSection />
         <ConnectSection />
       </div>
@@ -147,6 +153,85 @@ function ApiKeysSection() {
         </Button>
       </div>
     </section>
+  )
+}
+
+// ── Tool permissions (F-025 approval gate) ───────────────────────────────────
+
+const POLICY_OPTIONS: { value: ToolPolicy; label: string }[] = [
+  { value: 'ask',   label: 'Ask' },
+  { value: 'allow', label: 'Allow' },
+  { value: 'deny',  label: 'Deny' },
+]
+
+function ToolPermissionsSection() {
+  const [open, setOpen] = useState(true)
+  const toolsQ = useQuery({ queryKey: ['available-tools'], queryFn: fetchAvailableTools })
+  const { query: settingsQ, save } = useSettings()
+  const tools = toolsQ.data ?? []
+  const policies = settingsQ.data?.toolPolicies ?? {}
+
+  const setPolicy = (name: string, value: ToolPolicy) => {
+    save.mutate(
+      { toolPolicies: { ...policies, [name]: value } },
+      { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update tool permission.') },
+    )
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-panel p-4">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+        <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
+        <ShieldCheck size={15} className="text-accent" />
+        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Tool permissions</h2>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <p className="mb-3 mt-3 text-[12px] text-muted">
+          Control whether each tool the model can call runs automatically, is always blocked, or asks
+          for your approval in chat each time.
+        </p>
+
+        {toolsQ.isLoading && <p className="text-[13px] text-faint">Loading tools…</p>}
+        {!toolsQ.isLoading && tools.length === 0 && (
+          <p className="text-[13px] text-faint">No tools available.</p>
+        )}
+
+        {tools.length > 0 && (
+          <div className="divide-y divide-border rounded-md border border-border">
+            {tools.map((t) => {
+              const current = policies[t.name] ?? 'ask'
+              return (
+                <div key={t.name} className="flex items-center justify-between gap-3 px-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="font-mono text-[13px] font-medium text-ink">{friendlyName(t.name)}</div>
+                    {t.description && (
+                      <div className="truncate text-[11px] text-faint" title={t.description}>{t.description}</div>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 overflow-hidden rounded-lg border border-border">
+                    {POLICY_OPTIONS.map(({ value, label }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => setPolicy(t.name, value)}
+                        disabled={save.isPending}
+                        className="px-3 py-1.5 text-[12px] transition-colors disabled:opacity-60"
+                        style={{
+                          background: current === value ? 'var(--accent)' : 'transparent',
+                          color: current === value ? 'var(--on-accent)' : 'var(--muted)',
+                        }}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -26,6 +26,7 @@ import {
   useUpdatePolicyMutation,
 } from '../lib/queries'
 import { ApiError } from '../lib/api'
+import { primaryVendorSummary } from '../lib/vram'
 import type {
   CatalogEngine,
   Engine,
@@ -217,10 +218,14 @@ function StatusHero({
   const upd = activeEngine ? updates?.updates[activeEngine.id] : undefined
   const showRebuildChip = !!upd?.rebuild && !!upd?.hasUpdate && !!activeEngine?.sourceRepo
 
-  // Hardware line — prefer the recommendation's hardware, fall back to sysinfo.
+  // Hardware line — prefer the recommendation's hardware (already primary-vendor-summed
+  // across all GPUs); before it resolves (or if it errors — that query never retries),
+  // fall back to the same sum computed from raw sysinfo, NOT sys.gpus[0]. A single card's
+  // number here is exactly the multi-GPU bug users have reported ("shows 8gb, only 1 GPU").
   const hw = rec?.hardware
-  const gpuName = hw?.gpuName ?? sys?.gpus[0]?.name ?? null
-  const vramMb = hw?.vramMb ?? sys?.gpus[0]?.vramMb ?? 0
+  const sysFallback = primaryVendorSummary(sys?.gpus ?? [])
+  const gpuName = hw?.gpuName ?? sysFallback.gpuName
+  const vramMb = hw?.vramMb ?? sysFallback.vramMb
   const osName = hw ? platformName(hw.platform) : sys?.os.split('/')[0] ? platformName(sys.os.split('/')[0]) : ''
   const hwLine = [
     gpuName ?? 'CPU-only',

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -101,6 +101,23 @@ function NumberField({
 
 const clampN = (n: number, min: number, max: number) => Math.max(min, Math.min(max, Math.round(n)))
 
+/** A labeled range slider with a live formatted value (mirrors the per-model Slider in
+ *  ModelDetailDialog.tsx). */
+function Slider({ label, hint, value, min, max, step, onChange, fmt }: {
+  label: string; hint?: string; value: number; min: number; max: number; step: number; onChange: (v: number) => void; fmt?: (v: number) => string
+}) {
+  return (
+    <div className="py-2">
+      <div className="mb-1 flex items-baseline justify-between">
+        <span className="text-[14px] font-medium text-ink">{label}</span>
+        <span className="font-mono text-[12px] text-muted">{fmt ? fmt(value) : value}</span>
+      </div>
+      {hint && <div className="mb-1.5 text-[12px] text-muted">{hint}</div>}
+      <input type="range" min={min} max={max} step={step} value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full accent-[var(--accent)]" />
+    </div>
+  )
+}
+
 export function SettingsScreen() {
   const { theme, setTheme } = useUiStore()
   const { query: settingsQ, save } = useSettings()
@@ -111,6 +128,7 @@ export function SettingsScreen() {
   const primaryModelDir = modelDirsQ.data?.primaryDir ?? ''
 
   const [ttl, setTtl] = useState<number>(60)
+  const [vramHeadroom, setVramHeadroom] = useState<number>(1024)
   const [port, setPort] = useState<number>(6996)
   const [autoTitle, setAutoTitle] = useState(true)
   const [openBrowser, setOpenBrowser] = useState(true)
@@ -138,6 +156,7 @@ export function SettingsScreen() {
   useEffect(() => {
     if (settings) {
       setTtl(settings.idleTtlMinutes)
+      setVramHeadroom(settings.vramHeadroomMb ?? 1024)
       setPort(settings.port ?? 6996)
       setAutoTitle(settings.autoGenerateTitles)
       setOpenBrowser(settings.openBrowserOnStart)
@@ -171,6 +190,7 @@ export function SettingsScreen() {
     // Clamp defensively: NumberField commits unclamped while editing and only
     // snaps to range on blur, so guard the final ranges here too (spec 08 §2).
     idleTtlMinutes: clampN(ttl, 0, 1440),
+    vramHeadroomMb: clampN(vramHeadroom, 300, 2048),
     port: clampN(port, 1024, 65535),
     autoGenerateTitles: autoTitle,
     openBrowserOnStart: openBrowser,
@@ -308,6 +328,19 @@ export function SettingsScreen() {
               />
               <span className="text-[12px] text-muted">min</span>
             </div>
+          </div>
+
+          <div className="border-t border-border pt-1">
+            <Slider
+              label="VRAM headroom"
+              hint="VRAM to keep free during auto-tune, so a later app switch or render job doesn't spill the model into slower shared memory"
+              value={vramHeadroom}
+              min={300}
+              max={2048}
+              step={1}
+              onChange={setVramHeadroom}
+              fmt={(v) => (v >= 1024 ? `${(v / 1024).toFixed(1)} GB` : `${v} MB`)}
+            />
           </div>
         </section>
 

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useRef, useState, type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
-import { CheckCircle2, ChevronDown, ChevronRight, FileText, Loader2, Pencil, RefreshCw, Trash2, XCircle } from 'lucide-react'
+import { CheckCircle2, ChevronDown, ChevronRight, FileText, HelpCircle, Loader2, Pencil, RefreshCw, Trash2, XCircle } from 'lucide-react'
 import type { ClaimVerdict, LiveToolCall, Message, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from '../../lib/chat-types'
 import { Button } from '../../components/ui/button'
 import { CopyButton } from '../../components/ui/copy-button'
@@ -161,9 +161,9 @@ const Markdown = memo(function Markdown({ children, streaming }: { children: str
 
 // ── Tool call cards ───────────────────────────────────────────────────────────
 
-type CardCall = { id: string; name: string; status: 'pending' | 'done' | 'error'; result?: string }
+type CardCall = { id: string; name: string; status: 'pending' | 'done' | 'error' | 'awaiting_approval'; result?: string }
 
-function friendlyName(name: string): string {
+export function friendlyName(name: string): string {
   if (name.startsWith('mcp__')) return name.replace(/^mcp__[^_]+(?:_[^_]+)*__/, '')
   return name.replace(/_/g, ' ')
 }
@@ -171,21 +171,26 @@ function friendlyName(name: string): string {
 function ToolCallCard({ call }: { call: CardCall }) {
   const [expanded, setExpanded] = useState(false)
   const hasOutput = !!(call.result?.length)
+  const awaitingApproval = call.status === 'awaiting_approval'
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border bg-panel-2">
+    <div
+      className="overflow-hidden rounded-lg border bg-panel-2"
+      style={awaitingApproval ? { borderColor: 'var(--warn,#ca8a04)', background: 'color-mix(in srgb, var(--warn,#ca8a04) 6%, transparent)' } : { borderColor: 'var(--border)' }}
+    >
       <button
         type="button"
         onClick={() => hasOutput && setExpanded((e) => !e)}
         className="flex w-full items-center gap-2 px-3 py-1.5 text-left"
         style={{ cursor: hasOutput ? 'pointer' : 'default' }}
       >
-        {call.status === 'pending' && <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
-        {call.status === 'done'    && <CheckCircle2 size={12} className="shrink-0" style={{ color: '#4ade80' }} />}
-        {call.status === 'error'   && <XCircle size={12} className="shrink-0" style={{ color: 'var(--err)' }} />}
+        {call.status === 'pending'            && <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
+        {call.status === 'done'               && <CheckCircle2 size={12} className="shrink-0" style={{ color: '#4ade80' }} />}
+        {call.status === 'error'              && <XCircle size={12} className="shrink-0" style={{ color: 'var(--err)' }} />}
+        {call.status === 'awaiting_approval'  && <HelpCircle size={12} className="shrink-0" style={{ color: 'var(--warn,#ca8a04)' }} />}
         <span className="font-mono text-[12px] font-medium text-ink">{friendlyName(call.name)}</span>
         <span className="text-[11px] text-faint">
-          {call.status === 'pending' ? 'running…' : call.status === 'error' ? 'error' : 'done'}
+          {call.status === 'pending' ? 'running…' : call.status === 'error' ? 'error' : call.status === 'awaiting_approval' ? 'waiting on you' : 'done'}
         </span>
         {hasOutput && (
           <ChevronDown

--- a/turbollm/web/src/screens/chat/ToolApprovalBar.tsx
+++ b/turbollm/web/src/screens/chat/ToolApprovalBar.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { respondToolApproval } from '../../lib/chat-api'
+import { describeToolCall } from '../../lib/tool-explain'
+import { friendlyName } from './MessageBubble'
+import { Button } from '../../components/ui/button'
+import { toast } from '../../components/ui/sonner'
+import { ApiError } from '../../lib/api'
+import type { LiveToolCall } from '../../lib/chat-types'
+
+type Decision = 'allow' | 'deny' | 'allow_chat' | 'always_allow'
+
+/** Inline banner (not a modal) shown just above the composer while a tool call is
+ *  waiting on interactive approval. Reuses the bordered/tinted-background banner
+ *  visual language already used elsewhere in ChatScreen.tsx (e.g. the model-mismatch
+ *  banner). Sits in normal document flow so the transcript remains readable. */
+export function ToolApprovalBar({
+  pending,
+  convId,
+  onResolved,
+}: {
+  pending: LiveToolCall
+  convId: string
+  onResolved: () => void
+}) {
+  const [submitting, setSubmitting] = useState(false)
+  // Hidden the instant a button is clicked, rather than waiting ~1s for the SSE
+  // round-trip to move the tool call off 'awaiting_approval' — that lag read as the
+  // UI "blinking" / being unresponsive. Reappears only if the request itself failed,
+  // so a genuine failure doesn't strand the user with no way to retry.
+  const [dismissed, setDismissed] = useState(false)
+
+  const respond = async (decision: Decision) => {
+    if (submitting) return
+    setDismissed(true)
+    setSubmitting(true)
+    try {
+      await respondToolApproval(convId, pending.id, pending.name, decision)
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : 'Could not send your decision — please try again.')
+      setDismissed(false)
+    } finally {
+      setSubmitting(false)
+      onResolved()
+    }
+  }
+
+  if (dismissed) return null
+
+  return (
+    <div className="mx-8 mb-3 rounded-md border border-[color:var(--warn,#ca8a04)] bg-[color-mix(in_srgb,var(--warn,#ca8a04)_8%,transparent)] px-3 py-2.5 text-[13px]">
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className="font-medium text-ink">Tool call needs your approval:</span>
+        <span className="font-mono text-[12px] text-ink">{friendlyName(pending.name)}</span>
+      </div>
+      <p className="mt-0.5 text-[12px] text-muted">{describeToolCall(pending.name, pending.args)}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <Button size="sm" variant="outline" disabled={submitting} onClick={() => void respond('deny')}>
+          Deny
+        </Button>
+        <Button size="sm" disabled={submitting} onClick={() => void respond('allow')}>
+          Allow
+        </Button>
+        <Button size="sm" variant="outline" disabled={submitting} onClick={() => void respond('allow_chat')}>
+          Allow for this chat
+        </Button>
+        <Button size="sm" variant="outline" disabled={submitting} onClick={() => void respond('always_allow')}>
+          Always Allow
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
+++ b/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
@@ -24,6 +24,16 @@ import {
 } from '../../components/ui/dialog'
 import { AddEngineDialog } from './AddEngineDialog'
 
+// Mirrors build-prereqs.ts's CMAKE_CONFIGURE_ARGS / CUDA_RUNTIME_DLL_PREFIXES /
+// CUDA_RUNTIME_SO_PREFIXES — kept in lockstep by hand (the web bundle can't import Node
+// backend code). `-allow-unsupported-compiler` works around nvcc's hardcoded host-compiler
+// allowlist (a new VS/GCC release routinely ships before NVIDIA updates it); the runtime
+// DLLs/libs aren't bundled by the build itself, so without copying them the produced engine
+// silently falls back to CPU.
+const CMAKE_CONFIGURE_ARGS = ['-DGGML_CUDA=ON', '-DCMAKE_BUILD_TYPE=Release', '-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler']
+const CUDA_RUNTIME_DLL_PREFIXES = ['cudart64_', 'cublas64_', 'cublaslt64_', 'nvrtc64_', 'nvrtc-builtins64_', 'nvjitlink_']
+const CUDA_RUNTIME_SO_PREFIXES = ['libcudart.so', 'libcublas.so', 'libcublasLt.so', 'libnvrtc.so', 'libnvrtc-builtins.so', 'libnvJitLink.so']
+
 /** The exact build command list for a repo on `os` (mirrors the backend's PURE
  *  `buildCommands` in src/engines/build-prereqs.ts — kept in lockstep so the manual path
  *  matches what the 1-click build runs). */
@@ -32,21 +42,31 @@ function buildCommands(repoUrl: string, branch: string | undefined, os: 'windows
   const clone = b
     ? `git clone --branch ${b} --depth 1 ${repoUrl} turbo-build`
     : `git clone --depth 1 ${repoUrl} turbo-build`
+  const configure = `cmake -B build ${CMAKE_CONFIGURE_ARGS.join(' ')}`
   if (os === 'linux') {
+    const libGlobs = ['lib64', 'lib', 'targets/x86_64-linux/lib']
+      .flatMap((dir) => CUDA_RUNTIME_SO_PREFIXES.map((p) => `$CUDA_ROOT/${dir}/${p}*`))
+      .join(' ')
     return [
       clone,
       'cd turbo-build',
-      'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+      configure,
       'cmake --build build -j --target llama-server',
-      '# Built binary: build/bin/llama-server — add it via "Add your own engine".',
+      'CUDA_ROOT="$(dirname "$(dirname "$(command -v nvcc)")")"',
+      `cp ${libGlobs} build/bin/ 2>/dev/null`,
+      '# Built binary + its CUDA runtime libs: build/bin/llama-server — add it via "Add your own engine".',
     ]
   }
+  const dllGlobs = ['bin', 'bin\\x64']
+    .flatMap((dir) => CUDA_RUNTIME_DLL_PREFIXES.map((p) => `"%CUDA_PATH%\\${dir}\\${p}*.dll"`))
+    .join(' ')
   return [
     clone,
     'cd turbo-build',
-    'cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release',
+    configure,
     'cmake --build build --config Release -j --target llama-server',
-    '# Built binary: build\\bin\\Release\\llama-server.exe — add it via "Add your own engine".',
+    `for %f in (${dllGlobs}) do copy /y "%f" "build\\bin\\Release\\" >nul 2>&1`,
+    '# Built binary + its CUDA runtime DLLs: build\\bin\\Release\\llama-server.exe — add it via "Add your own engine".',
   ]
 }
 


### PR DESCRIPTION
## Summary
- Configurable VRAM headroom slider for auto-tune (300-2048 MB, Settings -> Engine)
- Cloud Launch: `turbollm --tunnel` (cloudflared quick tunnel + auto-provisioned token) + dual-GPU display fix on the Engines screen; RunPod one-click GUI built but paused behind an undocumented feature flag
- Real tool-call approval gate for chat (Deny/Allow/Allow-for-chat/Always-Allow), replacing the dead run_code-only confirmation
- Source builds now bundle the CUDA runtime and allow newer host compilers (VS2026) via nvcc's -allow-unsupported-compiler
- Fix: opencode connect snippet uses the correct singular `provider` config key

## Test plan
- [ ] Opus code review pass
- [ ] Existing unit test suite green
- [ ] Manual smoke: VRAM headroom slider round-trip, --tunnel launch, tool-call approval bar