### PR TITLE
fix(readme): correct npm package size claim (~0.3MB -> ~2MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ TurboLLM does the opposite:
   a **VRAM-fit verdict before you load** — no more flag guessing.
 - **📊 Real tokens/sec, never faked.** Speed in the model list is *measured on your machine*
   from actual generation — live while you chat, and remembered per model.
-- **🪶 Lightweight.** A ~0.3 MB npm package on Node — **no Electron, no bundled Chromium, no
+- **🪶 Lightweight.** A ~2 MB npm package on Node — **no Electron, no bundled Chromium, no
   Python**. It downloads only the engine your GPU actually needs (Vulkan ≈ 38 MB).
 - **🔌 Drop-in APIs.** OpenAI **and** Anthropic-compatible — so Claude Code and every existing
   tool work unchanged.
@@ -289,7 +289,7 @@ connected); **Remove** undoes it.
 
 <br/>
 
-- A **~0.3 MB npm package** on Node — no Electron, no bundled Chromium, no Python.
+- A **~2 MB npm package** on Node — no Electron, no bundled Chromium, no Python.
 - **Offline-first** — no account, no backend, no internet, no telemetry.
 - **Windows · macOS · Linux**, with a CPU fallback when there's no GPU.
 

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -79,7 +79,7 @@ TurboLLM does the opposite:
   a **VRAM-fit verdict before you load** — no more flag guessing.
 - **📊 Real tokens/sec, never faked.** Speed in the model list is *measured on your machine*
   from actual generation — live while you chat, and remembered per model.
-- **🪶 Lightweight.** A ~0.3 MB npm package on Node — **no Electron, no bundled Chromium, no
+- **🪶 Lightweight.** A ~2 MB npm package on Node — **no Electron, no bundled Chromium, no
   Python**. It downloads only the engine your GPU actually needs (Vulkan ≈ 38 MB).
 - **🔌 Drop-in APIs.** OpenAI **and** Anthropic-compatible — so Claude Code and every existing
   tool work unchanged.
@@ -289,7 +289,7 @@ connected); **Remove** undoes it.
 
 <br/>
 
-- A **~0.3 MB npm package** on Node — no Electron, no bundled Chromium, no Python.
+- A **~2 MB npm package** on Node — no Electron, no bundled Chromium, no Python.
 - **Offline-first** — no account, no backend, no internet, no telemetry.
 - **Windows · macOS · Linux**, with a CPU fallback when there's no GPU.
 


### PR DESCRIPTION
## Summary
- README.md and turbollm/README.md both claimed a ~0.3 MB npm package size, stale since the webdist bundle grew.
- Verified actual size via `npm pack --dry-run` against the live v1.7.0 tarball: 2.0 MB packed / 7.0 MB unpacked.
- Same fix already applied to docs/site (private docs repo, already deployed to turbollm.dev).

## Test plan
- [x] Verified 2.0 MB figure against `npm pack --dry-run` output for v1.7.0
- [x] Confirmed both README copies (root + turbollm/) stay in sync per the existing mirror convention