### PR TITLE
fix(bench): auto-tune the multi-GPU split, not just offload+KV

### DIFF
--- a/turbollm/src/bench/bench.split.test.ts
+++ b/turbollm/src/bench/bench.split.test.ts
@@ -1,0 +1,102 @@
+// Multi-GPU split-strategy selection for auto-tune (ADR-054). Covers pickSplitStrategies
+// (which split modes the sweep tries, in order) and the split-aware overHeadroom budget.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { pickSplitStrategies, overHeadroom } from './bench'
+import { deriveDefault } from '../models/profile'
+import type { LoadProfile } from '../models/profile'
+import type { ModelEntry } from '../models/scanner'
+import type { SysInfo } from '../sysinfo/sysinfo'
+
+function model(over: Partial<ModelEntry> = {}): ModelEntry {
+  return {
+    key: 'm|q4|1', name: 'm', path: '/models/m.gguf', dir: '/models', format: 'gguf',
+    sizeBytes: 8_000_000_000, sizeLabel: '8 GB', arch: 'llama', quant: 'Q4_K_M',
+    nativeCtx: 32768, blockCount: 32, headCountKv: 8, moe: false, expertCount: 0,
+    nextnLayers: 0, vision: false, audio: false, mmprojPath: null, hasChatTemplate: true, embedding: false,
+    incomplete: false, parseError: null, loaded: false, hasProfile: false,
+    benchTps: null, mtime: '', ...over,
+  }
+}
+
+function sys(gpus: number[]): SysInfo {
+  return {
+    os: 'linux/x64', cpu: 'test', cores: 16, ramMB: 64000,
+    gpus: gpus.map((vramMb, i) => ({ name: `gpu${i}`, vramMb, vendor: 'nvidia' as const })),
+  }
+}
+
+// Empty flags = graceful-degrade → all flags allowed (a probed engine that supports split).
+const caps = { kvTypes: ['f16', 'q8_0', 'turbo4'], flags: [] as string[] }
+
+function base(s: SysInfo, over: Partial<LoadProfile> = {}): LoadProfile {
+  return { ...deriveDefault(model(), s), ...over }
+}
+
+// ---- pickSplitStrategies ----------------------------------------------------
+
+test('single-GPU box → exactly one strategy (the profile default, unchanged behavior)', () => {
+  const s = sys([24000])
+  const strats = pickSplitStrategies(model(), s, base(s), caps)
+  assert.equal(strats.length, 1)
+  assert.equal(strats[0].splitMode, 'layer')
+})
+
+test('split-incapable engine → one strategy even on a multi-GPU box', () => {
+  const s = sys([24000, 24000])
+  const limited = { kvTypes: [], flags: ['-ngl', '--parallel'] } // no --split-mode / --main-gpu
+  const strats = pickSplitStrategies(model(), s, base(s), limited)
+  assert.equal(strats.length, 1)
+  assert.equal(strats[0].splitMode, 'layer')
+})
+
+test('multi-GPU, model fits one card → single-GPU FIRST, then layer-split', () => {
+  const s = sys([24000, 24000])
+  const strats = pickSplitStrategies(model({ sizeBytes: 8_000_000_000 }), s, base(s), caps)
+  assert.equal(strats.length, 2)
+  assert.equal(strats[0].splitMode, 'none') // tried first — the likely winner
+  assert.equal(strats[0].mainGpu, 0)
+  assert.equal(strats[1].splitMode, 'layer')
+})
+
+test('multi-GPU, model too big for one card even at smallest KV → layer-split only', () => {
+  const s = sys([24000, 24000])
+  // ~60 GB weights: overflows a single 24 GB card no matter the KV quant, but the summed pool is
+  // its only hope — so single-GPU is not offered, layer-split is kept.
+  const strats = pickSplitStrategies(model({ sizeBytes: 60_000_000_000 }), s, base(s), caps)
+  assert.equal(strats.length, 1)
+  assert.equal(strats[0].splitMode, 'layer')
+})
+
+test('single-GPU is offered thanks to the smallest-KV fit estimate (turbo4), not the base f16', () => {
+  const s = sys([16000, 16000])
+  // ~13.5 GB weights + a big f16 KV would overflow one 16 GB card, but turbo4 shrinks the KV enough
+  // to fit — pickSplitStrategies must estimate with the smallest quality KV so this branch appears.
+  const big = model({ sizeBytes: 13_500_000_000, blockCount: 48, headCountKv: 8, nativeCtx: 8192 })
+  const strats = pickSplitStrategies(big, s, base(s, { ctx: 8192 }), caps)
+  assert.ok(strats.some((g) => g.splitMode === 'none'), 'single-GPU strategy should be offered')
+})
+
+test('user already pinned single-GPU → deduped to one strategy', () => {
+  const s = sys([24000, 24000])
+  const pinned = base(s, { gpu: { splitMode: 'none', tensorSplit: [], mainGpu: 0, tensorParallelSize: 1 } })
+  const strats = pickSplitStrategies(model(), s, pinned, caps)
+  assert.equal(strats.length, 1)
+  assert.equal(strats[0].splitMode, 'none')
+})
+
+// ---- overHeadroom: budget-aware (per-GPU for single, summed for split) -------
+
+test('overHeadroom judges against the given budget, not a fixed pool', () => {
+  // 14.5 GB used is over one 15.36 GB card's 1 GB-headroom edge…
+  assert.equal(overHeadroom(14500, 15360, 1024), true)
+  // …but comfortably within the summed 30.72 GB pool of two cards.
+  assert.equal(overHeadroom(14500, 30720, 1024), false)
+  // Right under a single card's edge → fits.
+  assert.equal(overHeadroom(14000, 15360, 1024), false)
+})
+
+test('overHeadroom never blocks on unknown VRAM or zero budget', () => {
+  assert.equal(overHeadroom(null, 15360, 1024), false)
+  assert.equal(overHeadroom(14000, 0, 1024), false)
+})

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -17,7 +17,7 @@ import type { Manager, StartOpts } from '../engines/manager'
 import type { Registry } from '../engines/registry'
 import type { Engine } from '../config/config'
 import type { Scanner, ModelEntry } from '../models/scanner'
-import { deriveDefault, profileToArgs, resolveProfile, type LoadProfile } from '../models/profile'
+import { deriveDefault, estimateVram, gpuBudgetMb, profileToArgs, resolveProfile, type GpuProfile, type LoadProfile } from '../models/profile'
 import { getSysInfo, type SysInfo } from '../sysinfo/sysinfo'
 import type { HfClient } from '../hf/hf'
 import { inferRepoFromPath } from '../api/path-utils'
@@ -344,27 +344,48 @@ export class BenchRunner {
     //   • big KV → a smaller quant frees real VRAM for more of the model on the GPU, but its kernel
     //     can be slower (turbo4), so tune BOTH the smallest (max-fit) and q8_0 (stock fallback) and
     //     let the measured prefill + t/s decide.
-    const kvCandidates = pickKvQuants(baseProfile.kvTypeK, caps.kvTypes)
-    // Default to the user's own KV type (covers CPU-only — no VRAM pressure, the quant barely
-    // matters — and unprobed/single-candidate engines). Only with a GPU and a real choice do we
-    // size the cache and decide.
-    let kvToTune = kvCandidates.slice(0, 1)
-    if (sys.gpus.length > 0 && kvCandidates.length > 1) {
-      const spread = await this.calibrateKvSpread(entry, sys, baseProfile, caps, kvCandidates, results)
-      kvToTune = decideKvToBench(spread, kvCandidates)
-      const swing = spread < 0 ? 'unknown' : spread >= Number.MAX_SAFE_INTEGER ? 'huge' : `${Math.round(spread)} MB`
-      this.state = { ...this.state, step: `KV cache swing ${swing} → tuning ${kvToTune.join(' + ')}`, candidates: results }
-      this.emit(`KV spread ${swing} → tuning ${kvToTune.join(' + ')}`)
-    }
+    // --- Choose the multi-GPU SPLIT strategy too, not just offload+KV (ADR-054) ---
+    // llama.cpp's default is an even LAYER-split across every visible GPU. But a model that fits on
+    // ONE card is almost always faster there: a layer-split runs the GPUs as a sequential pipeline
+    // (one busy at a time) and copies activations across PCIe every token, so on a fits-on-one model
+    // it's strictly slower than single-GPU — the reported "dual-GPU is slower than my single GPU".
+    // So on a >1-GPU box we tune single-GPU (when the model plausibly fits one card, even only with
+    // the smallest quality KV) FIRST, then the layer-split, and let measured t/s pick. A single-GPU
+    // box or a split-incapable engine yields exactly one strategy → unchanged behavior. (Row-split
+    // is a deliberate follow-up: its per-layer all-reduce rarely pays off on PCIe-only multi-GPU.)
+    const splitStrategies = pickSplitStrategies(entry, sys, baseProfile, caps)
+    for (const gpu of splitStrategies) {
+      if (this.cancelled || Date.now() > this.deadline) break
+      const splitBase: LoadProfile = { ...baseProfile, gpu }
+      if (splitStrategies.length > 1) {
+        const label = splitLabel(gpu, sys.gpus.length)
+        this.state = { ...this.state, step: `Trying ${label}…`, candidates: results }
+        this.emit(`split strategy → ${label}`)
+      }
 
-    for (let i = 0; i < kvToTune.length && !this.cancelled && Date.now() <= this.deadline; i++) {
-      const kv = kvToTune[i]
-      const kvBase: LoadProfile = { ...baseProfile, kvTypeK: kv, kvTypeV: kv }
-      const found = entry.moe
-        ? await this.moeSearch(entry, sys, kvBase, caps, results, headroomMb)
-        : await this.denseSearch(entry, sys, kvBase, caps, results, headroomMb)
-      if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
-      if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
+      // Decide which KV quant(s) to tune UNDER THIS split: the VRAM budget differs (one card vs the
+      // summed pool), so single-GPU may need turbo4 to fit where a layer-split is fine at f16.
+      // Default to the user's own KV type (covers CPU-only — no VRAM pressure — and unprobed/single-
+      // candidate engines). Only with a GPU and a real choice do we size the cache and decide.
+      const kvCandidates = pickKvQuants(splitBase.kvTypeK, caps.kvTypes)
+      let kvToTune = kvCandidates.slice(0, 1)
+      if (sys.gpus.length > 0 && kvCandidates.length > 1) {
+        const spread = await this.calibrateKvSpread(entry, sys, splitBase, caps, kvCandidates, results)
+        kvToTune = decideKvToBench(spread, kvCandidates)
+        const swing = spread < 0 ? 'unknown' : spread >= Number.MAX_SAFE_INTEGER ? 'huge' : `${Math.round(spread)} MB`
+        this.state = { ...this.state, step: `KV cache swing ${swing} → tuning ${kvToTune.join(' + ')}`, candidates: results }
+        this.emit(`KV spread ${swing} → tuning ${kvToTune.join(' + ')}`)
+      }
+
+      for (let i = 0; i < kvToTune.length && !this.cancelled && Date.now() <= this.deadline; i++) {
+        const kv = kvToTune[i]
+        const kvBase: LoadProfile = { ...splitBase, kvTypeK: kv, kvTypeV: kv }
+        const found = entry.moe
+          ? await this.moeSearch(entry, sys, kvBase, caps, results, headroomMb)
+          : await this.denseSearch(entry, sys, kvBase, caps, results, headroomMb)
+        if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
+        if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
+      }
     }
 
     // Engine is always left stopped at the end of a run (AC#3 for cancel; also tidy
@@ -458,6 +479,10 @@ export class BenchRunner {
     let bestNgl: number | null = 0 // CPU-only box → everything on CPU, no probing needed.
 
     if (sys.gpus.length > 0) {
+      // The VRAM this split is allowed to use: all cards for a layer/row split, ONE card for a
+      // single-GPU 'none' split (ADR-054). The headroom gate must judge against THIS, not the summed
+      // pool — else a 14 GB single-GPU load looks safe against a 30 GB total when it's at one card's edge.
+      const budgetMb = gpuBudgetMb(sys, base)
       // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with enough headroom VRAM.
       const hi0 = entry.blockCount > 0 ? entry.blockCount : 99
       let lo = 0, hi = hi0
@@ -468,7 +493,7 @@ export class BenchRunner {
         const probe = await this.probeVram(entry, sys, { ...base, ngl: mid }, caps)
         this.pushProbe(results, base, 'ngl', mid, probe)
         await this.settleGpu()
-        if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, sys, headroomMb)) {
+        if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, budgetMb, headroomMb)) {
           bestNgl = mid // fits with headroom → record, try MORE GPU layers
           lo = mid + 1
         } else {
@@ -498,6 +523,8 @@ export class BenchRunner {
 
     const derived = deriveDefault(entry, sys)
     const maxN = entry.blockCount > 0 ? entry.blockCount : (derived.nCpuMoe || 0)
+    // VRAM budget for THIS split (one card for single-GPU 'none', summed pool otherwise) — see denseSearch.
+    const budgetMb = gpuBudgetMb(sys, base)
     let lo = 0, hi = maxN
     let bestN: number | null = null
 
@@ -507,7 +534,7 @@ export class BenchRunner {
       const probe = await this.probeVram(entry, sys, { ...base, nCpuMoe: mid }, caps)
       this.pushProbe(results, base, 'nCpuMoe', mid, probe)
       await this.settleGpu()
-      if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, sys, headroomMb)) {
+      if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, budgetMb, headroomMb)) {
         lo = mid + 1 // too much on GPU → more CPU experts to free VRAM / restore the headroom
       } else if (probe.outcome === 'ok') {
         bestN = mid // fits with headroom → record, try FEWER CPU experts (more on GPU)
@@ -1159,18 +1186,64 @@ function benchPromptTokens(ctx: number): number {
   return Math.max(256, Math.min(8_192, Math.floor(ctx * 0.75)))
 }
 
-/** Total dedicated VRAM across all GPUs, MB (0 when none / non-NVIDIA). */
-function totalVramMb(sys: SysInfo): number {
-  return sys.gpus.reduce((s, g) => s + (g.vramMb || 0), 0)
+/** True when a candidate's ABSOLUTE VRAM use leaves less than `headroomMb` free within `budgetMb`
+ *  — the VRAM this profile is allowed to use: the summed pool for a layer/row split, or a SINGLE
+ *  card for a single-GPU 'none' split (ADR-054; `gpuBudgetMb`). The search then offloads more so
+ *  the chosen config keeps a safety margin against a later desktop / ComfyUI VRAM grab. Unknown
+ *  VRAM (non-NVIDIA) or no budget → never blocks. */
+export function overHeadroom(vramAbsMb: number | null, budgetMb: number, headroomMb: number): boolean {
+  if (!vramAbsMb || budgetMb <= 0) return false
+  return vramAbsMb > budgetMb - headroomMb
 }
 
-/** True when a candidate's ABSOLUTE VRAM use leaves less than `headroomMb` free — i.e. it's too
- *  close to the spill edge. The search then offloads more so the chosen config keeps a safety
- *  margin against a later desktop / ComfyUI VRAM grab. Unknown VRAM (non-NVIDIA) → never blocks. */
-function overHeadroom(vramAbsMb: number | null, sys: SysInfo, headroomMb: number): boolean {
-  const total = totalVramMb(sys)
-  if (!vramAbsMb || total <= 0) return false
-  return vramAbsMb > total - headroomMb
+/** Which multi-GPU split strategies auto-tune should try, in search order (ADR-054). A single-GPU
+ *  box — or an engine whose probe didn't confirm the split flags — yields just the profile's own gpu
+ *  setting (one strategy → unchanged behavior). A >1-GPU box returns single-GPU FIRST (the whole
+ *  model on one card, offered when it plausibly fits even with the smallest quality-preserving KV
+ *  quant, which the inner sweep can then pick) and the profile's split (default: layer across all)
+ *  second. Single-GPU is tried first because, when the model fits one card, it beats any split (a
+ *  layer-split is a sequential cross-GPU pipeline + per-token PCIe activation copies), so a
+ *  budget-truncated run still measured the likely winner. */
+export function pickSplitStrategies(
+  entry: ModelEntry,
+  sys: SysInfo,
+  base: LoadProfile,
+  caps: Engine['capabilities'],
+): GpuProfile[] {
+  const has = (flag: string) => caps.flags.length === 0 || caps.flags.includes(flag)
+  if (sys.gpus.length <= 1 || !has('--split-mode') || !has('--main-gpu')) return [base.gpu]
+
+  const strategies: GpuProfile[] = []
+  // Single-GPU: whole model on one card. Judge feasibility with the SMALLEST quality-preserving KV
+  // the engine offers (the inner KV sweep can pick it to fit), so a model that only fits one card
+  // with turbo4 still gets the single-GPU branch it would win on.
+  const kvOpts = pickKvQuants(base.kvTypeK, caps.kvTypes)
+  const bestFitKv = kvOpts.reduce((a, b) => (kvBytes(b) < kvBytes(a) ? b : a), kvOpts[0] ?? base.kvTypeK)
+  const mainGpu = base.gpu.mainGpu >= 0 ? base.gpu.mainGpu : 0
+  const single: GpuProfile = { ...base.gpu, splitMode: 'none', mainGpu, tensorSplit: [] }
+  const singleFits =
+    estimateVram({ ...base, gpu: single, kvTypeK: bestFitKv, kvTypeV: bestFitKv }, entry, sys).verdict !== 'overflow'
+  if (singleFits) strategies.push(single)
+
+  // The profile's current split (default: layer across all GPUs) — always kept, as the fallback for
+  // models too big for one card and so a tuned result can never be worse than today's default.
+  strategies.push(base.gpu)
+
+  // De-dup by the fields that actually reach the launch args (e.g. the user already pinned 'none').
+  const seen = new Set<string>()
+  return strategies.filter((g) => {
+    const key = `${g.splitMode}|${g.mainGpu >= 0 ? g.mainGpu : 0}|${g.tensorSplit.join(',')}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+/** Human-readable label for a split strategy, for the live step / bench log. */
+function splitLabel(g: GpuProfile, gpuCount: number): string {
+  if (g.splitMode === 'none') return `single-GPU (GPU ${g.mainGpu >= 0 ? g.mainGpu : 0})`
+  if (g.splitMode === 'row') return `row-split across ${gpuCount} GPUs`
+  return `layer-split across ${gpuCount} GPUs`
 }
 
 /** The quality-preserving KV-cache types to try, in search order. The model's current/base type

--- a/turbollm/web/src/lib/vram.test.ts
+++ b/turbollm/web/src/lib/vram.test.ts
@@ -14,6 +14,7 @@ test('primaryVendorSummary: dual-GPU VRAM is summed, not just gpus[0]', () => {
   const summary = primaryVendorSummary(gpus)
   assert.equal(summary.vramMb, 32768, 'two 16GB cards pool to 32GB, not one card\'s 16GB')
   assert.equal(summary.gpuName, 'NVIDIA GeForce RTX 5060 Ti')
+  assert.equal(summary.count, 2, 'dual-GPU boxes must report a count so the UI can show "2×"')
 })
 
 test('primaryVendorSummary: an Intel iGPU alongside an NVIDIA dGPU is excluded from the sum', () => {
@@ -24,10 +25,12 @@ test('primaryVendorSummary: an Intel iGPU alongside an NVIDIA dGPU is excluded f
   const summary = primaryVendorSummary(gpus)
   assert.equal(summary.vramMb, 12288, 'the iGPU\'s 4GB must not inflate the usable budget')
   assert.equal(summary.gpuName, 'NVIDIA GeForce RTX 4070')
+  assert.equal(summary.count, 1, 'the excluded iGPU must not inflate the NVIDIA count')
 })
 
 test('primaryVendorSummary: no GPUs reports null name and 0 VRAM', () => {
   const summary = primaryVendorSummary([])
   assert.equal(summary.gpuName, null)
   assert.equal(summary.vramMb, 0)
+  assert.equal(summary.count, 0)
 })

--- a/turbollm/web/src/lib/vram.ts
+++ b/turbollm/web/src/lib/vram.ts
@@ -24,15 +24,15 @@ type VendorGpu = { name: string; vramMb: number; vendor: string }
  *  hardware.ts`) for use as the raw-sysinfo fallback on the Engines screen: before the
  *  `/recommendation` query resolves (or if it errors, since that query never retries), the
  *  hero must not regress to a single un-summed card's VRAM on a multi-GPU box. */
-export function primaryVendorSummary(gpus: VendorGpu[]): { gpuName: string | null; vramMb: number } {
-  if (!gpus.length) return { gpuName: null, vramMb: 0 }
+export function primaryVendorSummary(gpus: VendorGpu[]): { gpuName: string | null; vramMb: number; count: number } {
+  if (!gpus.length) return { gpuName: null, vramMb: 0, count: 0 }
   let vendor = 'unknown'
   for (const g of gpus) if ((VENDOR_RANK[g.vendor] ?? 1) > (VENDOR_RANK[vendor] ?? 1)) vendor = g.vendor
   const ofVendor = gpus.filter((g) => g.vendor === vendor)
   const pool = ofVendor.length ? ofVendor : gpus
   const headline = pool.reduce<VendorGpu | undefined>((best, g) => (!best || g.vramMb > best.vramMb ? g : best), undefined)
   const vramMb = ofVendor.reduce((sum, g) => sum + g.vramMb, 0)
-  return { gpuName: headline?.name ?? null, vramMb }
+  return { gpuName: headline?.name ?? null, vramMb, count: pool.length }
 }
 
 function kvBytesPerElem(t: string): number {

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -450,13 +450,16 @@ function EngineHeaderBar({
 
   // Hardware line — prefer the recommendation's summed hardware; fall back to the same
   // primary-vendor sum from raw sysinfo (NOT sys.gpus[0], which is the multi-GPU bug).
+  // GPU count always comes from raw sysinfo — it's the same physical GPUs either way, and
+  // the daemon's HardwareProfile doesn't carry a count, only the summed/headline fields.
   const hw = rec?.hardware
   const sysFallback = primaryVendorSummary(sys?.gpus ?? [])
   const gpuName = hw?.gpuName ?? sysFallback.gpuName
   const vramMb = hw?.vramMb ?? sysFallback.vramMb
+  const gpuCount = sysFallback.count
   const osName = hw ? platformName(hw.platform) : sys?.os.split('/')[0] ? platformName(sys.os.split('/')[0]) : ''
   const hwLine = [
-    gpuName ?? 'CPU-only',
+    gpuName ? (gpuCount > 1 ? `${gpuCount}× ${gpuName}` : gpuName) : 'CPU-only',
     vramMb > 0 ? `${(vramMb / 1024).toFixed(0)} GB` : null,
     osName || null,
   ]


### PR DESCRIPTION
## Summary
- Auto-tune now sweeps single-GPU placement (when the model plausibly fits one card) *before* the default even layer-split across all GPUs, and picks whichever measures faster.
- Fixes the reported regression where dual-GPU auto-tune produced a *slower* config than single-GPU: a layer-split runs GPUs as a sequential pipeline with per-token PCIe activation copies, so a model that fits on one card is strictly slower split than not.
- `overHeadroom` is now split-aware — it judges a single-GPU candidate against that one card's VRAM budget, not the summed multi-GPU pool (a single-GPU load at one card's edge was previously judged safe against the total).
- Engines screen now shows GPU count (e.g. "2× RTX 5060 Ti") instead of just the summed VRAM, so dual-GPU boxes are visually distinguishable from a single big card.
- Single-GPU boxes and engines whose capability probe didn't confirm `--split-mode`/`--main-gpu` support are unaffected — they still get exactly one strategy.

## Test plan
- [x] `tsx --test src/bench/bench.split.test.ts` — 8/8 pass (split-strategy selection + split-aware headroom)
- [x] `tsx --test web/src/lib/vram.test.ts` — 3/3 pass (GPU count in hardware summary)
- [x] `tsc --noEmit` on `turbollm/` — clean
- [x] Verified live on a Kaggle 2×T4 session (separate deploy/testing branch, not part of this PR)