### PR TITLE
v1.8.0 — launch command improvements

### DIFF
--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -370,12 +370,20 @@ turbollm launch claude               # auto-loads a model if none is running, th
 turbollm launch claude --model qwen3-8b   # load a specific model first, then launch
 ```
 
-It sets Claude Code's `ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` at TurboLLM and execs `claude`;
-extra args are forwarded. If no model is loaded it auto-loads your last-used one (or the first
-in your library); `--model` picks a specific one by key or name. If `claude` isn't installed,
-it tells you how. The in-app
-**Developer** screen also shows copy-paste env snippets for any OpenAI- or Anthropic-compatible
-tool (Open WebUI, Kilo Code, opencode, …).
+It sets Claude Code's `ANTHROPIC_BASE_URL` and pins `ANTHROPIC_MODEL` to whatever model is
+loaded (so the status line, `/status`, and context-window sizing all reflect the real model),
+then execs `claude`; extra args are forwarded. If no model is loaded it auto-loads your
+last-used one (or the first in your library); `--model` picks a specific one by key or name.
+If `claude` isn't installed, it tells you how.
+
+Other coding CLIs work too — `turbollm launch opencode`, `turbollm launch kilo`, and
+`turbollm launch openclaw` write a `turbollm` provider into that tool's own config file
+(preserving anything you already configured) and then launch it. If an existing config can't
+be parsed, TurboLLM refuses to overwrite it and prints how to add the provider by hand.
+`turbollm launch hermes` does the equivalent for [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+via its own `hermes config set` command (its config is YAML, so we drive its CLI instead of
+hand-editing that file). The in-app **Developer** screen also shows copy-paste snippets for
+any OpenAI- or Anthropic-compatible tool (Open WebUI, Kilo Code, opencode, …).
 
 ---
 
@@ -402,6 +410,7 @@ turbollm --addr 0.0.0.0:6996    # bind all interfaces (LAN sharing)
 turbollm --stop                 # stop a running daemon (any terminal)
 turbollm launch claude          # start Claude Code (auto-loads a model if none is running)
 turbollm launch claude --model qwen3-8b   # load a specific model, then launch
+turbollm launch opencode        # wire opencode (or kilo / openclaw) to TurboLLM, then launch
 ```
 
 | Flag | Description |
@@ -415,7 +424,9 @@ turbollm launch claude --model qwen3-8b   # load a specific model, then launch
 
 `turbollm launch claude` also accepts `--model <key|name>` to load a specific model before
 launching; without it, an already-loaded model is used, or the last-used / first model is
-auto-loaded.
+auto-loaded. The same command works with `opencode`, `kilo`, and `openclaw` — each gets a
+`turbollm` provider merged into its own config file before it starts — and with `hermes`,
+which gets configured via its own `hermes config set` command instead.
 
 ---
 

--- a/turbollm/src/cli-launch.config.test.ts
+++ b/turbollm/src/cli-launch.config.test.ts
@@ -1,0 +1,220 @@
+// Part C: prepareConfig merge for config-file launch targets (opencode / kilo / openclaw),
+// plus hermes's CLI-driven config (its config is YAML, so it's driven via `hermes config
+// set` rather than parsed/written directly). All tests use an in-memory ConfigFs / fake
+// RunCommand so neither the real filesystem nor a real hermes process is ever touched
+// (mirrors the _spawn/_fetch injection pattern used by the other cli-launch tests).
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { prepareOpencode, prepareKilo, prepareOpenclaw, prepareHermes, realRunCommand, type ConfigFs, type RunCommand } from './cli-launch.js'
+
+const HOME = '/home/tester'
+// Config paths are built with path.join, so they use the host's separator (backslash on
+// Windows). Compute expected paths the same way so the tests are cross-platform.
+const opencodePath = join(HOME, '.config', 'opencode', 'opencode.json')
+const kiloPath = join(HOME, '.config', 'kilo', 'kilo.jsonc')
+const openclawPath = join(HOME, '.config', 'openclaw', 'openclaw.json')
+
+/** In-memory ConfigFs seeded with any pre-existing files. Records writes + mkdirs. */
+function memFs(seed: Record<string, string> = {}): ConfigFs & { files: Map<string, string>; mkdirs: string[] } {
+  const files = new Map<string, string>(Object.entries(seed))
+  const mkdirs: string[] = []
+  return {
+    files,
+    mkdirs,
+    home: HOME,
+    readFile: async (p: string) => {
+      if (!files.has(p)) throw new Error('ENOENT')
+      return files.get(p)!
+    },
+    writeFile: async (p: string, data: string) => { files.set(p, data) },
+    mkdir: async (p: string) => { mkdirs.push(p) },
+  }
+}
+
+const BASE = 'http://127.0.0.1:6996'
+const TOKEN = 'turbollm-local'
+
+// ── opencode ────────────────────────────────────────────────────────────────────
+
+test('prepareOpencode: writes a turbollm provider on a fresh (absent) config', async () => {
+  const fs = memFs()
+  const res = await prepareOpencode(BASE, TOKEN, 'qwen3-8b', 'Qwen3 8B', fs)
+  assert.deepEqual(res, { ok: true })
+
+  const cfg = JSON.parse(fs.files.get(opencodePath)!)
+  assert.deepEqual(cfg.provider.turbollm, {
+    npm: '@ai-sdk/openai-compatible',
+    options: { baseURL: `${BASE}/v1`, apiKey: TOKEN },
+    models: { 'Qwen3 8B': { id: 'Qwen3 8B' } },
+  })
+})
+
+test('prepareOpencode: preserves sibling providers already in the config', async () => {
+  const fs = memFs({
+    [opencodePath]: JSON.stringify({ provider: { openai: { npm: 'x', options: {} } }, model: 'openai/gpt' }),
+  })
+  const res = await prepareOpencode(BASE, TOKEN, 'k', 'M', fs)
+  assert.deepEqual(res, { ok: true })
+
+  const cfg = JSON.parse(fs.files.get(opencodePath)!)
+  assert.ok(cfg.provider.openai, 'existing sibling provider must be preserved')
+  assert.ok(cfg.provider.turbollm, 'turbollm provider added')
+  assert.equal(cfg.model, 'openai/gpt', 'unrelated top-level keys untouched')
+})
+
+test('prepareOpencode: refuses to overwrite an unparseable config', async () => {
+  const original = '{ this is not valid json, // with a comment\n}'
+  const fs = memFs({ [opencodePath]: original })
+  const res = await prepareOpencode(BASE, TOKEN, 'k', 'M', fs)
+  assert.equal(res.ok, false)
+  assert.match((res as { message: string }).message, /doesn't parse/)
+  assert.equal(fs.files.get(opencodePath), original, 'the corrupt file must be left exactly as-is')
+})
+
+test('prepareOpencode: refuses (not throws) when an existing key is not an object', async () => {
+  // Valid JSON, but `provider` is a string — merging into it would otherwise throw
+  // (assigning a property to a primitive in strict mode) instead of failing safely.
+  const original = JSON.stringify({ provider: 'not-an-object' })
+  const fs = memFs({ [opencodePath]: original })
+  const res = await prepareOpencode(BASE, TOKEN, 'k', 'M', fs)
+  assert.equal(res.ok, false)
+  assert.equal(fs.files.get(opencodePath), original, 'the unusual file must be left exactly as-is')
+})
+
+test('prepareOpencode: a commented config already pointed at us succeeds WITHOUT rewriting it', async () => {
+  // Comments alone must not block the merge when there's nothing left to do — and the
+  // file must never be touched (rewriting would delete the user's comments).
+  const original =
+    '{\n  // hand-written\n  "provider": { "turbollm": { "options": { "baseURL": "' + BASE + '/v1" } } }\n}'
+  const fs = memFs({ [opencodePath]: original })
+  const res = await prepareOpencode(BASE, TOKEN, 'k', 'M', fs)
+  assert.deepEqual(res, { ok: true })
+  assert.equal(fs.files.get(opencodePath), original, 'already-correct commented file must be left byte-for-byte untouched')
+})
+
+test('prepareOpencode: a commented config NOT yet pointed at us fails without touching it', async () => {
+  const original = '{\n  // hand-written, no turbollm entry yet\n  "provider": { "openai": {} }\n}'
+  const fs = memFs({ [opencodePath]: original })
+  const res = await prepareOpencode(BASE, TOKEN, 'k', 'M', fs)
+  assert.equal(res.ok, false)
+  assert.match((res as { message: string }).message, /comments/)
+  assert.equal(fs.files.get(opencodePath), original, 'must not rewrite a commented file even on failure')
+})
+
+// ── kilo (verified against the live @kilocode/cli install) ────────────────────────
+
+test('prepareKilo: writes opencode-shaped provider + a default model string', async () => {
+  const fs = memFs()
+  const res = await prepareKilo(BASE, TOKEN, 'qwen3-8b', 'Qwen3 8B', fs)
+  assert.deepEqual(res, { ok: true })
+
+  const cfg = JSON.parse(fs.files.get(kiloPath)!)
+  // kilo rejects an array-form `models` (empirically: "Expected object") — must be an object map.
+  assert.deepEqual(cfg.provider.turbollm.models, { 'Qwen3 8B': { id: 'Qwen3 8B' } })
+  assert.equal(cfg.provider.turbollm.npm, '@ai-sdk/openai-compatible')
+  assert.equal(cfg.model, 'turbollm/Qwen3 8B', 'default model is provider/mapKey')
+})
+
+test('prepareKilo: a real-shaped kilo.jsonc (comments, already wired to us) succeeds without rewriting', async () => {
+  // Mirrors the ACTUAL kilo.jsonc found on a live install: section-divider comments, a
+  // baseURL pointed at our own gateway, and a URL value containing "//" inside a string
+  // (must not be mistaken for the start of a line comment).
+  const original =
+    '{\n' +
+    '  // ── Qwen3.6 35B-A3B ──\n' +
+    '  "provider": { "turbollm": { "options": { "baseURL": "' + BASE + '/v1" }, "models": {} } }\n' +
+    '}'
+  const fs = memFs({ [kiloPath]: original })
+  const res = await prepareKilo(BASE, TOKEN, 'k', 'M', fs)
+  assert.deepEqual(res, { ok: true })
+  assert.equal(fs.files.get(kiloPath), original, 'the real hand-curated file must never be rewritten')
+})
+
+test('prepareKilo: refuses corrupt (unparseable even after stripping comments) configs', async () => {
+  // Comments AND a trailing comma — still broken JSON even leniently, must not clobber.
+  const fs = memFs({ [kiloPath]: '{ "model": "x", // comment\n }' })
+  const res = await prepareKilo(BASE, TOKEN, 'k', 'M', fs)
+  assert.equal(res.ok, false)
+  assert.match((res as { message: string }).message, /Kilo Code/)
+})
+
+// ── openclaw ──────────────────────────────────────────────────────────────────────
+
+test('prepareOpenclaw: writes the provider under models.providers + a default primary', async () => {
+  const fs = memFs()
+  const res = await prepareOpenclaw(BASE, TOKEN, 'qwen3-8b', 'Qwen3 8B', fs)
+  assert.deepEqual(res, { ok: true })
+
+  const cfg = JSON.parse(fs.files.get(openclawPath)!)
+  assert.deepEqual(cfg.models.providers.turbollm, {
+    baseUrl: `${BASE}/v1`,
+    apiKey: TOKEN,
+    api: 'openai-completions',
+    models: [{ id: 'qwen3-8b', name: 'Qwen3 8B' }],
+  })
+  assert.deepEqual(cfg.agents.defaults.model, { primary: 'turbollm/qwen3-8b' })
+})
+
+test('prepareOpenclaw: preserves sibling providers and refuses corrupt configs', async () => {
+  const fs = memFs({
+    [openclawPath]: JSON.stringify({ models: { providers: { other: { baseUrl: 'y' } } } }),
+  })
+  const res = await prepareOpenclaw(BASE, TOKEN, 'k', 'M', fs)
+  assert.deepEqual(res, { ok: true })
+  const cfg = JSON.parse(fs.files.get(openclawPath)!)
+  assert.ok(cfg.models.providers.other, 'sibling provider preserved')
+  assert.ok(cfg.models.providers.turbollm, 'turbollm provider added')
+
+  const fs2 = memFs({ [openclawPath]: 'not json at all {' })
+  const res2 = await prepareOpenclaw(BASE, TOKEN, 'k', 'M', fs2)
+  assert.equal(res2.ok, false)
+})
+
+test('prepareOpenclaw: refuses (not throws) when models/agents is not an object', async () => {
+  const original = JSON.stringify({ models: 'not-an-object', agents: [] })
+  const fs = memFs({ [openclawPath]: original })
+  const res = await prepareOpenclaw(BASE, TOKEN, 'k', 'M', fs)
+  assert.equal(res.ok, false)
+  assert.equal(fs.files.get(openclawPath), original, 'the unusual file must be left exactly as-is')
+})
+
+// ── hermes (config driven via its own `config set`, verified against a live install) ──
+
+/** Fake RunCommand that records every invocation and can be told which ones to fail. */
+function fakeRun(failOn?: string): { calls: Array<[string, string[]]>; run: RunCommand } {
+  const calls: Array<[string, string[]]> = []
+  const run: RunCommand = async (bin, args) => {
+    calls.push([bin, args])
+    return !(failOn && args.includes(failOn))
+  }
+  return { calls, run }
+}
+
+test('prepareHermes: sets provider, base_url, and default via hermes config set', async () => {
+  const { calls, run } = fakeRun()
+  const res = await prepareHermes(BASE, TOKEN, 'qwen3-8b', 'Qwen3 8B', run)
+  assert.deepEqual(res, { ok: true })
+  assert.deepEqual(calls, [
+    ['hermes', ['config', 'set', 'model.provider', 'custom']],
+    ['hermes', ['config', 'set', 'model.base_url', `${BASE}/v1`]],
+    ['hermes', ['config', 'set', 'model.default', 'qwen3-8b']],
+  ])
+})
+
+test('prepareHermes: surfaces a manual-instructions message when a config set call fails', async () => {
+  const { run } = fakeRun(`${BASE}/v1`) // fail the base_url step
+  const res = await prepareHermes(BASE, TOKEN, 'qwen3-8b', 'Qwen3 8B', run)
+  assert.equal(res.ok, false)
+  assert.match((res as { message: string }).message, /hermes config set model\.base_url/)
+})
+
+test('realRunCommand: an argument containing "|" (a real turbollm model key shape) survives intact', async () => {
+  // Regression for a real bug: spawning with `shell: true` on Windows makes cmd.exe treat
+  // "|" as its pipe operator (args are concatenated, not escaped), silently mangling any
+  // model key like "qwen3.6-27b|IQ2_XXS|9388779744". Verified against a real `node`
+  // subprocess (always available in this test environment) rather than a fake.
+  const arg = 'qwen3.6-27b|IQ2_XXS|9388779744'
+  const ok = await realRunCommand('node', ['-e', `process.exit(process.argv[1] === ${JSON.stringify(arg)} ? 0 : 1)`, arg])
+  assert.equal(ok, true, 'the "|" must reach the child process as a literal argument character, not a shell pipe')
+})

--- a/turbollm/src/cli-launch.model.test.ts
+++ b/turbollm/src/cli-launch.model.test.ts
@@ -227,9 +227,8 @@ test('launchCli auto-load prefers lastLoaded.modelKey over the first library mod
     const code = await launchCli('claude', 6996, [], fn, undefined, lastUsedFetch)
     assert.equal(code, 0)
     assert.equal(startedKey, MODELS[1].key, 'should auto-load the last-used model, not the first')
-    // Without --model we auto-load a model but do NOT pin it: ANTHROPIC_MODEL stays unset
-    // so Claude Code uses the gateway's loaded model as-is.
-    assert.equal(calls[0].env['ANTHROPIC_MODEL'], undefined)
+    // We always pin ANTHROPIC_MODEL to the loaded model's key — even without --model.
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], MODELS[1].key)
   } finally {
     unsilence()
   }
@@ -292,7 +291,7 @@ test('launchCli --model already loaded with same key: skips load and launches', 
   }
 })
 
-test('launchCli without --model: does NOT set ANTHROPIC_MODEL (uses loaded model as-is)', async () => {
+test('launchCli without --model: pins ANTHROPIC_MODEL to the loaded model key', async () => {
   const { calls, fn } = makeSpawn()
   const unsilence = silenceOutput()
   try {
@@ -303,32 +302,32 @@ test('launchCli without --model: does NOT set ANTHROPIC_MODEL (uses loaded model
     )
     assert.equal(code, 0)
     assert.equal(calls.length, 1)
-    assert.equal(calls[0].env['ANTHROPIC_MODEL'], undefined, 'ANTHROPIC_MODEL must be unset without --model')
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], MODELS[0].key, 'ANTHROPIC_MODEL must be pinned to the loaded key')
     // The rest of the gateway wiring is still applied.
     assert.equal(calls[0].env['ANTHROPIC_BASE_URL'], 'http://127.0.0.1:6996')
     assert.equal(calls[0].env['ANTHROPIC_AUTH_TOKEN'], 'turbollm-local')
+    assert.equal(calls[0].env['CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY'], '1')
   } finally {
     unsilence()
   }
 })
 
-test('launchCli without --model: strips an ANTHROPIC_MODEL inherited from the environment', async () => {
+test('launchCli prefers the model key over its display name for ANTHROPIC_MODEL', async () => {
   const { calls, fn } = makeSpawn()
   const unsilence = silenceOutput()
-  const had = Object.prototype.hasOwnProperty.call(process.env, 'ANTHROPIC_MODEL')
-  const prev = process.env.ANTHROPIC_MODEL
-  process.env.ANTHROPIC_MODEL = 'stray-global-model'
+  // Status reports a distinct key + display name; the key must win.
+  const keyVsName: typeof fetch = (async (input: string | URL | globalThis.Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as globalThis.Request).url
+    if (url.includes('/api/v1/status')) {
+      return { ok: true, status: 200, json: async () => ({ engine: { state: 'running' }, model: { key: 'qwen3-8b', name: 'Qwen3 8B' } }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as unknown as typeof fetch
   try {
-    const code = await launchCli(
-      'claude', 6996, [], fn,
-      undefined, // no --model flag
-      makeFetch('running', MODELS[0].key),
-    )
+    const code = await launchCli('claude', 6996, [], fn, undefined, keyVsName)
     assert.equal(code, 0)
-    assert.equal(calls[0].env['ANTHROPIC_MODEL'], undefined, 'a stray inherited ANTHROPIC_MODEL must be stripped')
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], 'qwen3-8b', 'the key, not the display name, must be pinned')
   } finally {
-    if (had) process.env.ANTHROPIC_MODEL = prev
-    else delete process.env.ANTHROPIC_MODEL
     unsilence()
   }
 })

--- a/turbollm/src/cli-launch.ts
+++ b/turbollm/src/cli-launch.ts
@@ -1,22 +1,39 @@
-// `turbollm launch <cli>` — start an Anthropic-compatible coding CLI (e.g. Claude
-// Code) already wired to the local TurboLLM gateway, so it uses whatever model is
-// loaded here instead of a cloud API (spec 06 §6). Ships with the npm package.
+// `turbollm launch <cli>` — start a coding CLI already wired to the local TurboLLM
+// gateway, so it uses whatever model is loaded here instead of a cloud API (spec 06
+// §6). Ships with the npm package.
 //
-// The daemon must already be running; this command is a thin launcher that points
-// the CLI's ANTHROPIC_* env vars at TurboLLM and execs it. If no model is loaded,
-// it auto-loads the last-used model (or the first available one). With --model it
-// resolves and loads a specific model by key/name before launching.
+// The daemon must already be running; this command is a thin launcher. If no model is
+// loaded, it auto-loads the last-used model (or the first available one). With --model
+// it resolves and loads a specific model by key/name before launching.
+//
+// Two wiring styles: Anthropic-protocol tools (claude) get ANTHROPIC_* env vars at
+// spawn time; config-file tools (opencode/kilo/openclaw) get a `turbollm` provider
+// merged into their own config file (prepareConfig) before spawning.
 import { spawn } from 'node:child_process'
+import { homedir } from 'node:os'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
 
 interface CliSpec {
   bin: string
   label: string
   install: string
+  // Anthropic-protocol tools (today: claude) get ANTHROPIC_* env vars set at spawn time.
+  // Config-file tools (opencode/kilo/openclaw) instead get this called once before spawn
+  // to merge a local-gateway provider entry into the tool's own config file.
+  prepareConfig?: (base: string, apiKey: string, modelKey: string, modelName: string) => Promise<PrepareResult>
 }
 
-// Coding CLIs that speak the Anthropic /v1/messages API (what our gateway serves).
+type PrepareResult = { ok: true } | { ok: false; message: string }
+
+const AUTH_TOKEN = 'turbollm-local'
+
 const SUPPORTED: Record<string, CliSpec> = {
   claude: { bin: 'claude', label: 'Claude Code', install: 'npm install -g @anthropic-ai/claude-code' },
+  opencode: { bin: 'opencode', label: 'opencode', install: 'npm install -g opencode-ai', prepareConfig: prepareOpencode },
+  kilo: { bin: 'kilo', label: 'Kilo Code', install: 'npm install -g @kilocode/cli', prepareConfig: prepareKilo },
+  openclaw: { bin: 'openclaw', label: 'openclaw', install: 'npm install -g openclaw@latest', prepareConfig: prepareOpenclaw },
+  hermes: { bin: 'hermes', label: 'Hermes Agent', install: 'npm install -g hermes-agent', prepareConfig: prepareHermes },
 }
 
 interface DaemonStatus {
@@ -82,6 +99,265 @@ function resolveModelKey(models: ModelEntry[], input: string): string | null {
   if (partial) return partial.key
 
   return null
+}
+
+// ── Config-file provider merge (opencode / kilo / openclaw) ─────────────────────
+// Shared FS injection point so unit tests can supply a fake home + in-memory fs
+// without ever touching the real filesystem.
+export interface ConfigFs {
+  home: string
+  readFile: (p: string) => Promise<string>
+  writeFile: (p: string, data: string) => Promise<void>
+  mkdir: (p: string) => Promise<void>
+}
+
+const realFs: ConfigFs = {
+  home: homedir(),
+  readFile: (p) => readFile(p, 'utf8'),
+  writeFile: (p, data) => writeFile(p, data, 'utf8'),
+  mkdir: async (p) => { await mkdir(p, { recursive: true }) },
+}
+
+/** Strips `//` and `/* *\/` comments from JSONC/JSON5 text, tracking string literals
+ *  (single- and double-quoted, with escapes) so a value like `"http://host/v1"` is never
+ *  mistaken for a comment. Used only to DETECT what's already in a commented config —
+ *  we never write back through this (that would silently delete the user's comments). */
+function stripJsonComments(text: string): string {
+  let out = ''
+  let inString: '"' | "'" | null = null
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      out += ch
+      if (ch === '\\') { out += text[i + 1] ?? ''; i++; continue }
+      if (ch === inString) inString = null
+      continue
+    }
+    if (ch === '"' || ch === "'") { inString = ch; out += ch; continue }
+    if (ch === '/' && text[i + 1] === '/') {
+      while (i < text.length && text[i] !== '\n') i++
+      out += '\n'
+      continue
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      i += 2
+      while (i < text.length && !(text[i] === '*' && text[i + 1] === '/')) i++
+      i++ // land on the closing '/'
+      continue
+    }
+    out += ch
+  }
+  return out
+}
+
+/** Read + parse an existing config file. Returns:
+ *   - { obj, lenient: false } — clean JSON (or the file is absent: fresh first run) —
+ *     safe to rewrite.
+ *   - { obj, lenient: true }  — only parsed after stripping JSONC comments — NEVER
+ *     rewrite this (would silently delete the user's comments); callers may only
+ *     report success if the file already has what we'd otherwise write.
+ *   - { corrupt: true }       — doesn't parse even leniently; caller MUST NOT touch it. */
+async function readConfigObject(
+  fs: ConfigFs,
+  path: string,
+): Promise<{ obj: Record<string, unknown>; lenient: boolean } | { corrupt: true }> {
+  let raw: string
+  try {
+    raw = await fs.readFile(path)
+  } catch {
+    return { obj: {}, lenient: false } // absent — first run
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object') return { obj: parsed as Record<string, unknown>, lenient: false }
+    return { corrupt: true }
+  } catch {
+    // Not clean JSON — likely JSONC (kilo's config format allows comments, and real
+    // configs use them). Retry after stripping comments before giving up.
+    try {
+      const parsed = JSON.parse(stripJsonComments(raw)) as unknown
+      if (parsed && typeof parsed === 'object') return { obj: parsed as Record<string, unknown>, lenient: true }
+      return { corrupt: true }
+    } catch {
+      return { corrupt: true }
+    }
+  }
+}
+
+/** True when an existing provider entry (opencode/kilo's `options.baseURL`, or
+ *  openclaw's `baseUrl`) already points at our own gateway — used to treat a commented
+ *  config that's already correctly wired as success, without ever rewriting it. */
+function providerAlreadyPointsHere(entry: unknown, base: string): boolean {
+  if (!entry || typeof entry !== 'object') return false
+  const e = entry as Record<string, unknown>
+  const options = e.options as Record<string, unknown> | undefined
+  const baseUrl = (options?.baseURL ?? e.baseUrl) as string | undefined
+  return typeof baseUrl === 'string' && baseUrl.startsWith(base)
+}
+
+/** A commented config that ISN'T already pointed at us — we can detect this but can't
+ *  safely fix it (rewriting would delete the user's comments), so ask them to do it by
+ *  hand, same as a genuinely unparseable file. */
+function commentedConfigError(path: string, label: string): PrepareResult {
+  return {
+    ok: false,
+    message:
+      `Found an existing ${label} config at ${path} that uses comments and isn't yet ` +
+      `pointed at TurboLLM — auto-merging would delete your comments when rewriting the file, ` +
+      `so this is left to you.\n` +
+      `Add the "turbollm" provider by hand (see the Connect screen: TurboLLM UI → Developer → Connect a tool), then run this again.`,
+  }
+}
+
+/** Narrows a config sub-value to a plain object, treating absent as `{}` (fresh) but
+ *  any other non-object (a user's config has e.g. `provider: "foo"`) as unsafe to
+ *  merge into — callers bail out via corruptConfigError instead of throwing when a
+ *  property assignment hits a primitive. */
+function asObject(v: unknown): Record<string, unknown> | null {
+  if (v === undefined) return {}
+  return v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null
+}
+
+/** Standard "can't safely touch your config" failure — points at the same info the
+ *  web UI's Connect screen shows (Developer → Connect a tool). */
+function corruptConfigError(path: string, label: string): PrepareResult {
+  return {
+    ok: false,
+    message:
+      `Found an existing ${label} config at ${path} that doesn't parse as JSON — not overwriting it.\n` +
+      `Add the "turbollm" provider by hand (see the Connect screen: TurboLLM UI → Developer → Connect a tool), then run this again.`,
+  }
+}
+
+/** opencode — merge a `turbollm` provider into ~/.config/opencode/opencode.json,
+ *  preserving every sibling provider the user already configured. Shape mirrors
+ *  buildConnectSnippets (routes.ts) so both surfaces stay in lockstep. */
+export async function prepareOpencode(base: string, apiKey: string, _modelKey: string, modelName: string, fs: ConfigFs = realFs): Promise<PrepareResult> {
+  const path = join(fs.home, '.config', 'opencode', 'opencode.json')
+  const read = await readConfigObject(fs, path)
+  if ('corrupt' in read) return corruptConfigError(path, 'opencode')
+  const cfg = read.obj
+  const provider = asObject(cfg.provider)
+  if (!provider) return corruptConfigError(path, 'opencode')
+  if (read.lenient) {
+    // Has comments — never rewrite. Only succeed if it's already wired to us.
+    return providerAlreadyPointsHere(provider.turbollm, base) ? { ok: true } : commentedConfigError(path, 'opencode')
+  }
+  provider.turbollm = {
+    npm: '@ai-sdk/openai-compatible',
+    options: { baseURL: `${base}/v1`, apiKey },
+    models: { [modelName]: { id: modelName } },
+  }
+  cfg.provider = provider
+  await fs.mkdir(dirname(path))
+  await fs.writeFile(path, JSON.stringify(cfg, null, 2) + '\n')
+  return { ok: true }
+}
+
+/** kilo — Kilo Code is built on the opencode stack and uses the SAME provider shape
+ *  (verified against the live install: an array-form `models` is rejected with
+ *  "Expected object"). Its real config file is `kilo.jsonc` (JSONC — comments allowed),
+ *  confirmed against the live install, NOT `kilo.json`. Merge the `turbollm` provider
+ *  and set it as the default via the top-level `model` string. */
+export async function prepareKilo(base: string, apiKey: string, _modelKey: string, modelName: string, fs: ConfigFs = realFs): Promise<PrepareResult> {
+  const path = join(fs.home, '.config', 'kilo', 'kilo.jsonc')
+  const read = await readConfigObject(fs, path)
+  if ('corrupt' in read) return corruptConfigError(path, 'Kilo Code')
+  const cfg = read.obj
+  const provider = asObject(cfg.provider)
+  if (!provider) return corruptConfigError(path, 'Kilo Code')
+  if (read.lenient) {
+    // kilo.jsonc allowing comments is its NORMAL format, not an edge case — but we still
+    // never rewrite one (would delete the user's comments). Already-wired configs (like
+    // a hand-curated kilo.jsonc that already has a turbollm provider) succeed as-is.
+    return providerAlreadyPointsHere(provider.turbollm, base) ? { ok: true } : commentedConfigError(path, 'Kilo Code')
+  }
+  provider.turbollm = {
+    npm: '@ai-sdk/openai-compatible',
+    options: { baseURL: `${base}/v1`, apiKey },
+    models: { [modelName]: { id: modelName } },
+  }
+  cfg.provider = provider
+  // provider/model key selects the default model kilo boots with (format: provider/mapKey).
+  cfg.model = `turbollm/${modelName}`
+  await fs.mkdir(dirname(path))
+  await fs.writeFile(path, JSON.stringify(cfg, null, 2) + '\n')
+  return { ok: true }
+}
+
+/** openclaw — merge a `turbollm` provider under models.providers and set it as the
+ *  default primary model. Path per its docs (~/.config/openclaw/openclaw.json); the
+ *  CLI isn't installed on this box to verify empirically, so the path is assumed.
+ *  We write plain JSON (valid JSON5); JSON5-only files are handled on the READ side
+ *  by refusing to overwrite an unparseable file. */
+export async function prepareOpenclaw(base: string, apiKey: string, modelKey: string, modelName: string, fs: ConfigFs = realFs): Promise<PrepareResult> {
+  const path = join(fs.home, '.config', 'openclaw', 'openclaw.json')
+  const read = await readConfigObject(fs, path)
+  if ('corrupt' in read) return corruptConfigError(path, 'openclaw')
+  const cfg = read.obj
+  const models = asObject(cfg.models)
+  const providers = models && asObject(models.providers)
+  const agents = asObject(cfg.agents)
+  const defaults = agents && asObject(agents.defaults)
+  if (!models || !providers || !agents || !defaults) return corruptConfigError(path, 'openclaw')
+  if (read.lenient) {
+    return providerAlreadyPointsHere(providers.turbollm, base) ? { ok: true } : commentedConfigError(path, 'openclaw')
+  }
+  providers.turbollm = {
+    baseUrl: `${base}/v1`,
+    apiKey,
+    api: 'openai-completions',
+    models: [{ id: modelKey, name: modelName }],
+  }
+  models.providers = providers
+  cfg.models = models
+  defaults.model = { primary: `turbollm/${modelKey}` }
+  agents.defaults = defaults
+  cfg.agents = agents
+  await fs.mkdir(dirname(path))
+  await fs.writeFile(path, JSON.stringify(cfg, null, 2) + '\n')
+  return { ok: true }
+}
+
+/** Runs a CLI command to completion, resolving true on exit code 0. Deliberately spawned
+ *  WITHOUT a shell: hermes (the only current caller) is a real, directly-executable binary
+ *  on every platform (confirmed: a native .exe on Windows, not an npm-style .cmd shim), and
+ *  our own model keys contain `|` — under `shell: true` on Windows that's cmd.exe's pipe
+ *  operator, silently mangling the command (args aren't escaped, only concatenated; Node
+ *  itself deprecation-warns about this exact hazard). No shell means no metacharacters. */
+export type RunCommand = (bin: string, args: string[]) => Promise<boolean>
+
+export const realRunCommand: RunCommand = (bin, args) =>
+  new Promise<boolean>((resolve) => {
+    const child = spawn(bin, args, { stdio: 'ignore' })
+    child.on('error', () => resolve(false))
+    child.on('exit', (code) => resolve(code === 0))
+  })
+
+/** hermes — Nous Research's agent CLI. Its config is YAML, not JSON, so rather than
+ *  parsing/writing it ourselves (a YAML dependency, and real risk of corrupting a
+ *  hand-edited file) we shell out to hermes's own `config set <dotted.key> <value>`
+ *  command, same as its own docs recommend. Schema confirmed directly against a real,
+ *  live `hermes config show` on this machine (not just docs): the model block is
+ *  `{ provider, base_url, default }` under the top-level `model` key. */
+export async function prepareHermes(base: string, _apiKey: string, modelKey: string, _modelName: string, run: RunCommand = realRunCommand): Promise<PrepareResult> {
+  const sets: Array<[string, string]> = [
+    ['model.provider', 'custom'],
+    ['model.base_url', `${base}/v1`],
+    ['model.default', modelKey],
+  ]
+  for (const [key, value] of sets) {
+    if (!(await run('hermes', ['config', 'set', key, value]))) {
+      return {
+        ok: false,
+        message:
+          `Failed running "hermes config set ${key} ${value}".\n` +
+          `Configure it by hand: hermes config set model.provider custom && ` +
+          `hermes config set model.base_url ${base}/v1 && hermes config set model.default ${modelKey}`,
+      }
+    }
+  }
+  return { ok: true }
 }
 
 /**
@@ -231,34 +507,49 @@ export async function launchCli(
     return 1
   }
   const model = status.model.name
+  // Prefer the stable key over the display name — it's what the gateway routes on.
+  const pinnedModel = status.model.key ?? model
 
-  // Only PIN a model id (via ANTHROPIC_MODEL) when the user explicitly asked for one with
-  // --model. Without --model we leave it unset so Claude Code talks to whatever model the
-  // gateway currently has loaded, as-is. Pinning makes Claude Code send that id on every
-  // request, which forces the gateway's auto-swap router to resolve it and can surface
-  // model-specific behaviour (e.g. a strict chat template) the user didn't ask for —
-  // when they ran a bare `launch`, they just want "use the loaded model".
   const modelNote = modelKey ? `model: ${model}` : `using loaded model: ${model}`
   process.stdout.write(`▸ Launching ${spec.label} → TurboLLM  (${modelNote}, ${base})\n`)
+
+  // Config-file tools (opencode/kilo/openclaw): merge a `turbollm` provider into the
+  // tool's own config BEFORE spawning, then spawn with a clean env (no ANTHROPIC_* —
+  // those are meaningless to non-Anthropic-protocol tools).
+  if (spec.prepareConfig) {
+    const prep = await spec.prepareConfig(base, AUTH_TOKEN, pinnedModel, model)
+    if (!prep.ok) {
+      process.stderr.write(prep.message + '\n')
+      return 1
+    }
+    const child = _spawn(spec.bin, passthrough, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      env: process.env,
+    })
+    return await waitForChild(child, spec)
+  }
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     ANTHROPIC_BASE_URL: base,
     // No auth is enforced on the local gateway; the CLI just needs a non-empty token.
-    ANTHROPIC_AUTH_TOKEN: 'turbollm-local',
+    ANTHROPIC_AUTH_TOKEN: AUTH_TOKEN,
     // Local LLMs are 30–120 s per response — raise Claude Code's request timeout so it
     // doesn't abort mid-generation. 300 s (5 min) covers even the slowest local model.
     // Zero retries: retrying a slow local model cold-starts it again and makes things worse.
     ANTHROPIC_TIMEOUT: '300000',
     ANTHROPIC_MAX_RETRIES: '0',
-  }
-  if (modelKey) {
-    // --model was given: pin Claude Code to the resolved model.
-    env.ANTHROPIC_MODEL = model
-  } else {
-    // No --model: do not set a model, and strip any ANTHROPIC_MODEL inherited from the
-    // parent environment so a stray global value can't silently pin the model either.
-    delete env.ANTHROPIC_MODEL
+    // Always pin the loaded model's id (key preferred). Claude Code uses the model string
+    // for real client-side bookkeeping even behind a custom base URL — the status line,
+    // `/status`, and context-window / auto-compact sizing all read it — and never validates
+    // it against a cloud catalog when ANTHROPIC_BASE_URL is custom. Pinning to whatever's
+    // actually loaded is therefore safe and fixes those surfaces from silently assuming a
+    // wrong cloud default.
+    ANTHROPIC_MODEL: pinnedModel,
+    // Opt into gateway model discovery: Claude Code queries our /v1/models at startup and
+    // populates the /model picker with the local library (gateway synthesises the entries).
+    CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: '1',
   }
 
   const child = _spawn(spec.bin, passthrough, {
@@ -268,7 +559,12 @@ export async function launchCli(
     env,
   })
 
-  return await new Promise<number>((resolve) => {
+  return await waitForChild(child, spec)
+}
+
+/** Resolve the child's exit code, reporting a friendly install hint on ENOENT. */
+function waitForChild(child: Pick<ReturnType<typeof spawn>, 'on'>, spec: CliSpec): Promise<number> {
+  return new Promise<number>((resolve) => {
     child.on('error', (e: NodeJS.ErrnoException) => {
       if (e.code === 'ENOENT') {
         process.stderr.write(

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -131,10 +131,12 @@ if (hasFlag('--help', '-h')) {
     `  turbollm [options]\n` +
     `  turbollm launch <cli>            # run a coding CLI on your local model\n\n` +
     `Commands:\n` +
-    `  launch claude                    Launch Claude Code wired to TurboLLM\n` +
-    `                                   Uses whatever model is loaded (auto-loads the\n` +
-    `                                   last-used one if none is); does not pin a model.\n` +
-    `  launch claude --model <key>      Load a specific model by key or name and pin it\n\n` +
+    `  launch claude                    Launch Claude Code wired to TurboLLM. Auto-loads\n` +
+    `                                   the last-used model if none is loaded, and pins\n` +
+    `                                   Claude Code to whatever model is loaded.\n` +
+    `  launch claude --model <key>      Load a specific model by key or name, then launch\n` +
+    `  launch opencode|kilo|openclaw|hermes\n` +
+    `                                   Wire that CLI to TurboLLM (writes its config file)\n\n` +
     `Options:\n` +
     `  --port <n>     Port to listen on / connect to (default: 6996)\n` +
     `  --addr <h:p>   Full host:port override (e.g. 0.0.0.0:6996)\n` +
@@ -153,7 +155,8 @@ if (hasFlag('--help', '-h')) {
     `  turbollm --tunnel --no-open      # run on a rented GPU box, reachable via a public URL\n` +
     `  turbollm --stop                  # stop the running daemon\n` +
     `  turbollm launch claude           # open Claude Code on your loaded model\n` +
-    `  turbollm launch claude --model qwen3-8b   # load qwen3-8b, then launch\n\n`,
+    `  turbollm launch claude --model qwen3-8b   # load qwen3-8b, then launch\n` +
+    `  turbollm launch opencode         # wire opencode to TurboLLM, then launch it\n\n`,
   )
   process.exit(0)
 }

--- a/turbollm/src/gateway/gateway.models.test.ts
+++ b/turbollm/src/gateway/gateway.models.test.ts
@@ -1,0 +1,103 @@
+// Part B: /v1/models discovery synthesis + `claude-`-prefixed model round-trip.
+//   • GET /v1/models always lists the WHOLE local library (real key + `claude-<key>`
+//     alias), regardless of whether an engine is running — this is what populates
+//     Claude Code's /model picker via CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY.
+//   • POST /v1/messages strips a leading `claude-` so the router + the outbound engine
+//     request both see the REAL key.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerGateway } from './gateway'
+import type { Deps } from '../deps'
+
+const LIBRARY = [
+  { key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' },
+  { key: 'llama-3-70b|Q5|456', name: 'Llama 3 70B' },
+]
+
+/** Minimal Deps double: only the members the tested gateway paths touch. */
+function fakeDeps(routed: { model: string | null }, autoSwap = true): Deps {
+  return {
+    scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
+    modelRouter: {
+      route: async (m: string) => {
+        routed.model = m
+        return { target: 'http://engine.local' }
+      },
+    },
+    store: { snapshot: () => ({ modelDefaults: { maxTokens: 0 }, gateway: { autoSwap } }) },
+    manager: {
+      status: () => ({ state: 'stopped', model: null }),
+      target: () => 'http://engine.local',
+      generationStart: () => {},
+      generationEnd: () => {},
+    },
+    registry: { active: () => ({ kind: 'llama.cpp' }) },
+  } as unknown as Deps
+}
+
+// ── GET /v1/models synthesis ────────────────────────────────────────────────────
+
+test('GET /v1/models lists the whole library (real key + claude- alias) even with no engine', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps({ model: null }))
+
+  const res = await app.request('/v1/models', { method: 'GET' })
+  assert.equal(res.status, 200)
+  const body = (await res.json()) as { object: string; data: Array<Record<string, unknown>> }
+  assert.equal(body.object, 'list')
+  // Two entries per library model: real key + claude- alias.
+  assert.equal(body.data.length, LIBRARY.length * 2)
+
+  const real = body.data.find((e) => e.id === 'qwen3-8b|Q4|123')
+  assert.ok(real, 'real-key entry present')
+  assert.equal(real!.owned_by, 'turbollm')
+
+  const alias = body.data.find((e) => e.id === 'claude-qwen3-8b|Q4|123')
+  assert.ok(alias, 'claude- alias present for Claude Code discovery')
+  assert.equal(alias!.display_name, 'Qwen3 8B — TurboLLM')
+})
+
+test('GET /v1/models omits claude- aliases when gateway.autoSwap is off', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps({ model: null }, false))
+
+  const res = await app.request('/v1/models', { method: 'GET' })
+  const body = (await res.json()) as { data: Array<Record<string, unknown>> }
+  // Real-key entries still list (useful to OpenAI-style consumers regardless of autoSwap),
+  // but no claude- aliases — advertising them would let /model pick a model that autoSwap
+  // being off silently prevents from ever loading.
+  assert.equal(body.data.length, LIBRARY.length)
+  assert.ok(body.data.every((e) => !(e.id as string).startsWith('claude-')))
+})
+
+// ── POST /v1/messages claude- prefix strip ──────────────────────────────────────
+
+test('POST /v1/messages strips a claude- prefix before routing', async () => {
+  const routed = { model: null as string | null }
+  const app = new Hono()
+  registerGateway(app, fakeDeps(routed))
+
+  // The engine fetch will fail (no real server) — we only assert on what the router saw.
+  await app.request('/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'claude-llama-3-70b|Q5|456', max_tokens: 10, messages: [] }),
+  })
+
+  assert.equal(routed.model, 'llama-3-70b|Q5|456', 'router must see the real key, not the claude- alias')
+})
+
+test('POST /v1/messages leaves a non-prefixed model id untouched', async () => {
+  const routed = { model: null as string | null }
+  const app = new Hono()
+  registerGateway(app, fakeDeps(routed))
+
+  await app.request('/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'qwen3-8b|Q4|123', max_tokens: 10, messages: [] }),
+  })
+
+  assert.equal(routed.model, 'qwen3-8b|Q4|123')
+})

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -36,6 +36,13 @@ export function registerGateway(app: Hono, d: Deps): void {
         400,
       )
     }
+    // Claude Code's gateway model discovery only keeps /v1/models ids that start with
+    // `claude`/`anthropic`, so we advertise local models as `claude-<key>` (see /v1/models
+    // below). Strip that prefix in-place so both the router AND the outbound engine request
+    // (mapToOpenAI reads req.model again) use the real key. The alias is only ever advertised
+    // when gateway.autoSwap is on (see /v1/models below), so routing here still honors the
+    // user's global auto-swap preference like every other request.
+    if (req.model?.startsWith('claude-')) req.model = req.model.slice(7)
     if (!req.max_tokens) {
       return c.json(
         { type: 'error', error: { type: 'invalid_request_error', message: 'max_tokens is required.' } },
@@ -185,6 +192,23 @@ export function registerGateway(app: Hono, d: Deps): void {
 
   app.all('/v1/*', async (c) => {
     const url = new URL(c.req.url)
+
+    // GET /v1/models: always synthesise the list from the WHOLE local library (not just
+    // the loaded model), regardless of whether an engine is running — real key entries for
+    // OpenAI-style consumers. The `claude-<key>` alias (whose id passes Claude Code's
+    // discovery filter — it keeps only claude*/anthropic* ids — and which /v1/messages
+    // strips back to the real key before routing) is only added when gateway.autoSwap is
+    // on: picking a model from Claude Code's /model always requires a swap, so advertising
+    // it while auto-swap is off would let the user pick a model that silently never loads.
+    if (c.req.method === 'GET' && url.pathname === '/v1/models') {
+      const autoSwap = d.store.snapshot().gateway.autoSwap
+      const data = d.scanner.list().models.flatMap((m) => [
+        { id: m.key, object: 'model', owned_by: 'turbollm' },
+        ...(autoSwap ? [{ id: `claude-${m.key}`, object: 'model', display_name: `${m.name} — TurboLLM` }] : []),
+      ])
+      return c.json({ object: 'list', data })
+    }
+
     const isChat = c.req.method === 'POST' && url.pathname === '/v1/chat/completions'
 
     // For chat completions: parse the body to extract the model field for
@@ -198,9 +222,6 @@ export function registerGateway(app: Hono, d: Deps): void {
     const requestedModel = isChat ? ((parsedBody?.model as string | undefined) ?? '') : ''
     const routeResult = await d.modelRouter.route(requestedModel)
     if ('status' in routeResult) {
-      if (c.req.method === 'GET' && url.pathname === '/v1/models') {
-        return c.json({ object: 'list', data: [] })
-      }
       return c.json(
         { error: { message: routeResult.message, type: 'model_not_loaded', code: 'model_not_loaded' } },
         503,


### PR DESCRIPTION
## Summary
- `turbollm launch claude` always pins `ANTHROPIC_MODEL` to the loaded model's key by default (previously only with `--model`) — Claude Code uses the model string for real client-side bookkeeping (status line, `/status`, context-window/auto-compact sizing) even behind a custom base URL, and never validates it against a catalog there.
- Claude Code's `/model` picker now lists local models via Claude Code's documented gateway model-discovery feature, gated on the live `gateway.autoSwap` setting so a pick can never silently fail to load.
- New `turbollm launch` targets: `opencode`, `kilo`, `openclaw`, `hermes` — each wired to the local gateway via that tool's own config mechanism (JSON provider merge for the first three, tolerating existing JSONC comments without ever rewriting a commented file; hermes via its own `hermes config set` command since its config is YAML).
- Several bugs found via live testing against real installs on the dev machine (not just unit tests): a Windows shell-escaping bug in the hermes config driver (model keys contain `|`, which cmd.exe treats as a pipe under `shell: true`), a wrong `kilo.json` vs `kilo.jsonc` filename, a fabricated `openclaw` install command, and the `autoSwap`-gating fix above.

## Test plan
- [x] `npm run build` — typecheck + bundle, clean
- [x] `npm test` — 632/632 passing (3 pre-existing skips)
- [x] Live-verified against a real running daemon on this dev machine, including real `@kilocode/cli` and `hermes-agent` installs