### PR TITLE
v1.7.5 — chat branching, message editing, preserve-thinking, engine fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,19 @@ the detail:
   **Designer** persona produces polished, self-contained, previewable designs by default; **Lite**
   strips the hidden prompt to the bare minimum for the fastest responses. See below for editing
   built-ins or creating your own.
-- **Edit, regenerate, delete, copy** any message; **persistent, searchable conversations**
-  with rename, delete, and **auto-generated titles**, organized into **drag-resizable,
-  collapsible folders** you create/rename/move conversations into.
+- **Edit or regenerate any message without losing history** — both branch instead of
+  overwriting, with a **‹ 1/2 › switcher** to flip between versions (including nested branch
+  points); delete and copy still work as before. **Persistent, searchable conversations** with
+  rename, delete, and **auto-generated titles**, organized into **drag-resizable, collapsible
+  folders** you create/rename/move conversations into.
+- **Switching chats never cancels a reply** — an in-flight generation keeps running in the
+  background and saves normally; the sidebar shows a live indicator on any chat still generating,
+  and a dot on one that finished while you were elsewhere.
+- **Preserve thinking across turns** (on by default) — the model's past reasoning is resent on
+  later turns, not just its final answers, so follow-ups have real context to work with.
 - **Per-chat system prompt** and **per-chat sampling** overrides — temperature, top-p/k, min-p,
-  repeat/presence/frequency penalties, and **stop strings**.
+  repeat/presence/frequency penalties, and **stop strings** — prefilled from the loaded model's
+  own recommended values, available even before you send the first message.
 - **Image input** for vision models, **PDF and code/text attachments** (real extracted text,
   not raw bytes), and **TurboLLM Expert** — a built-in assistant that knows the app and your
   hardware for onboarding and troubleshooting without leaving the UI.

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,51 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.7.5] - 2026-07-09
+
+**Chat branching, message editing, preserve-thinking, and a background-generation UX pass — plus a real CUDA fallback bug and a model-swap silent failure fixed.**
+
+### Added
+- **Chat branching** — editing a message or regenerating a reply no longer overwrites history:
+  both create a branch, switchable via a ‹ 1/2 › control on the message, including nested branch
+  points (branching inside an already-branched conversation).
+- **In-place message editing for assistant replies** — fixes the text without triggering a new
+  generation; shows an "Edited" tag.
+- **Preserve thinking across turns** (Thread settings) — resends the model's past reasoning on
+  later turns, not just its final answers. On by default for new conversations.
+- **Thread settings usable on a blank chat** — reachable as soon as a model is loaded, even
+  before the first message is sent.
+- **Sampling sliders now default to the loaded model's own recommended values** instead of fixed
+  generic constants.
+- **Skills list in Thread settings is now collapsible** (collapsed by default) with a master
+  on/off checkbox.
+- **Pinned models now sort to the top of the chat model picker**, not just the Library list.
+- **Background-generation sidebar indicators** — a live spinner on any conversation still
+  generating in the background, and a dot on one that finished while you were elsewhere.
+
+### Changed
+- **Switching conversations no longer cancels an in-flight reply** — it keeps generating and
+  saves normally; only an explicit Stop/Eject/delete cancels a generation now.
+- Custom-added engines now render their own card in the engine gallery instead of being invisible
+  next to auto-downloaded official builds.
+
+### Fixed
+- The CUDA backend could silently fall back to CPU if its cudart runtime bundle never finished
+  downloading — a completeness check now catches this and backfills existing installs without
+  forcing a re-download.
+- Reloading the same model or switching models could sometimes leave nothing loaded, with no
+  error shown — a slow engine stop could abandon the load silently.
+- Engine directory scanning could crash on a permission-restricted subfolder.
+- A streaming display bug could briefly show an empty "thinking" block.
+- The Thread settings dialog could overflow off-screen with a lot of skills installed.
+- `ConversationSettingsDialog` now uses an accessible dialog title (screen-reader fix).
+
+### Discord
+- Editing a message or regenerating a reply no longer wipes out what came after it — every version is saved, and you can flip between them.
+- Chats now remember their own reasoning across turns by default, so follow-up questions actually build on what the model already figured out.
+- Switching to a different chat mid-reply no longer kills the generation — it finishes in the background, and the sidebar shows you which chats are still working (and which ones just finished).
+- Fixed a couple of real bugs: the CUDA backend silently falling back to CPU on some installs, and switching models sometimes leaving nothing loaded at all.
+
 ## [1.7.4] - 2026-07-07
 
 **Engines, Library, Developer, and Settings redesigned, and every screen now works on mobile.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -201,11 +201,19 @@ the detail:
   **Designer** persona produces polished, self-contained, previewable designs by default; **Lite**
   strips the hidden prompt to the bare minimum for the fastest responses. See below for editing
   built-ins or creating your own.
-- **Edit, regenerate, delete, copy** any message; **persistent, searchable conversations**
-  with rename, delete, and **auto-generated titles**, organized into **drag-resizable,
-  collapsible folders** you create/rename/move conversations into.
+- **Edit or regenerate any message without losing history** — both branch instead of
+  overwriting, with a **‹ 1/2 › switcher** to flip between versions (including nested branch
+  points); delete and copy still work as before. **Persistent, searchable conversations** with
+  rename, delete, and **auto-generated titles**, organized into **drag-resizable, collapsible
+  folders** you create/rename/move conversations into.
+- **Switching chats never cancels a reply** — an in-flight generation keeps running in the
+  background and saves normally; the sidebar shows a live indicator on any chat still generating,
+  and a dot on one that finished while you were elsewhere.
+- **Preserve thinking across turns** (on by default) — the model's past reasoning is resent on
+  later turns, not just its final answers, so follow-ups have real context to work with.
 - **Per-chat system prompt** and **per-chat sampling** overrides — temperature, top-p/k, min-p,
-  repeat/presence/frequency penalties, and **stop strings**.
+  repeat/presence/frequency penalties, and **stop strings** — prefilled from the loaded model's
+  own recommended values, available even before you send the first message.
 - **Image input** for vision models, **PDF and code/text attachments** (real extracted text,
   not raw bytes), and **TurboLLM Expert** — a built-in assistant that knows the app and your
   hardware for onboarding and troubleshooting without leaving the UI.

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/chat/branching.test.ts
+++ b/turbollm/src/chat/branching.test.ts
@@ -1,0 +1,314 @@
+// Chat branching (GitHub #52 item 2): regenerate used to delete the previous reply
+// outright. Now it's deactivated and kept as a sibling — these tests exercise the
+// db-layer primitives (deactivateMessage / getMessageVariants / setActiveVariant)
+// directly against a real sqlite instance, the same way scan.test.ts covers findFile.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ConversationStore } from './db.js'
+
+function tempStore(): { store: ConversationStore; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-branch-'))
+  return { store: new ConversationStore(dir), dir }
+}
+
+test('a fresh message has no variant group and is active', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const msg = store.addMessage(conv.id, 'assistant', 'hello')
+    assert.equal(msg.variantGroup, null)
+    assert.equal(msg.isActive, true)
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [msg.id])
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('deactivateMessage hides it from getMessages but keeps the row (not deleted)', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    store.addMessage(conv.id, 'user', 'question')
+    const reply = store.addMessage(conv.id, 'assistant', 'first answer')
+    store.deactivateMessage(reply.id)
+
+    assert.equal(store.getMessages(conv.id).some((m) => m.id === reply.id), false, 'deactivated message should not appear in the active list')
+    const stillThere = store.getMessage(reply.id)
+    assert.ok(stillThere, 'row must still exist — deactivate, not delete')
+    assert.equal(stillThere!.isActive, false)
+    assert.equal(stillThere!.variantGroup, reply.id, 'first deactivation establishes the group as its own id')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('deactivateMessage is idempotent about variant_group on repeated regenerations', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const first = store.addMessage(conv.id, 'assistant', 'v1')
+    store.deactivateMessage(first.id)
+    const groupId = store.getMessage(first.id)!.variantGroup
+
+    const second = store.addMessage(conv.id, 'assistant', 'v2', { variantGroup: groupId! })
+    store.deactivateMessage(second.id)
+
+    // Deactivating a message that ALREADY has a variant_group must not overwrite it
+    // with its own id — COALESCE should preserve the original group across the chain.
+    assert.equal(store.getMessage(second.id)!.variantGroup, groupId)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('getLastMessageAnyStatus sees a deactivated tail message that getLastMessage (active-only) skips', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const user = store.addMessage(conv.id, 'user', 'question')
+    const reply = store.addMessage(conv.id, 'assistant', 'first answer')
+    store.deactivateMessage(reply.id)
+
+    assert.equal(store.getLastMessage(conv.id)!.id, user.id, 'active-only view should now end at the user turn')
+    assert.equal(store.getLastMessageAnyStatus(conv.id)!.id, reply.id, 'any-status view still finds the deactivated reply')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('getNextMessageAfterSeq finds the specific message regenerate just deactivated, not an unrelated later branch (regression)', () => {
+  // Live-verification bug found in QA: a conversation with more than one branch point
+  // had /continue join a fresh regenerated reply to the WRONG variant group, because it
+  // used to look for "whatever has the globally highest seq" instead of "the message
+  // immediately after the current active tail." A later, unrelated branch's messages
+  // (created after the one being regenerated, but on a different — currently inactive —
+  // branch) have a higher seq and were incorrectly picked up instead.
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const a = store.addMessage(conv.id, 'user', 'A')
+    const b = store.addMessage(conv.id, 'assistant', 'B') // the reply about to be "regenerated"
+
+    // Build an entirely separate, LATER branch by editing an earlier point (simulating
+    // the real editMessage flow) so its messages get a higher seq than B.
+    store.freezeTail(conv.id, a.seq, a.id)
+    store.deactivateMessage(a.id)
+    const aGroup = store.getMessage(a.id)!.variantGroup!
+    store.addMessage(conv.id, 'user', 'A2', { variantGroup: aGroup })
+    const laterBranchReply = store.addMessage(conv.id, 'assistant', 'reply in the unrelated later branch')
+    store.deactivateMessage(laterBranchReply.id) // now inactive, higher seq than B, role assistant — exactly what a naive "highest seq" query would wrongly grab
+
+    // Switch back to the original A/B branch — B is active again.
+    store.restoreTail(a.id)
+    store.setActiveVariant(aGroup, a.id)
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a.id, b.id])
+
+    // Simulate /regenerate: deactivate B (the CURRENT active reply).
+    store.deactivateMessage(b.id)
+
+    // This is the fix under test: must resolve to B specifically, not laterBranchReply.
+    const lastActiveUser = store.getLastMessage(conv.id)! // now resolves to `a` (B just got deactivated)
+    const found = store.getNextMessageAfterSeq(conv.id, lastActiveUser.seq)
+    assert.equal(found!.id, b.id, 'must find B (the message actually being regenerated), not the unrelated later branch reply')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('getMessageVariants returns every sibling, active and inactive, oldest first', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const v1 = store.addMessage(conv.id, 'assistant', 'v1')
+    store.deactivateMessage(v1.id)
+    const groupId = store.getMessage(v1.id)!.variantGroup!
+    const v2 = store.addMessage(conv.id, 'assistant', 'v2', { variantGroup: groupId })
+    store.deactivateMessage(v2.id)
+    const v3 = store.addMessage(conv.id, 'assistant', 'v3', { variantGroup: groupId })
+
+    const variants = store.getMessageVariants(groupId)
+    assert.deepEqual(variants.map((m) => m.id), [v1.id, v2.id, v3.id])
+    assert.deepEqual(variants.map((m) => m.isActive), [false, false, true])
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('setActiveVariant switches which sibling is active and shown by getMessages', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const v1 = store.addMessage(conv.id, 'assistant', 'v1')
+    store.deactivateMessage(v1.id)
+    const groupId = store.getMessage(v1.id)!.variantGroup!
+    const v2 = store.addMessage(conv.id, 'assistant', 'v2', { variantGroup: groupId }) // active by default
+
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [v2.id])
+
+    const ok = store.setActiveVariant(groupId, v1.id)
+    assert.equal(ok, true)
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [v1.id], 'switching back to v1 should hide v2')
+    assert.equal(store.getMessage(v2.id)!.isActive, false)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('setActiveVariant returns false for a message that is not a member of the group', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const v1 = store.addMessage(conv.id, 'assistant', 'v1')
+    store.deactivateMessage(v1.id)
+    const groupId = store.getMessage(v1.id)!.variantGroup!
+    const unrelated = store.addMessage(conv.id, 'assistant', 'unrelated, different turn entirely')
+
+    const ok = store.setActiveVariant(groupId, unrelated.id)
+    assert.equal(ok, false)
+    // Nothing should have changed — the unrelated message wasn't touched.
+    assert.equal(store.getMessage(unrelated.id)!.isActive, true)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a never-regenerated message keeps variantGroup null forever (no branch UI for plain messages)', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    store.addMessage(conv.id, 'user', 'question')
+    const reply = store.addMessage(conv.id, 'assistant', 'only answer, never regenerated')
+    assert.equal(store.getMessage(reply.id)!.variantGroup, null)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ── User-message edit branching (freezeTail / restoreTail) ────────────────────
+
+test('freezeTail deactivates everything after a seq and tags it with the anchor, leaving earlier messages untouched', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const a = store.addMessage(conv.id, 'user', 'A')
+    const b = store.addMessage(conv.id, 'assistant', 'B')
+    const c = store.addMessage(conv.id, 'user', 'C')
+
+    store.freezeTail(conv.id, a.seq, a.id)
+
+    assert.equal(store.getMessage(a.id)!.isActive, true, 'the anchor message itself is untouched by freezeTail — caller deactivates it separately')
+    assert.equal(store.getMessage(b.id)!.isActive, false)
+    assert.equal(store.getMessage(b.id)!.branchOf, a.id)
+    assert.equal(store.getMessage(c.id)!.isActive, false)
+    assert.equal(store.getMessage(c.id)!.branchOf, a.id)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('restoreTail reactivates only messages tagged with that specific anchor', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const a = store.addMessage(conv.id, 'user', 'A')
+    const b = store.addMessage(conv.id, 'assistant', 'B')
+    store.freezeTail(conv.id, a.seq, a.id)
+
+    // An unrelated message frozen under a DIFFERENT anchor must not come back.
+    const other = store.addMessage(conv.id, 'assistant', 'unrelated')
+    store.freezeTail(conv.id, other.seq - 1, 'some-other-anchor-id')
+
+    store.restoreTail(a.id)
+    assert.equal(store.getMessage(b.id)!.isActive, true)
+    assert.equal(store.getMessage(other.id)!.isActive, false, 'restoring anchor A must not reactivate a message frozen under a different anchor')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('full round trip: editing an earlier user message freezes the whole downstream tail, and switching back restores it exactly', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const a = store.addMessage(conv.id, 'user', 'A original')
+    const b = store.addMessage(conv.id, 'assistant', 'B')
+    const c = store.addMessage(conv.id, 'user', 'C')
+    const d = store.addMessage(conv.id, 'assistant', 'D')
+
+    // Simulate the editMessage route's user-role branch: freeze tail, deactivate A,
+    // add the edited replacement joined to A's variant group.
+    store.freezeTail(conv.id, a.seq, a.id)
+    store.deactivateMessage(a.id)
+    const group = store.getMessage(a.id)!.variantGroup!
+    const a2 = store.addMessage(conv.id, 'user', 'A edited', { variantGroup: group })
+
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a2.id], 'only the edited message is active — B/C/D are frozen')
+
+    // Continue the new branch with a fresh reply.
+    const e = store.addMessage(conv.id, 'assistant', 'E, reply to the edited A')
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a2.id, e.id])
+
+    // Simulate the activate route's user-role branch: switch back to the ORIGINAL A.
+    const currentActive = store.getMessageVariants(group).find((v) => v.isActive)!
+    assert.equal(currentActive.id, a2.id)
+    store.freezeTail(conv.id, currentActive.seq, currentActive.id) // freezes [e] under a2.id
+    store.restoreTail(a.id) // restores [b, c, d]
+    store.setActiveVariant(group, a.id)
+
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a.id, b.id, c.id, d.id], 'switching back to A restores exactly the original conversation')
+
+    // And switching forward again restores the edited branch, not a blank slate.
+    store.freezeTail(conv.id, a.seq, a.id) // freezes [b, c, d] under a.id again
+    store.restoreTail(a2.id) // restores [e]
+    store.setActiveVariant(group, a2.id)
+
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a2.id, e.id], 'switching forward restores the edited branch\'s own continuation')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a regenerated reply nested inside a frozen tail is restored as whichever sibling was active when frozen', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const a = store.addMessage(conv.id, 'user', 'A')
+    const d1 = store.addMessage(conv.id, 'assistant', 'D v1')
+    // Regenerate D before ever touching A — D2 becomes the active sibling.
+    store.deactivateMessage(d1.id)
+    const dGroup = store.getMessage(d1.id)!.variantGroup!
+    const d2 = store.addMessage(conv.id, 'assistant', 'D v2', { variantGroup: dGroup })
+
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a.id, d2.id])
+
+    // Now edit A — freezeTail must capture D2 (whichever was active), not D1.
+    store.freezeTail(conv.id, a.seq, a.id)
+    store.deactivateMessage(a.id)
+    const aGroup = store.getMessage(a.id)!.variantGroup!
+    const a2 = store.addMessage(conv.id, 'user', 'A edited', { variantGroup: aGroup })
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a2.id])
+
+    // Switch back to the original A.
+    store.restoreTail(a.id)
+    store.setActiveVariant(aGroup, a.id)
+    assert.deepEqual(store.getMessages(conv.id).map((m) => m.id), [a.id, d2.id], 'D2 (the active sibling at freeze time) comes back, not D1')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/chat/chat-export.test.ts
+++ b/turbollm/src/chat/chat-export.test.ts
@@ -17,6 +17,7 @@ function makeConv(overrides: Partial<Conversation & { messages: Message[] }> = {
     expertMode: false,
     toolPolicy: undefined,
     kind: 'chat',
+    preserveThinking: false,
     createdAt: '2026-06-19T00:00:00.000Z',
     updatedAt: '2026-06-19T00:00:01.000Z',
     messages: [],
@@ -37,6 +38,9 @@ function makeMsg(role: 'user' | 'assistant', content: string, overrides: Partial
     toolCalls: [],
     stats: {},
     createdAt: '2026-06-19T00:00:02.000Z',
+    variantGroup: null,
+    isActive: true,
+    branchOf: null,
     ...overrides,
   }
 }

--- a/turbollm/src/chat/chat-export.test.ts
+++ b/turbollm/src/chat/chat-export.test.ts
@@ -41,6 +41,7 @@ function makeMsg(role: 'user' | 'assistant', content: string, overrides: Partial
     variantGroup: null,
     isActive: true,
     branchOf: null,
+    edited: false,
     ...overrides,
   }
 }

--- a/turbollm/src/chat/chat-import.test.ts
+++ b/turbollm/src/chat/chat-import.test.ts
@@ -43,6 +43,7 @@ function makeMsg(role: 'user' | 'assistant', content: string, extra?: Partial<Me
     variantGroup: null,
     isActive: true,
     branchOf: null,
+    edited: false,
     ...extra,
   }
 }

--- a/turbollm/src/chat/chat-import.test.ts
+++ b/turbollm/src/chat/chat-import.test.ts
@@ -19,6 +19,7 @@ function makeConv(overrides: Partial<Conversation & { messages: Message[] }> = {
     expertMode: false,
     toolPolicy: 'force_web_search',
     kind: 'chat',
+    preserveThinking: false,
     createdAt: '2026-06-19T00:00:00.000Z',
     updatedAt: '2026-06-19T00:00:01.000Z',
     messages: [],
@@ -39,6 +40,9 @@ function makeMsg(role: 'user' | 'assistant', content: string, extra?: Partial<Me
     toolCalls: [],
     stats: {},
     createdAt: '2026-06-19T00:00:02.000Z',
+    variantGroup: null,
+    isActive: true,
+    branchOf: null,
     ...extra,
   }
 }

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -107,7 +107,7 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
   })
 
   app.patch('/api/v1/conversations/:id', async (c) => {
-    const b = await body<{ title?: string; systemPrompt?: string; sampling?: Record<string, unknown>; skillIds?: string[] }>(c)
+    const b = await body<{ title?: string; systemPrompt?: string; sampling?: Record<string, unknown>; skillIds?: string[]; preserveThinking?: boolean }>(c)
     if (b.skillIds !== undefined) {
       const validIds = new Set(new SkillStore(d.store.dir()).list().map((s) => s.id))
       b.skillIds = b.skillIds.filter((sid) => validIds.has(sid))
@@ -231,7 +231,13 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
       const engineMessages: { role: string; content: unknown }[] = []
       if (conv.systemPrompt) engineMessages.push({ role: 'system', content: conv.systemPrompt })
       for (const m of allMsgs) {
-        engineMessages.push({ role: m.role, content: m.content })
+        // GitHub #52: when preserveThinking is on, fold past reasoning back into what's
+        // resent so the model sees its own prior thinking, not just the final answer —
+        // the default behavior (off) matches what's always been sent.
+        const content = (conv.preserveThinking && m.role === 'assistant' && m.reasoning?.trim())
+          ? `<think>\n${m.reasoning}\n</think>\n\n${m.content}`
+          : m.content
+        engineMessages.push({ role: m.role, content })
       }
       // Fold any attached document text into the prompt; attach images as multimodal parts.
       const fullContent = b.docContext
@@ -269,8 +275,19 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     const lastUser = (conv.messages ?? []).filter((m) => m.role === 'user').at(-1)
     if (!lastUser) return err(c, 400, 'no_user_message', 'No user message to respond to.')
 
+    // Chat branching (GitHub #52): if /regenerate just deactivated the prior reply, the new
+    // placeholder joins its variant_group so the client can render a ‹ 1/2 › sibling switcher
+    // instead of the old reply simply having vanished. Must look specifically at the message
+    // immediately after the current active tail (getNextMessageAfterSeq), NOT "whatever has
+    // the globally highest seq" — a conversation with more than one branch point can have
+    // unrelated, higher-seq messages sitting inactive in a completely different branch.
+    const priorVariant = db.getNextMessageAfterSeq(convId, lastUser.seq)
+    const variantGroup = priorVariant && priorVariant.role === 'assistant' && !priorVariant.isActive
+      ? (priorVariant.variantGroup ?? priorVariant.id)
+      : undefined
+
     // Create a placeholder assistant message
-    db.addMessage(convId, 'assistant', '', { stats: { aborted: false } })
+    db.addMessage(convId, 'assistant', '', { stats: { aborted: false }, variantGroup })
     const assistantMsg = db.getLastMessage(convId)!
 
     const ac = new AbortController()
@@ -287,7 +304,13 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
       const engineMessages: { role: string; content: unknown }[] = []
       if (conv.systemPrompt) engineMessages.push({ role: 'system', content: conv.systemPrompt })
       for (const m of allMsgs) {
-        engineMessages.push({ role: m.role, content: m.content })
+        // GitHub #52: when preserveThinking is on, fold past reasoning back into what's
+        // resent so the model sees its own prior thinking, not just the final answer —
+        // the default behavior (off) matches what's always been sent.
+        const content = (conv.preserveThinking && m.role === 'assistant' && m.reasoning?.trim())
+          ? `<think>\n${m.reasoning}\n</think>\n\n${m.content}`
+          : m.content
+        engineMessages.push({ role: m.role, content })
       }
 
       await runGeneration(d, stream, { convId, conv, engineMessages, assistantMsg, ms, target, ac, disableThinking: b.disableThinking ?? false })
@@ -310,13 +333,27 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
   app.put('/api/v1/conversations/:id/messages/:msgId', async (c) => {
     const { id: convId, msgId } = c.req.param()
     const b = await body<{ content?: string }>(c)
-    if (!b.content?.trim()) return err(c, 400, 'invalid_input', 'content required.')
+    const trimmed = b.content?.trim()
+    if (!trimmed) return err(c, 400, 'invalid_input', 'content required.')
     const msg = db.getMessage(msgId)
     if (!msg || msg.convId !== convId) return err(c, 404, 'not_found', 'Message not found.')
-    if (msg.role !== 'user') return err(c, 400, 'invalid_input', 'Can only edit user messages.')
     if (inflight.has(convId)) return err(c, 409, 'generation_in_flight', 'Stop generation first.')
-    db.updateMessage(msgId, { content: b.content.trim() })
-    db.deleteMessagesAfterSeq(convId, msg.seq)
+
+    if (msg.role === 'assistant') {
+      // GitHub #52: edit the model's own reply in place — just fixing text, not resending,
+      // so no branching/truncation. (Regenerating a NEW reply is the separate /regenerate flow.)
+      db.updateMessage(msgId, { content: trimmed })
+      return c.json({ messages: db.getMessages(convId) })
+    }
+
+    // role === 'user': edit-and-resend now BRANCHES instead of destroying the downstream
+    // history (GitHub #52) — the old message and everything after it is frozen, not deleted,
+    // the same way /regenerate keeps a deactivated reply instead of deleting it.
+    if (trimmed === msg.content) return c.json({ messages: db.getMessages(convId) }) // no-op
+    db.freezeTail(convId, msg.seq, msg.id)
+    db.deactivateMessage(msg.id)
+    const variantGroup = db.getMessage(msg.id)!.variantGroup!
+    db.addMessage(convId, 'user', trimmed, { variantGroup, attachments: msg.attachments, textAttachments: msg.textAttachments })
     return c.json({ messages: db.getMessages(convId) })
   })
 
@@ -332,8 +369,42 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     const convId = c.req.param('id')
     if (inflight.has(convId)) return err(c, 409, 'generation_in_flight', 'Stop generation first.')
     const last = db.getLastMessage(convId)
-    if (last?.role === 'assistant') db.deleteMessage(last.id)
+    // Chat branching (GitHub #52): deactivate rather than delete — the old reply is kept
+    // as a sibling variant, not destroyed. /continue (called next by the client) creates
+    // the new reply and joins it to the same variant_group.
+    if (last?.role === 'assistant') db.deactivateMessage(last.id)
     return c.json({ ok: true })
+  })
+
+  // Chat branching: list all siblings (active + inactive) for the ‹ 1/2 › switcher UI.
+  app.get('/api/v1/conversations/:id/messages/:msgId/variants', (c) => {
+    const { id: convId, msgId } = c.req.param()
+    const msg = db.getMessage(msgId)
+    if (!msg || msg.convId !== convId) return err(c, 404, 'not_found', 'Message not found.')
+    if (!msg.variantGroup) return c.json({ variants: [msg] })
+    return c.json({ variants: db.getMessageVariants(msg.variantGroup) })
+  })
+
+  // Chat branching: switch which sibling in a variant group is the active one. For a
+  // user-message group this also swaps the entire downstream tail (freeze the one we're
+  // leaving, restore the one we're entering) — an assistant-reply group never has anything
+  // downstream to move, since /regenerate only ever acts on the last message.
+  app.post('/api/v1/conversations/:id/messages/:msgId/activate', (c) => {
+    const { id: convId, msgId } = c.req.param()
+    const msg = db.getMessage(msgId)
+    if (!msg || msg.convId !== convId) return err(c, 404, 'not_found', 'Message not found.')
+    if (!msg.variantGroup) return err(c, 400, 'invalid_input', 'Message has no alternate versions.')
+    if (inflight.has(convId)) return err(c, 409, 'generation_in_flight', 'Stop generation first.')
+    if (msg.isActive) return c.json({ messages: db.getMessages(convId) }) // already active, no-op
+
+    if (msg.role === 'user') {
+      const currentActive = db.getMessageVariants(msg.variantGroup).find((v) => v.isActive)
+      if (currentActive) db.freezeTail(convId, currentActive.seq, currentActive.id)
+      db.restoreTail(msgId)
+    }
+    const ok = db.setActiveVariant(msg.variantGroup, msgId)
+    if (!ok) return err(c, 500, 'internal', 'Could not switch branch.')
+    return c.json({ messages: db.getMessages(convId) })
   })
 
   // ── F-023: export / debug snapshot ────────────────────────────────────────
@@ -690,10 +761,15 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
       const cappedMax = clampMaxTokens(reqBody.max_tokens as number | undefined, maxLimit)
       if (cappedMax != null) reqBody.max_tokens = cappedMax
       else delete reqBody.max_tokens
+      // GitHub #52: disableThinking (this turn) and preserveThinking (past turns) are
+      // independent and can both be relevant at once, so merge rather than overwrite.
+      const templateKwargs: Record<string, unknown> = {}
       if (disableThinking) {
         reqBody.reasoning_budget = 0
-        reqBody.chat_template_kwargs = { enable_thinking: false }
+        templateKwargs.enable_thinking = false
       }
+      if (conv.preserveThinking) templateKwargs.preserve_thinking = true
+      if (Object.keys(templateKwargs).length) reqBody.chat_template_kwargs = templateKwargs
       // Attach tools only to engines whose OpenAI server accepts a `tools` array as
       // passthrough. vLLM is strict: a `tools` array (which defaults tool_choice to
       // "auto") is REJECTED with HTTP 400 — "auto tool choice requires
@@ -1008,10 +1084,15 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
       const cappedMax = clampMaxTokens(reqBody.max_tokens as number | undefined, maxLimit)
       if (cappedMax != null) reqBody.max_tokens = cappedMax
       else delete reqBody.max_tokens
+      // GitHub #52: disableThinking (this turn) and preserveThinking (past turns) are
+      // independent and can both be relevant at once, so merge rather than overwrite.
+      const templateKwargs: Record<string, unknown> = {}
       if (disableThinking) {
         reqBody.reasoning_budget = 0
-        reqBody.chat_template_kwargs = { enable_thinking: false }
+        templateKwargs.enable_thinking = false
       }
+      if (conv.preserveThinking) templateKwargs.preserve_thinking = true
+      if (Object.keys(templateKwargs).length) reqBody.chat_template_kwargs = templateKwargs
 
       const res = await fetch(`${target}/v1/chat/completions`, {
         method: 'POST',

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -342,7 +342,9 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     if (msg.role === 'assistant') {
       // GitHub #52: edit the model's own reply in place — just fixing text, not resending,
       // so no branching/truncation. (Regenerating a NEW reply is the separate /regenerate flow.)
-      db.updateMessage(msgId, { content: trimmed })
+      // Tag it "edited" so the UI can show that — this route is the ONLY place that ever
+      // sets it, unlike the generation-completion save which writes content too.
+      db.updateMessage(msgId, { content: trimmed, edited: true })
       return c.json({ messages: db.getMessages(convId) })
     }
 

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -78,7 +78,7 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
   })
 
   app.post('/api/v1/conversations', async (c) => {
-    const b = await body<{ title?: string; systemPrompt?: string; modelKey?: string; toolPolicy?: string; skillIds?: string[]; allowedTools?: string[] }>(c)
+    const b = await body<{ title?: string; systemPrompt?: string; modelKey?: string; toolPolicy?: string; skillIds?: string[]; allowedTools?: string[]; sampling?: Record<string, number>; preserveThinking?: boolean }>(c)
     // Only keep ids that exist in the shared skill library; silently drop unknown ones.
     const validIds = new Set(new SkillStore(d.store.dir()).list().map((s) => s.id))
     const skillIds = Array.isArray(b.skillIds) ? b.skillIds.filter((sid) => validIds.has(sid)) : undefined
@@ -86,7 +86,9 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     // validated against the live tool catalog — an MCP server disconnecting later
     // shouldn't retroactively corrupt the conversation's saved intent.
     const allowedTools = Array.isArray(b.allowedTools) ? b.allowedTools.filter((t) => typeof t === 'string') : undefined
-    const conv = db.createConversation({ title: b.title, systemPrompt: b.systemPrompt, modelKey: b.modelKey, toolPolicy: b.toolPolicy, skillIds, allowedTools })
+    const sampling = (b.sampling && typeof b.sampling === 'object') ? b.sampling : undefined
+    const preserveThinking = typeof b.preserveThinking === 'boolean' ? b.preserveThinking : undefined
+    const conv = db.createConversation({ title: b.title, systemPrompt: b.systemPrompt, modelKey: b.modelKey, toolPolicy: b.toolPolicy, skillIds, allowedTools, sampling, preserveThinking })
     return c.json(conv, 201)
   })
 

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -200,12 +200,15 @@ export interface Message {
   /** Chat branching (user-message edits): the specific message-version id this row's
    *  downstream tail was frozen under, when it's not part of the live/active tail. */
   branchOf: string | null
+  /** True only when a user explicitly edited this assistant reply's text in place —
+   *  never set by the normal generation-completion save. */
+  edited: boolean
 }
 
 interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; agent_id: string | null; completed_at: string | null; read_scope: string | null; agent_mode: string | null; skill_ids: string | null; allowed_tools: string | null; preserve_thinking: number; created_at: string; updated_at: string }
 interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null }
 interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
-interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string; variant_group: string | null; is_active: number; branch_of: string | null }
+interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string; variant_group: string | null; is_active: number; branch_of: string | null; edited: number }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
 type P = Record<string, SQLInputValue>
@@ -246,7 +249,7 @@ function rowToAgentRun(r: AgentRunRow): AgentRun {
 }
 
 function rowToMsg(r: MsgRow): Message {
-  const msg: Message = { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], toolCalls: r.tool_calls ? safeJson(r.tool_calls) as ToolCallRecord[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at, variantGroup: r.variant_group, isActive: r.is_active !== 0, branchOf: r.branch_of }
+  const msg: Message = { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], toolCalls: r.tool_calls ? safeJson(r.tool_calls) as ToolCallRecord[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at, variantGroup: r.variant_group, isActive: r.is_active !== 0, branchOf: r.branch_of, edited: r.edited === 1 }
   if (r.research_meta) msg.researchMeta = safeJson(r.research_meta) as ResearchMeta
   return msg
 }
@@ -537,6 +540,13 @@ export class ConversationStore {
       if (!this.hasColumn('conversations', 'preserve_thinking')) this.db.exec(`ALTER TABLE conversations ADD COLUMN preserve_thinking INTEGER NOT NULL DEFAULT 0;`)
       this.db.exec(`PRAGMA user_version = 25;`)
     }
+    // v26: "Edited" tag — set only when a user explicitly edits an assistant reply's text
+    // in place (the PUT /messages/:msgId assistant-role path), never by the normal
+    // generation-completion save, so it means what it says.
+    if (v < 26) {
+      if (!this.hasColumn('messages', 'edited')) this.db.exec(`ALTER TABLE messages ADD COLUMN edited INTEGER NOT NULL DEFAULT 0;`)
+      this.db.exec(`PRAGMA user_version = 26;`)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -642,7 +652,7 @@ export class ConversationStore {
     return row ? rowToMsg(row) : null
   }
 
-  updateMessage(id: string, patch: Partial<Pick<Message, 'content' | 'reasoning' | 'toolCalls' | 'stats' | 'researchMeta'>>): boolean {
+  updateMessage(id: string, patch: Partial<Pick<Message, 'content' | 'reasoning' | 'toolCalls' | 'stats' | 'researchMeta' | 'edited'>>): boolean {
     const sets: string[] = []
     const params: Record<string, SQLInputValue> = { $id: id }
     if (patch.content      !== undefined) { sets.push('content = $content');         params.$content      = patch.content }
@@ -650,6 +660,7 @@ export class ConversationStore {
     if (patch.toolCalls    !== undefined) { sets.push('tool_calls = $tc');           params.$tc           = JSON.stringify(patch.toolCalls) }
     if (patch.stats        !== undefined) { sets.push('stats = $stats');             params.$stats        = JSON.stringify(patch.stats) }
     if (patch.researchMeta !== undefined) { sets.push('research_meta = $rm');        params.$rm           = JSON.stringify(patch.researchMeta) }
+    if (patch.edited       !== undefined) { sets.push('edited = $edited');           params.$edited       = patch.edited ? 1 : 0 }
     if (!sets.length) return false
     return ((this.db.prepare(`UPDATE messages SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0
   }

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -43,6 +43,11 @@ export interface Conversation {
   /** Tool-name allow-list baked in from a custom chat Agent at creation (Customize →
    *  Agents). Undefined/empty = unrestricted (every built-in persona). */
   allowedTools?: string[]
+  /** GitHub #52: when true, past turns' reasoning is folded back into what's resent to
+   *  the engine (wrapped in <think> tags, with chat_template_kwargs.preserve_thinking
+   *  set so the template doesn't strip it back out) instead of only their final content.
+   *  Off by default. */
+  preserveThinking: boolean
   createdAt: string
   updatedAt: string
   messages?: Message[]
@@ -186,12 +191,21 @@ export interface Message {
   /** F-021/F-022: research metadata (confidence, sources, referee verdicts). Absent on non-research messages. */
   researchMeta?: ResearchMeta
   createdAt: string
+  /** Chat branching (GitHub #52): shared by this message and its regenerated siblings.
+   *  Null when the message has never been regenerated (no branch UI to show). */
+  variantGroup: string | null
+  /** Chat branching: whether this is the sibling currently shown/sent as history.
+   *  getMessages() only returns active messages. */
+  isActive: boolean
+  /** Chat branching (user-message edits): the specific message-version id this row's
+   *  downstream tail was frozen under, when it's not part of the live/active tail. */
+  branchOf: string | null
 }
 
-interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; agent_id: string | null; completed_at: string | null; read_scope: string | null; agent_mode: string | null; skill_ids: string | null; allowed_tools: string | null; created_at: string; updated_at: string }
+interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; agent_id: string | null; completed_at: string | null; read_scope: string | null; agent_mode: string | null; skill_ids: string | null; allowed_tools: string | null; preserve_thinking: number; created_at: string; updated_at: string }
 interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null }
 interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
-interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string }
+interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string; variant_group: string | null; is_active: number; branch_of: string | null }
 
 // node:sqlite named-param objects need an explicit cast to Record<string, SQLInputValue>
 type P = Record<string, SQLInputValue>
@@ -210,7 +224,7 @@ function safeToolOverrides(s: string | null): Record<string, 'allow' | 'deny'> {
 }
 
 function rowToConv(r: ConvRow): Conversation {
-  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), folderId: r.folder_id ?? null, toolOverrides: safeToolOverrides(r.tool_overrides), agentId: r.agent_id ?? undefined, completedAt: r.completed_at ?? undefined, readScope: r.read_scope ? (safeJson(r.read_scope) as string[]) : undefined, agentMode: r.agent_mode ?? undefined, skillIds: r.skill_ids ? (safeJson(r.skill_ids) as string[]) : undefined, allowedTools: r.allowed_tools ? (safeJson(r.allowed_tools) as string[]) : undefined, createdAt: r.created_at, updatedAt: r.updated_at }
+  return { id: r.id, title: r.title, systemPrompt: r.system_prompt, modelKey: r.model_key, sampling: safeJson(r.sampling) as Record<string, unknown>, expertMode: r.expert_mode === 1, toolPolicy: r.tool_policy ?? undefined, kind: (r.kind === 'agent' ? 'agent' : 'chat'), folderId: r.folder_id ?? null, toolOverrides: safeToolOverrides(r.tool_overrides), agentId: r.agent_id ?? undefined, completedAt: r.completed_at ?? undefined, readScope: r.read_scope ? (safeJson(r.read_scope) as string[]) : undefined, agentMode: r.agent_mode ?? undefined, skillIds: r.skill_ids ? (safeJson(r.skill_ids) as string[]) : undefined, allowedTools: r.allowed_tools ? (safeJson(r.allowed_tools) as string[]) : undefined, preserveThinking: r.preserve_thinking === 1, createdAt: r.created_at, updatedAt: r.updated_at }
 }
 
 function rowToFolder(r: FolderRow): Folder {
@@ -232,7 +246,7 @@ function rowToAgentRun(r: AgentRunRow): AgentRun {
 }
 
 function rowToMsg(r: MsgRow): Message {
-  const msg: Message = { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], toolCalls: r.tool_calls ? safeJson(r.tool_calls) as ToolCallRecord[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at }
+  const msg: Message = { id: r.id, convId: r.conv_id, seq: r.seq, role: r.role, content: r.content, reasoning: r.reasoning, attachments: safeJson(r.attachments) as string[], textAttachments: r.text_attachments ? safeJson(r.text_attachments) as string[] : [], toolCalls: r.tool_calls ? safeJson(r.tool_calls) as ToolCallRecord[] : [], stats: safeJson(r.stats) as Partial<MessageStats>, createdAt: r.created_at, variantGroup: r.variant_group, isActive: r.is_active !== 0, branchOf: r.branch_of }
   if (r.research_meta) msg.researchMeta = safeJson(r.research_meta) as ResearchMeta
   return msg
 }
@@ -495,6 +509,34 @@ export class ConversationStore {
       if (!this.hasColumn('conversations', 'allowed_tools')) this.db.exec(`ALTER TABLE conversations ADD COLUMN allowed_tools TEXT;`)
       this.db.exec(`PRAGMA user_version = 22;`)
     }
+    // v23 (GitHub #52 item 2 — chat branching): regenerating a reply used to delete it
+    // outright. Now the old message is kept and deactivated instead — `variant_group`
+    // groups a message with its regenerated siblings (defaults to the group's own first
+    // message id), `is_active` marks which one is currently shown/sent as history.
+    // Existing rows default to is_active=1, variant_group=NULL (no branch UI for them).
+    if (v < 23) {
+      if (!this.hasColumn('messages', 'variant_group')) this.db.exec(`ALTER TABLE messages ADD COLUMN variant_group TEXT;`)
+      if (!this.hasColumn('messages', 'is_active')) this.db.exec(`ALTER TABLE messages ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;`)
+      this.db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_variant_group ON messages(conv_id, variant_group);`)
+      this.db.exec(`PRAGMA user_version = 23;`)
+    }
+    // v24 (GitHub #52 item 2, extended to user-message edits): editing an earlier user
+    // message used to hard-delete everything after it. Now that whole downstream tail is
+    // frozen (deactivated) instead, tagged with `branch_of` = the specific message version
+    // it was frozen under, so switching back to that version can restore exactly what was
+    // there — including whichever regenerate-sibling (variant_group) was active within it.
+    if (v < 24) {
+      if (!this.hasColumn('messages', 'branch_of')) this.db.exec(`ALTER TABLE messages ADD COLUMN branch_of TEXT;`)
+      this.db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_branch_of ON messages(conv_id, branch_of);`)
+      this.db.exec(`PRAGMA user_version = 24;`)
+    }
+    // v25 (GitHub #52 item 1): per-conversation "preserve thinking across turns" toggle.
+    // Off by default — matches today's behavior, where only the final visible content of
+    // past turns is ever resent to the engine, never raw reasoning.
+    if (v < 25) {
+      if (!this.hasColumn('conversations', 'preserve_thinking')) this.db.exec(`ALTER TABLE conversations ADD COLUMN preserve_thinking INTEGER NOT NULL DEFAULT 0;`)
+      this.db.exec(`PRAGMA user_version = 25;`)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -531,7 +573,7 @@ export class ConversationStore {
     return conv
   }
 
-  updateConversation(id: string, patch: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'modelKey' | 'skillIds'>>): boolean {
+  updateConversation(id: string, patch: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'modelKey' | 'skillIds' | 'preserveThinking'>>): boolean {
     const now = new Date().toISOString()
     const sets: string[] = ['updated_at = $now']
     const params: Record<string, SQLInputValue> = { $id: id, $now: now }
@@ -540,6 +582,7 @@ export class ConversationStore {
     if (patch.sampling !== undefined)     { sets.push('sampling = $samp');    params.$samp  = JSON.stringify(patch.sampling) }
     if (patch.modelKey !== undefined)     { sets.push('model_key = $mk');     params.$mk    = patch.modelKey }
     if (patch.skillIds !== undefined)     { sets.push('skill_ids = $sk');     params.$sk    = JSON.stringify(patch.skillIds) }
+    if (patch.preserveThinking !== undefined) { sets.push('preserve_thinking = $pt'); params.$pt = patch.preserveThinking ? 1 : 0 }
     return ((this.db.prepare(`UPDATE conversations SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0
   }
 
@@ -567,11 +610,13 @@ export class ConversationStore {
     return ((this.db.prepare(`DELETE FROM conversations WHERE id = $id`).run({ $id: id } as P) as unknown) as Changes).changes > 0
   }
 
+  /** Active-branch messages only — this is the conversation as the user sees it and as
+   *  it's sent to the engine. Regenerated-away siblings (is_active=0) are excluded. */
   getMessages(convId: string): Message[] {
-    return (this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id ORDER BY seq ASC`).all({ $id: convId } as P) as unknown as MsgRow[]).map(rowToMsg)
+    return (this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id AND is_active = 1 ORDER BY seq ASC`).all({ $id: convId } as P) as unknown as MsgRow[]).map(rowToMsg)
   }
 
-  addMessage(convId: string, role: 'user' | 'assistant', content: string, extra?: Partial<Pick<Message, 'reasoning' | 'attachments' | 'textAttachments' | 'toolCalls' | 'stats'>>): Message {
+  addMessage(convId: string, role: 'user' | 'assistant', content: string, extra?: Partial<Pick<Message, 'reasoning' | 'attachments' | 'textAttachments' | 'toolCalls' | 'stats' | 'variantGroup'>>): Message {
     const id = randomUUID()
     const now = new Date().toISOString()
     const row = this.db.prepare(`SELECT COALESCE(MAX(seq),0) AS ms FROM messages WHERE conv_id = $id`).get({ $id: convId } as P) as unknown as { ms: number }
@@ -580,8 +625,8 @@ export class ConversationStore {
     const modelKey = role === 'assistant' ? this.conversationModelKey(convId) : null
     const textAttachments = extra?.textAttachments?.length ? JSON.stringify(extra.textAttachments) : null
     const toolCalls = extra?.toolCalls?.length ? JSON.stringify(extra.toolCalls) : null
-    this.db.prepare(`INSERT INTO messages (id,conv_id,seq,role,content,reasoning,attachments,text_attachments,tool_calls,stats,model_key,created_at) VALUES ($id,$cid,$seq,$role,$content,$reasoning,$attachments,$ta,$tc,$stats,$mk,$now)`)
-      .run({ $id: id, $cid: convId, $seq: row.ms + 1, $role: role, $content: content, $reasoning: extra?.reasoning ?? '', $attachments: JSON.stringify(extra?.attachments ?? []), $ta: textAttachments, $tc: toolCalls, $stats: JSON.stringify(extra?.stats ?? {}), $mk: modelKey, $now: now } as P)
+    this.db.prepare(`INSERT INTO messages (id,conv_id,seq,role,content,reasoning,attachments,text_attachments,tool_calls,stats,model_key,created_at,variant_group,is_active) VALUES ($id,$cid,$seq,$role,$content,$reasoning,$attachments,$ta,$tc,$stats,$mk,$now,$vg,1)`)
+      .run({ $id: id, $cid: convId, $seq: row.ms + 1, $role: role, $content: content, $reasoning: extra?.reasoning ?? '', $attachments: JSON.stringify(extra?.attachments ?? []), $ta: textAttachments, $tc: toolCalls, $stats: JSON.stringify(extra?.stats ?? {}), $mk: modelKey, $now: now, $vg: extra?.variantGroup ?? null } as P)
     this.touchConversation(convId)
     return this.getMessage(id)!
   }
@@ -613,10 +658,6 @@ export class ConversationStore {
     return ((this.db.prepare(`DELETE FROM messages WHERE id = $id`).run({ $id: id } as P) as unknown) as Changes).changes > 0
   }
 
-  deleteMessagesAfterSeq(convId: string, seq: number): void {
-    this.db.prepare(`DELETE FROM messages WHERE conv_id = $id AND seq > $seq`).run({ $id: convId, $seq: seq } as P)
-  }
-
   /** Most-recent assistant gen t/s per model (spec 04 §5 `lastTps`). For each
    *  model_key, takes the newest assistant message that recorded a positive
    *  `stats.tps` and returns its value. Rows with NULL model_key (pre-v2) or no
@@ -636,9 +677,65 @@ export class ConversationStore {
     return out
   }
 
+  /** Active branch only — matches getMessages(). Used to find "the last thing the user
+   *  currently sees" (e.g. to decide whether a fresh assistant placeholder follows it). */
   getLastMessage(convId: string): Message | null {
+    const row = this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id AND is_active = 1 ORDER BY seq DESC LIMIT 1`).get({ $id: convId } as P) as unknown as MsgRow | undefined
+    return row ? rowToMsg(row) : null
+  }
+
+  /** Like getLastMessage, but ignores is_active — the globally last-inserted row in this
+   *  conversation, regardless of which branch it belongs to. */
+  getLastMessageAnyStatus(convId: string): Message | null {
     const row = this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id ORDER BY seq DESC LIMIT 1`).get({ $id: convId } as P) as unknown as MsgRow | undefined
     return row ? rowToMsg(row) : null
+  }
+
+  /** The message immediately after `afterSeq` in this conversation, regardless of
+   *  is_active — used right after regenerate deactivates a reply, to find specifically
+   *  THAT message (not just "whatever has the highest seq anywhere," which would pick up
+   *  an unrelated later branch's messages in a conversation with more than one branch
+   *  point — seq is monotonic and per-row-unique, so this is unambiguous). */
+  getNextMessageAfterSeq(convId: string, afterSeq: number): Message | null {
+    const row = this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id AND seq > $seq ORDER BY seq ASC LIMIT 1`).get({ $id: convId, $seq: afterSeq } as P) as unknown as MsgRow | undefined
+    return row ? rowToMsg(row) : null
+  }
+
+  /** Chat branching (GitHub #52): deactivate a message instead of deleting it, and
+   *  establish its variant_group (its own id) if this is its first regeneration. */
+  deactivateMessage(id: string): void {
+    this.db.prepare(`UPDATE messages SET is_active = 0, variant_group = COALESCE(variant_group, id) WHERE id = $id`).run({ $id: id } as P)
+  }
+
+  /** All siblings sharing a variant_group (active + inactive), oldest first — the full
+   *  set the branch switcher UI (‹ 2/3 ›) needs. */
+  getMessageVariants(variantGroup: string): Message[] {
+    return (this.db.prepare(`SELECT * FROM messages WHERE variant_group = $vg ORDER BY seq ASC`).all({ $vg: variantGroup } as P) as unknown as MsgRow[]).map(rowToMsg)
+  }
+
+  /** Switches which sibling in a variant group is the active/shown one. No-op (returns
+   *  false) if targetId isn't actually a member of that group. */
+  setActiveVariant(variantGroup: string, targetId: string): boolean {
+    const target = this.getMessage(targetId)
+    if (!target || target.variantGroup !== variantGroup) return false
+    this.db.prepare(`UPDATE messages SET is_active = 0 WHERE variant_group = $vg`).run({ $vg: variantGroup } as P)
+    this.db.prepare(`UPDATE messages SET is_active = 1 WHERE id = $id`).run({ $id: targetId } as P)
+    return true
+  }
+
+  /** Chat branching (user-message edits, GitHub #52): freeze the currently-active tail
+   *  after `afterSeq` — everything downstream of an edited/switched-away-from message —
+   *  by deactivating it and tagging it with `anchorId` so restoreTail can bring back
+   *  exactly this state later, including whichever regenerate-sibling was active in it. */
+  freezeTail(convId: string, afterSeq: number, anchorId: string): void {
+    this.db.prepare(`UPDATE messages SET is_active = 0, branch_of = $anchor WHERE conv_id = $id AND seq > $seq AND is_active = 1`)
+      .run({ $id: convId, $seq: afterSeq, $anchor: anchorId } as P)
+  }
+
+  /** Chat branching: reactivate every message previously frozen under `anchorId` — the
+   *  inverse of freezeTail, used when switching back to that message version. */
+  restoreTail(anchorId: string): void {
+    this.db.prepare(`UPDATE messages SET is_active = 1 WHERE branch_of = $anchor`).run({ $anchor: anchorId } as P)
   }
 
   // ── Folder methods (v10 migration) ────────────────────────────────────────

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -46,7 +46,8 @@ export interface Conversation {
   /** GitHub #52: when true, past turns' reasoning is folded back into what's resent to
    *  the engine (wrapped in <think> tags, with chat_template_kwargs.preserve_thinking
    *  set so the template doesn't strip it back out) instead of only their final content.
-   *  Off by default. */
+   *  On by default for new conversations (createConversation); the underlying column
+   *  still defaults to 0 for already-migrated rows — see createConversation's comment. */
   preserveThinking: boolean
   createdAt: string
   updatedAt: string
@@ -567,11 +568,14 @@ export class ConversationStore {
     return (this.db.prepare(`SELECT * FROM conversations ORDER BY updated_at DESC LIMIT 200`).all() as unknown as ConvRow[]).map(rowToConv)
   }
 
-  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy' | 'kind' | 'folderId' | 'agentId' | 'skillIds' | 'allowedTools'>>): Conversation {
+  createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'sampling' | 'expertMode' | 'toolPolicy' | 'kind' | 'folderId' | 'agentId' | 'skillIds' | 'allowedTools' | 'preserveThinking'>>): Conversation {
     const now = new Date().toISOString()
     const id = randomUUID()
-    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,kind,folder_id,agent_id,skill_ids,allowed_tools,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$kind,$fid,$aid,$sk,$at,$now,$now)`)
-      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $kind: partial?.kind ?? 'chat', $fid: partial?.folderId ?? null, $aid: partial?.agentId ?? null, $sk: partial?.skillIds ? JSON.stringify(partial.skillIds) : null, $at: partial?.allowedTools ? JSON.stringify(partial.allowedTools) : null, $now: now } as P)
+    // preserve_thinking's column default is baked in at ALTER TABLE time (v25) and can't
+    // be changed retroactively for already-migrated DBs — so "on by default for new chats"
+    // is enforced here instead, by always writing an explicit value.
+    this.db.prepare(`INSERT INTO conversations (id,title,system_prompt,model_key,sampling,expert_mode,tool_policy,kind,folder_id,agent_id,skill_ids,allowed_tools,preserve_thinking,created_at,updated_at) VALUES ($id,$title,$sp,$mk,$samp,$expert,$tp,$kind,$fid,$aid,$sk,$at,$pt,$now,$now)`)
+      .run({ $id: id, $title: partial?.title ?? 'New chat', $sp: partial?.systemPrompt ?? '', $mk: partial?.modelKey ?? '', $samp: JSON.stringify(partial?.sampling ?? {}), $expert: partial?.expertMode ? 1 : 0, $tp: partial?.toolPolicy ?? null, $kind: partial?.kind ?? 'chat', $fid: partial?.folderId ?? null, $aid: partial?.agentId ?? null, $sk: partial?.skillIds ? JSON.stringify(partial.skillIds) : null, $at: partial?.allowedTools ? JSON.stringify(partial.allowedTools) : null, $pt: (partial?.preserveThinking ?? true) ? 1 : 0, $now: now } as P)
     return this.getConversation(id)!
   }
 

--- a/turbollm/src/chat/edited-tag.test.ts
+++ b/turbollm/src/chat/edited-tag.test.ts
@@ -1,0 +1,70 @@
+// "Edited" tag on assistant replies — set only by an explicit in-place edit
+// (PUT /messages/:msgId's assistant-role path in chat-routes.ts), never by the normal
+// generation-completion save.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ConversationStore } from './db.js'
+
+function tempStore(): { store: ConversationStore; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-edited-'))
+  return { store: new ConversationStore(dir), dir }
+}
+
+test('a fresh message defaults to edited: false', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const msg = store.addMessage(conv.id, 'assistant', 'hello')
+    assert.equal(msg.edited, false)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('updateMessage with edited: true persists and survives a re-read', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const msg = store.addMessage(conv.id, 'assistant', 'hello')
+    store.updateMessage(msg.id, { content: 'hello, fixed', edited: true })
+    const reread = store.getMessage(msg.id)!
+    assert.equal(reread.edited, true)
+    assert.equal(reread.content, 'hello, fixed')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a normal generation-completion-style updateMessage call (no edited field) leaves edited false', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const msg = store.addMessage(conv.id, 'assistant', '')
+    // Mirrors the real call shape in chat-routes.ts/generation.ts: content/reasoning/
+    // toolCalls/stats, but never `edited` — that field is exclusive to the edit route.
+    store.updateMessage(msg.id, { content: 'final answer', reasoning: 'thinking...', stats: { tps: 42 } })
+    assert.equal(store.getMessage(msg.id)!.edited, false)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('setting edited: true does not disturb other fields left unset', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const msg = store.addMessage(conv.id, 'assistant', 'original', { reasoning: 'original thinking' })
+    store.updateMessage(msg.id, { content: 'edited text', edited: true })
+    const reread = store.getMessage(msg.id)!
+    assert.equal(reread.reasoning, 'original thinking', 'unrelated fields must be untouched by the edit')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/chat/preserve-thinking.test.ts
+++ b/turbollm/src/chat/preserve-thinking.test.ts
@@ -14,11 +14,11 @@ function tempStore(): { store: ConversationStore; dir: string } {
   return { store: new ConversationStore(dir), dir }
 }
 
-test('a fresh conversation defaults to preserveThinking: false', () => {
+test('a fresh conversation defaults to preserveThinking: true', () => {
   const { store, dir } = tempStore()
   try {
     const conv = store.createConversation()
-    assert.equal(conv.preserveThinking, false)
+    assert.equal(conv.preserveThinking, true)
   } finally {
     store.close()
     rmSync(dir, { recursive: true, force: true })

--- a/turbollm/src/chat/preserve-thinking.test.ts
+++ b/turbollm/src/chat/preserve-thinking.test.ts
@@ -1,0 +1,65 @@
+// Per-conversation "preserve thinking across turns" toggle (GitHub #52 item 1).
+// Covers the db-layer round trip; the actual chat_template_kwargs merge and
+// content-folding logic live in chat-routes.ts and are exercised via live
+// verification (no HTTP harness in this test suite).
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ConversationStore } from './db.js'
+
+function tempStore(): { store: ConversationStore; dir: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-preserve-thinking-'))
+  return { store: new ConversationStore(dir), dir }
+}
+
+test('a fresh conversation defaults to preserveThinking: false', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    assert.equal(conv.preserveThinking, false)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('updateConversation persists preserveThinking: true and it survives a re-read', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    const ok = store.updateConversation(conv.id, { preserveThinking: true })
+    assert.equal(ok, true)
+    assert.equal(store.getConversation(conv.id)!.preserveThinking, true)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('updateConversation can turn preserveThinking back off', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    store.updateConversation(conv.id, { preserveThinking: true })
+    store.updateConversation(conv.id, { preserveThinking: false })
+    assert.equal(store.getConversation(conv.id)!.preserveThinking, false)
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('updateConversation omitting preserveThinking leaves the existing value untouched', () => {
+  const { store, dir } = tempStore()
+  try {
+    const conv = store.createConversation()
+    store.updateConversation(conv.id, { preserveThinking: true })
+    store.updateConversation(conv.id, { title: 'renamed, unrelated field' })
+    assert.equal(store.getConversation(conv.id)!.preserveThinking, true, 'an unrelated PATCH must not silently reset the toggle')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/engines/download.installed.test.ts
+++ b/turbollm/src/engines/download.installed.test.ts
@@ -11,11 +11,35 @@ function tmpRoot(): string {
   return mkdtempSync(join(tmpdir(), 'tllm-dl-'))
 }
 
-/** Create an extracted backend build dir `llama.cpp-<tag>-<id>/` with a server binary. */
+/** Create a FULLY (marker included) extracted backend build dir `llama.cpp-<tag>-<id>/`
+ *  with a server binary — a real, complete install. */
 function seedBuild(root: string, tag: string, id: string): string {
   const dir = join(root, `llama.cpp-${tag}-${id}`)
   mkdirSync(dir, { recursive: true })
   writeFileSync(join(dir, serverBin), '')
+  writeFileSync(join(dir, '.turbollm-provisioned'), '{}')
+  return dir
+}
+
+/** Create a PARTIAL build dir — has the server binary but no completion marker, e.g. a
+ *  multi-asset backend (CUDA) whose second asset (cudart) was never fetched. Regression
+ *  fixture for the real bug this covers: such a dir used to be reported as "installed"
+ *  and the CUDA backend would silently fall back to CPU. */
+function seedPartialBuild(root: string, tag: string, id: string): string {
+  const dir = join(root, `llama.cpp-${tag}-${id}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, serverBin), '')
+  return dir
+}
+
+/** Create a build dir that's actually complete but predates the completion marker
+ *  (installed by an older TurboLLM version) — server binary + cudart DLL for CUDA,
+ *  server binary alone for anything else, no marker file. */
+function seedLegacyBuild(root: string, tag: string, id: string): string {
+  const dir = join(root, `llama.cpp-${tag}-${id}`)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, serverBin), '')
+  if (id === 'cuda') writeFileSync(join(dir, 'cudart64_13.dll'), '')
   return dir
 }
 
@@ -48,6 +72,49 @@ test('installedBackendBuild ignores a build dir with no server binary', () => {
   const root = tmpRoot()
   mkdirSync(join(root, 'llama.cpp-b9754-cuda'), { recursive: true }) // empty, no binary
   assert.equal(installedBackendBuild(root, 'cuda'), null)
+})
+
+// Regression: a CUDA build with the server binary present but its cudart runtime asset
+// never extracted (no completion marker) used to be reported as a working install — the
+// CUDA backend then silently falls back to CPU (ggml-cuda.dll can't find cudart64_*/
+// cublas64_*/cublasLt64_* at runtime, with no error logged).
+test('installedBackendBuild ignores a build dir with a binary but no completion marker (partial multi-asset install)', () => {
+  const root = tmpRoot()
+  seedPartialBuild(root, 'b9754', 'cuda')
+  assert.equal(installedBackendBuild(root, 'cuda'), null)
+})
+
+test('installedBackendBuild prefers a fully-provisioned older build over a partial newer one', () => {
+  const root = tmpRoot()
+  seedBuild(root, 'b9700', 'cuda')
+  seedPartialBuild(root, 'b9754', 'cuda') // newer tag, but incomplete
+  assert.equal(installedBackendBuild(root, 'cuda')!.tag, 'b9700')
+})
+
+// Backward compat: a build installed by a TurboLLM version older than the completion
+// marker has no marker file even though it's genuinely complete — must not be treated
+// as broken (that would force every existing user to re-download their working engines).
+test('installedBackendBuild recognizes a legacy (pre-marker) CUDA build that actually has the cudart DLLs', () => {
+  const root = tmpRoot()
+  const dir = seedLegacyBuild(root, 'b9608', 'cuda')
+  const found = installedBackendBuild(root, 'cuda')
+  assert.ok(found, 'a genuinely-complete legacy build must still be recognized')
+  assert.equal(found!.tag, 'b9608')
+  assert.ok(existsSync(join(dir, '.turbollm-provisioned')), 'the marker is backfilled so this only needs deriving once')
+})
+
+test('installedBackendBuild does NOT backfill a legacy CUDA build that is missing the cudart DLLs', () => {
+  const root = tmpRoot()
+  seedPartialBuild(root, 'b9736', 'cuda') // binary only — the exact real-world broken case
+  assert.equal(installedBackendBuild(root, 'cuda'), null)
+})
+
+test('installedBackendBuild recognizes a legacy non-CUDA build with no marker (single-asset backends never needed one)', () => {
+  const root = tmpRoot()
+  seedLegacyBuild(root, 'b9754', 'rocm')
+  const found = installedBackendBuild(root, 'rocm')
+  assert.ok(found, 'a single-asset backend is complete as soon as its one binary exists')
+  assert.equal(found!.tag, 'b9754')
 })
 
 test('installedBackendBuild returns null for a missing engines root', () => {

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -285,7 +285,9 @@ function isFullyProvisioned(dir: string): boolean {
   const bin = findServer(dir)
   if (!bin) return false
   if (/-cuda$/.test(dir) && !hasCudartRuntime(dir)) return false
-  writeFileSync(join(dir, PROVISION_MARKER), JSON.stringify({ backfilled: true }))
+  // Best-effort: a read-only dir or full disk shouldn't 500 the caller (this runs inside
+  // route handlers) — a failed write just means the next call re-derives it the same way.
+  try { writeFileSync(join(dir, PROVISION_MARKER), JSON.stringify({ backfilled: true })) } catch { /* re-derived next time */ }
   return true
 }
 

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -174,7 +174,9 @@ export function installedBackendBuild(
  *  huge tree can't make the scan hang — default keeps the original full-walk
  *  behavior for existing callers. */
 export function findFile(dir: string, name: string, skipDir?: (dirName: string) => boolean): string | null {
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
+  const entries = tryReaddir(dir)
+  if (!entries) return null
+  for (const e of entries) {
     const full = join(dir, e.name)
     if (e.isDirectory()) {
       if (skipDir?.(e.name)) continue
@@ -185,6 +187,16 @@ export function findFile(dir: string, name: string, skipDir?: (dirName: string) 
     }
   }
   return null
+}
+
+/** Read a directory's entries, or null if it can't be read (e.g. an OS-protected folder
+ *  throwing EPERM/EACCES) — lets a broad recursive scan skip past it instead of crashing. */
+function tryReaddir(dir: string) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return null
+  }
 }
 
 function findServer(dir: string): string | null {

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -4,7 +4,7 @@
 // the app-data engines dir. No bundling, no system paths, dependency-free
 // (Node fetch; PowerShell Expand-Archive / tar for extraction). The user can
 // override the backend; we fall back GPU → Vulkan → CPU if a build won't run.
-import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { execFile, execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
@@ -162,8 +162,10 @@ export function installedBackendBuild(
     const m = re.exec(name)
     if (!m) continue
     const dir = join(enginesRoot, name)
-    const bin = findServer(dir)
-    if (!bin) continue
+    // A dir with a server binary but no completion marker is a partial/legacy install
+    // (see PROVISION_MARKER) — must not be reported as a working, installed build.
+    if (!isFullyProvisioned(dir)) continue
+    const bin = findServer(dir)!
     if (!best || buildNum(m[1]) > buildNum(best.tag)) best = { dir, tag: m[1], bin }
   }
   return best
@@ -250,6 +252,43 @@ export async function extractArchive(archive: string, destDir: string): Promise<
   stripMacOsQuarantine(destDir)
 }
 
+// Written into a backend build dir once EVERY asset (e.g. CUDA's binary + its cudart
+// runtime bundle) has downloaded and extracted successfully. Its presence is what
+// "installed" actually means — a dir with a server binary but no marker means an
+// earlier run stopped partway (e.g. an asset was added to a backend after this dir was
+// first provisioned, or a prior version only fetched one of several required assets),
+// which used to be silently mistaken for a complete, working install (real bug: the CUDA
+// backend then falls back to CPU with no error, because ggml-cuda.dll can't find the
+// cudart64_*/cublas64_*/cublasLt64_* DLLs it needs but nothing downloaded them).
+const PROVISION_MARKER = '.turbollm-provisioned'
+
+/** Whether `dir` has the CUDA cudart runtime DLLs directly beside the server binary
+ *  (`cudart64_*.dll` — extracted from the second asset). Non-recursive: the multi-asset
+ *  extraction always places them at the top level, same as the server binary itself. */
+function hasCudartRuntime(dir: string): boolean {
+  try {
+    return readdirSync(dir).some((f) => /^cudart64_\d+\.dll$/i.test(f))
+  } catch {
+    return false
+  }
+}
+
+/** Whether every asset for this backend was ever confirmed downloaded. Presence of
+ *  PROVISION_MARKER is the fast path. Builds installed by a TurboLLM version older than
+ *  the marker (or before this backend needed a second asset) have no marker yet — for
+ *  those, backfill: a CUDA dir only counts as complete if the cudart DLLs are actually
+ *  there (the real signal this whole check exists to verify); any other backend is
+ *  single-asset, so the binary alone is proof enough. Writes the marker on first pass so
+ *  this only needs to re-derive it once per build dir. */
+function isFullyProvisioned(dir: string): boolean {
+  if (existsSync(join(dir, PROVISION_MARKER))) return !!findServer(dir)
+  const bin = findServer(dir)
+  if (!bin) return false
+  if (/-cuda$/.test(dir) && !hasCudartRuntime(dir)) return false
+  writeFileSync(join(dir, PROVISION_MARKER), JSON.stringify({ backfilled: true }))
+  return true
+}
+
 /**
  * Ensure a backend is downloaded + extracted; return the llama-server path.
  * Multi-asset backends (CUDA = binary + cudart) extract into the same dir so the
@@ -264,7 +303,7 @@ export async function provisionBackend(
 ): Promise<string> {
   const destDir = join(enginesRoot, `llama.cpp-${tag}-${backend.id}`)
 
-  if (existsSync(destDir)) {
+  if (isFullyProvisioned(destDir)) {
     const found = findServer(destDir)
     if (found) return found
   }
@@ -293,6 +332,7 @@ export async function provisionBackend(
 
   const bin = findServer(destDir)
   if (!bin) throw new Error('llama-server not found in extracted archive(s)')
+  writeFileSync(join(destDir, PROVISION_MARKER), JSON.stringify({ assets: backend.assets, tag }))
   return bin
 }
 

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -165,12 +165,22 @@ export class Manager {
    *  outcome. */
   async load(opts: StartOpts, hooks?: { beforeStart?: () => Promise<void> }): Promise<void> {
     await Manager.runExclusive(async () => {
-      if (this.state === 'running' || this.state === 'starting' || this.state === 'stopping') {
-        await this.stopAndWait()
+      try {
+        if (this.state === 'running' || this.state === 'starting' || this.state === 'stopping') {
+          await this.stopAndWait()
+        }
+        if (hooks?.beforeStart) await hooks.beforeStart()
+        await this.startInternal(opts)
+        await this.awaitNotStarting()
+      } catch (e) {
+        // routes.ts fires load() without awaiting and only console.warns the rejection —
+        // without this, a failed swap left `state` wherever it last was (often still
+        // 'stopping'), which read to the user as "no model loaded" with no indication
+        // anything went wrong or that a retry could help.
+        this.state = 'error'
+        this.errInfo = { code: 'load_failed', message: e instanceof Error ? e.message : String(e), exitCode: -1, logTail: [] }
+        throw e
       }
-      if (hooks?.beforeStart) await hooks.beforeStart()
-      await this.startInternal(opts)
-      await this.awaitNotStarting()
     })
   }
 
@@ -308,12 +318,27 @@ export class Manager {
       // Used by the ComfyUI guard, which needs the VRAM freed NOW before ComfyUI runs.
       if (opts?.force) this.forceStop()
       else this.stop()
-      await Promise.race([exited, sleep(10_000)])
+      await this.waitForExit(exited)
     } else if (this.state === 'stopping') {
-      await Promise.race([exited, sleep(10_000)])
+      await this.waitForExit(exited)
     } else if (this.state === 'error') {
       this.state = 'stopped'
       this.errInfo = null
+    }
+  }
+
+  /** Wait for `exited` up to 10s; if it hasn't resolved by then, force-kill and wait
+   *  unconditionally. A bare timeout here previously let stopAndWait() return with the
+   *  process still alive and `state` stuck at 'stopping' (e.g. a slow Windows tree-kill) —
+   *  the very next startInternal() would then throw BusyError, silently abandoning a model
+   *  swap (the caller in routes.ts fires load() without awaiting and only logs the
+   *  rejection). Bypasses forceStop()'s running/starting-only guard by calling the
+   *  module-level forceKill directly, since by this point state is already 'stopping'. */
+  private async waitForExit(exited: Promise<void>): Promise<void> {
+    const result = await Promise.race([exited.then(() => 'exited' as const), sleep(10_000).then(() => 'timeout' as const)])
+    if (result === 'timeout' && this.child) {
+      forceKill(this.child)
+      await exited
     }
   }
 

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -338,7 +338,11 @@ export class Manager {
     const result = await Promise.race([exited.then(() => 'exited' as const), sleep(10_000).then(() => 'timeout' as const)])
     if (result === 'timeout' && this.child) {
       forceKill(this.child)
-      await exited
+      // Bounded too: forceKill's taskkill is fire-and-forget (failures swallowed), so an
+      // unbounded await here on an unkillable/zombie process would wedge this forever —
+      // and since stopAndWait() runs inside the exclusive load gate, that deadlocks every
+      // future load(), which is worse than the 'stuck at stopping' bug this replaced.
+      await Promise.race([exited, sleep(5_000)])
     }
   }
 

--- a/turbollm/web/src/components/ModelLoadMenu.tsx
+++ b/turbollm/web/src/components/ModelLoadMenu.tsx
@@ -1,5 +1,6 @@
-import { Check, ChevronDown, CircleSlash, Cpu, Loader2, SlidersHorizontal } from 'lucide-react'
+import { Check, ChevronDown, CircleSlash, Cpu, Loader2, SlidersHorizontal, Star } from 'lucide-react'
 import type { ModelEntry } from '../lib/types'
+import { usePinnedModels } from '../lib/usePinnedModels'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,7 +36,17 @@ export function ModelLoadMenu({
   onSettings?: (key: string) => void
   align?: 'start' | 'end'
 }) {
-  const loadable = models.filter((m) => !m.incomplete && !m.parseError)
+  const { isPinned } = usePinnedModels()
+  // Pinned models float to the top (same convention as the library list in ModelsScreen),
+  // stable otherwise so unpinned order is unaffected.
+  const loadable = models
+    .filter((m) => !m.incomplete && !m.parseError)
+    .map((m, i) => ({ m, i }))
+    .sort((a, b) => {
+      const p = Number(isPinned(b.m.key)) - Number(isPinned(a.m.key))
+      return p !== 0 ? p : a.i - b.i
+    })
+    .map(({ m }) => m)
   const label = ejecting ? 'Ejecting…' : (loadedName || (loadedKey ? 'Loaded model' : 'Load a model'))
 
   return (
@@ -58,6 +69,7 @@ export function ModelLoadMenu({
         </div>
         {loadable.map((m) => {
           const active = m.key === loadedKey
+          const pinned = isPinned(m.key)
           return (
             <div
               key={m.key}
@@ -72,6 +84,7 @@ export function ModelLoadMenu({
               <span className="flex h-4 w-4 shrink-0 items-center justify-center">
                 {active && <Check size={14} className="text-accent" />}
               </span>
+              {pinned && <Star size={12} className="shrink-0 fill-current text-accent" />}
               <span className="min-w-0 flex-1 truncate">{m.name}</span>
               {onSettings && (
                 <button

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -32,7 +32,7 @@ export function getConversation(id: string): Promise<Conversation> {
   return req(`/api/v1/conversations/${encodeURIComponent(id)}`)
 }
 
-export function updateConversation(id: string, patch: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'skillIds'>>): Promise<Conversation> {
+export function updateConversation(id: string, patch: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'skillIds' | 'preserveThinking'>>): Promise<Conversation> {
   return req(`/api/v1/conversations/${encodeURIComponent(id)}`, { method: 'PATCH', json: patch })
 }
 
@@ -77,6 +77,19 @@ export function deleteMessage(convId: string, msgId: string): Promise<{ ok: true
 
 export function regenerate(convId: string): Promise<{ ok: true }> {
   return req(`/api/v1/conversations/${encodeURIComponent(convId)}/regenerate`, { method: 'POST', json: {} })
+}
+
+// ── Chat branching (GitHub #52) ────────────────────────────────────────────────
+
+/** All siblings (active + inactive) sharing a message's variant_group, oldest first —
+ *  for the ‹ 1/2 › branch switcher. Only meaningful when message.variantGroup is set. */
+export function getMessageVariants(convId: string, msgId: string): Promise<{ variants: Message[] }> {
+  return req(`/api/v1/conversations/${encodeURIComponent(convId)}/messages/${encodeURIComponent(msgId)}/variants`)
+}
+
+/** Switch which sibling in a variant group is active/shown. */
+export function activateVariant(convId: string, msgId: string): Promise<{ messages: Message[] }> {
+  return req(`/api/v1/conversations/${encodeURIComponent(convId)}/messages/${encodeURIComponent(msgId)}/activate`, { method: 'POST', json: {} })
 }
 
 // ── Tool-call approval gate ───────────────────────────────────────────────────

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -24,7 +24,7 @@ export function listConversations(q?: string): Promise<{ conversations: Conversa
   return req(`/api/v1/conversations${q ? `?q=${encodeURIComponent(q)}` : ''}`)
 }
 
-export function createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy' | 'skillIds' | 'allowedTools'>>): Promise<Conversation> {
+export function createConversation(partial?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy' | 'skillIds' | 'allowedTools' | 'sampling' | 'preserveThinking'>>): Promise<Conversation> {
   return req('/api/v1/conversations', { method: 'POST', json: partial ?? {} })
 }
 

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -72,7 +72,11 @@ update: useMutation({
     }),
     regenerate: useMutation({
       mutationFn: (convId: string) => regenerate(convId),
-      onSuccess: (_d, convId) => invalidateDetail(convId),
+      // Regenerate adds a new sibling to a variant group; without this the switcher's
+      // cached list is stale until something else happens to remount it (it self-corrects
+      // today only because the active message's id changes on refetch, which is load-bearing
+      // but not obvious — invalidate explicitly instead of relying on that).
+      onSuccess: (_d, convId) => { invalidateDetail(convId); void qc.invalidateQueries({ queryKey: ['message-variants'] }) },
     }),
     createFolder: useMutation({
       mutationFn: (name: string) => createFolder(name),

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -52,7 +52,7 @@ export function useConversationMutations() {
       onSuccess: invalidateList,
     }),
 update: useMutation({
-      mutationFn: (v: { id: string } & Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'skillIds'>>) => updateConversation(v.id, v),
+      mutationFn: (v: { id: string } & Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'sampling' | 'skillIds' | 'preserveThinking'>>) => updateConversation(v.id, v),
       onSuccess: (_d, v) => { invalidateList(); invalidateDetail(v.id) },
     }),
     remove: useMutation({

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -48,7 +48,7 @@ export function useConversationMutations() {
 
   return {
     create: useMutation({
-      mutationFn: (p?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy' | 'skillIds' | 'allowedTools'>>) => createConversation(p),
+      mutationFn: (p?: Partial<Pick<Conversation, 'title' | 'systemPrompt' | 'modelKey' | 'toolPolicy' | 'skillIds' | 'allowedTools' | 'sampling' | 'preserveThinking'>>) => createConversation(p),
       onSuccess: invalidateList,
     }),
 update: useMutation({

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -104,7 +104,8 @@ export interface Conversation {
    *  Agents). Undefined/empty = unrestricted (every built-in persona). */
   allowedTools?: string[]
   /** GitHub #52: when true, past turns' reasoning is resent to the engine (not just
-   *  their final answer) so the model can see its own prior thinking. Off by default. */
+   *  their final answer) so the model can see its own prior thinking. On by default for
+   *  new conversations; conversations from before this default flipped stay off. */
   preserveThinking: boolean
   createdAt: string
   updatedAt: string

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -73,6 +73,11 @@ export interface Message {
   /** F-021/F-022: research metadata (confidence, sources, referee verdicts). */
   researchMeta?: ResearchMeta
   createdAt: string
+  /** Chat branching (GitHub #52): shared by this message and its regenerated siblings.
+   *  Null when it's never been regenerated — no branch switcher to show. */
+  variantGroup: string | null
+  /** Chat branching: whether this is the sibling currently shown/sent as history. */
+  isActive: boolean
 }
 
 export interface Conversation {
@@ -96,6 +101,9 @@ export interface Conversation {
   /** Tool-name allow-list baked in from a custom chat Agent at creation (Customize →
    *  Agents). Undefined/empty = unrestricted (every built-in persona). */
   allowedTools?: string[]
+  /** GitHub #52: when true, past turns' reasoning is resent to the engine (not just
+   *  their final answer) so the model can see its own prior thinking. Off by default. */
+  preserveThinking: boolean
   createdAt: string
   updatedAt: string
   messages?: Message[]

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -78,6 +78,8 @@ export interface Message {
   variantGroup: string | null
   /** Chat branching: whether this is the sibling currently shown/sent as history. */
   isActive: boolean
+  /** True only when a user explicitly edited this assistant reply's text in place. */
+  edited: boolean
 }
 
 export interface Conversation {

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -17,15 +17,17 @@ const TURBOLLM_KNOWLEDGE =
   '  in/out via its "Move to folder" menu). Deleting a folder never deletes the conversations\n' +
   '  inside it — they move back to Uncategorized. The sidebar\'s width is drag-resizable.\n' +
   '- Pick a **persona** before the first message; it locks after that (per-conversation).\n' +
-  '- Override **sampling** (temperature, top-p, top-k, min-p, repeat/frequency/presence penalty, stop strings) per conversation via conversation settings.\n' +
+  '- Override **sampling** (temperature, top-p, top-k, min-p, repeat/frequency/presence penalty, stop strings) per conversation via Thread settings — sliders default to the loaded model\'s own recommended values, not generic constants. Thread settings is reachable even before the first message is sent (as soon as a model is loaded).\n' +
   '- Set a custom **system prompt** per conversation.\n' +
+  '- **Preserve thinking across turns** (Thread settings toggle, on by default for new conversations) — resends the model\'s past reasoning on later turns, not just its final answers, so it has real context for follow-ups. Uses more tokens per request.\n' +
   '- **Artifacts**: HTML/SVG/Mermaid fenced blocks render as sandboxed live previews (shown as images). Download as PNG/JPEG/SVG/GIF/HTML depending on type.\n' +
   '- **Thinking/reasoning**: models that emit `<think>` blocks get a collapsible fold; visible prose renders normally below.\n' +
   '- **Tool-call approval gate**: every tool call (web search, fetch URL, run code, MCP tools) asks for approval by default before it runs — an inline bar above the composer offers Deny, Allow, Allow for this chat, or Always Allow. Live cards still show each call\'s status (awaiting approval → pending → done / error). Per-tool defaults (Ask / Allow / Deny) are set globally in Settings → Tools & safety. Background agent runs never see this prompt (no one there to answer it) — a tool the agent is configured to use runs without asking.\n' +
   '- **Web search**: Research persona forces 3–5 `web_search` calls; other personas use it when a search provider key is configured.\n' +
   '- **Export/Import**: export as `.turbollm-chat.json` or OpenAI-format JSON; re-import resumes the conversation. Share button gives a LAN read-only link and a debug snapshot.\n' +
   '- **Attachments** (paperclip): images (vision models), PDFs (real extracted text via pdf.js, not raw bytes), and plain-text/code files (`.txt`/`.md`/`.csv`/`.json`/`.yaml`/`.log` and common source extensions).\n' +
-  '- Edit messages, delete a message, regenerate the last response.\n\n' +
+  '- **Edit a message or regenerate a reply and neither destroys history** — both create a branch, switchable via a ‹ 1/2 › control on the message (works for nested branch points too); delete a message or copy any message\'s text.\n' +
+  '- **Switching to a different conversation never cancels a reply that\'s still generating** — it keeps going in the background and saves when done. The sidebar shows a spinning indicator on any conversation generating in the background, and a dot on one that just finished while you were elsewhere (clears once you open it).\n\n' +
 
   '**Models** — discover and manage local models.\n' +
   '- **All models** view: scans configured local directories for GGUF, MLX safetensors, vLLM safetensors; badges incompatible models for the active engine.\n' +

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -74,7 +74,19 @@ export function ChatScreen() {
   const readonly = searchParams.get('readonly') === '1'
 
   const [activeId, setActiveId] = useState<string | null>(routeConvId ?? null)
-  const [live, setLive] = useState<LiveState | null>(null)
+  // streamFrom's async loop outlives the render that started it, so it needs the CURRENT
+  // activeId (not the one closed over when the generation began) to tell whether a
+  // 'done'/'error' event landed on the conversation the user is still looking at.
+  const activeIdRef = useRef(activeId)
+  activeIdRef.current = activeId
+  // Keyed by convId, not a single global value — a generation keeps running server-side
+  // after the user navigates away (b6d84f3), so its live state must survive navigation
+  // too, and multiple conversations can legitimately be generating at once.
+  const [liveByConv, setLiveByConv] = useState<Record<string, LiveState>>({})
+  const live = activeId ? liveByConv[activeId] : undefined
+  // Conversations whose generation finished while the user was elsewhere. Cleared when
+  // the user navigates to that conversation. Session-only by design (not persisted).
+  const [recentlyCompletedIds, setRecentlyCompletedIds] = useState<Set<string>>(new Set())
   const [input, setInput] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
@@ -121,8 +133,10 @@ export function ChatScreen() {
   const builtinOverridesQ = useBuiltinAgentOverrides()
   const allAgents = resolveAgents(customAgentsQ.data ?? [], builtinOverridesQ.data ?? {})
   const selectedAgent = allAgents.find((a) => a.id === selectedPersonaId)
-  const abortRef = useRef<AbortController | null>(null)
-  const deltaTimestamps = useRef<number[]>([])
+  // Keyed by convId — generations can run concurrently across conversations now that
+  // switching away no longer aborts them (b6d84f3).
+  const abortRefs = useRef<Record<string, AbortController>>({})
+  const deltaTimestamps = useRef<Record<string, number[]>>({})
   const scrollerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -231,7 +245,13 @@ export function ChatScreen() {
     )
   }
   const handleEject = () => {
-    if (live) { abortRef.current?.abort(); setLive(null) }
+    // Ejecting kills the whole engine — every in-flight generation across every
+    // conversation dies with it, not just the active one.
+    if (Object.keys(abortRefs.current).length > 0) {
+      for (const ac of Object.values(abortRefs.current)) ac.abort()
+      abortRefs.current = {}
+    }
+    setLiveByConv((prev) => (Object.keys(prev).length > 0 ? {} : prev))
     modelActions.eject.mutate(undefined, {
       onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not eject model.'),
     })
@@ -281,7 +301,7 @@ export function ChatScreen() {
         handleNew()
         return
       }
-      if (e.key === 'Escape' && live) { void handleStop() }
+      if (e.key === 'Escape' && activeId && liveByConv[activeId]) { void handleStop() }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
@@ -382,7 +402,6 @@ export function ChatScreen() {
   const handleNew = () => {
     setActiveId(null)
     setInput('')
-    setLive(null)
     setSelectedPersonaId(getDefaultAgentId())
     inputRef.current?.focus()
   }
@@ -390,12 +409,19 @@ export function ChatScreen() {
   const handleSelect = (id: string) => {
     // Switching conversations must not kill an in-flight generation — only an explicit
     // Stop/Eject/delete should. The backend keeps generating and saves the result when
-    // done; we just stop showing its live bubble here (setLive(null)) since it belongs
-    // to the conversation being left, not the one we're switching to.
-    if (live) setLive(null)
+    // done; live state is now per-conversation (keyed by convId, not activeId), so it
+    // needs no clearing here — the render layer just looks up whatever entry (if any)
+    // matches the newly-active id.
     setActiveId(id)
     setEditingId(null)
     setSelectedPersonaId(getConvAgentId(id))
+    if (recentlyCompletedIds.has(id)) {
+      setRecentlyCompletedIds((prev) => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
     userScrolledUp.current = false
     setTimeout(() => scrollToBottom(true), 50)
   }
@@ -404,7 +430,14 @@ export function ChatScreen() {
   // close it (clear activeId) so we don't hold a dangling reference.
   const handleActiveDeleted = (id: string) => {
     if (id !== activeId) return
-    if (live) { abortRef.current?.abort(); setLive(null) }
+    abortRefs.current[id]?.abort()
+    delete abortRefs.current[id]
+    setLiveByConv((prev) => {
+      if (!(id in prev)) return prev
+      const next = { ...prev }
+      delete next[id]
+      return next
+    })
     setActiveId(null)
     setEditingId(null)
     setInput('')
@@ -412,8 +445,10 @@ export function ChatScreen() {
   }
 
   const handleStop = async () => {
-    abortRef.current?.abort()
-    if (activeId) await mut.stop.mutateAsync(activeId).catch(() => {})
+    if (activeId) {
+      abortRefs.current[activeId]?.abort()
+      await mut.stop.mutateAsync(activeId).catch(() => {})
+    }
   }
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -437,59 +472,80 @@ export function ChatScreen() {
     e.target.value = ''
   }
 
-  // Record one generated token and return the rolling 2-second tok/s estimate.
-  const pushGenToken = () => {
+  // Record one generated token for `convId` and return its rolling 2-second tok/s estimate.
+  const pushGenToken = (convId: string) => {
     const now = Date.now()
-    deltaTimestamps.current.push(now)
-    deltaTimestamps.current = deltaTimestamps.current.filter((t) => t > now - 2000)
-    return Math.round((deltaTimestamps.current.length / 2) * 10) / 10
+    const timestamps = [...(deltaTimestamps.current[convId] ?? []), now].filter((t) => t > now - 2000)
+    deltaTimestamps.current[convId] = timestamps
+    return Math.round((timestamps.length / 2) * 10) / 10
+  }
+
+  // Applies `updater` to convId's live entry, no-op if it's already gone (e.g. the
+  // conversation was deleted or ejected mid-stream) — mirrors the old `l ? ... : l` guard.
+  const updateLive = (convId: string, updater: (l: LiveState) => LiveState) => {
+    setLiveByConv((prev) => (prev[convId] ? { ...prev, [convId]: updater(prev[convId]) } : prev))
+  }
+  const clearLive = (convId: string) => {
+    setLiveByConv((prev) => {
+      if (!(convId in prev)) return prev
+      const next = { ...prev }
+      delete next[convId]
+      return next
+    })
   }
 
   // Shared SSE consumer: drives live streaming state for either a fresh send or a continue.
+  // Every setLiveByConv/abortRefs access below targets `convId` — the parameter — not
+  // `activeId`, because by the time an event arrives the user may have navigated to a
+  // different conversation while this generation keeps running in the background.
   const streamFrom = async (convId: string, gen: AsyncGenerator<ChatSseEvent>) => {
     try {
       for await (const evt of gen) {
         if (evt.event === 'meta') {
-          deltaTimestamps.current = []
-          setLive({ assistantId: evt.data.assistantMessageId, content: '', reasoning: '', progress: null, liveGenTps: 0, genTokens: 0, timeline: [] })
+          deltaTimestamps.current[convId] = []
+          setLiveByConv((prev) => ({
+            ...prev,
+            [convId]: { assistantId: evt.data.assistantMessageId, content: '', reasoning: '', progress: null, liveGenTps: 0, genTokens: 0, timeline: [] },
+          }))
           // Optimistically reflect the new/last user msg in the UI by invalidating
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
         } else if (evt.event === 'progress') {
-          setLive((l) => l ? { ...l, progress: { phase: evt.data.phase, pct: evt.data.pct, tps: evt.data.tps } } : l)
+          updateLive(convId, (l) => ({ ...l, progress: { phase: evt.data.phase, pct: evt.data.pct, tps: evt.data.tps } }))
         } else if (evt.event === 'reasoning') {
           // Thinking tokens count toward generation too — track rate + count.
-          const liveTps = pushGenToken()
-          setLive((l) => l ? { ...l, reasoning: l.reasoning + evt.data.delta, progress: null, liveGenTps: liveTps, genTokens: l.genTokens + 1 } : l)
+          const liveTps = pushGenToken(convId)
+          updateLive(convId, (l) => ({ ...l, reasoning: l.reasoning + evt.data.delta, progress: null, liveGenTps: liveTps, genTokens: l.genTokens + 1 }))
         } else if (evt.event === 'delta') {
-          const liveTps = pushGenToken()
-          setLive((l) => l ? { ...l, content: l.content + evt.data.delta, timeline: appendTextDelta(l.timeline, evt.data.delta), progress: null, liveGenTps: liveTps, genTokens: l.genTokens + 1 } : l)
+          const liveTps = pushGenToken(convId)
+          updateLive(convId, (l) => ({ ...l, content: l.content + evt.data.delta, timeline: appendTextDelta(l.timeline, evt.data.delta), progress: null, liveGenTps: liveTps, genTokens: l.genTokens + 1 }))
         } else if (evt.event === 'tool_call') {
           const tc = evt.data
-          setLive((l) => {
-            if (!l) return l
-            const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result }
-            return { ...l, timeline: upsertToolCall(l.timeline, call) }
-          })
+          const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result }
+          updateLive(convId, (l) => ({ ...l, timeline: upsertToolCall(l.timeline, call) }))
         } else if (evt.event === 'done') {
-          setLive(null)
+          clearLive(convId)
+          if (convId !== activeIdRef.current) setRecentlyCompletedIds((prev) => new Set(prev).add(convId))
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
           void qc.invalidateQueries({ queryKey: ['conversations'] })
           setTimeout(() => scrollToBottom(true), 80)
         } else if (evt.event === 'error') {
-          setLive(null)
+          clearLive(convId)
+          if (convId !== activeIdRef.current) setRecentlyCompletedIds((prev) => new Set(prev).add(convId))
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
           toast.error(evt.data.message)
         }
       }
       // Stream ended without an explicit done/error (e.g. network cut, silent close)
-      setLive(null)
+      clearLive(convId)
       void qc.invalidateQueries({ queryKey: ['conversation', convId] })
     } catch (e) {
-      setLive(null)
+      clearLive(convId)
       if ((e as Error)?.name !== 'AbortError') {
         toast.error(e instanceof ApiError ? e.message : 'Request failed.')
       }
       void qc.invalidateQueries({ queryKey: ['conversation', convId] })
+    } finally {
+      delete abortRefs.current[convId]
     }
   }
 
@@ -519,9 +575,11 @@ export function ChatScreen() {
     setTimeout(autoResize, 0)
     userScrolledUp.current = false
 
+    // Hoisted above the try so the catch block can target the right conversation's
+    // live/abort state even when it fails partway through creating a new conversation.
+    let convId = activeId
     try {
       // Create conversation on first message, baking in the selected agent + personalization.
-      let convId = activeId
       if (!convId) {
         const resolved = allAgents.find((a) => a.id === selectedPersonaId)
         let sp = buildSystemPrompt(selectedPersonaId, resolved?.systemPrompt ?? '', getPersonalization())
@@ -567,16 +625,16 @@ export function ChatScreen() {
       if (matchedSkill) toast.success(`Using skill: ${matchedSkill.name}`)
 
       const ac = new AbortController()
-      abortRef.current = ac
+      abortRefs.current[convId] = ac
 
       const textAttachmentNames = textAttachments.map((a) => a.file.name)
       await streamFrom(convId, sendMessage(convId, text, ac.signal, images, docContext, textAttachmentNames, !thinkingEnabled))
     } catch (e) {
-      setLive(null)
+      if (convId) clearLive(convId)
       if ((e as Error)?.name !== 'AbortError') {
         toast.error(e instanceof ApiError ? e.message : 'Request failed.')
       }
-      if (activeId) void qc.invalidateQueries({ queryKey: ['conversation', activeId] })
+      if (convId) void qc.invalidateQueries({ queryKey: ['conversation', convId] })
     }
   }
 
@@ -592,7 +650,7 @@ export function ChatScreen() {
         userScrolledUp.current = false
         if (isUserMessage && engineState === 'running' && model) {
           const ac = new AbortController()
-          abortRef.current = ac
+          abortRefs.current[activeId] = ac
           void streamFrom(activeId, continueConversation(activeId, ac.signal, !thinkingEnabled))
         }
       },
@@ -605,7 +663,7 @@ export function ChatScreen() {
     if (engineState !== 'running' || !model) { toast.error('Load a model first.'); return }
     await mut.regenerate.mutateAsync(activeId).catch(() => {})
     const ac = new AbortController()
-    abortRef.current = ac
+    abortRefs.current[activeId] = ac
     void streamFrom(activeId, continueConversation(activeId, ac.signal, !thinkingEnabled))
   }
 
@@ -629,6 +687,8 @@ export function ChatScreen() {
   // Read from the timeline — the actual live-updated source — not a separate tracked array.
   const pendingApprovalBlock = live?.timeline.find((b) => b.kind === 'tool' && b.call.status === 'awaiting_approval')
   const pendingApproval = pendingApprovalBlock?.kind === 'tool' ? pendingApprovalBlock.call : undefined
+
+  const generatingIds = useMemo(() => new Set(Object.keys(liveByConv)), [liveByConv])
 
   return (
     <div className="flex h-full overflow-hidden">
@@ -665,6 +725,8 @@ export function ChatScreen() {
           collapsed={isDesktop ? !sidebarOpen : false}
           onToggle={isDesktop ? () => setSidebarOpen((o) => !o) : () => setMobileSidebarOpen(false)}
           generating={!!live}
+          generatingIds={generatingIds}
+          recentlyCompletedIds={recentlyCompletedIds}
           onDeleted={handleActiveDeleted}
         />
       </div>

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -528,11 +528,15 @@ export function ChatScreen() {
 
   const handleEditSave = (msgId: string, content: string) => {
     if (!activeId) return
+    // GitHub #52: editing the model's own reply just fixes its text in place — no reason
+    // to trigger ANOTHER reply after it. Only a user-message edit resends (branching the
+    // downstream history, per ADR — see chat-routes.ts's PUT /messages/:msgId).
+    const isUserMessage = messages.find((m) => m.id === msgId)?.role === 'user'
     setEditingId(null)
     mut.editMsg.mutate({ convId: activeId, msgId, content }, {
       onSuccess: () => {
         userScrolledUp.current = false
-        if (engineState === 'running' && model) {
+        if (isUserMessage && engineState === 'running' && model) {
           const ac = new AbortController()
           abortRef.current = ac
           void streamFrom(activeId, continueConversation(activeId, ac.signal, !thinkingEnabled))
@@ -796,6 +800,7 @@ export function ChatScreen() {
               <MessageBubble
                 key={m.id}
                 message={m}
+                convId={readonly ? undefined : activeId ?? undefined}
                 isLast={i === messages.length - 1 && !live}
                 onEdit={readonly ? undefined : (msg) => setEditingId(msg.id)}
                 onDelete={readonly ? undefined : handleDelete}

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { ArrowDown, Brain, Copy, Download, PanelLeft, Paperclip, SendHorizontal, Share2, SlidersHorizontal, Square, UserRound, X } from 'lucide-react'
 import { continueConversation, fetchSysInfo, sendMessage } from '../lib/chat-api'
 import { extractPdfText } from '../lib/pdf-extract'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
-import { useBuiltinAgentOverrides, useChatAgents, useModelActions, useModels, useStatus } from '../lib/queries'
+import { useBuiltinAgentOverrides, useChatAgents, useEngines, useModelActions, useModelDetail, useModels, useStatus } from '../lib/queries'
 import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
 import { appendTextDelta, upsertToolCall, type LiveBlock } from '../lib/live-timeline'
 import { ApiError, downloadChatExport, getDebugSnapshot, getShareUrl, importChat } from '../lib/api'
@@ -19,7 +19,7 @@ import { ContextMeter } from './chat/ContextMeter'
 import { ConversationSidebar } from './chat/ConversationSidebar'
 import { ModelLoadMenu } from '../components/ModelLoadMenu'
 import { ModelDetailDialog } from './models/ModelDetailDialog'
-import { ConversationSettingsDialog } from './chat/ConversationSettingsDialog'
+import { ConversationSettingsDialog, type ConversationSettingsDraft } from './chat/ConversationSettingsDialog'
 import { useUiStore } from '../stores/ui'
 import { useIsDesktop } from '../lib/useIsDesktop'
 import {
@@ -59,6 +59,14 @@ export function ChatScreen() {
   const { data: status } = useStatus()
   const model = status?.model
   const engineState = status?.engine.state
+
+  // The loaded model's resolved sampling defaults, for the Thread settings sliders
+  // (LoadedModel itself carries no sampling — it lives on the per-engine LoadProfile,
+  // same source ModelDetailDialog reads/writes; see ADR discussion in that file).
+  const enginesQ = useEngines()
+  const activeEngine = enginesQ.data?.engines.find((e) => e.id === enginesQ.data?.activeEngineId)
+  const modelDetailQ = useModelDetail(model?.key ?? null, activeEngine?.id)
+  const modelSampling = modelDetailQ.data?.profile.sampling
 
   // Route params: /chat/:convId?readonly=1
   const { convId: routeConvId } = useParams<{ convId?: string }>()
@@ -133,6 +141,40 @@ export function ChatScreen() {
   // Once activeId exists, conv.skillIds is the source of truth instead.
   const [pendingSkillIds, setPendingSkillIds] = useState<string[]>([])
   const enabledSkillIds = conv?.skillIds ?? pendingSkillIds
+
+  // Same pattern, extended to the other Thread-settings fields (GitHub #52 follow-up):
+  // lets the settings dialog be used on a blank chat screen, before a conversation
+  // exists to PATCH. Folded into mut.create.mutateAsync() on first send, then reset.
+  const [pendingSystemPrompt, setPendingSystemPrompt] = useState('')
+  const [pendingSampling, setPendingSampling] = useState<Record<string, number>>({})
+  const [pendingPreserveThinking, setPendingPreserveThinking] = useState(true)
+  const draftOnChange = useCallback((patch: Partial<{
+    systemPrompt: string
+    sampling: Record<string, number>
+    skillIds: string[]
+    preserveThinking: boolean
+  }>) => {
+    if (patch.systemPrompt !== undefined) setPendingSystemPrompt(patch.systemPrompt)
+    if (patch.sampling !== undefined) setPendingSampling(patch.sampling)
+    if (patch.skillIds !== undefined) setPendingSkillIds(patch.skillIds)
+    if (patch.preserveThinking !== undefined) setPendingPreserveThinking(patch.preserveThinking)
+  }, [])
+  // draft is undefined until a model is loaded — the settings dialog uses its presence
+  // to enable/disable the trigger on a not-yet-created conversation. Memoized so its
+  // identity is stable across unrelated re-renders (composer typing, etc.) — the dialog
+  // resyncs its local state whenever this object changes identity.
+  const hasConv = !!conv
+  const modelLoaded = !!model
+  const draft: ConversationSettingsDraft | undefined = useMemo(() => {
+    if (hasConv || !modelLoaded) return undefined
+    return {
+      systemPrompt: pendingSystemPrompt,
+      sampling: pendingSampling,
+      skillIds: pendingSkillIds,
+      preserveThinking: pendingPreserveThinking,
+      onChange: draftOnChange,
+    }
+  }, [hasConv, modelLoaded, pendingSystemPrompt, pendingSampling, pendingSkillIds, pendingPreserveThinking, draftOnChange])
 
   // '/' picker: typing '/' (optionally followed by letters, at the START of an
   // otherwise-empty composer) shows a filtered skill list. Selecting one enables
@@ -346,7 +388,11 @@ export function ChatScreen() {
   }
 
   const handleSelect = (id: string) => {
-    if (live) { abortRef.current?.abort(); setLive(null) }
+    // Switching conversations must not kill an in-flight generation — only an explicit
+    // Stop/Eject/delete should. The backend keeps generating and saves the result when
+    // done; we just stop showing its live bubble here (setLive(null)) since it belongs
+    // to the conversation being left, not the one we're switching to.
+    if (live) setLive(null)
     setActiveId(id)
     setEditingId(null)
     setSelectedPersonaId(getConvAgentId(id))
@@ -494,17 +540,25 @@ export function ChatScreen() {
           ...(resolved?.skillIds ?? []),
           ...(matchedSkill ? [matchedSkill.id] : []),
         ]))
+        // A system prompt set via Thread settings before the first message is an
+        // explicit override — it wins over the agent's own default system prompt.
+        const finalSystemPrompt = pendingSystemPrompt.trim() || sp
         const newConv = await mut.create.mutateAsync({
           modelKey: model.key,
-          systemPrompt: sp || undefined,
+          systemPrompt: finalSystemPrompt || undefined,
           toolPolicy: selectedPersonaId === 'research' ? 'force_web_search' : undefined,
           skillIds: initialSkillIds.length ? initialSkillIds : undefined,
           allowedTools: resolved?.tools?.length ? resolved.tools : undefined,
+          sampling: Object.keys(pendingSampling).length ? pendingSampling : undefined,
+          preserveThinking: pendingPreserveThinking,
         })
         convId = newConv.id
         setConvAgentId(convId, selectedPersonaId)
         setActiveId(convId)
         setPendingSkillIds([])
+        setPendingSystemPrompt('')
+        setPendingSampling({})
+        setPendingPreserveThinking(true)
       } else if (matchedSkill && !enabledSkillIds.includes(matchedSkill.id)) {
         // Existing conversation missing this skill — enable it before sending so the
         // system-prompt injection picks it up on this very turn, not the next one.
@@ -661,7 +715,7 @@ export function ChatScreen() {
               <SlidersHorizontal size={15} />
             </Button>
           )}
-          <ConversationSettingsDialog conv={conv} />
+          <ConversationSettingsDialog conv={conv} draft={draft} modelSampling={modelSampling} />
           <Button
             size="icon"
             variant="ghost"

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -637,7 +637,7 @@ function EngineGallery({
   const install = useBackendInstall()
   const engineMut = useEngineMutations()
   const policyMut = useUpdatePolicyMutation()
-  const [deleteTarget, setDeleteTarget] = useState<{ e: CatalogEngine; registryId: string } | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<{ name: string; registryId: string } | null>(null)
 
   const catalogById = useMemo(() => {
     const m = new Map<string, CatalogEngine>()
@@ -751,18 +751,19 @@ function EngineGallery({
   const requestDelete = (e: CatalogEngine) => {
     const registryId = registryEngineId(e)
     if (!registryId) { toast.error(`Could not find the installed ${e.name} engine to delete.`); return }
-    setDeleteTarget({ e, registryId })
+    setDeleteTarget({ name: e.name, registryId })
   }
+  const requestDeleteCustom = (eng: Engine) => setDeleteTarget({ name: eng.name, registryId: eng.id })
   const doDelete = () => {
     if (!deleteTarget) return
     engineMut.purge.mutate(deleteTarget.registryId, {
       onSuccess: () => {
-        toast.success(`${deleteTarget.e.name} deleted`)
+        toast.success(`${deleteTarget.name} deleted`)
         setDeleteTarget(null)
       },
       onError: (err) => {
         setDeleteTarget(null)
-        toast.error(err instanceof ApiError ? err.message : `Could not delete ${deleteTarget.e.name}.`)
+        toast.error(err instanceof ApiError ? err.message : `Could not delete ${deleteTarget.name}.`)
       },
     })
   }
@@ -776,6 +777,20 @@ function EngineGallery({
     })
     // Push engines that can't run here (red) to the bottom; stable otherwise.
     .sort((a, b) => (a.compatible.length === 0 ? 1 : 0) - (b.compatible.length === 0 ? 1 : 0))
+
+  // GitHub #51: a custom-added engine (arbitrary binPath, matches no catalog entry) used to be
+  // silently omitted here — it only ever showed up buried in the "Running now" dropdown above,
+  // even though the backend registered it correctly. Surface it as its own card so "add your own
+  // engine" actually shows the engine you added.
+  const matchedRegistryIds = new Set(
+    fits.map((fit) => registryEngineId(catalogById.get(fit.engine.id) ?? (fit.engine as CatalogEngine))).filter(Boolean),
+  )
+  // Auto-downloaded official llama.cpp builds already have dedicated UI — the llama.cpp
+  // card's own "Manage GPU builds" expander (LlamaCppBackendRows) — so exclude those too;
+  // only a genuinely uncategorized engine (any binPath outside both conventions) is "custom".
+  const customEngines = (registry?.engines ?? []).filter(
+    (e) => !matchedRegistryIds.has(e.id) && !isOfficialLlama(e.binPath),
+  )
 
   return (
     <section className="flex flex-col gap-3">
@@ -806,6 +821,34 @@ function EngineGallery({
         })}
       </div>
 
+      {customEngines.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {customEngines.map((eng) => (
+            <div
+              key={eng.id}
+              className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-panel px-4 py-3"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <Wrench size={15} className="shrink-0 text-accent" />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-ink">{eng.name}</span>
+                    <Badge>Custom</Badge>
+                  </div>
+                  <div className="truncate text-[12px] text-muted" title={eng.binPath}>{eng.binPath}</div>
+                </div>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {eng.version && <span className="text-[12px] text-faint">{eng.version}</span>}
+                <Button variant="outline" size="sm" onClick={() => requestDeleteCustom(eng)}>
+                  Delete
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Add your own engine — a compact strip, not a half-empty card. */}
       <div className="mt-1 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-border-strong bg-panel px-4 py-3">
         <div className="min-w-0">
@@ -828,7 +871,7 @@ function EngineGallery({
       <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete {deleteTarget?.e.name}?</AlertDialogTitle>
+            <AlertDialogTitle>Delete {deleteTarget?.name}?</AlertDialogTitle>
             <AlertDialogDescription>
               Files for this engine are removed from disk. Your models are not affected.
             </AlertDialogDescription>

--- a/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
@@ -6,6 +6,8 @@ import {
   Dialog,
   DialogContent,
   DialogClose,
+  DialogHeader,
+  DialogTitle,
   DialogTrigger,
 } from '../../components/ui/dialog'
 import { useConversationMutations } from '../../lib/chat-queries'
@@ -93,9 +95,9 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
       </DialogTrigger>
 
       <DialogContent className="max-w-md">
-        <div className="mb-4">
-          <span className="text-[15px] font-semibold text-ink">Thread settings</span>
-        </div>
+        <DialogHeader>
+          <DialogTitle>Thread settings</DialogTitle>
+        </DialogHeader>
 
         <div className="flex flex-col gap-5">
           {/* System prompt */}

--- a/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Settings2 } from 'lucide-react'
+import { ChevronRight, Settings2 } from 'lucide-react'
 import { Button } from '../../components/ui/button'
 import {
   Dialog,
@@ -10,52 +10,107 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '../../components/ui/dialog'
+import { Switch } from '../../components/ui/switch'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
 import { useConversationMutations } from '../../lib/chat-queries'
 import type { Conversation } from '../../lib/chat-types'
 import { ApiError } from '../../lib/api'
 import { toast } from '../../components/ui/sonner'
 import { skillKeys, fetchSkills } from '../../lib/agent-api'
+import { cn } from '../../lib/utils'
 
 // Skills a plain chat can't use yet — they grant filesystem tools that aren't wired
 // into chat (reserved for the future Code surface). Hidden from the picker so toggling
 // them on never promises a capability that silently doesn't work.
 const CHAT_UNSUPPORTED_SKILLS = new Set(['filesystem'])
 
-// Sampling fields per spec 07 §5 (identical to spec 05 §2 sliders)
+// Sampling fields per spec 07 §5 (identical to spec 05 §2 sliders). `modelField` maps
+// each slider to the matching key on the currently-loaded model's own Sampling block,
+// so the resting position reflects that model's real defaults instead of one fixed
+// constant for every model; `def` is the last-resort fallback when no model is loaded.
 const SAMPLING_FIELDS = [
-  { key: 'temperature', label: 'Temperature', min: 0, max: 2,   step: 0.01, def: 0.8 },
-  { key: 'top_p',       label: 'Top P',       min: 0, max: 1,   step: 0.01, def: 0.95 },
-  { key: 'top_k',       label: 'Top K',       min: 0, max: 200, step: 1,    def: 40 },
-  { key: 'min_p',       label: 'Min P',       min: 0, max: 1,   step: 0.01, def: 0.05 },
+  { key: 'temperature', label: 'Temperature', min: 0, max: 2,   step: 0.01, def: 0.8,  modelField: 'temp' as const },
+  { key: 'top_p',       label: 'Top P',       min: 0, max: 1,   step: 0.01, def: 0.95, modelField: 'topP' as const },
+  { key: 'top_k',       label: 'Top K',       min: 0, max: 200, step: 1,    def: 40,   modelField: 'topK' as const },
+  { key: 'min_p',       label: 'Min P',       min: 0, max: 1,   step: 0.01, def: 0.05, modelField: 'minP' as const },
 ] as const
+
+/** Draft thread settings for a not-yet-created conversation (a blank chat screen with a
+ *  model loaded but no first message sent yet). Mirrors ChatScreen's existing
+ *  `pendingSkillIds` pattern, extended to the other three thread-settings fields. */
+export interface ConversationSettingsDraft {
+  systemPrompt: string
+  sampling: Record<string, number>
+  skillIds: string[]
+  preserveThinking: boolean
+  onChange: (patch: Partial<{
+    systemPrompt: string
+    sampling: Record<string, number>
+    skillIds: string[]
+    preserveThinking: boolean
+  }>) => void
+}
 
 /**
  * Per-thread settings dialog: system prompt textarea + sampling overrides.
  * Renders as a trigger button; opens a dialog on click. Changes apply to
  * the next message and don't require a model reload (spec 07 §5).
+ *
+ * Works in two modes: "live" (conv exists — Save PATCHes it) and "draft" (conv
+ * doesn't exist yet but a model is loaded — Save just commits local draft state via
+ * `draft.onChange`, no network call, since there's nothing to PATCH).
  */
-export function ConversationSettingsDialog({ conv }: { conv: Conversation | undefined }) {
+export function ConversationSettingsDialog({
+  conv,
+  draft,
+  modelSampling,
+}: {
+  conv: Conversation | undefined
+  draft?: ConversationSettingsDraft
+  modelSampling?: { temp: number; topP: number; topK: number; minP: number }
+}) {
   const mut = useConversationMutations()
   const [open, setOpen] = useState(false)
   const [systemPrompt, setSystemPrompt] = useState('')
   const [sampling, setSampling] = useState<Record<string, number>>({})
   const [skillIds, setSkillIds] = useState<string[]>([])
-  const [preserveThinking, setPreserveThinking] = useState(false)
+  const [preserveThinking, setPreserveThinking] = useState(true)
+  const [skillsOpen, setSkillsOpen] = useState(false)
 
   const skillsQ = useQuery({ queryKey: skillKeys.list(), queryFn: fetchSkills, enabled: open, staleTime: 0 })
   const pickableSkills = (skillsQ.data ?? []).filter((s) => !CHAT_UNSUPPORTED_SKILLS.has(s.id))
 
   useEffect(() => {
-    if (open && conv) {
+    if (!open) return
+    // The dialog component stays mounted for the lifetime of the chat screen (only
+    // Radix's portal content mounts/unmounts), so local state like skillsOpen would
+    // otherwise carry over from a previous open — always start the skills section
+    // collapsed on every open, not just the first.
+    setSkillsOpen(false)
+    if (conv) {
       setSystemPrompt(conv.systemPrompt ?? '')
       setSampling(conv.sampling ?? {})
       setSkillIds(conv.skillIds ?? [])
       setPreserveThinking(conv.preserveThinking ?? false)
+    } else if (draft) {
+      setSystemPrompt(draft.systemPrompt ?? '')
+      setSampling(draft.sampling ?? {})
+      setSkillIds(draft.skillIds ?? [])
+      setPreserveThinking(draft.preserveThinking ?? true)
     }
-  }, [open, conv])
+  }, [open, conv, draft])
 
   const toggleSkill = (id: string) =>
     setSkillIds((prev) => (prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]))
+
+  const allSkillsSelected = pickableSkills.length > 0 && pickableSkills.every((s) => skillIds.includes(s.id))
+  const someSkillsSelected = pickableSkills.some((s) => skillIds.includes(s.id))
+  const masterCheckboxRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (masterCheckboxRef.current) masterCheckboxRef.current.indeterminate = someSkillsSelected && !allSkillsSelected
+  }, [someSkillsSelected, allSkillsSelected])
+  const toggleAllSkills = () =>
+    setSkillIds(allSkillsSelected ? [] : pickableSkills.map((s) => s.id))
 
   const hasOverrides = Object.keys(sampling).length > 0
   const isExpert = conv?.expertMode ?? false
@@ -66,7 +121,12 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
   const resetSampling = () => setSampling({})
 
   const save = () => {
-    if (!conv) return
+    if (!conv) {
+      // Draft mode: nothing to PATCH yet — just commit the local draft state.
+      draft?.onChange({ systemPrompt, sampling, skillIds, preserveThinking })
+      setOpen(false)
+      return
+    }
     // Expert threads keep their server-managed system prompt — only sampling is editable.
     const patch = isExpert
       ? { id: conv.id, sampling, skillIds, preserveThinking }
@@ -88,7 +148,7 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
           variant="ghost"
           className="h-8 w-8"
           title="Thread settings — system prompt & sampling overrides"
-          disabled={!conv}
+          disabled={!conv && !draft}
         >
           <Settings2 size={15} />
         </Button>
@@ -140,7 +200,9 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
             <div className="flex flex-col gap-3.5">
               {SAMPLING_FIELDS.map((f) => {
                 const isSet = f.key in sampling
-                const val = isSet ? (sampling[f.key] ?? f.def) : f.def
+                const modelDef = modelSampling?.[f.modelField]
+                const effectiveDef = modelDef ?? f.def
+                const val = isSet ? (sampling[f.key] ?? effectiveDef) : effectiveDef
                 return (
                   <div key={f.key} className="flex items-center gap-3">
                     <span
@@ -175,52 +237,69 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
           </div>
 
           {/* Skills — the shared SKILL.md library, enabled per thread. Also toggleable
-              inline via the '/' picker in the composer. */}
-          <div>
-            <span className="mb-2.5 block text-[11px] font-medium uppercase tracking-wide text-faint">
-              Skills
-            </span>
-            {skillsQ.isLoading ? (
-              <p className="text-[12px] text-faint">Loading…</p>
-            ) : pickableSkills.length === 0 ? (
-              <p className="text-[12px] text-faint">No skills yet — create one under Skills.</p>
-            ) : (
-              <div className="flex flex-col gap-2">
-                {pickableSkills.map((s) => (
-                  <label key={s.id} className="flex cursor-pointer items-start gap-2 text-[13px]">
-                    <input
-                      type="checkbox"
-                      className="mt-0.5"
-                      checked={skillIds.includes(s.id)}
-                      onChange={() => toggleSkill(s.id)}
-                    />
-                    <span className="flex flex-col">
-                      <span className="text-ink">{s.name}</span>
-                      {s.description && <span className="text-[12px] text-muted">{s.description}</span>}
-                    </span>
-                  </label>
-                ))}
+              inline via the '/' picker in the composer. Collapsed by default; a master
+              checkbox in the trigger row selects/deselects all skills at once. */}
+          <Collapsible open={skillsOpen} onOpenChange={setSkillsOpen}>
+            <div className="flex items-center gap-2">
+              <CollapsibleTrigger className="flex flex-1 items-center gap-2 text-left">
+                <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', skillsOpen && 'rotate-90')} />
+                <span className="text-[11px] font-medium uppercase tracking-wide text-faint">
+                  Skills{skillIds.length > 0 ? ` (${skillIds.length})` : ''}
+                </span>
+              </CollapsibleTrigger>
+              {pickableSkills.length > 0 && (
+                <label className="flex cursor-pointer items-center gap-1.5 text-[11px] text-muted">
+                  <input
+                    ref={masterCheckboxRef}
+                    type="checkbox"
+                    checked={allSkillsSelected}
+                    onChange={toggleAllSkills}
+                  />
+                  All
+                </label>
+              )}
+            </div>
+            <CollapsibleContent>
+              <div className="mt-2.5">
+                {skillsQ.isLoading ? (
+                  <p className="text-[12px] text-faint">Loading…</p>
+                ) : pickableSkills.length === 0 ? (
+                  <p className="text-[12px] text-faint">No skills yet — create one under Skills.</p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    {pickableSkills.map((s) => (
+                      <label key={s.id} className="flex cursor-pointer items-start gap-2 text-[13px]">
+                        <input
+                          type="checkbox"
+                          className="mt-0.5"
+                          checked={skillIds.includes(s.id)}
+                          onChange={() => toggleSkill(s.id)}
+                        />
+                        <span className="flex flex-col">
+                          <span className="text-ink">{s.name}</span>
+                          {s.description && <span className="text-[12px] text-muted">{s.description}</span>}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
+            </CollapsibleContent>
+          </Collapsible>
 
           {/* GitHub #52: fold past reasoning back into what's resent to the model,
-              instead of only ever resending each turn's final answer. */}
-          <div>
-            <label className="flex cursor-pointer items-start gap-2 text-[13px]">
-              <input
-                type="checkbox"
-                className="mt-0.5"
-                checked={preserveThinking}
-                onChange={(e) => setPreserveThinking(e.target.checked)}
-              />
-              <span className="flex flex-col">
-                <span className="text-ink">Preserve thinking across turns</span>
-                <span className="text-[12px] text-muted">
-                  Resend the model's past reasoning on later turns, not just its final answers. Off by default — uses more tokens per request.
-                </span>
+              instead of only ever resending each turn's final answer. A persistent
+              behavior toggle, not a feature to enable — styled as its own settings
+              row (Switch) rather than a checkbox like the skills above, so it doesn't
+              read as just another item in that list. */}
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-panel-2 px-3 py-2.5">
+            <span className="flex flex-col">
+              <span className="text-[13px] text-ink">Preserve thinking across turns</span>
+              <span className="text-[12px] text-muted">
+                Resend the model's past reasoning on later turns, not just its final answers — uses more tokens per request.
               </span>
-            </label>
+            </span>
+            <Switch checked={preserveThinking} onCheckedChange={setPreserveThinking} />
           </div>
         </div>
 

--- a/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
@@ -99,7 +99,7 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
           <DialogTitle>Thread settings</DialogTitle>
         </DialogHeader>
 
-        <div className="flex flex-col gap-5">
+        <div className="flex max-h-[60vh] flex-col gap-5 overflow-y-auto">
           {/* System prompt */}
           <div>
             <label className="mb-1.5 block text-[11px] font-medium uppercase tracking-wide text-faint">

--- a/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSettingsDialog.tsx
@@ -38,6 +38,7 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
   const [systemPrompt, setSystemPrompt] = useState('')
   const [sampling, setSampling] = useState<Record<string, number>>({})
   const [skillIds, setSkillIds] = useState<string[]>([])
+  const [preserveThinking, setPreserveThinking] = useState(false)
 
   const skillsQ = useQuery({ queryKey: skillKeys.list(), queryFn: fetchSkills, enabled: open, staleTime: 0 })
   const pickableSkills = (skillsQ.data ?? []).filter((s) => !CHAT_UNSUPPORTED_SKILLS.has(s.id))
@@ -47,6 +48,7 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
       setSystemPrompt(conv.systemPrompt ?? '')
       setSampling(conv.sampling ?? {})
       setSkillIds(conv.skillIds ?? [])
+      setPreserveThinking(conv.preserveThinking ?? false)
     }
   }, [open, conv])
 
@@ -64,7 +66,9 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
   const save = () => {
     if (!conv) return
     // Expert threads keep their server-managed system prompt — only sampling is editable.
-    const patch = isExpert ? { id: conv.id, sampling, skillIds } : { id: conv.id, systemPrompt, sampling, skillIds }
+    const patch = isExpert
+      ? { id: conv.id, sampling, skillIds, preserveThinking }
+      : { id: conv.id, systemPrompt, sampling, skillIds, preserveThinking }
     mut.update.mutate(
       patch,
       {
@@ -196,6 +200,25 @@ export function ConversationSettingsDialog({ conv }: { conv: Conversation | unde
                 ))}
               </div>
             )}
+          </div>
+
+          {/* GitHub #52: fold past reasoning back into what's resent to the model,
+              instead of only ever resending each turn's final answer. */}
+          <div>
+            <label className="flex cursor-pointer items-start gap-2 text-[13px]">
+              <input
+                type="checkbox"
+                className="mt-0.5"
+                checked={preserveThinking}
+                onChange={(e) => setPreserveThinking(e.target.checked)}
+              />
+              <span className="flex flex-col">
+                <span className="text-ink">Preserve thinking across turns</span>
+                <span className="text-[12px] text-muted">
+                  Resend the model's past reasoning on later turns, not just its final answers. Off by default — uses more tokens per request.
+                </span>
+              </span>
+            </label>
           </div>
         </div>
 

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronDown, ChevronLeft, ChevronRight, Download, Folder as FolderIcon, FolderInput, FolderPlus, MessageSquarePlus, MoreHorizontal, Pencil, Search, Trash2 } from 'lucide-react'
+import { ChevronDown, ChevronLeft, ChevronRight, Circle, Download, Folder as FolderIcon, FolderInput, FolderPlus, Loader2, MessageSquarePlus, MoreHorizontal, Pencil, Search, Trash2 } from 'lucide-react'
 import type { Conversation, Folder } from '../../lib/chat-types'
 import { useConversationMutations, useConversations, useFolders } from '../../lib/chat-queries'
 import { Button } from '../../components/ui/button'
@@ -45,6 +45,8 @@ export function ConversationSidebar({
   collapsed,
   onToggle,
   generating,
+  generatingIds,
+  recentlyCompletedIds,
   onDeleted,
 }: {
   activeId: string | null
@@ -56,6 +58,12 @@ export function ConversationSidebar({
   onToggle?: () => void
   /** True when a generation is streaming in the active conversation. */
   generating?: boolean
+  /** Ids of every conversation currently streaming a generation (including ones the
+   *  user has navigated away from) — drives the spinning in-progress indicator. */
+  generatingIds?: Set<string>
+  /** Ids of conversations whose generation finished while the user was elsewhere —
+   *  drives the "new result" dot until the user visits that conversation. */
+  recentlyCompletedIds?: Set<string>
   /** Called after a conversation is deleted so the parent can clear its active
    *  reference when the deleted conversation was the open one. */
   onDeleted?: (id: string) => void
@@ -248,7 +256,17 @@ export function ConversationSidebar({
               <p className="px-3 py-4 text-[12px] text-faint">No results.</p>
             )}
             {convs.map((conv) => (
-              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+              <ConvItem
+                key={conv.id}
+                conv={conv}
+                active={conv.id === activeId}
+                folders={folders}
+                onSelect={onSelect}
+                onDelete={onDelete}
+                onMove={onMove}
+                generating={generatingIds?.has(conv.id)}
+                recentlyCompleted={recentlyCompletedIds?.has(conv.id)}
+              />
             ))}
           </>
         ) : (
@@ -271,6 +289,8 @@ export function ConversationSidebar({
                 onSelect={onSelect}
                 onDelete={onDelete}
                 onMove={onMove}
+                generatingIds={generatingIds}
+                recentlyCompletedIds={recentlyCompletedIds}
               />
             ))}
 
@@ -283,7 +303,17 @@ export function ConversationSidebar({
               </div>
             )}
             {ungrouped.map((conv) => (
-              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+              <ConvItem
+                key={conv.id}
+                conv={conv}
+                active={conv.id === activeId}
+                folders={folders}
+                onSelect={onSelect}
+                onDelete={onDelete}
+                onMove={onMove}
+                generating={generatingIds?.has(conv.id)}
+                recentlyCompleted={recentlyCompletedIds?.has(conv.id)}
+              />
             ))}
           </>
         )}
@@ -360,6 +390,8 @@ function FolderSection({
   onSelect,
   onDelete,
   onMove,
+  generatingIds,
+  recentlyCompletedIds,
 }: {
   folder: Folder
   items: Conversation[]
@@ -371,6 +403,8 @@ function FolderSection({
   onSelect: (id: string) => void
   onDelete: (e: React.MouseEvent, conv: Conversation) => void
   onMove: (conv: Conversation, folderId: string | null) => void
+  generatingIds?: Set<string>
+  recentlyCompletedIds?: Set<string>
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(folder.name)
@@ -442,7 +476,17 @@ function FolderSection({
             <p className="px-3 py-1.5 text-[11px] text-faint">Empty folder</p>
           ) : (
             items.map((conv) => (
-              <ConvItem key={conv.id} conv={conv} active={conv.id === activeId} folders={folders} onSelect={onSelect} onDelete={onDelete} onMove={onMove} />
+              <ConvItem
+                key={conv.id}
+                conv={conv}
+                active={conv.id === activeId}
+                folders={folders}
+                onSelect={onSelect}
+                onDelete={onDelete}
+                onMove={onMove}
+                generating={generatingIds?.has(conv.id)}
+                recentlyCompleted={recentlyCompletedIds?.has(conv.id)}
+              />
             ))
           )}
         </div>
@@ -458,6 +502,8 @@ function ConvItem({
   onSelect,
   onDelete,
   onMove,
+  generating,
+  recentlyCompleted,
 }: {
   conv: Conversation
   active: boolean
@@ -465,6 +511,10 @@ function ConvItem({
   onSelect: (id: string) => void
   onDelete: (e: React.MouseEvent, conv: Conversation) => void
   onMove: (conv: Conversation, folderId: string | null) => void
+  /** True while this conversation is streaming a generation (foreground or background). */
+  generating?: boolean
+  /** True when this conversation's generation finished while the user was elsewhere. */
+  recentlyCompleted?: boolean
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(conv.title)
@@ -497,13 +547,21 @@ function ConvItem({
           onClick={(e) => e.stopPropagation()}
         />
       ) : (
-        <span
-          className="truncate text-[13px] font-medium text-ink"
-          style={{ color: active ? 'var(--accent)' : undefined }}
-          onDoubleClick={(e) => { e.stopPropagation(); setEditing(true) }}
-        >
-          {conv.title}
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span
+            className="min-w-0 truncate text-[13px] font-medium text-ink"
+            style={{ color: active ? 'var(--accent)' : undefined }}
+            onDoubleClick={(e) => { e.stopPropagation(); setEditing(true) }}
+          >
+            {conv.title}
+          </span>
+          {generating && (
+            <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} aria-label="Generating" />
+          )}
+          {!generating && recentlyCompleted && (
+            <Circle size={7} className="shrink-0 fill-current text-accent" aria-label="New reply" />
+          )}
+        </div>
       )}
       <span className="text-[11px] text-faint">{relTime(conv.updatedAt)}</span>
       {!editing && (

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -431,56 +431,53 @@ export function StreamingBubble({
   const generating = liveGenTps > 0
 
   return (
-    <div className="flex gap-3">
-      <ModelAvatar />
-      <div className="min-w-0 flex-1 pt-0.5">
-        {reasoning?.trim() && <ThinkingBlock reasoning={reasoning} streaming />}
+    <div className="min-w-0 pt-0.5">
+      {reasoning?.trim() && <ThinkingBlock reasoning={reasoning} streaming />}
 
-        {/* Interleaved timeline: text the model wrote and tools it ran, in order */}
-        {timeline.map((b, i) =>
-          b.kind === 'text'
-            ? (b.text
-                ? <div key={i} className="prose-tllm text-[15px] leading-[1.7] text-ink"><Markdown streaming>{b.text}</Markdown></div>
-                : null)
-            : <InlineToolStep key={b.call.id} call={b.call} />,
-        )}
+      {/* Interleaved timeline: text the model wrote and tools it ran, in order */}
+      {timeline.map((b, i) =>
+        b.kind === 'text'
+          ? (b.text
+              ? <div key={i} className="prose-tllm text-[15px] leading-[1.7] text-ink"><Markdown streaming>{b.text}</Markdown></div>
+              : null)
+          : <InlineToolStep key={b.call.id} call={b.call} />,
+      )}
 
-        {/* Prefill progress bar */}
-        {isPrefill && (
-          <div className="mt-2 space-y-1">
-            <div className="flex items-center gap-1.5 text-[11px] text-faint">
-              <Loader2 size={11} className="animate-spin" style={{ color: 'var(--accent)' }} />
-              <span>Processing prompt</span>
-              <span className="font-medium" style={{ color: 'var(--ink)' }}>{progress.pct}%</span>
-              {progress.tps > 0 && <span>· {progress.tps.toFixed(0)} tok/s prefill</span>}
-            </div>
-            <div className="h-[3px] w-full overflow-hidden rounded-full" style={{ background: 'var(--border)' }}>
-              <div
-                className="h-full rounded-full transition-all duration-200"
-                style={{ width: `${progress.pct}%`, background: 'var(--accent)' }}
-              />
-            </div>
+      {/* Prefill progress bar */}
+      {isPrefill && (
+        <div className="mt-2 space-y-1">
+          <div className="flex items-center gap-1.5 text-[11px] text-faint">
+            <Loader2 size={11} className="animate-spin" style={{ color: 'var(--accent)' }} />
+            <span>Processing prompt</span>
+            <span className="font-medium" style={{ color: 'var(--ink)' }}>{progress.pct}%</span>
+            {progress.tps > 0 && <span>· {progress.tps.toFixed(0)} tok/s prefill</span>}
           </div>
-        )}
+          <div className="h-[3px] w-full overflow-hidden rounded-full" style={{ background: 'var(--border)' }}>
+            <div
+              className="h-full rounded-full transition-all duration-200"
+              style={{ width: `${progress.pct}%`, background: 'var(--accent)' }}
+            />
+          </div>
+        </div>
+      )}
 
-        {/* Always-on activity line — guarantees the bubble never looks hung.
-            While a tool is running its inline step shows the spinner, so we only
-            need a foot line for active generation and the gaps between steps. */}
-        {!isPrefill && !pendingTool && (
-          generating ? (
-            <div className="mt-1 flex items-center gap-1.5 text-[11px] text-faint">
-              <span className="tllm-pulse">·</span>
-              {genTokens > 0 && <span className="font-medium" style={{ color: 'var(--ink)' }}>{genTokens} tok</span>}
-              <span>· {liveGenTps.toFixed(1)} tok/s</span>
-            </div>
-          ) : (
-            <div className="mt-1.5 flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--accent)' }}>
-              <Loader2 size={12} className="animate-spin" />
-              <span>{hasTool ? 'Working…' : reasoning ? 'Generating…' : 'Thinking…'}</span>
-            </div>
-          )
-        )}
-      </div>
+      {/* Always-on activity line — guarantees the bubble never looks hung.
+          While a tool is running its inline step shows the spinner, so we only
+          need a foot line for active generation and the gaps between steps. */}
+      {!isPrefill && !pendingTool && (
+        generating ? (
+          <div className="mt-1 flex items-center gap-1.5 text-[11px] text-faint">
+            <span className="tllm-pulse">·</span>
+            {genTokens > 0 && <span className="font-medium" style={{ color: 'var(--ink)' }}>{genTokens} tok</span>}
+            <span>· {liveGenTps.toFixed(1)} tok/s</span>
+          </div>
+        ) : (
+          <div className="mt-1.5 flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--accent)' }}>
+            <Loader2 size={12} className="animate-spin" />
+            <span>{hasTool ? 'Working…' : reasoning ? 'Generating…' : 'Thinking…'}</span>
+          </div>
+        )
+      )}
     </div>
   )
 }
@@ -584,67 +581,68 @@ export function MessageBubble({
   const rm: ResearchMeta | undefined = message.researchMeta
   const verdicts = rm?.refereeVerdicts ?? []
   return (
-    <div className="group flex gap-3">
-      <ModelAvatar />
-      <div className="min-w-0 flex-1 pt-0.5">
-        {message.reasoning?.trim() && (
-          <ThinkingBlock reasoning={message.reasoning} thinkMs={message.stats.thinkMs} showThinking={showThinking} />
-        )}
-        <ToolCallsPanel calls={completedToolCalls} />
-        {isEditing ? (
-          <div className="w-full">
-            <textarea
-              autoFocus
-              className="w-full resize-none rounded-[var(--radius-lg)] border border-accent bg-panel px-4 py-2.5 text-[15px] leading-[1.6] text-ink outline-none"
-              rows={4}
-              value={editDraft}
-              onChange={(e) => setEditDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); onEditSave(editDraft) }
-                if (e.key === 'Escape') onEditCancel()
-              }}
-            />
-            <div className="mt-1.5 flex gap-1.5">
-              <Button size="sm" variant="ghost" onClick={onEditCancel}>Cancel</Button>
-              {/* GitHub #52: unlike a user-message edit, this only fixes the reply's own
-                  text in place — it doesn't resend or trigger a new generation. */}
-              <Button size="sm" onClick={() => onEditSave(editDraft)}>Save</Button>
-            </div>
+    <div className="group min-w-0 pt-0.5">
+      {message.reasoning?.trim() && (
+        <ThinkingBlock reasoning={message.reasoning} thinkMs={message.stats.thinkMs} showThinking={showThinking} />
+      )}
+      <ToolCallsPanel calls={completedToolCalls} />
+      {isEditing ? (
+        <div className="w-full">
+          <textarea
+            autoFocus
+            className="w-full resize-none rounded-[var(--radius-lg)] border border-accent bg-panel px-4 py-2.5 text-[15px] leading-[1.6] text-ink outline-none"
+            rows={4}
+            value={editDraft}
+            onChange={(e) => setEditDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); onEditSave(editDraft) }
+              if (e.key === 'Escape') onEditCancel()
+            }}
+          />
+          <div className="mt-1.5 flex gap-1.5">
+            <Button size="sm" variant="ghost" onClick={onEditCancel}>Cancel</Button>
+            {/* GitHub #52: unlike a user-message edit, this only fixes the reply's own
+                text in place — it doesn't resend or trigger a new generation. */}
+            <Button size="sm" onClick={() => onEditSave(editDraft)}>Save</Button>
           </div>
-        ) : hasError ? (
-          <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
-            Generation failed or was stopped.
-            {isLast && onRegenerate && <button type="button" className="ml-3 underline" onClick={onRegenerate}>Regenerate</button>}
-          </div>
-        ) : (
-          <div className="prose-tllm text-[15px] leading-[1.7] text-ink">
-            {verdicts.length > 0
-              ? <AnnotatedReply content={message.content} verdicts={verdicts} />
-              : <Markdown>{message.content}</Markdown>
-            }
-          </div>
-        )}
-        {/* F-021: confidence badge */}
-        {rm?.confidence !== undefined && (
-          <div className="mt-1.5">
-            <ConfidenceBadge confidence={rm.confidence} />
-          </div>
-        )}
-        {/* F-021: sources panel */}
-        {rm && <SourcesPanel meta={rm} />}
+        </div>
+      ) : hasError ? (
+        <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
+          Generation failed or was stopped.
+          {isLast && onRegenerate && <button type="button" className="ml-3 underline" onClick={onRegenerate}>Regenerate</button>}
+        </div>
+      ) : (
+        <div className="prose-tllm text-[15px] leading-[1.7] text-ink">
+          {verdicts.length > 0
+            ? <AnnotatedReply content={message.content} verdicts={verdicts} />
+            : <Markdown>{message.content}</Markdown>
+          }
+        </div>
+      )}
+      {/* F-021: confidence badge */}
+      {rm?.confidence !== undefined && (
+        <div className="mt-1.5">
+          <ConfidenceBadge confidence={rm.confidence} />
+        </div>
+      )}
+      {/* F-021: sources panel */}
+      {rm && <SourcesPanel meta={rm} />}
+      <div className="flex items-center gap-1.5">
         <StatsRow stats={message.stats} />
-        {!isEditing && (
-          <div className="mt-1 flex items-center gap-0.5">
-            {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
-            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-              <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
-              {onEdit && <ActionBtn icon={<Pencil size={12} />} label="Edit" onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
-              {isLast && onRegenerate && <ActionBtn icon={<RefreshCw size={12} />} label="Regenerate" onClick={onRegenerate} />}
-              {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
-            </div>
-          </div>
-        )}
+        {/* GitHub #52: only ever set by an explicit in-place edit, never by generation. */}
+        {message.edited && <span className="text-[11px] text-faint">· Edited</span>}
       </div>
+      {!isEditing && (
+        <div className="mt-1 flex items-center gap-0.5">
+          {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
+          <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+            <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
+            {onEdit && <ActionBtn icon={<Pencil size={12} />} label="Edit" onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
+            {isLast && onRegenerate && <ActionBtn icon={<RefreshCw size={12} />} label="Regenerate" onClick={onRegenerate} />}
+            {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -699,10 +697,6 @@ function VariantSwitcher({ convId, message }: { convId: string; message: Message
       </button>
     </div>
   )
-}
-
-function ModelAvatar() {
-  return <div className="mt-1 grid h-5 w-5 shrink-0 place-items-center rounded bg-panel-2 text-[9px] font-bold text-muted">T</div>
 }
 
 function ActionBtn({ icon, label, onClick, destructive }: { icon: ReactNode; label: string; onClick: () => void; destructive?: boolean }) {

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -432,7 +432,7 @@ export function StreamingBubble({
     <div className="flex gap-3">
       <ModelAvatar />
       <div className="min-w-0 flex-1 pt-0.5">
-        {reasoning && <ThinkingBlock reasoning={reasoning} streaming />}
+        {reasoning?.trim() && <ThinkingBlock reasoning={reasoning} streaming />}
 
         {/* Interleaved timeline: text the model wrote and tools it ran, in order */}
         {timeline.map((b, i) =>
@@ -578,7 +578,7 @@ export function MessageBubble({
     <div className="group flex gap-3">
       <ModelAvatar />
       <div className="min-w-0 flex-1 pt-0.5">
-        {message.reasoning && (
+        {message.reasoning?.trim() && (
           <ThinkingBlock reasoning={message.reasoning} thinkMs={message.stats.thinkMs} showThinking={showThinking} />
         )}
         <ToolCallsPanel calls={completedToolCalls} />

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -1,10 +1,12 @@
 import { memo, useEffect, useRef, useState, type ReactNode } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
-import { CheckCircle2, ChevronDown, ChevronRight, FileText, HelpCircle, Loader2, Pencil, RefreshCw, Trash2, XCircle } from 'lucide-react'
+import { CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, FileText, HelpCircle, Loader2, Pencil, RefreshCw, Trash2, XCircle } from 'lucide-react'
 import type { ClaimVerdict, LiveToolCall, Message, MessageStats, ResearchMeta, ResearchSource, ToolCallRecord } from '../../lib/chat-types'
 import type { LiveBlock } from '../../lib/live-timeline'
+import { activateVariant, getMessageVariants } from '../../lib/chat-api'
 import { Button } from '../../components/ui/button'
 import { CopyButton } from '../../components/ui/copy-button'
 import { ArtifactCard, isArtifactLang } from '../../components/ArtifactCard'
@@ -487,6 +489,7 @@ export function StreamingBubble({
 
 export function MessageBubble({
   message,
+  convId,
   isLast,
   onEdit,
   onDelete,
@@ -497,6 +500,9 @@ export function MessageBubble({
   showThinking = true,
 }: {
   message: Message
+  /** Needed for the chat-branching variant switcher (GitHub #52); optional so read-only
+   *  share views can keep omitting it — the switcher just doesn't render without it. */
+  convId?: string
   isLast: boolean
   /** When undefined, edit/delete/regenerate action buttons are hidden (read-only mode). */
   onEdit?: (m: Message) => void
@@ -553,10 +559,13 @@ export function MessageBubble({
             </div>
           )}
           {!isEditing && (
-            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-              <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
-              {onEdit && <ActionBtn icon={<Pencil size={12} />}  label="Edit"   onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
-              {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
+            <div className="flex items-center gap-0.5">
+              {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
+              <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
+                {onEdit && <ActionBtn icon={<Pencil size={12} />}  label="Edit"   onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
+                {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
+              </div>
             </div>
           )}
         </div>
@@ -582,7 +591,27 @@ export function MessageBubble({
           <ThinkingBlock reasoning={message.reasoning} thinkMs={message.stats.thinkMs} showThinking={showThinking} />
         )}
         <ToolCallsPanel calls={completedToolCalls} />
-        {hasError ? (
+        {isEditing ? (
+          <div className="w-full">
+            <textarea
+              autoFocus
+              className="w-full resize-none rounded-[var(--radius-lg)] border border-accent bg-panel px-4 py-2.5 text-[15px] leading-[1.6] text-ink outline-none"
+              rows={4}
+              value={editDraft}
+              onChange={(e) => setEditDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); onEditSave(editDraft) }
+                if (e.key === 'Escape') onEditCancel()
+              }}
+            />
+            <div className="mt-1.5 flex gap-1.5">
+              <Button size="sm" variant="ghost" onClick={onEditCancel}>Cancel</Button>
+              {/* GitHub #52: unlike a user-message edit, this only fixes the reply's own
+                  text in place — it doesn't resend or trigger a new generation. */}
+              <Button size="sm" onClick={() => onEditSave(editDraft)}>Save</Button>
+            </div>
+          </div>
+        ) : hasError ? (
           <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
             Generation failed or was stopped.
             {isLast && onRegenerate && <button type="button" className="ml-3 underline" onClick={onRegenerate}>Regenerate</button>}
@@ -604,12 +633,70 @@ export function MessageBubble({
         {/* F-021: sources panel */}
         {rm && <SourcesPanel meta={rm} />}
         <StatsRow stats={message.stats} />
-        <div className="mt-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-          <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
-          {isLast && onRegenerate && <ActionBtn icon={<RefreshCw size={12} />} label="Regenerate" onClick={onRegenerate} />}
-          {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
-        </div>
+        {!isEditing && (
+          <div className="mt-1 flex items-center gap-0.5">
+            {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
+            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+              <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
+              {onEdit && <ActionBtn icon={<Pencil size={12} />} label="Edit" onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
+              {isLast && onRegenerate && <ActionBtn icon={<RefreshCw size={12} />} label="Regenerate" onClick={onRegenerate} />}
+              {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
+            </div>
+          </div>
+        )}
       </div>
+    </div>
+  )
+}
+
+// ── Chat branching (GitHub #52): ‹ 2/3 › switcher for regenerated sibling replies ──
+
+function VariantSwitcher({ convId, message }: { convId: string; message: Message }) {
+  const qc = useQueryClient()
+  const group = message.variantGroup!
+  const variantsQ = useQuery({
+    queryKey: ['message-variants', group],
+    queryFn: () => getMessageVariants(convId, message.id),
+  })
+  const [switching, setSwitching] = useState(false)
+
+  const variants = variantsQ.data?.variants ?? []
+  const index = variants.findIndex((v) => v.id === message.id)
+  // Bail if still loading, a group that collapsed to one, or a stale query mid-refetch
+  // (index -1 — this message isn't in the list yet) rather than risk indexing variants[-2].
+  if (variants.length < 2 || index === -1) return null
+  const go = async (targetId: string) => {
+    setSwitching(true)
+    try {
+      await activateVariant(convId, targetId)
+      await qc.invalidateQueries({ queryKey: ['message-variants', group] })
+      await qc.invalidateQueries({ queryKey: ['conversation', convId] })
+    } finally {
+      setSwitching(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-0.5 text-[11px] text-faint">
+      <button
+        type="button"
+        disabled={switching || index <= 0}
+        onClick={() => go(variants[index - 1].id)}
+        className="grid h-5 w-5 place-items-center rounded hover:bg-panel-2 disabled:pointer-events-none disabled:opacity-30"
+        title="Previous version"
+      >
+        <ChevronLeft size={12} />
+      </button>
+      <span className="tabular-nums">{index + 1}/{variants.length}</span>
+      <button
+        type="button"
+        disabled={switching || index >= variants.length - 1}
+        onClick={() => go(variants[index + 1].id)}
+        className="grid h-5 w-5 place-items-center rounded hover:bg-panel-2 disabled:pointer-events-none disabled:opacity-30"
+        title="Next version"
+      >
+        <ChevronRight size={12} />
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Chat branching**: regenerate and user-message edits now branch instead of destroying history, with a switcher UI (‹ N/M ›), including nested branch points.
- **In-place message editing**: assistant replies can be edited without triggering a new generation; shows an "Edited" tag.
- **Preserve-thinking toggle**: per-conversation setting to fold past reasoning into resent context; now on by default with a proper Switch UI, and usable on a blank chat before the first message.
- **Model-sourced sampling defaults**: Thread settings sliders now default to the loaded model's own recommended values instead of fixed constants.
- **Collapsible skills list**: collapsed by default, with a master on/off checkbox and correct indeterminate state.
- **Per-conversation background generation**: switching conversations no longer aborts an in-flight generation; the sidebar now shows a live spinner for background generations and a completed indicator when one finishes elsewhere.
- **Fixes**: CUDA backend silently falling back to CPU on an incomplete multi-asset download; a model swap that could silently abandon the load after a slow stop, leaving no model loaded with no error; custom engines not appearing in the engine gallery; an EPERM crash during engine scanning; a streaming empty-block bug; a Thread settings dialog overflow with many skills; a missing DialogTitle a11y issue; pinned models not sorting to the top of the chat model picker.

## Test plan
- [x] Typecheck clean, full suite green (711/711, 3 pre-existing skips) after every commit
- [x] Live-verified against a real running daemon + model throughout, including: actual generation request payload confirming `chat_template_kwargs.preserve_thinking`; multi-branch regenerate; CUDA VRAM before/after (0 MiB → 7,554 MiB); model swap smoke test; background generation surviving conversation switches with sidebar indicators confirmed via DOM inspection
- [ ] User's own hands-on pass (QA checklist shared earlier this cycle)