### PR TITLE
v1.7.7 — streaming empty-block fix, iGPU VRAM fix, engine self-service, auto-fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ the detail:
   (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **KV-cache quant type** (incl.
   low-bit on supporting forks), CPU threads, flash attention, and **speculative decoding (NextN /
   MTP / draft, with a configurable draft min/max window)**.
+- **Auto-fit GPU layers / MoE offload** — an optional toggle (off by default) that hands the
+  GPU/CPU split decision to llama.cpp's own memory-fitting logic at load time instead of a fixed
+  number, honored by Auto-tune too. Useful when a large context or model doesn't fit your usual
+  fixed setting.
 - **Fast by default:** flash attention on, NextN self-speculative decoding on for models that
   carry a draft head, threads auto — safely gated to what your engine actually accepts.
 - **Multi-GPU, per model** — split a model across cards (layer/row split + main-GPU pick on
@@ -362,6 +366,10 @@ No prebuilt for your OS? The **build-from-source guide** checks your toolchain (
 CUDA / a compiler — MSVC on Windows, gcc/clang on Linux), hands you the exact build commands
 (or a 1-click **"Build it for me"** on Windows and Linux), then drops you into the folder scan
 above.
+
+**Or skip the manual clone entirely** — Engines screen → **Add via git repo**: paste any
+llama.cpp-compatible fork's git URL (+ optional branch, defaults to the repo's own default) and
+build it in-app with the same 1-click flow, no separate "point at a folder" step needed.
 
 **Auto-provisioned default.** Don't want to fetch anything? On first run TurboLLM downloads
 the right upstream prebuilt for your GPU automatically — and a **backend picker** lets you

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,31 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.7.7] - 2026-07-10
+
+**Custom engine self-service, auto-fit GPU/MoE offload, and two real bug fixes.**
+
+### Added
+- **Custom engine: build from any git repo** — Engines → "Add via git repo" lets you point at
+  any llama.cpp-compatible fork's URL (+ optional branch) and build it in-app with one click,
+  reusing the existing build pipeline. No more manually cloning and adding the binary by hand.
+- **Auto-fit GPU layers / MoE CPU offload** — new toggles in a model's Load settings (and
+  honored by Auto-tune) that let llama.cpp decide the GPU/CPU split for you at load time,
+  instead of a fixed number — useful when a large context or model doesn't fit the old fixed
+  default. Off by default.
+
+### Fixed
+- A brief empty message bubble could appear above the real reply on a fresh chat send, with
+  working Copy/Edit/Delete controls on it — a backend placeholder message racing the UI's
+  optimistic refresh.
+- On a machine with an integrated GPU, its VRAM was sometimes reported as if it were dedicated
+  graphics memory, causing wrong model-quant defaults and false "won't fit" warnings.
+
+### Discord
+- Add a custom engine straight from a git repo URL and build it in one click — no more manual clone-and-point.
+- New "Auto-fit" option for GPU layers and MoE offload: let TurboLLM figure out the best split automatically instead of guessing a number yourself.
+- Fixed a rare empty-message flash in chat and a VRAM-reporting bug on integrated GPUs.
+
 ## [1.7.6] - 2026-07-09
 
 **Token usage dashboard and an opt-in auto-memory feature.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -170,6 +170,10 @@ the detail:
   (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **KV-cache quant type** (incl.
   low-bit on supporting forks), CPU threads, flash attention, and **speculative decoding (NextN /
   MTP / draft, with a configurable draft min/max window)**.
+- **Auto-fit GPU layers / MoE offload** — an optional toggle (off by default) that hands the
+  GPU/CPU split decision to llama.cpp's own memory-fitting logic at load time instead of a fixed
+  number, honored by Auto-tune too. Useful when a large context or model doesn't fit your usual
+  fixed setting.
 - **Fast by default:** flash attention on, NextN self-speculative decoding on for models that
   carry a draft head, threads auto — safely gated to what your engine actually accepts.
 - **Multi-GPU, per model** — split a model across cards (layer/row split + main-GPU pick on
@@ -362,6 +366,10 @@ No prebuilt for your OS? The **build-from-source guide** checks your toolchain (
 CUDA / a compiler — MSVC on Windows, gcc/clang on Linux), hands you the exact build commands
 (or a 1-click **"Build it for me"** on Windows and Linux), then drops you into the folder scan
 above.
+
+**Or skip the manual clone entirely** — Engines screen → **Add via git repo**: paste any
+llama.cpp-compatible fork's git URL (+ optional branch, defaults to the repo's own default) and
+build it in-app with the same 1-click flow, no separate "point at a folder" step needed.
 
 **Auto-provisioned default.** Don't want to fetch anything? On first run TurboLLM downloads
 the right upstream prebuilt for your GPU automatically — and a **backend picker** lets you

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -34,7 +34,19 @@ import {
  *  the failure mode (timeout/crash/oom) — the sweep keeps going on a failure. */
 export interface BenchCandidate {
   label: string
-  params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
+  params: {
+    ctx: number
+    ngl: number
+    /** True when this candidate used auto-fit (-ngl omitted) instead of the pinned `ngl` value —
+     *  see `LoadProfile.nglFit`. `ngl` itself is meaningless/stale when this is true. */
+    nglFit?: boolean
+    nCpuMoe: number
+    /** Same idea as `nglFit`, for `--n-cpu-moe` — see `LoadProfile.nCpuMoeFit`. */
+    nCpuMoeFit?: boolean
+    parallel: number
+    kvTypeK: string
+    flashAttn: string
+  }
   outcome: 'ok' | 'timeout' | 'crash' | 'oom'
   tps: number | null
   /** Prefill (prompt-processing) speed, tok/s — from the engine's `prompt_per_second`. Part of
@@ -437,6 +449,12 @@ export class BenchRunner {
     results: BenchCandidate[],
     headroomMb: number,
   ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
+    // User chose auto-fit (LoadProfile.nglFit) — trust llama.cpp's own -fit logic for the
+    // GPU/CPU split instead of empirically binary-searching it ourselves; just measure speed
+    // once at whatever it picks. Skips the whole probe phase, and the winning profile keeps
+    // nglFit:true so future loads stay adaptive rather than pinning today's specific number.
+    if (base.nglFit) return this.benchAt(entry, sys, base, caps, results, 'auto-fit')
+
     let bestNgl: number | null = 0 // CPU-only box → everything on CPU, no probing needed.
 
     if (sys.gpus.length > 0) {
@@ -475,6 +493,9 @@ export class BenchRunner {
     results: BenchCandidate[],
     headroomMb: number,
   ): Promise<{ cand: BenchCandidate; profile: LoadProfile } | null> {
+    // Same idea as denseSearch's nglFit check, for MoE CPU-offload auto-fit.
+    if (base.nCpuMoeFit) return this.benchAt(entry, sys, base, caps, results, 'auto-fit')
+
     const derived = deriveDefault(entry, sys)
     const maxN = entry.blockCount > 0 ? entry.blockCount : (derived.nCpuMoe || 0)
     let lo = 0, hi = maxN
@@ -644,7 +665,9 @@ export class BenchRunner {
     const params = {
       ctx: profile.ctx,
       ngl: profile.ngl,
+      nglFit: profile.nglFit,
       nCpuMoe: profile.nCpuMoe,
+      nCpuMoeFit: profile.nCpuMoeFit,
       parallel: profile.parallel,
       kvTypeK: profile.kvTypeK,
       flashAttn: profile.flashAttn,

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -72,7 +72,7 @@ export interface BenchResult {
   tps: number
   ttftMs: number
   vramMb: number | null
-  params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
+  params: { ctx: number; ngl: number; nglFit?: boolean; nCpuMoe: number; nCpuMoeFit?: boolean; parallel: number; kvTypeK: string; flashAttn: string }
   ts: string
 }
 export interface ApiKey {

--- a/turbollm/src/models/profile.test.ts
+++ b/turbollm/src/models/profile.test.ts
@@ -63,3 +63,12 @@ test('profileToArgs: --n-cpu-moe never emitted for a non-MoE model even without 
   const args = profileToArgs(p, denseModel, caps)
   assert.equal(args.includes('--n-cpu-moe'), false)
 })
+
+test('profileToArgs: nglFit is ignored for MoE models — -ngl still emitted (pre-release review, Finding D)', () => {
+  // The UI hides "Auto-fit GPU layers" and force-shows the slider for MoE models (nCpuMoeFit
+  // is the real MoE offload control there); a stray nglFit:true on a MoE profile must not
+  // silently turn that still-visible slider into a no-op.
+  const p = { ...deriveDefault(moeModel, sys), ngl: 20, nglFit: true }
+  const args = profileToArgs(p, moeModel, caps)
+  assert.deepEqual(args.slice(args.indexOf('-ngl'), args.indexOf('-ngl') + 2), ['-ngl', '20'])
+})

--- a/turbollm/src/models/profile.test.ts
+++ b/turbollm/src/models/profile.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { deriveDefault, profileToArgs } from './profile'
+import type { ModelEntry } from './scanner'
+import type { SysInfo } from '../sysinfo/sysinfo'
+import type { Capabilities } from '../config/config'
+
+const sys: SysInfo = {
+  os: 'win32/x64',
+  cpu: 'Test CPU',
+  cores: 16,
+  ramMB: 65536,
+  gpus: [{ name: 'Test GPU', vramMb: 16000, vendor: 'nvidia' }],
+}
+
+const denseModel: ModelEntry = {
+  key: 'dense-test', name: 'Dense Test', path: 'x.gguf', dir: '.', format: 'gguf',
+  sizeBytes: 1e9, sizeLabel: '1B', arch: 'llama', quant: 'Q4_K_M', nativeCtx: 8192,
+  blockCount: 32, headCountKv: 8, moe: false, expertCount: 0, nextnLayers: 0,
+  vision: false, mmprojPath: null, hasChatTemplate: true, embedding: false,
+  incomplete: false, parseError: null, loaded: false, hasProfile: false,
+  benchTps: null, mtime: '',
+}
+
+const moeModel: ModelEntry = { ...denseModel, key: 'moe-test', name: 'MoE Test', moe: true, expertCount: 8 }
+
+// Empty flags/kvTypes = unprobed → `has()` and `kvOk()` in profileToArgs graceful-degrade to
+// "allow" (see profile.ts comments), so every flag under test is actually emitted when expected.
+const caps: Capabilities = { kvTypes: [], flags: [] }
+
+test('profileToArgs: emits -ngl by default', () => {
+  const p = { ...deriveDefault(denseModel, sys), ngl: 20 }
+  const args = profileToArgs(p, denseModel, caps)
+  assert.deepEqual(args.slice(args.indexOf('-ngl'), args.indexOf('-ngl') + 2), ['-ngl', '20'])
+})
+
+test('profileToArgs: nglFit omits -ngl entirely, regardless of the stale ngl value', () => {
+  const p = { ...deriveDefault(denseModel, sys), ngl: 20, nglFit: true }
+  const args = profileToArgs(p, denseModel, caps)
+  assert.equal(args.includes('-ngl'), false)
+})
+
+test('profileToArgs: nglFit false/absent keeps emitting -ngl (backward compat)', () => {
+  const p = { ...deriveDefault(denseModel, sys), ngl: 99 }
+  const args = profileToArgs(p, denseModel, caps)
+  assert.equal(args.includes('-ngl'), true)
+})
+
+test('profileToArgs: emits --n-cpu-moe by default on an MoE model', () => {
+  const p = { ...deriveDefault(moeModel, sys), nCpuMoe: 4 }
+  const args = profileToArgs(p, moeModel, caps)
+  assert.deepEqual(args.slice(args.indexOf('--n-cpu-moe'), args.indexOf('--n-cpu-moe') + 2), ['--n-cpu-moe', '4'])
+})
+
+test('profileToArgs: nCpuMoeFit omits --n-cpu-moe entirely, regardless of the stale value', () => {
+  const p = { ...deriveDefault(moeModel, sys), nCpuMoe: 4, nCpuMoeFit: true }
+  const args = profileToArgs(p, moeModel, caps)
+  assert.equal(args.includes('--n-cpu-moe'), false)
+})
+
+test('profileToArgs: --n-cpu-moe never emitted for a non-MoE model even without nCpuMoeFit', () => {
+  const p = { ...deriveDefault(denseModel, sys), nCpuMoe: 4 }
+  const args = profileToArgs(p, denseModel, caps)
+  assert.equal(args.includes('--n-cpu-moe'), false)
+})

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -84,14 +84,22 @@ export interface LoadProfile {
   /** When true, omit `-ngl` entirely and let llama.cpp's own `-fit` memory-fitting logic (always
    *  active unless overridden) decide how many layers land on GPU vs CPU at load time, instead of
    *  the fixed `ngl` value. `ngl` is kept as the last manual value so switching back restores it.
-   *  Absent / false on pre-feature profiles → unchanged existing behavior (always emit -ngl). */
+   *  Absent / false on pre-feature profiles → unchanged existing behavior (always emit -ngl).
+   *  Ignored for MoE models (see {@link profileToArgs}) — `nCpuMoeFit` is the real MoE offload
+   *  control there. **Assumption, not yet capability-probed (pre-release review, Finding C):**
+   *  this relies on the active engine's llama.cpp build actually implementing `-fit` when `-ngl`
+   *  is omitted — a build old enough to predate it would default to CPU-only (`n_gpu_layers=0`)
+   *  instead, silently tanking performance with no error. Opt-in and off by default, so the blast
+   *  radius is small, but worth a capability probe (mirroring how `caps.kvTypes` gates KV-quant
+   *  options) if this turns out to bite a user on an older engine build. */
   nglFit?: boolean
   nCpuMoe: number
   /** Same idea as {@link nglFit}, for `--n-cpu-moe` (MoE expert CPU-offload count). llama.cpp's
    *  `-fit` handles MoE offload with a more granular per-tensor fractional strategy than the
    *  simple N-experts-on-CPU count this app exposes (live-verified: it can fit MORE onto the GPU
    *  than a coarse fixed count would), so omitting the flag can genuinely do better than a manual
-   *  number. Absent / false → unchanged existing behavior. */
+   *  number. Absent / false → unchanged existing behavior. Same engine-version assumption as
+   *  {@link nglFit} applies here too. */
   nCpuMoeFit?: boolean
   parallel: number
   kvUnified: boolean
@@ -345,7 +353,11 @@ export function profileToArgs(p: LoadProfile, m: ModelEntry, caps: Capabilities,
   const has = (flag: string) => caps.flags.length === 0 || caps.flags.includes(flag)
   const a: string[] = ['-c', String(p.ctx)]
   // nglFit: omit -ngl entirely so llama.cpp's own -fit logic picks the offload (see LoadProfile).
-  if (!p.nglFit && p.ngl > 0) a.push('-ngl', String(p.ngl))
+  // Ignored for MoE models (pre-release review, Finding D) — the UI hides the "Auto-fit GPU
+  // layers" toggle and force-shows the plain slider for MoE (nCpuMoeFit is the real MoE
+  // offload control), so honoring a stray nglFit:true here would silently make that slider a
+  // no-op with no UI path to notice or undo it.
+  if ((!p.nglFit || m.moe) && p.ngl > 0) a.push('-ngl', String(p.ngl))
   // Multi-GPU split (ADR-054). Defaults are no-ops: 'layer' + empty tensorSplit +
   // mainGpu -1 emit nothing, preserving llama.cpp's built-in even split across GPUs.
   const g = p.gpu

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -81,7 +81,18 @@ export function defaultVllm(): VllmProfile {
 export interface LoadProfile {
   ctx: number
   ngl: number
+  /** When true, omit `-ngl` entirely and let llama.cpp's own `-fit` memory-fitting logic (always
+   *  active unless overridden) decide how many layers land on GPU vs CPU at load time, instead of
+   *  the fixed `ngl` value. `ngl` is kept as the last manual value so switching back restores it.
+   *  Absent / false on pre-feature profiles → unchanged existing behavior (always emit -ngl). */
+  nglFit?: boolean
   nCpuMoe: number
+  /** Same idea as {@link nglFit}, for `--n-cpu-moe` (MoE expert CPU-offload count). llama.cpp's
+   *  `-fit` handles MoE offload with a more granular per-tensor fractional strategy than the
+   *  simple N-experts-on-CPU count this app exposes (live-verified: it can fit MORE onto the GPU
+   *  than a coarse fixed count would), so omitting the flag can genuinely do better than a manual
+   *  number. Absent / false → unchanged existing behavior. */
+  nCpuMoeFit?: boolean
   parallel: number
   kvUnified: boolean
   kvTypeK: string
@@ -333,7 +344,8 @@ export function resolveProfile(
 export function profileToArgs(p: LoadProfile, m: ModelEntry, caps: Capabilities, cores = 0): string[] {
   const has = (flag: string) => caps.flags.length === 0 || caps.flags.includes(flag)
   const a: string[] = ['-c', String(p.ctx)]
-  if (p.ngl > 0) a.push('-ngl', String(p.ngl))
+  // nglFit: omit -ngl entirely so llama.cpp's own -fit logic picks the offload (see LoadProfile).
+  if (!p.nglFit && p.ngl > 0) a.push('-ngl', String(p.ngl))
   // Multi-GPU split (ADR-054). Defaults are no-ops: 'layer' + empty tensorSplit +
   // mainGpu -1 emit nothing, preserving llama.cpp's built-in even split across GPUs.
   const g = p.gpu
@@ -349,7 +361,8 @@ export function profileToArgs(p: LoadProfile, m: ModelEntry, caps: Capabilities,
   // quadrupling KV memory (seen in logs).
   if (has('--parallel')) a.push('--parallel', String(p.parallel))
   if (p.parallel > 1 && p.kvUnified && has('--kv-unified')) a.push('--kv-unified')
-  if (m.moe && p.nCpuMoe > 0 && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
+  // nCpuMoeFit: omit --n-cpu-moe so -fit's finer-grained MoE offload strategy decides instead.
+  if (m.moe && !p.nCpuMoeFit && p.nCpuMoe > 0 && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
   // Emit a non-default KV cache type only when the engine supports the VALUE, not just
   // the --cache-type-k FLAG: e.g. TurboQuant's turbo2/3/4 must NOT leak into a standard
   // llama.cpp / llamafile engine (which has the flag but rejects the value → launch fails).

--- a/turbollm/src/sysinfo/sysinfo.test.ts
+++ b/turbollm/src/sysinfo/sysinfo.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseRocmSmi } from './sysinfo'
+import { parseRocmSmi, isIntegratedGpuName } from './sysinfo'
 
 // rocm-smi --showmeminfo vram --json output for an RX 7900 XTX (24GB). The WMI
 // AdapterRAM fallback would cap this at ~4GB; rocm-smi reports the true total.
@@ -50,4 +50,40 @@ test('parseRocmSmi: cards reporting zero/unknown VRAM are skipped', () => {
     card1: { 'Some Other Field': 'x' },
   })
   assert.equal(parseRocmSmi(badMem).length, 0)
+})
+
+test('isIntegratedGpuName: classic Intel integrated branding is integrated', () => {
+  assert.equal(isIntegratedGpuName('Intel(R) Iris(R) Xe Graphics'), true)
+  assert.equal(isIntegratedGpuName('Intel(R) UHD Graphics 770'), true)
+  assert.equal(isIntegratedGpuName('Intel(R) HD Graphics 620'), true)
+})
+
+test('isIntegratedGpuName: Intel Arc iGPU (no model number) is integrated', () => {
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) Graphics'), true)
+})
+
+test('isIntegratedGpuName: discrete Intel Arc cards (model number) are NOT integrated', () => {
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) A770 Graphics'), false)
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) A380'), false)
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) B580'), false)
+})
+
+test('isIntegratedGpuName: newest generic Intel branding (no UHD/Iris/Arc qualifier) is integrated', () => {
+  // Real name reported by WMI on a Core Ultra 7 265K (Arrow Lake-S) dev box.
+  assert.equal(isIntegratedGpuName('Intel(R) Graphics'), true)
+})
+
+test('isIntegratedGpuName: generic AMD APU branding is integrated', () => {
+  assert.equal(isIntegratedGpuName('AMD Radeon(TM) Graphics'), true)
+})
+
+test('isIntegratedGpuName: discrete AMD cards are NOT integrated', () => {
+  assert.equal(isIntegratedGpuName('AMD Radeon RX 7900 XTX'), false)
+  assert.equal(isIntegratedGpuName('AMD Radeon PRO W7900'), false)
+  assert.equal(isIntegratedGpuName('AMD Instinct MI300X'), false)
+})
+
+test('isIntegratedGpuName: NVIDIA and unrelated names are NOT integrated', () => {
+  assert.equal(isIntegratedGpuName('NVIDIA GeForce RTX 5070 Ti'), false)
+  assert.equal(isIntegratedGpuName('Apple M3 Max'), false)
 })

--- a/turbollm/src/sysinfo/sysinfo.test.ts
+++ b/turbollm/src/sysinfo/sysinfo.test.ts
@@ -68,6 +68,15 @@ test('isIntegratedGpuName: discrete Intel Arc cards (model number) are NOT integ
   assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) B580'), false)
 })
 
+test('isIntegratedGpuName: discrete Intel Arc Pro workstation cards (2-digit model) are NOT integrated', () => {
+  // Pre-release review regression: the original 3-digit-only pattern misclassified these
+  // as integrated, over-reporting their VRAM (the dangerous direction — a load could pass
+  // the fit check on a system-RAM estimate then OOM on the card's real, smaller VRAM).
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) Pro A60 Graphics'), false)
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) Pro A50'), false)
+  assert.equal(isIntegratedGpuName('Intel(R) Arc(TM) Pro B60'), false)
+})
+
 test('isIntegratedGpuName: newest generic Intel branding (no UHD/Iris/Arc qualifier) is integrated', () => {
   // Real name reported by WMI on a Core Ultra 7 265K (Arrow Lake-S) dev box.
   assert.equal(isIntegratedGpuName('Intel(R) Graphics'), true)

--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -65,8 +65,13 @@ export function isIntegratedGpuName(name: string): boolean {
   // Classic Intel integrated branding — never used for a discrete card.
   if (/iris|uhd graphics|hd graphics/.test(n)) return true
   // Intel's newer "Arc Graphics" iGPU branding (Meteor Lake/Lunar Lake+) carries no
-  // model number; every discrete Arc card does (A380/A750/A770/B570/B580/...).
-  if (/\barc\b/.test(n) && !/\b[ab]\d{3}\b/.test(n)) return true
+  // model number; every discrete Arc card does — consumer 3-digit (A380/A750/A770/
+  // B570/B580) AND the 2-digit "Arc Pro" workstation line (A40/A50/A60, B50/B60).
+  // Pre-release review caught the original 3-digit-only pattern misclassifying Arc
+  // Pro cards as integrated, over-reporting their VRAM (dangerous direction — could
+  // green-light a load that then OOMs); \d{2,4} plus an optional "pro" also covers
+  // any future model-number length without narrowing further.
+  if (/\barc\b/.test(n) && !/\b(?:pro\s+)?[ab]\d{2,4}\b/.test(n)) return true
   // AMD APU iGPU branding ("Radeon(TM) Graphics", generic) vs. a discrete card, which
   // always carries an RX/PRO/Instinct/Vega-N model name.
   if (/radeon.*graphics/.test(n) && !/\b(rx|pro|instinct|vega\s*\d|firepro)\b/.test(n)) return true

--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -53,6 +53,31 @@ export function classifyVendor(name: string): GpuVendor {
   return 'unknown'
 }
 
+/** True for GPU names that are almost certainly an integrated GPU sharing system RAM
+ *  rather than having independent dedicated VRAM. Used to correct dedicated-VRAM
+ *  readings that are actively wrong for iGPUs (WMI's AdapterRAM on Windows, the missing
+ *  sysfs attribute on Linux — see enumWindowsGpus/linuxVramMb below) without
+ *  misclassifying a discrete card that happens to share a vendor (e.g. Intel Arc dGPUs,
+ *  which do report real dedicated VRAM). Name-pattern heuristic, not yet live-verified
+ *  against real iGPU hardware — see docs/TODO.md Release 4. */
+export function isIntegratedGpuName(name: string): boolean {
+  const n = name.toLowerCase()
+  // Classic Intel integrated branding — never used for a discrete card.
+  if (/iris|uhd graphics|hd graphics/.test(n)) return true
+  // Intel's newer "Arc Graphics" iGPU branding (Meteor Lake/Lunar Lake+) carries no
+  // model number; every discrete Arc card does (A380/A750/A770/B570/B580/...).
+  if (/\barc\b/.test(n) && !/\b[ab]\d{3}\b/.test(n)) return true
+  // AMD APU iGPU branding ("Radeon(TM) Graphics", generic) vs. a discrete card, which
+  // always carries an RX/PRO/Instinct/Vega-N model name.
+  if (/radeon.*graphics/.test(n) && !/\b(rx|pro|instinct|vega\s*\d|firepro)\b/.test(n)) return true
+  // Newest Intel Core Ultra generic branding — plain "Intel(R) Graphics" with no
+  // qualifier at all (confirmed on a real Core Ultra 7 265K / Arrow Lake-S box).
+  // Intel's only current discrete lineup is Arc-branded, so any other Intel name
+  // containing "graphics" with no Arc qualifier is integrated.
+  if (/intel/.test(n) && /graphics/.test(n) && !/\barc\b/.test(n)) return true
+  return false
+}
+
 function detectGpus(): GpuInfo[] {
   // 1) NVIDIA (Windows/Linux): nvidia-smi gives exact name + VRAM.
   try {
@@ -131,7 +156,17 @@ function enumWindowsGpus(): GpuInfo[] {
       const [name, ram] = line.split('|')
       const nm = (name ?? '').trim()
       const bytes = parseInt((ram ?? '').trim(), 10) || 0
-      return { name: nm, vramMb: bytes > 0 ? Math.round(bytes / 1e6) : 0, vendor: classifyVendor(nm) }
+      // AdapterRAM is a weak hint at best (see comment above) and is actively wrong
+      // for integrated GPUs — it reports a tiny fixed aperture (or 0), not the real
+      // chunk of system RAM the OS lets an iGPU use, which was making quant
+      // auto-selection always pick the smallest file and the fit check always show
+      // red. Apply the same shared-memory heuristic used for Apple Silicon below,
+      // scaled down (50% vs. 65%) to match Windows' more conservative default
+      // "shared GPU memory" cap.
+      const vramMb = isIntegratedGpuName(nm)
+        ? Math.round((os.totalmem() / 1e6) * 0.5)
+        : bytes > 0 ? Math.round(bytes / 1e6) : 0
+      return { name: nm, vramMb, vendor: classifyVendor(nm) }
     })
     .filter((g) => g.name && g.vendor !== 'unknown')
 }
@@ -193,7 +228,19 @@ function enumLinuxGpus(): GpuInfo[] {
     .map((line) => {
       const vendor = classifyVendor(line)
       const slot = line.trim().split(/\s+/)[0] ?? ''
-      return { name: line.replace(/"/g, '').trim().slice(0, 80), vramMb: linuxVramMb(slot), vendor }
+      const name = line.replace(/"/g, '').trim().slice(0, 80)
+      const sysfsVramMb = linuxVramMb(slot)
+      // sysfs's mem_info_vram_total only exists for amdgpu-driven cards (dedicated
+      // VRAM, or an APU's BIOS carveout) — Intel iGPUs / nouveau read 0 here, which
+      // means "no dedicated VRAM", not "no usable memory". Reporting that literal 0
+      // was making quant auto-selection always pick the smallest file and the fit
+      // check always show red, on hardware where the real constraint is different.
+      const vramMb = sysfsVramMb > 0
+        ? sysfsVramMb
+        : isIntegratedGpuName(name)
+          ? Math.round((os.totalmem() / 1e6) * 0.5)
+          : 0
+      return { name, vramMb, vendor }
     })
     .filter((g) => g.vendor !== 'unknown')
 }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -46,6 +46,7 @@ const TURBOLLM_KNOWLEDGE =
   '- **Engine gallery**: cards for every engine with a **hardware-fit mark** (green Compatible / amber "runs after a build" / red incompatible + reason), a real pros/cons list, and speed/VRAM/OS attributes.\n' +
   '- **Manage GPU builds** (llama.cpp card): per-backend variants — CUDA, ROCm, CPU, Vulkan, SYCL. Install, update, or switch the active build here.\n' +
   '- **Add your own engine** (compact strip at the bottom): guided folder scan that probes a binary and registers it as a custom engine. Filesystem browsing here is local-only (only the machine running TurboLLM can browse it) but reaches the whole local filesystem, including other drives on Windows.\n' +
+  '- **Add via git repo** (same strip): paste any llama.cpp-compatible fork\'s git URL (+ optional branch, blank = the repo\'s own default) and build it in-app with one click — no manual clone/point-at-folder step needed, reuses the same build pipeline as the catalog\'s "Build it for me".\n' +
   '- **In-app build**: clone → cmake → compile (CUDA), on Windows or Linux (incl. WSL2); auto-downloads CUDA toolkit if absent on Windows (~490 MB from NVIDIA redist — on Linux, install CUDA via your distro/NVIDIA installer first); live phase log + success screen.\n' +
   '- **Engine updates**: honest check vs GitHub releases/latest; rollback-safe (probe new build before swap, old build kept until success).\n' +
   '- Per-engine auto-update policy: Off / Notify / Auto (default Notify).\n\n' +
@@ -117,13 +118,13 @@ const TURBOLLM_KNOWLEDGE =
 
   '## Load Profile Parameters\n\n' +
   '**Core**:\n' +
-  '- `ngl` (GPU layers): 0 = CPU only; blockCount = all layers on GPU. Higher = faster inference but more VRAM. Shown as a slider with the real layer count as max.\n' +
+  '- `ngl` (GPU layers): 0 = CPU only; blockCount = all layers on GPU. Higher = faster inference but more VRAM. Shown as a slider with the real layer count as max. An **Auto-fit GPU layers** toggle (off by default, hidden for MoE models) hands this decision to llama.cpp\'s own memory-fitting logic at load time instead — Auto-tune honors it too, skipping its own search when on.\n' +
   '- `ctx` (context length): max token window. VRAM scales linearly with ctx (KV cache). Reduce if VRAM is tight; increase for long conversations.\n' +
   '- `threads`: CPU threads for computation. Defaults to core count.\n' +
   '- `batchSize` (`--batch-size`, default 2048): logical batch size — how many prompt tokens are submitted per decode step during prefill. Larger = faster prefill on long prompts, more VRAM at load. Leave blank for the engine default.\n' +
   '- `uBatchSize` (`--ubatch-size`, default 512): physical micro-batch size — the chunk actually computed at once. Must be ≤ batchSize. Tune down if a large batch OOMs at load. Both live in the main llama.cpp settings (not Advanced); blank = engine default.\n\n' +
   '**MoE models only**:\n' +
-  '- `nCpuMoe` (CPU MoE expert count): number of MoE router experts kept on CPU. Reducing it frees GPU VRAM (moves more routing to GPU). Auto-tune searches this for MoE models.\n\n' +
+  '- `nCpuMoe` (CPU MoE expert count): number of MoE router experts kept on CPU. Reducing it frees GPU VRAM (moves more routing to GPU). Auto-tune searches this for MoE models. An **Auto-fit MoE CPU offload** toggle (off by default) hands this to llama.cpp\'s own fit logic instead — a finer-grained per-tensor strategy than the fixed count — and Auto-tune skips its own search when it\'s on.\n\n' +
   '**KV Cache**:\n' +
   '- `kvTypeK` / `kvTypeV`: KV cache quantization. `f16` = best quality, most VRAM. `q8_0` = good quality, ~2× smaller. `q4_0` / `q4_1` = smaller, lower quality. `turbo4` = TurboQuant-specific, high-speed specialized quant. Auto-tune picks automatically.\n' +
   '- `flashAttn`: Flash Attention 2 — reduces KV memory footprint especially at large ctx. Strongly recommended when ctx > 32k.\n\n' +

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -75,7 +75,7 @@ export type EngineStats = {
  *  measured run, else the failure mode — the sweep records it and continues. */
 export type BenchCandidate = {
   label: string
-  params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
+  params: { ctx: number; ngl: number; nglFit?: boolean; nCpuMoe: number; nCpuMoeFit?: boolean; parallel: number; kvTypeK: string; flashAttn: string }
   outcome: 'ok' | 'timeout' | 'crash' | 'oom'
   tps: number | null
   ttftMs: number | null
@@ -549,7 +549,11 @@ export type Sampling = {
 export type LoadProfile = {
   ctx: number
   ngl: number
+  /** Auto-fit: when true, omit -ngl and let llama.cpp's own -fit logic pick the GPU/CPU split. */
+  nglFit?: boolean
   nCpuMoe: number
+  /** Auto-fit for MoE CPU offload: when true, omit --n-cpu-moe and let -fit decide. */
+  nCpuMoeFit?: boolean
   parallel: number
   kvUnified: boolean
   kvTypeK: string

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -922,21 +922,28 @@ export function ChatScreen() {
               </div>
             )}
 
-            {/* Messages */}
-            {messages.map((m, i) => (
-              <MessageBubble
-                key={m.id}
-                message={m}
-                convId={readonly ? undefined : activeId ?? undefined}
-                isLast={i === messages.length - 1 && !live}
-                onEdit={readonly ? undefined : (msg) => setEditingId(msg.id)}
-                onDelete={readonly ? undefined : handleDelete}
-                onRegenerate={readonly ? undefined : handleRegenerate}
-                editingId={editingId}
-                onEditSave={(content) => handleEditSave(m.id, content)}
-                onEditCancel={() => setEditingId(null)}
-              />
-            ))}
+            {/* Messages — skip the in-flight assistant placeholder while it's still live
+                below. The backend inserts that row the moment generation starts
+                (chat-routes.ts: `db.addMessage(convId, 'assistant', '', ...)`, before any
+                token has streamed), and the 'meta' event's optimistic refetch can pull it
+                into this list before the StreamingBubble below has caught up — a real empty
+                message bubble momentarily rendering above the answer that's still typing in. */}
+            {messages
+              .filter((m) => m.id !== live?.assistantId)
+              .map((m, i, arr) => (
+                <MessageBubble
+                  key={m.id}
+                  message={m}
+                  convId={readonly ? undefined : activeId ?? undefined}
+                  isLast={i === arr.length - 1 && !live}
+                  onEdit={readonly ? undefined : (msg) => setEditingId(msg.id)}
+                  onDelete={readonly ? undefined : handleDelete}
+                  onRegenerate={readonly ? undefined : handleRegenerate}
+                  editingId={editingId}
+                  onEditSave={(content) => handleEditSave(m.id, content)}
+                  onEditCancel={() => setEditingId(null)}
+                />
+              ))}
 
             {/* Streaming bubble */}
             {live && (

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -5,7 +5,7 @@ import { continueConversation, fetchSysInfo, listMemoryFacts, sendMessage } from
 import { extractPdfText } from '../lib/pdf-extract'
 import { useConversation, useConversationMutations } from '../lib/chat-queries'
 import { useBuiltinAgentOverrides, useChatAgents, useEngines, useModelActions, useModelDetail, useModels, useSettings, useStatus } from '../lib/queries'
-import type { ChatSseEvent, LiveToolCall, Message } from '../lib/chat-types'
+import type { ChatSseEvent, Conversation, LiveToolCall, Message } from '../lib/chat-types'
 import { appendTextDelta, upsertToolCall, type LiveBlock } from '../lib/live-timeline'
 import { ApiError, downloadChatExport, getDebugSnapshot, getShareUrl, importChat } from '../lib/api'
 import { Button } from '../components/ui/button'
@@ -524,7 +524,27 @@ export function ChatScreen() {
           const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result }
           updateLive(convId, (l) => ({ ...l, timeline: upsertToolCall(l.timeline, call) }))
         } else if (evt.event === 'done') {
-          clearLive(convId)
+          // Patch the final content into the cache BEFORE clearing live state (pre-release
+          // review, Finding A): clearLive un-hides the placeholder synchronously, but the real
+          // content only arrives via the async invalidateQueries refetch below — without this
+          // patch, the now-visible placeholder would briefly render with its stale empty
+          // content (a "This message is empty." flash) in that window. Reading the live
+          // snapshot via setLiveByConv's own functional updater guarantees it isn't stale, even
+          // though React may batch prior delta/reasoning updates that haven't rendered yet.
+          setLiveByConv((prev) => {
+            const l = prev[convId]
+            if (l) {
+              qc.setQueryData<Conversation>(['conversation', convId], (old) =>
+                old
+                  ? { ...old, messages: (old.messages ?? []).map((m) => (m.id === l.assistantId ? { ...m, content: l.content, reasoning: l.reasoning } : m)) }
+                  : old,
+              )
+            }
+            if (!(convId in prev)) return prev
+            const next = { ...prev }
+            delete next[convId]
+            return next
+          })
           if (convId !== activeIdRef.current) setRecentlyCompletedIds((prev) => new Set(prev).add(convId))
           void qc.invalidateQueries({ queryKey: ['conversation', convId] })
           void qc.invalidateQueries({ queryKey: ['conversations'] })

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -73,6 +73,7 @@ import {
 } from '../components/ui/alert-dialog'
 import { AddEngineDialog } from './engines/AddEngineDialog'
 import { BuildGuideDialog } from './engines/BuildGuideDialog'
+import { CustomBuildDialog } from './engines/CustomBuildDialog'
 import { EngineStatusHeader } from './engines/EngineStatusHeader'
 import { EngineLogPanel } from './engines/EngineLogPanel'
 import { LlamaCppBackendRows } from './engines/ManagedEngines'
@@ -864,6 +865,7 @@ function EngineGallery({
           >
             Request an engine <ExternalLink size={11} />
           </a>
+          <CustomBuildDialog />
           <AddEngineDialog />
         </div>
       </div>

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -582,7 +582,10 @@ export function MessageBubble({
   // "phantom" content area that still shows Copy/Edit/Regenerate/Delete on hover (the
   // streaming-side ADR-174 .trim() guard only ever covered the reasoning block above, never
   // this completed-message path).
-  const isEmptyFinish = !message.content?.trim() && !message.reasoning?.trim() && completedToolCalls.length === 0
+  // researchMeta excluded (pre-release review, Finding E): a research-only turn can finish
+  // with empty content/reasoning but a real sources panel + confidence badge below — showing
+  // "This message is empty." above real, populated content would be self-contradictory.
+  const isEmptyFinish = !message.content?.trim() && !message.reasoning?.trim() && completedToolCalls.length === 0 && !message.researchMeta
   const hasError = isEmptyFinish
   const rm: ResearchMeta | undefined = message.researchMeta
   const verdicts = rm?.refereeVerdicts ?? []

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -571,13 +571,19 @@ export function MessageBubble({
   }
 
   // Assistant
-  const hasError = message.stats.aborted && !message.content
   const completedToolCalls: CardCall[] = (message.toolCalls ?? []).map((tc: ToolCallRecord) => ({
     id: tc.id,
     name: tc.name,
     status: tc.error ? 'error' : 'done',
     result: tc.error ?? tc.result,
   }))
+  // A message with no content, no reasoning, and no tool calls has nothing to show — render
+  // the same fallback card an aborted-empty finish already used, instead of leaving a blank
+  // "phantom" content area that still shows Copy/Edit/Regenerate/Delete on hover (the
+  // streaming-side ADR-174 .trim() guard only ever covered the reasoning block above, never
+  // this completed-message path).
+  const isEmptyFinish = !message.content?.trim() && !message.reasoning?.trim() && completedToolCalls.length === 0
+  const hasError = isEmptyFinish
   const rm: ResearchMeta | undefined = message.researchMeta
   const verdicts = rm?.refereeVerdicts ?? []
   return (
@@ -608,7 +614,7 @@ export function MessageBubble({
         </div>
       ) : hasError ? (
         <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
-          Generation failed or was stopped.
+          {message.stats.aborted ? 'Generation failed or was stopped.' : 'This message is empty.'}
           {isLast && onRegenerate && <button type="button" className="ml-3 underline" onClick={onRegenerate}>Regenerate</button>}
         </div>
       ) : (

--- a/turbollm/web/src/screens/engines/CustomBuildDialog.tsx
+++ b/turbollm/web/src/screens/engines/CustomBuildDialog.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { GitBranch } from 'lucide-react'
+import { Button } from '../../components/ui/button'
+import { Input } from '../../components/ui/input'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../../components/ui/dialog'
+import { BuildGuideDialog } from './BuildGuideDialog'
+
+/** "Add via git repo" (Release 4, ADR-183/184): type an arbitrary git repo URL — plus an
+ *  optional branch (any branch, including `main`) — and hand off to {@link BuildGuideDialog}.
+ *  That dialog already accepts any `repoUrl`/`branch` (ADR-089/100); every existing call site
+ *  just happened to hardcode a catalog entry's URL. This is the missing UI wiring only — no
+ *  new backend pipeline, same `POST /api/v1/build/run` every catalog build already uses. */
+export function CustomBuildDialog() {
+  const [formOpen, setFormOpen] = useState(false)
+  const [buildOpen, setBuildOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [repoUrl, setRepoUrl] = useState('')
+  const [branch, setBranch] = useState('')
+
+  const canContinue = name.trim().length > 0 && /^https?:\/\/\S+/.test(repoUrl.trim())
+
+  const reset = () => {
+    setName('')
+    setRepoUrl('')
+    setBranch('')
+  }
+
+  return (
+    <>
+      <Dialog open={formOpen} onOpenChange={(o) => { setFormOpen(o); if (!o) reset() }}>
+        <DialogTrigger asChild>
+          <Button variant="outline">
+            <GitBranch size={16} /> Add via git repo
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Build an engine from a git repo</DialogTitle>
+            <DialogDescription>
+              Any llama.cpp-compatible fork. Pick the branch to build — including{' '}
+              <code className="font-mono">main</code> — and TurboLLM clones + compiles it for you.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3">
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[13px] font-medium text-ink">Name</span>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="My llama.cpp fork" autoFocus />
+              <span className="text-[12px] text-muted">Any label you choose — shown in the engine list.</span>
+            </label>
+
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[13px] font-medium text-ink">Git repo URL</span>
+              <Input value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} placeholder="https://github.com/owner/repo" />
+            </label>
+
+            <label className="flex flex-col gap-1.5">
+              <span className="text-[13px] font-medium text-ink">Branch (optional)</span>
+              <Input value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="main" />
+              <span className="text-[12px] text-muted">Leave blank to build the repo&apos;s own default branch.</span>
+            </label>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFormOpen(false)}>Cancel</Button>
+            <Button onClick={() => { setFormOpen(false); setBuildOpen(true) }} disabled={!canContinue}>
+              Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {buildOpen && (
+        <BuildGuideDialog
+          open={buildOpen}
+          onOpenChange={(o) => {
+            setBuildOpen(o)
+            if (!o) reset()
+          }}
+          repoUrl={repoUrl.trim()}
+          branch={branch.trim() || undefined}
+          engineName={name.trim()}
+        />
+      )}
+    </>
+  )
+}

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -234,7 +234,16 @@ export function ModelDetailDialog({
           <div className="py-10 text-center text-[13px] text-muted">Loading…</div>
         ) : (
           <div className="flex flex-col gap-4">
-            {fit && <VramBar estMb={fit.estMb} totalMb={fit.totalVramMb} verdict={fit.verdict} />}
+            {fit && (
+              (draft.nglFit || draft.nCpuMoeFit) ? (
+                <div className="rounded-md border border-border bg-panel-2 px-3 py-2 text-[12px] text-muted">
+                  Auto-fit is on — llama.cpp will choose how much of the model fits on GPU at load
+                  time, so no estimate is shown here.
+                </div>
+              ) : (
+                <VramBar estMb={fit.estMb} totalMb={fit.totalVramMb} verdict={fit.verdict} />
+              )
+            )}
 
             {isLlamaCpp && detail.gpu && (
               <AutoTune
@@ -294,10 +303,37 @@ export function ModelDetailDialog({
             <Section>
               <Slider label="Context length" hint="Tokens of history the model can use." value={draft.ctx} min={512} max={Math.max(512, detail.nativeCtx || 8192)} step={512} onChange={(v) => set('ctx', v)} fmt={(v) => v.toLocaleString()} />
               {detail.gpu && (
-                <Slider label="GPU layers" hint={detail.blockCount > 0 ? `${detail.blockCount} total layers.` : 'All layers on GPU = max performance.'} value={draft.ngl} min={0} max={detail.blockCount > 0 ? detail.blockCount : 99} step={1} onChange={(v) => set('ngl', v)} fmt={(v) => (v >= (detail.blockCount > 0 ? detail.blockCount : 99) ? 'All' : String(v))} />
+                <>
+                  {/* MoE models' GPU/CPU tradeoff is governed by nCpuMoe below, not ngl —
+                      auto-tune's moeSearch never touches ngl for them either — so "Auto-fit GPU
+                      layers" has nothing meaningful to control here; hidden for MoE models. The
+                      slider still shows unconditionally for MoE (guarding against nglFit somehow
+                      being true with no UI path to turn it back off). */}
+                  {!detail.moe && (
+                    <Toggle
+                      label="Auto-fit GPU layers"
+                      hint="Let llama.cpp decide how many layers fit on GPU at load time, instead of a fixed number. Adapts automatically if free VRAM changes; off by default."
+                      value={draft.nglFit ?? false}
+                      onChange={(v) => set('nglFit', v)}
+                    />
+                  )}
+                  {(!draft.nglFit || detail.moe) && (
+                    <Slider label="GPU layers" hint={detail.blockCount > 0 ? `${detail.blockCount} total layers.` : 'All layers on GPU = max performance.'} value={draft.ngl} min={0} max={detail.blockCount > 0 ? detail.blockCount : 99} step={1} onChange={(v) => set('ngl', v)} fmt={(v) => (v >= (detail.blockCount > 0 ? detail.blockCount : 99) ? 'All' : String(v))} />
+                  )}
+                </>
               )}
               {detail.moe && detail.blockCount > 0 && (
-                <Slider label="MoE experts on CPU" hint="Higher = less VRAM, slower. Lower = faster if it fits." value={draft.nCpuMoe} min={0} max={detail.blockCount} step={1} onChange={(v) => set('nCpuMoe', v)} />
+                <>
+                  <Toggle
+                    label="Auto-fit MoE CPU offload"
+                    hint="Let llama.cpp decide the GPU/CPU split for MoE experts at load time — a finer-grained strategy than a fixed count. Off by default."
+                    value={draft.nCpuMoeFit ?? false}
+                    onChange={(v) => set('nCpuMoeFit', v)}
+                  />
+                  {!draft.nCpuMoeFit && (
+                    <Slider label="MoE experts on CPU" hint="Higher = less VRAM, slower. Lower = faster if it fits." value={draft.nCpuMoe} min={0} max={detail.blockCount} step={1} onChange={(v) => set('nCpuMoe', v)} />
+                  )}
+                </>
               )}
               <Row label="Context overflow" hint="What to do when the context window fills up.">
                 <Segmented
@@ -637,7 +673,7 @@ function AutoTuneResultDialog({
   onCancel,
 }: {
   result?: {
-    params: { ctx: number; ngl: number; nCpuMoe: number; parallel: number; kvTypeK: string; flashAttn: string }
+    params: { ctx: number; ngl: number; nglFit?: boolean; nCpuMoe: number; nCpuMoeFit?: boolean; parallel: number; kvTypeK: string; flashAttn: string }
     tps: number
     ttftMs?: number
     vramMb: number | null
@@ -675,8 +711,10 @@ function AutoTuneResultDialog({
               {result && (
                 <div className="rounded-md border border-border bg-panel-2 px-3 py-1.5">
                   <ConfigSection title="Runtime" />
-                  <ConfigRow label="GPU layers" value={result.params.ngl} />
-                  {result.params.nCpuMoe > 0 && <ConfigRow label="MoE experts on CPU" value={result.params.nCpuMoe} />}
+                  <ConfigRow label="GPU layers" value={result.params.nglFit ? 'Auto-fit' : result.params.ngl} />
+                  {(result.params.nCpuMoeFit || result.params.nCpuMoe > 0) && (
+                    <ConfigRow label="MoE experts on CPU" value={result.params.nCpuMoeFit ? 'Auto-fit' : result.params.nCpuMoe} />
+                  )}
                   <ConfigRow label="Context length" value={`${result.params.ctx.toLocaleString()} tok`} />
                   <ConfigRow label="KV cache type" value={result.params.kvTypeK} />
                   <ConfigRow label="Flash attention" value={result.params.flashAttn} />


### PR DESCRIPTION
## Summary
- Fix: streaming empty-block regression — a real backend placeholder assistant message could briefly render above the live reply on a fresh send; filtered out at the source, plus a defense-in-depth render guard.
- Fix: iGPU VRAM reported as if it were dedicated graphics memory, causing wrong quant defaults and false "won't fit" warnings on iGPU-only boxes.
- Custom engine self-service: add an engine from an arbitrary git repo URL + branch, then 1-click build.
- Auto-fit GPU layers / MoE CPU offload toggles, in both model load settings and auto-tune (auto-tune skips its empirical search when fit is chosen).

## Test plan
- [x] Full backend test suite passing (733/733)
- [x] Both typechecks (backend + web) clean
- [x] Live-verified against a real daemon: chat send/receive, custom engine dialog + prereq probe, Auto-fit toggles show/hide correctly per model type
- [ ] User to spot-check: the empty-block race in real usage, a real custom-engine build to completion, auto-fit load + auto-tune run end-to-end