### PR TITLE
chore(release): v1.7.6 — token usage dashboard + auto-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ the detail:
 - **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
   with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
   composer. Set per-tool defaults globally from Settings → Tools & safety.
+- **Usage dashboard** — a GitHub-style activity heatmap of your local generation history (adaptive
+  1h/12h/24h boxes for the 7-day/30-day/all-time views), streaks, peak hour, a per-model
+  breakdown, and a lifetime token-milestone tracker.
+- **Auto-memory** *(experimental, off by default)* — silently extracts durable facts you mention
+  in chat (name, preferences, hardware) using your own loaded model, and carries them into future
+  new conversations. Nothing leaves your device; the full fact list is reviewable and deletable
+  from Settings → Memory, and turning the toggle off stops new chats from seeing it immediately.
 
 </details>
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -43,11 +43,11 @@ _Nothing yet._
   stops new facts from being injected into new chats.
 
 ### Discord
-- New **Usage** tab: a GitHub-style heatmap of your local generation activity, streaks, and a fun
-  milestone tracker ("you've generated more tokens than the complete works of Shakespeare").
-- New **experimental** auto-memory option (off by default): TurboLLM can quietly remember things
-  you mention — like your name or hardware — and bring them into new chats automatically. Fully
-  reviewable and deletable from Settings, and it never leaves your machine.
+- Added a usage dashboard to show your tokens — input and output, per model, with a daily
+  activity heatmap and streaks.
+- Added an experimental auto-memory option (off by default): TurboLLM can remember things you
+  mention, like your name or hardware, and bring them into new chats. Reviewable and deletable
+  from Settings, and it never leaves your machine.
 
 ## [1.7.5] - 2026-07-09
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,30 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.7.6] - 2026-07-09
+
+**Token usage dashboard and an opt-in auto-memory feature.**
+
+### Added
+- **Usage dashboard** (new nav tab, replaces nothing — sits above Developer) — an adaptive
+  GitHub-style activity heatmap (1-hour boxes for the 7-day view, 12-hour for 30-day, 1-day for
+  all-time, always the same overall size), 8 stat tiles (sessions, messages, total tokens, active
+  days, streaks, peak hour, favorite model), a per-model tab with a stacked usage chart and ranked
+  legend, and a lifetime milestone ladder with a rotating "you've generated more tokens than X"
+  comparison.
+- **Auto-memory** (Settings → Memory, tagged **Experimental**, off by default) — silently extracts
+  durable facts you mention in chat (name, preferences, hardware, projects) using the model you
+  already have loaded, and adds them to future new conversations. Nothing leaves your device. A
+  reviewable, deletable fact list lives right in the toggle section — turning it off immediately
+  stops new facts from being injected into new chats.
+
+### Discord
+- New **Usage** tab: a GitHub-style heatmap of your local generation activity, streaks, and a fun
+  milestone tracker ("you've generated more tokens than the complete works of Shakespeare").
+- New **experimental** auto-memory option (off by default): TurboLLM can quietly remember things
+  you mention — like your name or hardware — and bring them into new chats automatically. Fully
+  reviewable and deletable from Settings, and it never leaves your machine.
+
 ## [1.7.5] - 2026-07-09
 
 **Chat branching, message editing, preserve-thinking, and a background-generation UX pass — plus a real CUDA fallback bug and a model-swap silent failure fixed.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -225,6 +225,13 @@ the detail:
 - **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
   with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
   composer. Set per-tool defaults globally from Settings → Tools & safety.
+- **Usage dashboard** — a GitHub-style activity heatmap of your local generation history (adaptive
+  1h/12h/24h boxes for the 7-day/30-day/all-time views), streaks, peak hour, a per-model
+  breakdown, and a lifetime token-milestone tracker.
+- **Auto-memory** *(experimental, off by default)* — silently extracts durable facts you mention
+  in chat (name, preferences, hardware) using your own loaded model, and carries them into future
+  new conversations. Nothing leaves your device; the full fact list is reviewable and deletable
+  from Settings → Memory, and turning the toggle off stops new chats from seeing it immediately.
 
 </details>
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1385,6 +1385,7 @@ export function registerApi(app: Hono, d: Deps): void {
       port?: number
       theme?: string
       autoGenerateTitles?: boolean
+      autoMemoryEnabled?: boolean
       openBrowserOnStart?: boolean
       autoLoadOnStart?: boolean
       vramHeadroomMb?: number
@@ -1422,6 +1423,7 @@ export function registerApi(app: Hono, d: Deps): void {
       updates.theme = b.theme
     }
     if (b.autoGenerateTitles !== undefined) updates.autoGenerateTitles = !!b.autoGenerateTitles
+    if (b.autoMemoryEnabled !== undefined) updates.autoMemoryEnabled = !!b.autoMemoryEnabled
     if (b.openBrowserOnStart !== undefined) updates.openBrowserOnStart = !!b.openBrowserOnStart
 
     // VRAM headroom slider for auto-tune (bench.ts's overHeadroom). config.validate() also
@@ -2006,6 +2008,7 @@ function settingsPayload(d: Deps) {
     port: cfg.daemon.port,
     theme: cfg.daemon.theme,
     autoGenerateTitles: cfg.daemon.autoGenerateTitles,
+    autoMemoryEnabled: cfg.daemon.autoMemoryEnabled,
     openBrowserOnStart: cfg.daemon.openBrowserOnStart,
     autoLoadOnStart: cfg.autoLoadOnStart,
     vramHeadroomMb: cfg.vramHeadroomMb,

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -17,6 +17,7 @@ import { resolveToolApproval } from '../tools/approval-gate'
 import { buildSaveSkillTool } from '../agents/agent-tools'
 import { SkillStore } from '../agents/skills'
 import { saveSkillFromConversation } from '../agents/skill-jobs'
+import { extractMemoryFacts } from './memory'
 
 // Track in-flight abort controllers per conversation id.
 const inflight = new Map<string, AbortController>()
@@ -68,6 +69,24 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
     const ok = db.deleteFolder(c.req.param('id'))
     if (!ok) return err(c, 404, 'not_found', 'Folder not found.')
     return c.json({ ok: true })
+  })
+
+  // ── auto-memory (Release 3) ────────────────────────────────────────────────
+
+  app.get('/api/v1/memory', (c) => c.json({ facts: db.listMemoryFacts() }))
+
+  app.delete('/api/v1/memory/:id', (c) => {
+    const ok = db.deleteMemoryFact(c.req.param('id'))
+    if (!ok) return err(c, 404, 'not_found', 'Fact not found.')
+    return c.json({ ok: true })
+  })
+
+  // ── token usage dashboard (Release 3) ─────────────────────────────────────
+
+  app.get('/api/v1/tokens/usage', (c) => {
+    const q = c.req.query('range')
+    const range = q === '30d' || q === '7d' ? q : 'all'
+    return c.json(db.tokenUsageStats(range))
   })
 
   // ── conversations CRUD ─────────────────────────────────────────────────────
@@ -253,7 +272,7 @@ export function registerChatRoutes(app: Hono, d: Deps): void {
         : fullContent
       engineMessages.push({ role: 'user', content: userContent })
 
-      await runGeneration(d, stream, { convId, conv, engineMessages, assistantMsg, ms, target, ac, disableThinking: b.disableThinking ?? false })
+      await runGeneration(d, stream, { convId, conv, engineMessages, assistantMsg, ms, target, ac, disableThinking: b.disableThinking ?? false, userText: content })
     })
   })
 
@@ -619,6 +638,10 @@ interface GenerationCtx {
   /** When true, instruct the engine to skip reasoning entirely (model answers
    *  directly). Mirrors the params autoTitle uses. */
   disableThinking: boolean
+  /** Release 3, auto-memory: the clean, just-typed user text (never docContext/attachments/
+   *  tool output) for this turn. Undefined on regenerate — no new user text exists there,
+   *  so extraction is skipped by design (also avoids re-extracting already-scanned text). */
+  userText?: string
 }
 
 /**
@@ -1257,6 +1280,14 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
 
   if (!aborted && conv.title === 'New chat' && d.store.snapshot().daemon.autoGenerateTitles) {
     setTimeout(() => { void autoTitle(d, convId, ctx.engineMessages, fullContent, target) }, 1000)
+  }
+
+  // Release 3, auto-memory: extract durable facts from the just-typed user text (never
+  // fires on regenerate, where ctx.userText is unset). Staggered slightly after autoTitle's
+  // own setTimeout so the two out-of-band calls don't hit the engine on the exact same tick
+  // — not load-bearing, both are fire-and-forget.
+  if (!aborted && ctx.userText && d.store.snapshot().daemon.autoMemoryEnabled) {
+    setTimeout(() => { void extractMemoryFacts(d, convId, ctx.userText!, target) }, 1500)
   }
 }
 

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -64,6 +64,15 @@ export interface Folder {
   updatedAt: string
 }
 
+/** One durable fact extracted from a user's own chat messages (Release 3, auto-memory).
+ *  No FK to conversations — deleting the source chat shouldn't delete the fact it produced. */
+export interface MemoryFact {
+  id: string
+  factText: string
+  sourceConvId?: string
+  createdAt: string
+}
+
 /** One per-agent lesson distilled by the reviewer (spec 13 redesign §3, Reflexion). */
 export interface AgentLesson {
   id: string
@@ -122,6 +131,88 @@ export interface ModelStat {
   total: number
   complete: number
   successRate: number
+}
+
+export interface TokenUsageDay {
+  date: string
+  promptTokens: number
+  genTokens: number
+  totalTokens: number
+  messageCount: number
+}
+
+/** Per-model usage within the selected range, for the Tokens dashboard's Models tab. */
+export interface ModelUsage {
+  modelKey: string
+  displayName: string
+  messageCount: number
+  promptTokens: number
+  genTokens: number
+  totalTokens: number
+}
+
+/** One day's per-model token split, for the Models tab's stacked bar chart. Only models
+ *  with activity that day are listed (no zero entries). */
+export interface DailyModelBreakdown {
+  date: string
+  totalTokens: number
+  byModel: { modelKey: string; tokens: number }[]
+}
+
+export type TokenUsageRange = 'all' | '30d' | '7d'
+
+/** One heatmap cell. `start` is a bucket key whose format depends on `granularityHours`:
+ *  "YYYY-MM-DDTHH" for hourly, "YYYY-MM-DD-AM"/"-PM" for 12h, "YYYY-MM-DD" for daily. */
+export interface ActivityBucket {
+  start: string
+  totalTokens: number
+  messageCount: number
+}
+
+/** Overview heatmap data — box granularity zooms in as the range narrows (1 box = 1h for
+ *  7d, 12h for 30d, 1 day for all) so the grid stays visually dense instead of showing a
+ *  handful of sparse day-cells for short ranges. */
+export interface TokenActivity {
+  granularityHours: 1 | 12 | 24
+  buckets: ActivityBucket[]
+}
+
+export interface TokenUsageStats {
+  range: TokenUsageRange
+  sessions: number
+  messages: number
+  totalTokens: number
+  activeDays: number
+  /** Lifetime, not scoped by `range` — a streak isn't a "last N days" concept. */
+  currentStreak: number
+  longestStreak: number
+  /** Local hour of day (0-23) with the most messages in range; null with no data. */
+  peakHour: number | null
+  favoriteModel: string | null
+  firstMessageAt: string | null
+  /** Lifetime, not scoped by `range` — same as the streak fields. Drives the milestone
+   *  ladder and the frontend's fun-fact comparison, both of which should stay stable as
+   *  the user switches the range tab, not jump around with it. */
+  lifetimeTotalTokens: number
+  milestone: { achieved: number | null; next: number | null; progressPct: number | null }
+  activity: TokenActivity
+  dailyByModel: DailyModelBreakdown[]
+  byModel: ModelUsage[]
+}
+
+const RANGE_WINDOW_DAYS: Record<'30d' | '7d', number> = { '30d': 30, '7d': 7 }
+
+const TOKEN_MILESTONES = [
+  1_000, 10_000, 100_000, 500_000, 1_000_000, 5_000_000,
+  10_000_000, 50_000_000, 100_000_000, 500_000_000, 1_000_000_000,
+]
+
+/** "gemma 4 e4b|Q6_K|6217256480" -> "Gemma 4 E4b". Good enough for a dashboard label —
+ *  the model may since have been renamed/deleted, so this derives purely from the stored
+ *  key rather than cross-referencing the live model list. */
+function titleCaseModelName(modelKey: string): string {
+  const raw = modelKey.split('|')[0] ?? modelKey
+  return raw.replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 export interface MessageStats {
@@ -548,6 +639,22 @@ export class ConversationStore {
       if (!this.hasColumn('messages', 'edited')) this.db.exec(`ALTER TABLE messages ADD COLUMN edited INTEGER NOT NULL DEFAULT 0;`)
       this.db.exec(`PRAGMA user_version = 26;`)
     }
+    // v27 (Release 3, auto-memory): durable facts extracted from the user's own chat
+    // messages, injected into future new conversations. No FK to conversations — deleting
+    // a source chat shouldn't delete the fact it produced (same provenance-column pattern
+    // as agent_lessons above).
+    if (v < 27) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS memory_facts (
+          id             TEXT PRIMARY KEY,
+          fact_text      TEXT NOT NULL,
+          source_conv_id TEXT,
+          created_at     TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_facts_created ON memory_facts(created_at);
+        PRAGMA user_version = 27;
+      `)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -690,6 +797,196 @@ export class ConversationStore {
       if (typeof tps === 'number' && tps > 0) out.set(r.model_key, Math.round(tps * 10) / 10)
     }
     return out
+  }
+
+  /** Token usage dashboard (Release 3): sessions/messages/tokens/active-days scoped to
+   *  `range`, lifetime streaks (a streak isn't a "last N days" concept), the local hour
+   *  with the most activity, a per-model breakdown, and the heatmap day buckets — all from
+   *  one pass over `messages`. Days are bucketed by LOCAL calendar date (this daemon and its
+   *  user are always the same machine), not UTC, so a late-night session lands on the day
+   *  the user actually thinks of as "today". */
+  tokenUsageStats(range: TokenUsageRange = 'all'): TokenUsageStats {
+    const rows = this.db.prepare(`
+      SELECT conv_id, created_at, stats, model_key FROM messages
+      WHERE role = 'assistant'
+      ORDER BY created_at ASC
+    `).all() as unknown as { conv_id: string; created_at: string; stats: string; model_key: string | null }[]
+
+    if (rows.length === 0) {
+      return {
+        range, sessions: 0, messages: 0, totalTokens: 0, activeDays: 0,
+        currentStreak: 0, longestStreak: 0, peakHour: null, favoriteModel: null,
+        firstMessageAt: null, lifetimeTotalTokens: 0, milestone: { achieved: null, next: null, progressPct: null },
+        activity: { granularityHours: 24, buckets: [] }, dailyByModel: [], byModel: [],
+      }
+    }
+
+    const dayKey = (iso: string) => {
+      const d = new Date(iso)
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    }
+    const addDays = (key: string, n: number) => {
+      const [y, m, d] = key.split('-').map(Number)
+      const dt = new Date(y, m - 1, d + n)
+      return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`
+    }
+
+    // Per-local-day totals across the FULL history — needed for the lifetime streaks
+    // regardless of `range`, and reused below for the heatmap window.
+    const dayBuckets = new Map<string, { promptTokens: number; genTokens: number; messageCount: number }>()
+    const firstMessageAt = rows[0].created_at
+    for (const r of rows) {
+      const key = dayKey(r.created_at)
+      const b = dayBuckets.get(key) ?? { promptTokens: 0, genTokens: 0, messageCount: 0 }
+      const s = safeJson(r.stats) as Partial<MessageStats>
+      b.promptTokens += typeof s.promptTokens === 'number' ? s.promptTokens : 0
+      b.genTokens += typeof s.genTokens === 'number' ? s.genTokens : 0
+      b.messageCount++
+      dayBuckets.set(key, b)
+    }
+
+    const todayKey = dayKey(new Date().toISOString())
+    const firstKey = dayKey(firstMessageAt)
+
+    let longestStreak = 0, run = 0
+    for (let key = firstKey; key <= todayKey; key = addDays(key, 1)) {
+      if (dayBuckets.has(key)) { run++; longestStreak = Math.max(longestStreak, run) } else { run = 0 }
+    }
+    let currentStreak = 0
+    {
+      // Grace period: if today has no activity yet, the streak isn't broken until
+      // tomorrow — check from yesterday instead of reporting 0 the moment you wake up.
+      let key = dayBuckets.has(todayKey) ? todayKey : addDays(todayKey, -1)
+      while (key >= firstKey && dayBuckets.has(key)) { currentStreak++; key = addDays(key, -1) }
+    }
+
+    // "all" always shows at least 180 days of boxes (GitHub-graph convention, scaled
+    // down) — a brand-new account pads out with empty cells before its first message
+    // instead of rendering a tiny, sparse-looking grid. An account older than that still
+    // shows its full real history (never truncated).
+    const minAllStart = addDays(todayKey, -179)
+    const heatStart = range === 'all'
+      ? (firstKey < minAllStart ? firstKey : minAllStart)
+      : addDays(todayKey, -(RANGE_WINDOW_DAYS[range] - 1))
+    // String comparison is safe and deliberately used over Date parsing here — both sides
+    // are zero-padded "YYYY-MM-DD" keys, and `new Date("YYYY-MM-DD")` parses as UTC
+    // midnight (not local), a classic footgun this sidesteps entirely.
+    const scopedRows = range === 'all' ? rows : rows.filter((r) => dayKey(r.created_at) >= heatStart)
+
+    const convIds = new Set<string>()
+    const hourTally = new Map<number, number>()
+    const modelTally = new Map<string, { messageCount: number; promptTokens: number; genTokens: number }>()
+    const dayModelTally = new Map<string, Map<string, number>>()
+    let totalTokens = 0
+    for (const r of scopedRows) {
+      convIds.add(r.conv_id)
+      const s = safeJson(r.stats) as Partial<MessageStats>
+      const pt = typeof s.promptTokens === 'number' ? s.promptTokens : 0
+      const gt = typeof s.genTokens === 'number' ? s.genTokens : 0
+      totalTokens += pt + gt
+      const hour = new Date(r.created_at).getHours()
+      hourTally.set(hour, (hourTally.get(hour) ?? 0) + 1)
+      if (r.model_key) {
+        const m = modelTally.get(r.model_key) ?? { messageCount: 0, promptTokens: 0, genTokens: 0 }
+        m.messageCount++; m.promptTokens += pt; m.genTokens += gt
+        modelTally.set(r.model_key, m)
+
+        const day = dayKey(r.created_at)
+        const dm = dayModelTally.get(day) ?? new Map<string, number>()
+        dm.set(r.model_key, (dm.get(r.model_key) ?? 0) + pt + gt)
+        dayModelTally.set(day, dm)
+      }
+    }
+
+    let peakHour: number | null = null, peakHourCount = -1
+    for (const [hour, count] of hourTally) if (count > peakHourCount) { peakHour = hour; peakHourCount = count }
+
+    const byModel: ModelUsage[] = [...modelTally.entries()]
+      .map(([modelKey, m]) => ({
+        modelKey, displayName: titleCaseModelName(modelKey),
+        messageCount: m.messageCount, promptTokens: m.promptTokens, genTokens: m.genTokens,
+        totalTokens: m.promptTokens + m.genTokens,
+      }))
+      .sort((a, b) => b.totalTokens - a.totalTokens)
+
+    const days: TokenUsageDay[] = []
+    const dailyByModel: DailyModelBreakdown[] = []
+    let activeDays = 0
+    for (let key = heatStart; key <= todayKey; key = addDays(key, 1)) {
+      const b = dayBuckets.get(key)
+      if (b && b.messageCount > 0) activeDays++
+      const dayTotalTokens = (b?.promptTokens ?? 0) + (b?.genTokens ?? 0)
+      days.push({
+        date: key,
+        promptTokens: b?.promptTokens ?? 0, genTokens: b?.genTokens ?? 0,
+        totalTokens: dayTotalTokens, messageCount: b?.messageCount ?? 0,
+      })
+      const dm = dayModelTally.get(key)
+      dailyByModel.push({
+        date: key, totalTokens: dayTotalTokens,
+        byModel: dm ? [...dm.entries()].map(([modelKey, tokens]) => ({ modelKey, tokens })) : [],
+      })
+    }
+
+    // Overview heatmap: box granularity zooms in as the range narrows so the grid stays
+    // visually dense (a 7-cell or 30-cell day-level grid looks broken/sparse) — 1h boxes
+    // for 7d, 12h boxes for 30d, 1-day boxes (the classic GitHub-style grid) for all.
+    let activity: TokenActivity
+    if (range === 'all') {
+      activity = {
+        granularityHours: 24,
+        buckets: days.map((d) => ({ start: d.date, totalTokens: d.totalTokens, messageCount: d.messageCount })),
+      }
+    } else {
+      const granularityHours = range === '7d' ? 1 : 12
+      const subTally = new Map<string, { totalTokens: number; messageCount: number }>()
+      for (const r of scopedRows) {
+        const d = new Date(r.created_at)
+        const day = dayKey(r.created_at)
+        const bucketKey = granularityHours === 1
+          ? `${day}T${String(d.getHours()).padStart(2, '0')}`
+          : `${day}-${d.getHours() < 12 ? 'AM' : 'PM'}`
+        const s = safeJson(r.stats) as Partial<MessageStats>
+        const pt = typeof s.promptTokens === 'number' ? s.promptTokens : 0
+        const gt = typeof s.genTokens === 'number' ? s.genTokens : 0
+        const b = subTally.get(bucketKey) ?? { totalTokens: 0, messageCount: 0 }
+        b.totalTokens += pt + gt; b.messageCount++
+        subTally.set(bucketKey, b)
+      }
+      const buckets: ActivityBucket[] = []
+      for (let key = heatStart; key <= todayKey; key = addDays(key, 1)) {
+        if (granularityHours === 1) {
+          for (let h = 0; h < 24; h++) {
+            const bucketKey = `${key}T${String(h).padStart(2, '0')}`
+            const b = subTally.get(bucketKey)
+            buckets.push({ start: bucketKey, totalTokens: b?.totalTokens ?? 0, messageCount: b?.messageCount ?? 0 })
+          }
+        } else {
+          for (const half of ['AM', 'PM'] as const) {
+            const bucketKey = `${key}-${half}`
+            const b = subTally.get(bucketKey)
+            buckets.push({ start: bucketKey, totalTokens: b?.totalTokens ?? 0, messageCount: b?.messageCount ?? 0 })
+          }
+        }
+      }
+      activity = { granularityHours, buckets }
+    }
+
+    let lifetimeTotalTokens = 0
+    for (const b of dayBuckets.values()) lifetimeTotalTokens += b.promptTokens + b.genTokens
+    const achieved = [...TOKEN_MILESTONES].reverse().find((m) => m <= lifetimeTotalTokens) ?? null
+    const next = TOKEN_MILESTONES.find((m) => m > lifetimeTotalTokens) ?? null
+    const progressPct = next !== null
+      ? Math.round(((lifetimeTotalTokens - (achieved ?? 0)) / (next - (achieved ?? 0))) * 1000) / 10
+      : null
+
+    return {
+      range, sessions: convIds.size, messages: scopedRows.length, totalTokens, activeDays,
+      currentStreak, longestStreak, peakHour,
+      favoriteModel: byModel[0]?.displayName ?? null,
+      firstMessageAt, lifetimeTotalTokens, milestone: { achieved, next, progressPct },
+      activity, dailyByModel, byModel,
+    }
   }
 
   /** Active branch only — matches getMessages(). Used to find "the last thing the user
@@ -945,6 +1242,27 @@ export class ConversationStore {
 
   pruneAgentLessons(agentId: string): void {
     this.db.prepare(`DELETE FROM agent_lessons WHERE agent_id = $a`).run({ $a: agentId } as P)
+  }
+
+  // ── Auto-memory (Release 3) ───────────────────────────────────────────────────
+  // Insert/list/delete only — no update. Facts are reviewed and removed, not hand-edited.
+
+  addMemoryFact(row: { factText: string; sourceConvId?: string }): MemoryFact {
+    const id = randomUUID()
+    const now = new Date().toISOString()
+    this.db.prepare(`INSERT INTO memory_facts (id,fact_text,source_conv_id,created_at) VALUES ($id,$ft,$sc,$now)`)
+      .run({ $id: id, $ft: row.factText, $sc: row.sourceConvId ?? null, $now: now } as P)
+    return { id, factText: row.factText, sourceConvId: row.sourceConvId, createdAt: now }
+  }
+
+  listMemoryFacts(): MemoryFact[] {
+    const rows = this.db.prepare(`SELECT * FROM memory_facts ORDER BY created_at DESC`)
+      .all() as Array<{ id: string; fact_text: string; source_conv_id: string | null; created_at: string }>
+    return rows.map((r) => ({ id: r.id, factText: r.fact_text, sourceConvId: r.source_conv_id ?? undefined, createdAt: r.created_at }))
+  }
+
+  deleteMemoryFact(id: string): boolean {
+    return ((this.db.prepare(`DELETE FROM memory_facts WHERE id = $id`).run({ $id: id } as P) as unknown) as Changes).changes > 0
   }
 
   // ── Skills grown from experience (redesign §3.3, Voyager) ─────────────────────

--- a/turbollm/src/chat/memory.test.ts
+++ b/turbollm/src/chat/memory.test.ts
@@ -1,0 +1,38 @@
+// Regression coverage for isDuplicateFact's Jaccard dedup — a v1.7.6 pre-release review
+// found the pre-fix version (raw word overlap, no stopword stripping) silently dropped
+// genuinely different facts of the same shape ("I live in Paris" vs "I live in Berlin").
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isDuplicateFact } from './memory.js'
+
+test('a fact with no prior facts is never a duplicate', () => {
+  assert.equal(isDuplicateFact([], 'The user lives in Berlin.'), false)
+})
+
+test('an exact repeat is a duplicate', () => {
+  assert.equal(isDuplicateFact(['The user lives in Berlin.'], 'The user lives in Berlin.'), true)
+})
+
+test('a case/punctuation-only variant is a duplicate', () => {
+  assert.equal(isDuplicateFact(['The user lives in Berlin.'], 'the user lives in berlin'), true)
+})
+
+test('one fact containing the other is a duplicate', () => {
+  assert.equal(isDuplicateFact(['My name is Alice.'], 'My name is Alice Smith.'), true)
+})
+
+test('facts differing only in the one word that matters are NOT duplicates', () => {
+  // These four pairs are the exact failure cases the pre-fix Jaccard-on-raw-words
+  // comparison collapsed to "duplicate" — stopwords dominated the overlap score.
+  assert.equal(isDuplicateFact(['I live in Paris.'], 'I live in Berlin.'), false)
+  assert.equal(isDuplicateFact(['My name is Alice.'], 'My name is Bob.'), false)
+  assert.equal(isDuplicateFact(['I work as a teacher.'], 'I work as a nurse.'), false)
+  assert.equal(isDuplicateFact(['I use a Mac.'], 'I use a PC.'), false)
+})
+
+test('a genuinely reworded duplicate is still caught via word overlap', () => {
+  assert.equal(
+    isDuplicateFact(['The user has an RTX 5070 Ti GPU.'], 'User has an RTX 5070 Ti GPU.'),
+    true,
+  )
+})

--- a/turbollm/src/chat/memory.ts
+++ b/turbollm/src/chat/memory.ts
@@ -1,0 +1,101 @@
+// Auto-memory extraction (Release 3): durable facts extracted from the user's own chat
+// messages, injected into future NEW conversations. Mirrors autoTitle's out-of-band
+// inference pattern (chat-routes.ts) but is fed a single clean string, never conversation
+// history, attachments, or tool output — the strongest form of the "don't leak anything
+// but the user's own words" guarantee.
+import type { Deps } from '../deps'
+import { engineModelAlias } from '../engines/compat'
+
+const MIN_LENGTH = 12
+const MAX_FACTS_PER_TURN = 5
+const MAX_FACT_LENGTH = 200
+
+function extractionPrompt(userText: string): string {
+  return `Extract any durable personal facts the user stated about themselves in the message below — the kind of thing worth remembering for future conversations (name, role/job, location, preferences, hardware/software setup, ongoing projects, goals, recurring constraints).
+
+Rules:
+- Only use what the user explicitly said about themselves in THIS message. Never infer, guess, or invent.
+- Skip one-off requests, questions, opinions about the current topic, or anything not durable (e.g. "I'm tired today" is not durable; "I work as a nurse" is).
+- Each fact must be a short, self-contained sentence (max ~15 words) that makes sense with no other context.
+- If there are no durable personal facts, reply with exactly: NONE
+- Otherwise reply with ONLY a list, one fact per line, each line starting with "- ". No preamble, no explanation, nothing else.
+
+User's message:
+"""
+${userText.slice(0, 2000)}
+"""`
+}
+
+/** Cheap, pure string-similarity dedup — no second model call. Duplicate if either
+ *  string contains the other, or word-overlap (Jaccard) is high. Exported for unit tests. */
+export function isDuplicateFact(existing: string[], candidate: string): boolean {
+  const norm = (s: string) => s.toLowerCase().trim().replace(/[.!?]+$/, '')
+  const c = norm(candidate)
+  if (!c) return true
+  for (const e of existing) {
+    const ne = norm(e)
+    if (!ne) continue
+    if (ne.includes(c) || c.includes(ne)) return true
+    const ws1 = new Set(ne.split(/\s+/))
+    const ws2 = new Set(c.split(/\s+/))
+    const intersection = [...ws1].filter((w) => ws2.has(w)).length
+    const union = new Set([...ws1, ...ws2]).size
+    if (union > 0 && intersection / union >= 0.6) return true
+  }
+  return false
+}
+
+function parseFacts(raw: string): string[] {
+  const cleaned = raw.replace(/<think>[\s\S]*?<\/think>/gi, '').trim() // strip any leaked reasoning
+  if (!cleaned || /^none$/i.test(cleaned)) return []
+  return cleaned
+    .split('\n')
+    .map((l) => l.replace(/^[-*•]\s*/, '').trim())
+    .filter((l) => l.length > 0 && l.length <= MAX_FACT_LENGTH)
+    .slice(0, MAX_FACTS_PER_TURN)
+}
+
+/** Fire-and-forget: extract durable facts from a just-sent user message and persist any
+ *  new (non-duplicate) ones. Never throws — errors are silently swallowed, same as
+ *  autoTitle, since this must never surface to the user or affect the chat response. */
+export async function extractMemoryFacts(d: Deps, convId: string, userText: string, target: string): Promise<void> {
+  try {
+    if (userText.trim().length < MIN_LENGTH) return
+    const ms = d.manager.status()
+    if (ms.state !== 'running') return
+
+    // Low-priority afterthought, same as autoTitle: acquire the engine gate at 'bg' so any
+    // foreground chat or agent run preempts it, and release as soon as the call returns.
+    const release = d.gate ? await d.gate.acquire('bg') : null
+    let res: Response
+    try {
+      res = await fetch(`${target}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: engineModelAlias(d.registry.active()?.kind ?? '') ?? ms.model?.key,
+          messages: [{ role: 'user', content: extractionPrompt(userText) }],
+          stream: false,
+          temperature: 0.2,
+          max_tokens: 200,
+          reasoning_budget: 0,
+          chat_template_kwargs: { enable_thinking: false },
+        }),
+        signal: AbortSignal.timeout(20_000),
+      })
+    } finally {
+      release?.()
+    }
+    if (!res.ok) return
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+    const facts = parseFacts(data.choices?.[0]?.message?.content ?? '')
+    if (!facts.length) return
+
+    const existing = d.db.listMemoryFacts().map((f) => f.factText)
+    for (const fact of facts) {
+      if (isDuplicateFact(existing, fact)) continue
+      d.db.addMemoryFact({ factText: fact, sourceConvId: convId })
+      existing.push(fact)
+    }
+  } catch { /* silently ignore */ }
+}

--- a/turbollm/src/chat/memory.ts
+++ b/turbollm/src/chat/memory.ts
@@ -26,18 +26,28 @@ ${userText.slice(0, 2000)}
 """`
 }
 
+// Filler words common to first-person fact statements ("I live in X", "my name is Y") —
+// stripped before the Jaccard comparison below, since two DIFFERENT facts of the same
+// shape (e.g. "I live in Paris" vs "I live in Berlin") share every word except the one
+// that actually matters, which otherwise pushes their overlap over the dedup threshold.
+const FACT_STOPWORDS = new Set([
+  'i', 'a', 'an', 'the', 'is', 'am', 'are', 'was', 'were', 'in', 'on', 'at',
+  'as', 'my', 'of', 'to', 'for', 'and', 'or', 'with',
+])
+
 /** Cheap, pure string-similarity dedup — no second model call. Duplicate if either
- *  string contains the other, or word-overlap (Jaccard) is high. Exported for unit tests. */
+ *  string contains the other, or word-overlap (Jaccard) over CONTENT words is high. */
 export function isDuplicateFact(existing: string[], candidate: string): boolean {
   const norm = (s: string) => s.toLowerCase().trim().replace(/[.!?]+$/, '')
+  const contentWords = (s: string) => new Set(s.split(/\s+/).filter((w) => w && !FACT_STOPWORDS.has(w)))
   const c = norm(candidate)
   if (!c) return true
   for (const e of existing) {
     const ne = norm(e)
     if (!ne) continue
     if (ne.includes(c) || c.includes(ne)) return true
-    const ws1 = new Set(ne.split(/\s+/))
-    const ws2 = new Set(c.split(/\s+/))
+    const ws1 = contentWords(ne)
+    const ws2 = contentWords(c)
     const intersection = [...ws1].filter((w) => ws2.has(w)).length
     const union = new Set([...ws1, ...ws2]).size
     if (union > 0 && intersection / union >= 0.6) return true

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -54,6 +54,11 @@ export interface Daemon {
   openBrowserOnStart: boolean
   theme: string
   autoGenerateTitles: boolean
+  /** Release 3: background extraction of durable facts from the user's own chat messages,
+   *  injected into future new conversations. Off by default — unlike autoGenerateTitles,
+   *  this builds a persistent cross-conversation profile of the user, so it's opt-in
+   *  (same trust-surface posture as lanBind), not default-on. */
+  autoMemoryEnabled: boolean
 }
 export interface Telemetry {
   level: string
@@ -396,6 +401,7 @@ export function defaultConfig(): Config {
       openBrowserOnStart: true,
       theme: 'system',
       autoGenerateTitles: true,
+      autoMemoryEnabled: false,
     },
     telemetry: { level: 'unset', machineId: '' },
     apiKeys: [],

--- a/turbollm/web/src/App.tsx
+++ b/turbollm/web/src/App.tsx
@@ -18,6 +18,7 @@ const ChatScreen = lazy(() => import('./screens/ChatScreen').then((m) => ({ defa
 const SkillEditPage = lazy(() => import('./screens/skills/SkillEditPage').then((m) => ({ default: m.SkillEditPage })))
 const AgentEditPage = lazy(() => import('./screens/agents/AgentEditPage').then((m) => ({ default: m.AgentEditPage })))
 const ModelsScreen = lazy(() => import('./screens/ModelsScreen').then((m) => ({ default: m.ModelsScreen })))
+const TokensScreen = lazy(() => import('./screens/TokensScreen').then((m) => ({ default: m.TokensScreen })))
 const EnginesScreen = lazy(() => import('./screens/EnginesScreen').then((m) => ({ default: m.EnginesScreen })))
 const DeveloperScreen = lazy(() => import('./screens/DeveloperScreen').then((m) => ({ default: m.DeveloperScreen })))
 const CustomizeScreen = lazy(() => import('./screens/CustomizeScreen').then((m) => ({ default: m.CustomizeScreen })))
@@ -92,6 +93,7 @@ export function App() {
             {/* Agents: managed from within Customize; this route is just the create/edit page. */}
             <Route path="/agents/:agentId" element={<AgentEditPage />} />
             <Route path="/models" element={<ModelsScreen />} />
+            <Route path="/usage" element={<TokensScreen />} />
             <Route path="/engines" element={<EnginesScreen />} />
             <Route path="/developer" element={<DeveloperScreen />} />
             <Route path="/customize" element={<CustomizeScreen />} />

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
-import { Boxes, Code2, Cpu, PanelsTopLeft, Puzzle, Settings2 } from 'lucide-react'
+import { BarChart3, Boxes, Code2, Cpu, PanelsTopLeft, Puzzle, Settings2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import type { Status } from '../lib/types'
 import { StateChip } from './StateChip'
@@ -17,6 +17,7 @@ const NAV = [
   { to: '/models',    label: 'Models',    icon: Boxes },
   { to: '/engines',   label: 'Engines',   icon: Cpu },
   { to: '/customize', label: 'Customize', icon: Puzzle },
+  { to: '/usage',     label: 'Usage',     icon: BarChart3 },
   { to: '/developer', label: 'Developer', icon: Code2 },
   { to: '/settings',  label: 'Settings',  icon: Settings2 },
 ] as const

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -27,6 +27,8 @@ import type {
   ModelsList,
   Status,
   AppUpdate,
+  TokenUsageStats,
+  TokenUsageRange,
 } from './types'
 
 const AUTH_KEY = 'tllm.authToken'
@@ -107,6 +109,11 @@ export function getStatus(): Promise<Status> {
 /** Live running-session stats (B4) ride on the status payload — surfaced from the
  *  status poll rather than a separate endpoint. Re-exported for convenience. */
 export type { EngineStats } from './types'
+
+// ── Token usage dashboard (Release 3) ────────────────────────────────────────
+export function getTokenUsage(range: TokenUsageRange = 'all'): Promise<TokenUsageStats> {
+  return request<TokenUsageStats>(`/api/v1/tokens/usage?range=${range}`)
+}
 
 // ── Engines registry (spec 02 §2) ────────────────────────────────────────────
 export function listEngines(): Promise<EnginesList> {
@@ -497,6 +504,9 @@ export type DaemonSettings = {
   port: number
   theme: string
   autoGenerateTitles: boolean
+  /** Release 3: background extraction of durable facts from the user's own chat messages,
+   *  injected into future new conversations. Off by default (opt-in trust surface). */
+  autoMemoryEnabled: boolean
   openBrowserOnStart: boolean
   autoLoadOnStart: boolean
   /** VRAM to keep free during auto-tune's offload search, MB (300–2048, default 1024). A

--- a/turbollm/web/src/lib/chat-api.ts
+++ b/turbollm/web/src/lib/chat-api.ts
@@ -1,4 +1,4 @@
-import type { Conversation, Folder, Message, ChatSseEvent } from './chat-types'
+import type { Conversation, Folder, Message, ChatSseEvent, MemoryFact } from './chat-types'
 import { ApiError, authHeaders } from './api'
 
 async function req<T>(path: string, init?: RequestInit & { json?: unknown }): Promise<T> {
@@ -77,6 +77,16 @@ export function deleteMessage(convId: string, msgId: string): Promise<{ ok: true
 
 export function regenerate(convId: string): Promise<{ ok: true }> {
   return req(`/api/v1/conversations/${encodeURIComponent(convId)}/regenerate`, { method: 'POST', json: {} })
+}
+
+// ── Auto-memory (Release 3) ─────────────────────────────────────────────────────
+
+export function listMemoryFacts(): Promise<{ facts: MemoryFact[] }> {
+  return req('/api/v1/memory')
+}
+
+export function deleteMemoryFact(id: string): Promise<{ ok: true }> {
+  return req(`/api/v1/memory/${encodeURIComponent(id)}`, { method: 'DELETE' })
 }
 
 // ── Chat branching (GitHub #52) ────────────────────────────────────────────────

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  createConversation, createFolder, deleteConversation, deleteFolder, deleteMessage, editMessage,
-  getConversation, listConversations, listFolders, moveConversationToFolder, regenerate,
+  createConversation, createFolder, deleteConversation, deleteFolder, deleteMemoryFact, deleteMessage, editMessage,
+  getConversation, listConversations, listFolders, listMemoryFacts, moveConversationToFolder, regenerate,
   renameFolder, stopGeneration, updateConversation,
 } from './chat-api'
 import type { Conversation } from './chat-types'
@@ -10,6 +10,31 @@ export const chatKeys = {
   list: (q?: string) => ['conversations', q ?? ''] as const,
   detail: (id: string | null) => ['conversation', id] as const,
   folders: ['folders'] as const,
+}
+
+export const memoryKeys = {
+  list: ['memory-facts'] as const,
+}
+
+/** Auto-memory (Release 3) fact list — fetched regardless of the feature toggle so a user
+ *  can review/clean up what's been saved even with extraction turned off. */
+export function useMemoryFacts() {
+  return useQuery({
+    queryKey: memoryKeys.list,
+    queryFn: listMemoryFacts,
+    staleTime: 0,
+    retry: false,
+  })
+}
+
+export function useMemoryFactMutations() {
+  const qc = useQueryClient()
+  return {
+    remove: useMutation({
+      mutationFn: (id: string) => deleteMemoryFact(id),
+      onSuccess: () => void qc.invalidateQueries({ queryKey: memoryKeys.list }),
+    }),
+  }
 }
 
 export function useConversations(q?: string) {

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -112,6 +112,14 @@ export interface Conversation {
   messages?: Message[]
 }
 
+/** A durable fact extracted from the user's own chat messages (Release 3, auto-memory). */
+export interface MemoryFact {
+  id: string
+  factText: string
+  sourceConvId?: string
+  createdAt: string
+}
+
 /** A chat folder for grouping conversations in the sidebar (v10). Flat — no nesting. */
 export interface Folder {
   id: string

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -7,6 +7,8 @@ export interface Persona {
   systemPrompt: string
 }
 
+const MAX_INJECTED_MEMORY_FACTS = 50
+
 const TURBOLLM_KNOWLEDGE =
   'You are the TurboLLM Expert — the authoritative in-app guide for TurboLLM, a local-first AI desktop platform (`npx turbollm`). Everything runs on the user\'s own machine: no cloud, no external data transmission. The daemon listens on port 6996 and serves a React UI plus an OpenAI/Anthropic-compatible gateway. Data is stored in a local SQLite database.\n\n' +
 
@@ -64,8 +66,13 @@ const TURBOLLM_KNOWLEDGE =
   '- **Custom MCP servers**: add/edit/delete your own MCP servers (stdio subprocess or SSE/HTTP). Tools from all connected servers appear automatically as callable tools in chat, with no daemon restart.\n' +
   '- **Agents**: the built-in personas (below) plus any you create yourself — name, description, system prompt, and a checklist of which shared skills and which tools it may use (everything checked by default). Custom agents are picked from the same in-chat picker as the built-ins.\n\n' +
 
+  '**Usage** (BarChart3 icon in nav, between Customize and Developer): a token-usage dashboard sourced from message-level stats already persisted per turn — no separate opt-in.\n' +
+  '- **Overview tab**: 8 stat tiles (sessions, messages, total tokens, active days, current/longest streak, peak hour, favorite model — all range-scoped except streaks/favorite/milestone, which are lifetime), a milestone bar (lifetime tokens vs. the next round-number milestone, plus a rotating "you\'ve generated more tokens than X" comparison), and an adaptive activity heatmap: 1-hour boxes for the 7-day range, 12-hour for 30-day, 1-day (classic GitHub-style) for all-time — always rendered at a constant overall size regardless of range.\n' +
+  '- **Models tab**: a stacked daily bar chart plus a ranked legend (input/output split, % of total, "Show N more" past the top 6).\n' +
+  '- Range control (7d / 30d / all) at the top switches every stat and the heatmap together.\n\n' +
+
   '**Settings** — a two-pane layout, five categories in the left rail, one sticky Save bar:\n' +
-  '- **General**: theme (light/dark/system), enable-thinking-by-default, confirm-before-delete, personalization (assistant name / your name), auto-generate chat titles, open browser on start.\n' +
+  '- **General**: theme (light/dark/system), enable-thinking-by-default, confirm-before-delete, personalization (assistant name / your name), **Memory** *(experimental, off by default)* — a toggle that silently extracts durable facts you mention in chat (name, preferences, hardware, projects) using your own loaded model and injects them into future new conversations, plus a reviewable/deletable fact list right in the same section (visible even with the toggle off), auto-generate chat titles, open browser on start.\n' +
   '- **Models & loading**: idle timeout (auto-stop after N minutes), default context length, Gateway (auto model-swap + Keep-N pool, 1–4 models), model folders, Hugging Face token, and an **Advanced** collapsible for expert knobs — default GPU layers, VRAM headroom (300 MB–2 GB, default 1 GB), and image/response token caps.\n' +
   '- **Tools & safety**: per-tool Ask/Allow/Deny defaults for every tool the model can call (web_search, fetch_url, run_code, MCP tools).\n' +
   '- **Network & sharing**: LAN exposure (bind to 0.0.0.0 vs loopback-only), port, require-API-key auth, and ComfyUI integration (URL, Reverse GPU gate, update banner).\n' +
@@ -476,8 +483,11 @@ export function buildSystemPrompt(agentId: string, systemPrompt: string, p: Pers
   // Release 3, auto-memory: facts extracted from the user's own past messages. Baked in
   // once at conversation creation (same as everything else here) — new conversations pick
   // up whatever's known at creation time; an already-open chat never retroactively gains it.
+  // Capped to the most recent N (listMemoryFacts() returns newest-first) so a long-lived
+  // account's fact list can't quietly eat an ever-growing slice of every new chat's context.
   if (memoryFacts.length) {
-    parts.push(`What you know about the user from past conversations:\n${memoryFacts.map((f) => `- ${f}`).join('\n')}`)
+    const capped = memoryFacts.slice(0, MAX_INJECTED_MEMORY_FACTS)
+    parts.push(`What you know about the user from past conversations:\n${capped.map((f) => `- ${f}`).join('\n')}`)
   }
   return parts.join('\n\n')
 }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -461,7 +461,7 @@ export function resolveAgents(customAgents: MinimalCustomAgent[], overrides: Rec
 /** Build the hidden system prompt for a new conversation. `agentId` drives the
  *  Blank/Lite special-cases; `systemPrompt` is the already-resolved effective text
  *  (built-in default, its override, or a custom agent's prompt — see {@link resolveAgents}). */
-export function buildSystemPrompt(agentId: string, systemPrompt: string, p: Personalization): string {
+export function buildSystemPrompt(agentId: string, systemPrompt: string, p: Personalization, memoryFacts: string[] = []): string {
   if (agentId === 'blank') return ''
   const today = new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
   // Lite skips the chart/artifact capability injection entirely — the point of the
@@ -473,5 +473,11 @@ export function buildSystemPrompt(agentId: string, systemPrompt: string, p: Pers
   if (p.assistantName.trim()) parts.push(`Your name is ${p.assistantName.trim()}.`)
   if (p.userName.trim()) parts.push(`The user's name is ${p.userName.trim()}.`)
   if (p.customInstructions.trim()) parts.push(p.customInstructions.trim())
+  // Release 3, auto-memory: facts extracted from the user's own past messages. Baked in
+  // once at conversation creation (same as everything else here) — new conversations pick
+  // up whatever's known at creation time; an already-open chat never retroactively gains it.
+  if (memoryFacts.length) {
+    parts.push(`What you know about the user from past conversations:\n${memoryFacts.map((f) => `- ${f}`).join('\n')}`)
+  }
   return parts.join('\n\n')
 }

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -41,6 +41,7 @@ import {
   getAppUpdate,
   setEngineUpdatePolicy,
   getStatus,
+  getTokenUsage,
   startBench,
   getSettings,
   installComfyGate,
@@ -115,6 +116,8 @@ import type {
   ModelDirs,
   ModelsList,
   Status,
+  TokenUsageStats,
+  TokenUsageRange,
 } from './types'
 // SysInfo is defined in api.ts (not types.ts) — re-export for convenience
 export type { SysInfo }
@@ -130,6 +133,7 @@ export const queryKeys = {
   models: ['models'] as const,
   modelDirs: ['modeldirs'] as const,
   downloads: ['downloads'] as const,
+  tokenUsage: (range: TokenUsageRange) => ['token-usage', range] as const,
 }
 
 /** Status poll every 2s, paused when the tab is hidden (spec 00 §4). Polls at 1s
@@ -148,6 +152,22 @@ export function useStatus(): UseQueryResult<Status> {
         : 2000,
     refetchIntervalInBackground: false,
     // Keep the prior value visible while a poll is in flight to avoid flicker.
+    placeholderData: (prev) => prev,
+    retry: false,
+  })
+}
+
+/** Token usage dashboard (Release 3) — a "check when visited" screen, not a live
+ *  status indicator, so no polling: default TanStack refetch-on-focus/mount is enough.
+ *  `placeholderData` keeps the previous range's data visible while a new range loads —
+ *  besides avoiding a loading flicker on tab switch, this matters functionally: without
+ *  it, `data` would briefly go undefined on every range switch, which would reroll
+ *  anything memoized off a `data`-derived value (e.g. the fun-fact pick) even though nothing
+ *  about the lifetime totals actually changed. */
+export function useTokenUsage(range: TokenUsageRange = 'all'): UseQueryResult<TokenUsageStats> {
+  return useQuery({
+    queryKey: queryKeys.tokenUsage(range),
+    queryFn: () => getTokenUsage(range),
     placeholderData: (prev) => prev,
     retry: false,
   })

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -487,6 +487,53 @@ export type ModelDirs = {
   primaryDir: string
 }
 
+// ── Token usage dashboard (Release 3) ────────────────────────────────────────
+export type ActivityBucket = {
+  start: string
+  totalTokens: number
+  messageCount: number
+}
+
+export type TokenActivity = {
+  granularityHours: 1 | 12 | 24
+  buckets: ActivityBucket[]
+}
+
+export type ModelUsage = {
+  modelKey: string
+  displayName: string
+  messageCount: number
+  promptTokens: number
+  genTokens: number
+  totalTokens: number
+}
+
+export type DailyModelBreakdown = {
+  date: string
+  totalTokens: number
+  byModel: { modelKey: string; tokens: number }[]
+}
+
+export type TokenUsageRange = 'all' | '30d' | '7d'
+
+export type TokenUsageStats = {
+  range: TokenUsageRange
+  sessions: number
+  messages: number
+  totalTokens: number
+  activeDays: number
+  currentStreak: number
+  longestStreak: number
+  peakHour: number | null
+  favoriteModel: string | null
+  firstMessageAt: string | null
+  lifetimeTotalTokens: number
+  milestone: { achieved: number | null; next: number | null; progressPct: number | null }
+  activity: TokenActivity
+  dailyByModel: DailyModelBreakdown[]
+  byModel: ModelUsage[]
+}
+
 // ── Load profiles + VRAM fit (A4, spec 05) ───────────────────────────────────
 export type Sampling = {
   temp: number

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type RefObject } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
 import { ArrowDown, Brain, Copy, Download, PanelLeft, Paperclip, SendHorizontal, Share2, SlidersHorizontal, Square, UserRound, X } from 'lucide-react'
-import { continueConversation, fetchSysInfo, sendMessage } from '../lib/chat-api'
+import { continueConversation, fetchSysInfo, listMemoryFacts, sendMessage } from '../lib/chat-api'
 import { extractPdfText } from '../lib/pdf-extract'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
-import { useBuiltinAgentOverrides, useChatAgents, useEngines, useModelActions, useModelDetail, useModels, useStatus } from '../lib/queries'
+import { useBuiltinAgentOverrides, useChatAgents, useEngines, useModelActions, useModelDetail, useModels, useSettings, useStatus } from '../lib/queries'
 import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
 import { appendTextDelta, upsertToolCall, type LiveBlock } from '../lib/live-timeline'
 import { ApiError, downloadChatExport, getDebugSnapshot, getShareUrl, importChat } from '../lib/api'
@@ -59,6 +59,7 @@ export function ChatScreen() {
   const { data: status } = useStatus()
   const model = status?.model
   const engineState = status?.engine.state
+  const { query: settingsQ } = useSettings()
 
   // The loaded model's resolved sampling defaults, for the Thread settings sliders
   // (LoadedModel itself carries no sampling — it lives on the per-engine LoadProfile,
@@ -582,7 +583,17 @@ export function ChatScreen() {
       // Create conversation on first message, baking in the selected agent + personalization.
       if (!convId) {
         const resolved = allAgents.find((a) => a.id === selectedPersonaId)
-        let sp = buildSystemPrompt(selectedPersonaId, resolved?.systemPrompt ?? '', getPersonalization())
+        // Release 3, auto-memory: only fetched when the toggle is on, so turning it off is
+        // a complete off-switch for new chats (not just "extraction stops" while stale
+        // facts keep leaking into every future conversation).
+        let memoryFacts: string[] = []
+        if (settingsQ.data?.autoMemoryEnabled) {
+          try {
+            const { facts } = await listMemoryFacts()
+            memoryFacts = facts.map((f) => f.factText)
+          } catch { /* non-fatal — proceed without memory */ }
+        }
+        let sp = buildSystemPrompt(selectedPersonaId, resolved?.systemPrompt ?? '', getPersonalization(), memoryFacts)
         if (selectedPersonaId === 'expert') {
           try {
             const sys = await fetchSysInfo()

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -22,6 +22,7 @@ import {
 import { CopyButton } from '../components/ui/copy-button'
 import { ModelDirs } from './models/ModelDirs'
 import { ToolPermissionsSection } from './settings/ToolPermissionsSection'
+import { MemorySection } from './settings/MemorySection'
 
 import { ApiError, type TelemetryLevel } from '../lib/api'
 import { TELEMETRY_UI_ENABLED } from '../lib/flags'
@@ -373,6 +374,9 @@ export function SettingsScreen() {
 
               {/* Personalization */}
               <PersonalizationSection />
+
+              {/* Auto-memory (Release 3) */}
+              <MemorySection />
 
               {/* Chat */}
               <section className="rounded-lg border border-border bg-panel p-4">

--- a/turbollm/web/src/screens/TokensScreen.tsx
+++ b/turbollm/web/src/screens/TokensScreen.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react'
+import { BarChart3 } from 'lucide-react'
+import { EmptyState, InlineError, ScreenHeader } from '../components/common'
+import { Skeleton } from '../components/ui/skeleton'
+import { useTokenUsage } from '../lib/queries'
+import type { TokenUsageRange } from '../lib/types'
+import { ActivityHeatmap } from './tokens/ActivityHeatmap'
+import { ModelsTab } from './tokens/ModelsTab'
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(n >= 10_000_000_000 ? 0 : 1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`
+  return n.toLocaleString()
+}
+
+function formatHour(h: number): string {
+  const period = h < 12 ? 'AM' : 'PM'
+  const hour12 = h % 12 === 0 ? 12 : h % 12
+  return `${hour12} ${period}`
+}
+
+// Rough word-count × ~1.3 tokens/word estimates — good enough for a novelty comparison,
+// not meant to be precise. Bucketed by order of magnitude of the user's lifetime total so
+// the picked reference is always a meaningfully SMALLER thing (never a weak "~1x" fact) —
+// each band's own pool is sized comfortably below that band's lower bound.
+const FUN_FACT_BANDS: { min: number; refs: { name: string; tokens: number }[] }[] = [
+  { min: 1, refs: [
+    { name: 'a haiku', tokens: 20 },
+    { name: 'a text message', tokens: 50 },
+    { name: 'a tweet', tokens: 70 },
+  ] },
+  { min: 10_000, refs: [
+    { name: 'a short email', tokens: 300 },
+    { name: 'a news article', tokens: 1_200 },
+    { name: '"The Tell-Tale Heart"', tokens: 4_800 },
+  ] },
+  { min: 100_000, refs: [
+    { name: '"The Little Prince"', tokens: 26_000 },
+  ] },
+  { min: 1_000_000, refs: [
+    { name: '"The Great Gatsby"', tokens: 68_000 },
+    { name: "Harry Potter and the Philosopher's Stone", tokens: 100_000 },
+    { name: '"The Hobbit"', tokens: 125_000 },
+  ] },
+  { min: 10_000_000, refs: [
+    { name: 'The Lord of the Rings', tokens: 590_000 },
+    { name: 'War and Peace', tokens: 760_000 },
+    { name: 'the King James Bible', tokens: 1_020_000 },
+    { name: 'the complete works of Shakespeare', tokens: 1_170_000 },
+  ] },
+  { min: 100_000_000, refs: [
+    { name: 'the Encyclopedia Britannica', tokens: 57_000_000 },
+  ] },
+]
+
+/** Picks one reference from the band matching the user's lifetime total's order of
+ *  magnitude, so the multiplier always lands in a meaningful (never ~1x) range. */
+function pickFunFact(lifetimeTotalTokens: number): string | null {
+  let band = null
+  for (const b of FUN_FACT_BANDS) {
+    if (lifetimeTotalTokens >= b.min) band = b
+    else break
+  }
+  if (!band) return null
+  const pick = band.refs[Math.floor(Math.random() * band.refs.length)]
+  const multiplier = Math.round(lifetimeTotalTokens / pick.tokens)
+  if (multiplier < 1) return null
+  return `You've used ~${multiplier.toLocaleString()}x more tokens than ${pick.name}.`
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-panel p-4">
+      <div className="text-[12px] text-muted">{label}</div>
+      <div className="mt-1 truncate text-[20px] font-semibold tracking-[-0.01em] text-ink tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function MilestoneBar({
+  lifetimeTotalTokens, next, progressPct, funFact,
+}: { lifetimeTotalTokens: number; next: number | null; progressPct: number | null; funFact: string | null }) {
+  return (
+    <div className="rounded-lg border border-border bg-panel p-5">
+      {funFact && (
+        <div className="mb-4 text-center text-[17px] font-semibold leading-snug tracking-[-0.01em] text-ink">
+          {funFact}
+        </div>
+      )}
+      {next === null ? (
+        <div className="text-center text-[13px] text-muted">Every milestone on the ladder is cleared 🎉</div>
+      ) : (
+        <>
+          <div className="flex items-baseline justify-between text-[12px] text-muted">
+            <span>{formatTokenCount(lifetimeTotalTokens)} tokens</span>
+            <span>Next: {formatTokenCount(next)} tokens</span>
+          </div>
+          <div className="mt-2 h-2 overflow-hidden rounded-full bg-panel-2">
+            <div className="h-full rounded-full" style={{ width: `${progressPct ?? 0}%`, background: 'var(--accent)' }} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function Segmented<T extends string>({
+  value, onChange, options,
+}: { value: T; onChange: (v: T) => void; options: { value: T; label: string }[] }) {
+  return (
+    <div className="flex shrink-0 overflow-hidden rounded-lg border border-border">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          onClick={() => onChange(o.value)}
+          className="px-3 py-1.5 text-[12px] font-medium transition-colors"
+          style={{
+            background: value === o.value ? 'var(--accent)' : 'transparent',
+            color: value === o.value ? 'var(--on-accent)' : 'var(--muted)',
+          }}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** Token usage dashboard (Release 3) — GitHub-style per-day heatmap, gamified stats
+ *  (streaks, peak hour, favorite model), a per-model breakdown, and a range filter —
+ *  sourced entirely from message-level stats already persisted per turn. */
+export function TokensScreen() {
+  const [range, setRange] = useState<TokenUsageRange>('all')
+  const [tab, setTab] = useState<'overview' | 'models'>('overview')
+  const { data, isLoading, isError, refetch } = useTokenUsage(range)
+
+  // Lifetime-driven, not range-scoped, and re-rolled only when the underlying lifetime
+  // total actually changes (new messages sent) — never on a tab/range switch.
+  const lifetimeTotalTokens = data?.lifetimeTotalTokens ?? 0
+  const funFact = useMemo(
+    () => (lifetimeTotalTokens > 0 ? pickFunFact(lifetimeTotalTokens) : null),
+    [lifetimeTotalTokens],
+  )
+  const isEmpty = data?.firstMessageAt === null
+
+  return (
+    <div className="w-full px-4 py-6 md:px-6">
+      <ScreenHeader title="Usage" description="How much you've generated locally, over time." />
+
+      {isLoading && (
+        <div className="flex flex-col gap-4">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            {[0, 1, 2, 3, 4, 5, 6, 7].map((i) => <Skeleton key={i} className="h-[70px]" />)}
+          </div>
+          <Skeleton className="h-[180px]" />
+        </div>
+      )}
+
+      {isError && !isLoading && (
+        <InlineError message="Couldn't load token usage." onRetry={() => void refetch()} />
+      )}
+
+      {!isLoading && !isError && data && isEmpty && (
+        <EmptyState icon={<BarChart3 size={28} />} message="Start a chat to see your token usage here." />
+      )}
+
+      {!isLoading && !isError && data && !isEmpty && (
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Segmented
+              value={tab}
+              onChange={setTab}
+              options={[{ value: 'overview', label: 'Overview' }, { value: 'models', label: 'Models' }]}
+            />
+            <Segmented
+              value={range}
+              onChange={setRange}
+              options={[{ value: 'all', label: 'All' }, { value: '30d', label: '30d' }, { value: '7d', label: '7d' }]}
+            />
+          </div>
+
+          {tab === 'overview' && (
+            <>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <StatTile label="Sessions" value={data.sessions.toLocaleString()} />
+                <StatTile label="Messages" value={data.messages.toLocaleString()} />
+                <StatTile label="Total tokens" value={formatTokenCount(data.totalTokens)} />
+                <StatTile label="Active days" value={data.activeDays.toLocaleString()} />
+                <StatTile label="Current streak" value={`${data.currentStreak}d`} />
+                <StatTile label="Longest streak" value={`${data.longestStreak}d`} />
+                <StatTile label="Peak hour" value={data.peakHour !== null ? formatHour(data.peakHour) : '—'} />
+                <StatTile label="Favorite model" value={data.favoriteModel ?? '—'} />
+              </div>
+
+              <MilestoneBar
+                lifetimeTotalTokens={data.lifetimeTotalTokens}
+                next={data.milestone.next}
+                progressPct={data.milestone.progressPct}
+                funFact={funFact}
+              />
+
+              <div className="rounded-lg border border-border bg-panel p-4">
+                <div className="mb-3 text-[13px] font-medium text-ink">Daily activity</div>
+                <ActivityHeatmap activity={data.activity} />
+              </div>
+            </>
+          )}
+
+          {tab === 'models' && (
+            <ModelsTab models={data.byModel} dailyByModel={data.dailyByModel} totalTokens={data.totalTokens} />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/TokensScreen.tsx
+++ b/turbollm/web/src/screens/TokensScreen.tsx
@@ -65,7 +65,11 @@ function pickFunFact(lifetimeTotalTokens: number): string | null {
   if (!band) return null
   const pick = band.refs[Math.floor(Math.random() * band.refs.length)]
   const multiplier = Math.round(lifetimeTotalTokens / pick.tokens)
-  if (multiplier < 1) return null
+  // A total near a band's own lower boundary can still land a weak "~1x" against that
+  // band's smallest reference, depending on which ref the random pick landed on — bump the
+  // floor to 2x so the fact is either meaningfully large or (consistently) absent, never a
+  // coin-flip between "~1x" and no fact at all for two nearby totals in the same band.
+  if (multiplier < 2) return null
   return `You've used ~${multiplier.toLocaleString()}x more tokens than ${pick.name}.`
 }
 

--- a/turbollm/web/src/screens/settings/MemorySection.tsx
+++ b/turbollm/web/src/screens/settings/MemorySection.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../../lib/queries'
 import { useMemoryFacts, useMemoryFactMutations } from '../../lib/chat-queries'
 import { ApiError } from '../../lib/api'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
+import { Badge } from '../../components/ui/badge'
 import { toast } from '../../components/ui/sonner'
 import { cn } from '../../lib/utils'
 
@@ -46,6 +47,7 @@ export function MemorySection() {
         <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
         <Brain size={15} className="text-accent" />
         <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Memory</h2>
+        <Badge variant="accent" className="normal-case tracking-normal">Experimental</Badge>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <label className="mt-3 flex cursor-pointer items-center justify-between border-b border-border py-2 pb-3">

--- a/turbollm/web/src/screens/settings/MemorySection.tsx
+++ b/turbollm/web/src/screens/settings/MemorySection.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import { Brain, ChevronRight, Trash2 } from 'lucide-react'
+import { useSettings } from '../../lib/queries'
+import { useMemoryFacts, useMemoryFactMutations } from '../../lib/chat-queries'
+import { ApiError } from '../../lib/api'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
+import { toast } from '../../components/ui/sonner'
+import { cn } from '../../lib/utils'
+
+/** Compact relative-time ("just now", "3h ago", "2d ago"), same convention as
+ *  ManagedEngines.tsx / EnginesScreen.tsx's file-local helper. */
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (!Number.isFinite(then)) return ''
+  const diff = Date.now() - then
+  if (diff < 60_000) return 'just now'
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+/** Auto-memory (Release 3): background extraction of durable facts from the user's own
+ *  chat messages, injected into future new conversations. Extraction itself is silent (no
+ *  per-fact confirmation) — this section is the transparency surface: a master toggle plus
+ *  a "saved memory" list the user can review and delete from at any time. */
+export function MemorySection() {
+  const [open, setOpen] = useState(false)
+  const { query: settingsQ, save } = useSettings()
+  const factsQ = useMemoryFacts()
+  const { remove } = useMemoryFactMutations()
+  const enabled = settingsQ.data?.autoMemoryEnabled ?? false
+  const facts = factsQ.data?.facts ?? []
+
+  const setEnabled = (v: boolean) => {
+    save.mutate(
+      { autoMemoryEnabled: v },
+      { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update memory setting.') },
+    )
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-panel p-4">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+        <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
+        <Brain size={15} className="text-accent" />
+        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Memory</h2>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <label className="mt-3 flex cursor-pointer items-center justify-between border-b border-border py-2 pb-3">
+          <div>
+            <div className="text-[14px] font-medium text-ink">Remember facts about you</div>
+            <div className="text-[12px] text-muted">
+              Silently extracts durable facts you mention in chat (name, preferences, setup) and adds them to
+              new conversations. Nothing leaves your device — it uses the model you already have loaded.
+            </div>
+          </div>
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="h-4 w-4 shrink-0 accent-[var(--accent)]"
+          />
+        </label>
+
+        <p className="mb-3 mt-3 text-[11px] text-faint">
+          Facts apply to new chats going forward — the conversation where something was mentioned won't
+          retroactively include it.
+        </p>
+
+        {factsQ.isLoading && <p className="text-[13px] text-faint">Loading…</p>}
+        {!factsQ.isLoading && facts.length === 0 && (
+          <p className="text-[13px] text-faint">No facts saved yet.</p>
+        )}
+
+        {facts.length > 0 && (
+          <div className="divide-y divide-border rounded-md border border-border">
+            {facts.map((f) => (
+              <div key={f.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
+                <div className="min-w-0">
+                  <div className="text-[13px] text-ink">{f.factText}</div>
+                  <div className="text-[11px] text-faint">{relativeTime(f.createdAt)}</div>
+                </div>
+                <button
+                  type="button"
+                  title="Delete"
+                  onClick={() => remove.mutate(f.id)}
+                  disabled={remove.isPending}
+                  className="shrink-0 rounded p-1 transition-colors hover:bg-bg disabled:opacity-60"
+                  style={{ color: 'var(--err)' }}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/turbollm/web/src/screens/tokens/ActivityHeatmap.tsx
+++ b/turbollm/web/src/screens/tokens/ActivityHeatmap.tsx
@@ -1,0 +1,256 @@
+import { useLayoutEffect, useRef } from 'react'
+import type { ActivityBucket, TokenActivity } from '../../lib/types'
+
+// GitHub-contribution-graph style intensity ladder — reuses the app's existing
+// color-mix idiom against the accent color, so dark/light theming is automatic.
+const LEVELS = [0, 20, 45, 70, 100]
+const CELL = 20
+const GAP = 4
+const RADIUS = 4
+const WEEKDAY_LABELS: Record<number, string> = { 1: 'Mon', 3: 'Wed', 5: 'Fri' }
+
+function levelFor(total: number, max: number): number {
+  if (total <= 0 || max <= 0) return 0
+  const frac = total / max
+  if (frac > 0.75) return 4
+  if (frac > 0.5) return 3
+  if (frac > 0.25) return 2
+  return 1
+}
+
+function cellBg(level: number): string {
+  return level === 0 ? 'var(--panel-2)' : `color-mix(in srgb, var(--accent) ${LEVELS[level]}%, var(--panel-2))`
+}
+
+const dayPart = (start: string) => start.slice(0, 10)
+const subPart = (start: string) => start.slice(11)
+
+function hourLabel(h: number): string {
+  if (h === 0) return '12 AM'
+  if (h === 12) return '12 PM'
+  return h < 12 ? `${h} AM` : `${h - 12} PM`
+}
+
+function tooltipFor(bucket: ActivityBucket, granularityHours: 1 | 12 | 24): string {
+  const tokens = bucket.totalTokens.toLocaleString()
+  if (granularityHours === 24) return `${bucket.start}: ${tokens} tokens`
+  const day = dayPart(bucket.start)
+  if (granularityHours === 12) return `${day} ${subPart(bucket.start)}: ${tokens} tokens`
+  return `${day} ${hourLabel(Number(subPart(bucket.start)))}: ${tokens} tokens`
+}
+
+/** Classic GitHub-style weekly grid: 7 rows (Sun-Sat), one column per week, one box per
+ *  day. Used for the "all" range, where day-level granularity gives a rich, familiar grid. */
+function DailyGrid({ buckets, max }: { buckets: ActivityBucket[]; max: number }) {
+  const firstWeekday = new Date(`${buckets[0].start}T00:00:00Z`).getUTCDay()
+  const padded: (ActivityBucket | null)[] = [...(Array(firstWeekday).fill(null) as null[]), ...buckets]
+  const weeks = Math.ceil(padded.length / 7)
+  const cells: (ActivityBucket | null)[] = [...padded, ...(Array(weeks * 7 - padded.length).fill(null) as null[])]
+
+  const monthLabels: { col: number; label: string }[] = []
+  let lastMonth = -1
+  for (let col = 0; col < weeks; col++) {
+    for (let row = 0; row < 7; row++) {
+      const cell = cells[col * 7 + row]
+      if (!cell) continue
+      const d = new Date(`${cell.start}T00:00:00Z`)
+      if (d.getUTCDate() <= 7) {
+        if (d.getUTCMonth() !== lastMonth) {
+          lastMonth = d.getUTCMonth()
+          monthLabels.push({ col, label: d.toLocaleDateString(undefined, { month: 'short', timeZone: 'UTC' }) })
+        }
+        break
+      }
+    }
+  }
+
+  return (
+    <div>
+      <div
+        className="relative mb-1"
+        style={{ height: 14, display: 'grid', gridTemplateColumns: `repeat(${weeks}, ${CELL}px)`, columnGap: GAP }}
+      >
+        {monthLabels.map(({ col, label }) => (
+          <span key={col} style={{ gridColumn: col + 1 }} className="text-[10px] text-faint">{label}</span>
+        ))}
+      </div>
+      <div className="flex" style={{ gap: GAP }}>
+        <div className="flex shrink-0 flex-col pr-1" style={{ gap: GAP }}>
+          {[0, 1, 2, 3, 4, 5, 6].map((row) => (
+            <div key={row} style={{ height: CELL }} className="flex items-center text-[10px] text-faint">
+              {WEEKDAY_LABELS[row] ?? ''}
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'grid', gridTemplateRows: `repeat(7, ${CELL}px)`, gridAutoFlow: 'column', gap: GAP }}>
+          {cells.map((cell, i) =>
+            cell ? (
+              <div
+                key={i}
+                title={tooltipFor(cell, 24)}
+                style={{ width: CELL, height: CELL, borderRadius: RADIUS, background: cellBg(levelFor(cell.totalTokens, max)) }}
+              />
+            ) : (
+              <div key={i} style={{ width: CELL, height: CELL }} />
+            ),
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 30d: the SAME weekday-aligned week grid as DailyGrid (still 7 rows — keeps the
+ *  overall rectangle the same height as the "all" range) but each day gets 2 adjacent
+ *  columns (AM, PM) instead of 1, doubling the in-week resolution to 12h boxes. */
+function HalfDayGrid({ buckets, max }: { buckets: ActivityBucket[]; max: number }) {
+  const days: { am: ActivityBucket; pm: ActivityBucket }[] = []
+  for (let i = 0; i < buckets.length; i += 2) days.push({ am: buckets[i], pm: buckets[i + 1] })
+
+  const firstWeekday = new Date(`${dayPart(days[0].am.start)}T00:00:00Z`).getUTCDay()
+  const weeks = Math.ceil((firstWeekday + days.length) / 7)
+
+  const monthLabels: { col: number; label: string }[] = []
+  let lastMonth = -1
+  days.forEach((d, i) => {
+    const week = Math.floor((firstWeekday + i) / 7)
+    const date = new Date(`${dayPart(d.am.start)}T00:00:00Z`)
+    if (date.getUTCDate() <= 7 && date.getUTCMonth() !== lastMonth) {
+      lastMonth = date.getUTCMonth()
+      monthLabels.push({ col: week * 2, label: date.toLocaleDateString(undefined, { month: 'short', timeZone: 'UTC' }) })
+    }
+  })
+
+  return (
+    <div>
+      <div
+        className="relative mb-1"
+        style={{ height: 14, display: 'grid', gridTemplateColumns: `repeat(${weeks * 2}, ${CELL}px)`, columnGap: GAP }}
+      >
+        {monthLabels.map(({ col, label }) => (
+          <span key={col} style={{ gridColumn: col + 1 }} className="text-[10px] text-faint">{label}</span>
+        ))}
+      </div>
+      <div className="flex" style={{ gap: GAP }}>
+        <div className="flex shrink-0 flex-col pr-1" style={{ gap: GAP }}>
+          {[0, 1, 2, 3, 4, 5, 6].map((row) => (
+            <div key={row} style={{ height: CELL }} className="flex items-center text-[10px] text-faint">
+              {WEEKDAY_LABELS[row] ?? ''}
+            </div>
+          ))}
+        </div>
+        <div
+          style={{
+            display: 'grid', gridTemplateRows: `repeat(7, ${CELL}px)`,
+            gridTemplateColumns: `repeat(${weeks * 2}, ${CELL}px)`, gap: GAP,
+          }}
+        >
+          {days.flatMap((d, i) => {
+            const row = (firstWeekday + i) % 7
+            const week = Math.floor((firstWeekday + i) / 7)
+            return [
+              <div
+                key={`${i}-am`}
+                title={tooltipFor(d.am, 12)}
+                style={{
+                  gridRow: row + 1, gridColumn: week * 2 + 1, width: CELL, height: CELL,
+                  borderRadius: RADIUS, background: cellBg(levelFor(d.am.totalTokens, max)),
+                }}
+              />,
+              <div
+                key={`${i}-pm`}
+                title={tooltipFor(d.pm, 12)}
+                style={{
+                  gridRow: row + 1, gridColumn: week * 2 + 2, width: CELL, height: CELL,
+                  borderRadius: RADIUS, background: cellBg(levelFor(d.pm.totalTokens, max)),
+                }}
+              />,
+            ]
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** 7d: one row per day (the 7 real days in the window, oldest to newest — not weekday-
+ *  aligned, since a 7-day window would mostly land on empty padding rows in a weekly
+ *  grid), one column per hour (0-23). Still exactly 7 rows, so the rectangle is the same
+ *  height as the other two ranges. Buckets already arrive day-major (24 consecutive
+ *  hours per day), so a plain row-major grid fill lines up correctly with no padding. */
+function HourGrid({ buckets, max }: { buckets: ActivityBucket[]; max: number }) {
+  const days = buckets.length / 24
+  const rowLabels = Array.from({ length: days }, (_, i) => dayPart(buckets[i * 24].start))
+
+  return (
+    <div>
+      <div className="flex" style={{ gap: GAP }}>
+        <div className="flex shrink-0 flex-col pr-1" style={{ gap: GAP }}>
+          {rowLabels.map((d, row) => (
+            <div key={row} style={{ height: CELL }} className="flex items-center text-[10px] text-faint">
+              {d.slice(5)}
+            </div>
+          ))}
+        </div>
+        <div>
+          <div
+            style={{
+              display: 'grid', gridTemplateRows: `repeat(${days}, ${CELL}px)`,
+              gridTemplateColumns: `repeat(24, ${CELL}px)`, gridAutoFlow: 'row', gap: GAP,
+            }}
+          >
+            {buckets.map((b, i) => (
+              <div
+                key={i}
+                title={tooltipFor(b, 1)}
+                style={{ width: CELL, height: CELL, borderRadius: RADIUS, background: cellBg(levelFor(b.totalTokens, max)) }}
+              />
+            ))}
+          </div>
+          <div className="mt-1 flex text-[10px] text-faint" style={{ gap: GAP }}>
+            {Array.from({ length: 24 }, (_, h) => (
+              <div key={h} style={{ width: CELL }} className="text-center">{h % 6 === 0 ? h : ''}</div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Adaptive-resolution activity heatmap (Release 3) — hand-rolled, no charting library.
+ *  Box granularity comes from the backend (`activity.granularityHours`): 1h boxes for the
+ *  7d range, 12h boxes for 30d, and the classic GitHub-style 1-day boxes for all. Every
+ *  layout uses exactly 7 rows, so the overall rectangle is the same height regardless of
+ *  which range is selected — only the column count (and box meaning) changes. */
+export function ActivityHeatmap({ activity }: { activity: TokenActivity }) {
+  const { buckets, granularityHours } = activity
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Default scrolled to the right edge — the most recent (and usually most interesting)
+  // activity should be visible without the user having to scroll past a year of padding.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollLeft = el.scrollWidth
+  }, [buckets])
+
+  if (!buckets.length) return null
+  const max = Math.max(1, ...buckets.map((b) => b.totalTokens))
+
+  return (
+    <div className="overflow-x-auto" ref={scrollRef}>
+      <div className="inline-block">
+        {granularityHours === 24 && <DailyGrid buckets={buckets} max={max} />}
+        {granularityHours === 12 && <HalfDayGrid buckets={buckets} max={max} />}
+        {granularityHours === 1 && <HourGrid buckets={buckets} max={max} />}
+        <div className="mt-2 flex items-center justify-end gap-1 text-[11px] text-muted">
+          <span>Less</span>
+          {LEVELS.map((l, i) => (
+            <div key={l} style={{ width: 14, height: 14, borderRadius: RADIUS, background: cellBg(i) }} />
+          ))}
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/tokens/DailyBarChart.tsx
+++ b/turbollm/web/src/screens/tokens/DailyBarChart.tsx
@@ -1,0 +1,85 @@
+const CHART_HEIGHT = 160
+const BAR_GAP = 2
+const MIN_TOTAL_WIDTH = 320
+const MIN_BAR_WIDTH = 4
+
+export interface BarSegment {
+  key: string
+  tokens: number
+  color: string
+}
+
+export interface BarChartDay {
+  date: string
+  totalTokens: number
+  segments: BarSegment[]
+}
+
+function niceMax(n: number): number {
+  if (n <= 0) return 1
+  const magnitude = 10 ** Math.floor(Math.log10(n))
+  const normalized = n / magnitude
+  const step = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10
+  return step * magnitude
+}
+
+function formatAxisTick(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
+  return String(Math.round(n))
+}
+
+/** Daily (optionally stacked) token usage bar chart — shared by the Tokens dashboard's
+ *  Overview (single series) and Models (stacked by model) tabs. Hand-rolled with plain
+ *  divs, no charting library. The y-axis scale is always derived from the days actually
+ *  passed in, so it re-scales per range (7d/30d/all) instead of looking blank against a
+ *  fixed axis sized for a much longer window. Stretches to fill its container's full
+ *  width — only falls back to a fixed (scrollable) width when there are genuinely too
+ *  many days to render legibly at the container's width. */
+export function DailyBarChart({ days }: { days: BarChartDay[] }) {
+  if (!days.length) return null
+
+  const rawMax = Math.max(...days.map((d) => d.totalTokens), 0)
+  const axisMax = niceMax(rawMax)
+  const ticks = [axisMax, axisMax * 0.75, axisMax * 0.5, axisMax * 0.25, 0]
+  const labelEvery = Math.max(1, Math.ceil(days.length / 8))
+  const contentMinWidth = days.length * (MIN_BAR_WIDTH + BAR_GAP)
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex" style={{ width: '100%', minWidth: Math.max(MIN_TOTAL_WIDTH, contentMinWidth) }}>
+        <div
+          className="flex shrink-0 flex-col justify-between pr-2 text-right text-[10px] text-faint"
+          style={{ height: CHART_HEIGHT }}
+        >
+          {ticks.map((t) => <div key={t}>{formatAxisTick(t)}</div>)}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-end border-b border-border" style={{ height: CHART_HEIGHT, gap: BAR_GAP }}>
+            {days.map((d) => (
+              <div
+                key={d.date}
+                className="flex min-w-0 flex-1 flex-col-reverse"
+                title={`${d.date}: ${d.totalTokens.toLocaleString()} tokens`}
+              >
+                {d.segments.map((s) => (
+                  <div
+                    key={s.key}
+                    style={{ height: axisMax > 0 ? (s.tokens / axisMax) * CHART_HEIGHT : 0, background: s.color }}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+          <div className="mt-1 flex text-[10px] text-faint" style={{ gap: BAR_GAP }}>
+            {days.map((d, i) => (
+              <div key={d.date} className="min-w-0 flex-1 text-center">
+                {i % labelEvery === 0 || i === days.length - 1 ? d.date.slice(5) : ''}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/tokens/DailyBarChart.tsx
+++ b/turbollm/web/src/screens/tokens/DailyBarChart.tsx
@@ -25,7 +25,10 @@ function niceMax(n: number): number {
 
 function formatAxisTick(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
+  // A bare toFixed(0) here collapsed adjacent ticks to the same label (e.g. axisMax=2000
+  // gives ticks [2000, 1500, 1000, ...] and both 2000 and 1500 round to "2K") — one decimal
+  // for non-round-thousand values disambiguates them, same as the M branch above.
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n % 1_000 === 0 ? 0 : 1)}K`
   return String(Math.round(n))
 }
 

--- a/turbollm/web/src/screens/tokens/ModelsTab.tsx
+++ b/turbollm/web/src/screens/tokens/ModelsTab.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import type { DailyModelBreakdown, ModelUsage } from '../../lib/types'
+import { DailyBarChart } from './DailyBarChart'
+
+const INITIAL_VISIBLE = 6
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(n >= 10_000_000_000 ? 0 : 1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`
+  return n.toLocaleString()
+}
+
+/** Rank-based accent shade — top model gets the full accent, later ranks fade toward
+ *  the panel color. Keeps the legend and chart colors identical and theme-automatic. */
+function colorForRank(rank: number): string {
+  const intensity = Math.max(20, 85 - rank * 12)
+  return `color-mix(in srgb, var(--accent) ${intensity}%, var(--panel-2))`
+}
+
+/** Per-model breakdown — stacked usage chart + a ranked legend with in/out split and
+ *  share of total (Release 3, Models tab). */
+export function ModelsTab({
+  models, dailyByModel, totalTokens,
+}: { models: ModelUsage[]; dailyByModel: DailyModelBreakdown[]; totalTokens: number }) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (!models.length) {
+    return <p className="py-8 text-center text-[13px] text-faint">No model usage in this range yet.</p>
+  }
+
+  const rankOf = new Map(models.map((m, i) => [m.modelKey, i]))
+  const chartDays = dailyByModel.map((d) => ({
+    date: d.date,
+    totalTokens: d.totalTokens,
+    segments: [...d.byModel]
+      .sort((a, b) => (rankOf.get(a.modelKey) ?? 999) - (rankOf.get(b.modelKey) ?? 999))
+      .map((m) => ({ key: m.modelKey, tokens: m.tokens, color: colorForRank(rankOf.get(m.modelKey) ?? models.length) })),
+  }))
+
+  const visible = expanded ? models : models.slice(0, INITIAL_VISIBLE)
+  const hiddenCount = models.length - visible.length
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg border border-border bg-panel p-4">
+        <DailyBarChart days={chartDays} />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {visible.map((m, i) => (
+          <div key={m.modelKey} className="flex items-center gap-3 rounded-md px-2 py-2 text-[13px]">
+            <span className="h-2.5 w-2.5 shrink-0 rounded-sm" style={{ background: colorForRank(i) }} />
+            <span className="min-w-0 flex-1 truncate text-ink">{m.displayName}</span>
+            <span className="shrink-0 tabular-nums text-muted">
+              {formatTokenCount(m.promptTokens)} in · {formatTokenCount(m.genTokens)} out
+            </span>
+            <span className="w-12 shrink-0 text-right tabular-nums text-faint">
+              {totalTokens > 0 ? `${((m.totalTokens / totalTokens) * 100).toFixed(1)}%` : '—'}
+            </span>
+          </div>
+        ))}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="px-2 py-1 text-left text-[12px] text-accent hover:underline"
+          >
+            Show {hiddenCount} more
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Token usage dashboard (Usage nav tab): adaptive-granularity heatmap (1h/12h/24h boxes for 7d/30d/all), 8 stat tiles, per-model breakdown with stacked chart + ranked legend, lifetime milestone ladder with a fun-fact comparison.
- Auto-memory: silent background extraction of durable user facts (opt-in, off by default), Settings toggle + reviewable/deletable fact list, injected into future new conversations only. Tagged **Experimental** in the Settings UI.

## Test plan
- [x] `npm run typecheck` (frontend)
- [x] Verified live against the real daemon (127.0.0.1:6996): dashboard renders across 7d/30d/all ranges, Models tab stacked chart, Settings Memory section toggle + fact list + Experimental badge
- [x] Auto-memory outbound-payload verified: fact appears in a new conversation's persisted system prompt; deletion and toggle-off both correctly remove it