### PR TITLE
fix: Code reliability/sync batch + auto-tune accuracy fixes

### DIFF
--- a/turbollm/src/bench/bench.test.ts
+++ b/turbollm/src/bench/bench.test.ts
@@ -82,6 +82,23 @@ test('kvSpeedAdvisory: slow result but already at the smallest available type �
   assert.equal(kvSpeedAdvisory(5, 'q4_0', ['f16', 'q8_0', 'q4_0']), null)
 })
 
+test('kvSpeedAdvisory: NON-turbo current type on a TurboQuant fork must never recommend a turbo type (regression — caught in independent review before merge)', () => {
+  // f16/q8_0 are the common case (most users aren't on turbo* to begin with). Turbo types must
+  // be excluded from the candidate pool regardless of what the CURRENT type is — a prior version
+  // gated the exclusion on the current type already being turbo, so it silently did nothing here
+  // and recommended turbo2 (the smallest nominal size) instead of a real standard type.
+  const supported = ['f16', 'q8_0', 'q4_0', 'turbo2', 'turbo3', 'turbo4']
+  const msgF16 = kvSpeedAdvisory(10, 'f16', supported)
+  assert.ok(msgF16)
+  assert.match(msgF16, /q4_0|q8_0/)
+  assert.doesNotMatch(msgF16, /turbo/)
+
+  const msgQ80 = kvSpeedAdvisory(10, 'q8_0', supported)
+  assert.ok(msgQ80)
+  assert.match(msgQ80, /q4_0/)
+  assert.doesNotMatch(msgQ80, /turbo/)
+})
+
 test('kvSpeedAdvisory: unprobed engine (empty kvTypes) → no advisory, nothing to suggest', () => {
   assert.equal(kvSpeedAdvisory(5, 'f16', []), null)
 })

--- a/turbollm/src/bench/bench.test.ts
+++ b/turbollm/src/bench/bench.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { pickKvQuants, betterBySpeed, decideKvToBench } from './bench'
+import { pickKvQuants, betterBySpeed, decideKvToBench, parseRocmVramUsed, benchPromptTokens, buildBenchMessages } from './bench'
 
 // ---- pickKvQuants: quality-preserving KV sweep, base-first ------------------
 
@@ -92,4 +92,80 @@ test('decideKvToBench: un-sizable (spread < 0) is treated as big-KV, safely', ()
 test('decideKvToBench: stock engine (no turbo) → just q8_0 in the big-KV regime', () => {
   assert.deepEqual(decideKvToBench(5000, STOCK), ['q8_0'])
   assert.deepEqual(decideKvToBench(-1, STOCK), ['q8_0'])
+})
+
+// ---- parseRocmVramUsed: AMD live VRAM reading (ADR-217 — the headroom gate was fully inert on
+// AMD before this; readGpuVramMb falls back to this when the box has an AMD GPU) ---------------
+
+test('parseRocmVramUsed: single card sums used memory in MB', () => {
+  const memJson = JSON.stringify({
+    card0: { 'VRAM Total Memory (B)': '25753026560', 'VRAM Total Used Memory (B)': '1234567890' },
+  })
+  assert.equal(parseRocmVramUsed(memJson), 1235) // 1234567890 / 1e6, rounded
+})
+
+test('parseRocmVramUsed: multiple cards are summed, not just the first', () => {
+  const memJson = JSON.stringify({
+    card0: { 'VRAM Total Used Memory (B)': '1000000000' },
+    card1: { 'VRAM Total Used Memory (B)': '2000000000' },
+  })
+  assert.equal(parseRocmVramUsed(memJson), 3000) // (1e9 + 2e9) / 1e6
+})
+
+test('parseRocmVramUsed: a card missing the used-memory key contributes 0, not a throw', () => {
+  const memJson = JSON.stringify({
+    card0: { 'VRAM Total Used Memory (B)': '1000000000' },
+    card1: { 'Some Other Field': 'x' },
+  })
+  assert.equal(parseRocmVramUsed(memJson), 1000)
+})
+
+test('parseRocmVramUsed: zero used memory across every card → null (not 0)', () => {
+  const memJson = JSON.stringify({ card0: { 'VRAM Total Used Memory (B)': '0' } })
+  assert.equal(parseRocmVramUsed(memJson), null)
+})
+
+test('parseRocmVramUsed: malformed JSON → null, never throws', () => {
+  assert.equal(parseRocmVramUsed('not json'), null)
+  assert.equal(parseRocmVramUsed(''), null)
+})
+
+// ---- benchPromptTokens / buildBenchMessages: bench depth tracks the CONFIGURED ctx, uncapped
+// (ADR-217 round 2 — a shallow bench measured 26 tok/s while a real 22k-token conversation at the
+// same ctx measured 10 tok/s; the founder wants auto-tune to predict the second number) ----------
+
+test('benchPromptTokens: targets 75% of ctx, capped at 32k (ADR-217 round 3)', () => {
+  assert.equal(benchPromptTokens(8_192), 6_144) // under the cap — unaffected
+  assert.equal(benchPromptTokens(40_000), 30_000) // under the cap — unaffected
+  assert.equal(benchPromptTokens(200_000), 32_000) // 150k uncapped measured 3.2 tok/s — worse than real chat, not just slower
+  assert.equal(benchPromptTokens(1_000_000), 32_000) // cap holds regardless of how large ctx gets configured
+})
+
+test('benchPromptTokens: floors small ctx at 256', () => {
+  assert.equal(benchPromptTokens(100), 256)
+  assert.equal(benchPromptTokens(0), 256)
+})
+
+test('buildBenchMessages: small ctx needs no filler — system + the fixed question only', () => {
+  const messages = buildBenchMessages(256) // benchPromptTokens(256) floors to 256 tokens ≈ 1024 chars, under the system prompt's own length
+  assert.equal(messages[0].role, 'system')
+  assert.equal(messages[messages.length - 1].role, 'user')
+  assert.match(messages[messages.length - 1].content, /TCP and UDP/)
+})
+
+test('buildBenchMessages: large ctx pads with filler user/assistant pairs to reach depth', () => {
+  const shallow = buildBenchMessages(8_192)
+  const deep = buildBenchMessages(200_000)
+  assert.ok(deep.length > shallow.length, 'a deep target needs more filler turns than a shallow one')
+  const totalChars = (msgs: { content: string }[]) => msgs.reduce((n, m) => n + m.content.length, 0)
+  assert.ok(totalChars(deep) > totalChars(shallow))
+  // Every message role alternates user/assistant between the system prompt and the final question.
+  for (let i = 1; i < deep.length - 1; i++) {
+    assert.equal(deep[i].role, i % 2 === 1 ? 'user' : 'assistant')
+  }
+  assert.equal(deep[deep.length - 1].role, 'user')
+})
+
+test('buildBenchMessages: deterministic — same ctx always produces the identical message list', () => {
+  assert.deepEqual(buildBenchMessages(50_000), buildBenchMessages(50_000))
 })

--- a/turbollm/src/bench/bench.test.ts
+++ b/turbollm/src/bench/bench.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { pickKvQuants, betterBySpeed, decideKvToBench, parseRocmVramUsed, benchPromptTokens, buildBenchMessages } from './bench'
+import { pickKvQuants, betterBySpeed, kvSpeedAdvisory, parseRocmVramUsed, benchPromptTokens, buildBenchMessages } from './bench'
 
 // ---- pickKvQuants: quality-preserving KV sweep, base-first ------------------
 
@@ -64,34 +64,30 @@ test('betterBySpeed: null / zero handling', () => {
   assert.equal(betterBySpeed({ tps: null, prefillTps: null }, { tps: null, prefillTps: null }), false)
 })
 
-// ---- decideKvToBench: VRAM-reasoned KV pruning (the fast path) ---------------
+// ---- kvSpeedAdvisory: ADR-219 — auto-tune no longer picks the KV type, just notes when a
+// nominally-smaller one is available and the result is slow --------------------------------
 
-const TURBO = ['f16', 'q8_0', 'turbo4'] // TurboQuant fork
-const STOCK = ['f16', 'q8_0'] // official llama.cpp
-
-test('decideKvToBench: tiny KV swing → tune only the largest (f16), no sweep', () => {
-  assert.deepEqual(decideKvToBench(300, TURBO), ['f16'])
-  assert.deepEqual(decideKvToBench(1024, TURBO), ['f16']) // boundary is inclusive
-  assert.deepEqual(decideKvToBench(800, STOCK), ['f16'])
+test('kvSpeedAdvisory: fast result (>=20 tok/s) → no advisory even if a smaller type exists', () => {
+  assert.equal(kvSpeedAdvisory(25, 'turbo4', ['f16', 'q8_0', 'q4_0', 'turbo4']), null)
 })
 
-test('decideKvToBench: 35B (hybrid MoE, ~3 GB swing) → turbo4 + q8_0, picks q8_0 once measured', () => {
-  // The ~3 GB f16↔turbo4 swing puts us in the big-KV path; measurement then prefers q8_0.
-  assert.deepEqual(decideKvToBench(3186, TURBO), ['turbo4', 'q8_0'])
+test('kvSpeedAdvisory: slow result + a real nominally-smaller type available → advisory names it', () => {
+  const msg = kvSpeedAdvisory(10.4, 'turbo4', ['f16', 'q8_0', 'q4_0', 'turbo4'])
+  assert.ok(msg)
+  assert.match(msg, /turbo4/)
+  assert.match(msg, /q4_0/)
 })
 
-test('decideKvToBench: 27B / Gemma (huge KV) → turbo4 + q8_0 (measurement splits them)', () => {
-  assert.deepEqual(decideKvToBench(13000, TURBO), ['turbo4', 'q8_0'])
-  assert.deepEqual(decideKvToBench(Number.MAX_SAFE_INTEGER, TURBO), ['turbo4', 'q8_0'])
+test('kvSpeedAdvisory: slow result but already at the smallest available type → no advisory', () => {
+  assert.equal(kvSpeedAdvisory(5, 'q4_0', ['f16', 'q8_0', 'q4_0']), null)
 })
 
-test('decideKvToBench: un-sizable (spread < 0) is treated as big-KV, safely', () => {
-  assert.deepEqual(decideKvToBench(-1, TURBO), ['turbo4', 'q8_0'])
+test('kvSpeedAdvisory: unprobed engine (empty kvTypes) → no advisory, nothing to suggest', () => {
+  assert.equal(kvSpeedAdvisory(5, 'f16', []), null)
 })
 
-test('decideKvToBench: stock engine (no turbo) → just q8_0 in the big-KV regime', () => {
-  assert.deepEqual(decideKvToBench(5000, STOCK), ['q8_0'])
-  assert.deepEqual(decideKvToBench(-1, STOCK), ['q8_0'])
+test('kvSpeedAdvisory: null tps treated as 0 (slow) — still checks for a smaller type', () => {
+  assert.ok(kvSpeedAdvisory(null, 'f16', ['f16', 'q4_0']))
 })
 
 // ---- parseRocmVramUsed: AMD live VRAM reading (ADR-217 — the headroom gate was fully inert on

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -107,6 +107,10 @@ export interface BenchState {
     /** The subset of `sampling` that came from the HF card (ADR-099), when any was found —
      *  used to mark those rows "from model card". Absent when no card / nothing parsed. */
     recommendedSampling?: CardSampling
+    /** ADR-219: a note shown (not acted on) when the winner is under 20 tok/s and the engine
+     *  supports a smaller KV-cache type than the one tuned — surfaces that a faster, lower-
+     *  quality option exists without auto-tune silently picking it. Absent otherwise. */
+    kvAdvisory?: string
   }
 }
 
@@ -152,10 +156,6 @@ const QUALITY_KV = ['f16', 'q8_0', 'turbo4']
 // Output-t/s tie band for the speed objective: when two configs are within this relative margin
 // on generation speed, the one with faster prefill wins (best prefill AND t/s, not just t/s).
 const OUTPUT_TIE = 0.05
-// If swapping the KV-cache quant from largest (f16) to smallest changes VRAM by less than this, the
-// cache is small enough that the quant barely affects how much of the model fits on the GPU — so
-// the highest-precision, fastest-kernel type (f16) is the right pick and no quant sweep is needed.
-const KV_SPREAD_MIN = 1024
 // Bytes per cached element by KV-cache type — used only to order candidates by size (largest =
 // most VRAM, smallest = least) so calibration probes the two extremes. Mirrors llama.cpp's types.
 const KV_BYTES: Record<string, number> = {
@@ -218,6 +218,17 @@ export class BenchRunner {
     if (!this.state.running) return
     this.cancelled = true
     this.abort?.abort()
+  }
+
+  /** Stop the engine — force-killed immediately when the run is cancelled (the user is actively
+   *  waiting for it to stop, ADR-220), gracefully otherwise (lets llama-server release resources
+   *  cleanly between candidates during a normal run). Every stop in this file goes through this
+   *  one chokepoint instead of calling `manager.stopAndWait()` directly, so a cancel is fast
+   *  regardless of which code path notices it first. Previously every stop used the graceful
+   *  TERM→8s-then-kill path unconditionally, so cancelling could take up to 8s per in-flight
+   *  stop — a real, reported "Cancel doesn't cancel immediately" bug. */
+  private async stopEngine(): Promise<void> {
+    await this.manager.stopAndWait({ force: this.cancelled }).catch(() => {})
   }
 
   /** Persist the finished run's winning profile (the user clicked Save). Returns false if there is
@@ -295,7 +306,7 @@ export class BenchRunner {
       // The run is fully guarded internally; this is a last-resort net so a thrown
       // error never leaves `running` stuck true.
       this.state = { running: false, modelKey, done: true, error: e instanceof Error ? e.message : String(e), candidates: this.state.candidates }
-      void this.manager.stopAndWait().catch(() => {})
+      void this.stopEngine()
     })
   }
 
@@ -340,16 +351,13 @@ export class BenchRunner {
     const results: BenchCandidate[] = []
     let best: { cand: BenchCandidate; profile: LoadProfile } | null = null
 
-    // --- Choose which KV-cache type(s) to tune, by reasoning about VRAM (not by sweeping all) ---
-    // The quant only matters in proportion to how big the KV cache actually is. Measure that cheaply:
-    // the VRAM SPREAD between the largest and smallest candidate at one shared offload is exactly
-    // their KV-size difference (weights/overhead cancel) — true for any architecture, hybrid or not.
-    //   • tiny KV (spread ≤ KV_SPREAD_MIN) → the quant barely changes the fit, so the highest-
-    //     precision/fastest-kernel type (f16) wins outright → tune just that.
-    //   • big KV → a smaller quant frees real VRAM for more of the model on the GPU, but its kernel
-    //     can be slower (turbo4), so tune BOTH the smallest (max-fit) and q8_0 (stock fallback) and
-    //     let the measured prefill + t/s decide.
-    // --- Choose the multi-GPU SPLIT strategy too, not just offload+KV (ADR-054) ---
+    // --- Choose the multi-GPU SPLIT strategy (ADR-054) — the KV-cache TYPE is no longer swept
+    // here (ADR-219): auto-tune tunes offload (ngl/nCpuMoe) on whatever KV type the user already
+    // has selected, instead of silently choosing between f16/q8_0/turbo4 itself. Founder call
+    // after live-testing showed a lower-precision type (q4_0) measurably outperforming turbo4 on
+    // deep-context real chat — that's a genuine quality/speed tradeoff the user should make
+    // explicitly, not one auto-tune should pick for them. See the KV-cache speed advisory below
+    // instead, which surfaces the option without silently taking it.
     // llama.cpp's default is an even LAYER-split across every visible GPU. But a model that fits on
     // ONE card is almost always faster there: a layer-split runs the GPUs as a sequential pipeline
     // (one busy at a time) and copies activations across PCIe every token, so on a fits-on-one model
@@ -368,34 +376,16 @@ export class BenchRunner {
         this.emit(`split strategy → ${label}`)
       }
 
-      // Decide which KV quant(s) to tune UNDER THIS split: the VRAM budget differs (one card vs the
-      // summed pool), so single-GPU may need turbo4 to fit where a layer-split is fine at f16.
-      // Default to the user's own KV type (covers CPU-only — no VRAM pressure — and unprobed/single-
-      // candidate engines). Only with a GPU and a real choice do we size the cache and decide.
-      const kvCandidates = pickKvQuants(splitBase.kvTypeK, caps.kvTypes)
-      let kvToTune = kvCandidates.slice(0, 1)
-      if (sys.gpus.length > 0 && kvCandidates.length > 1) {
-        const spread = await this.calibrateKvSpread(entry, sys, splitBase, caps, kvCandidates, results)
-        kvToTune = decideKvToBench(spread, kvCandidates)
-        const swing = spread < 0 ? 'unknown' : spread >= Number.MAX_SAFE_INTEGER ? 'huge' : `${Math.round(spread)} MB`
-        this.state = { ...this.state, step: `KV cache swing ${swing} → tuning ${kvToTune.join(' + ')}`, candidates: results }
-        this.emit(`KV spread ${swing} → tuning ${kvToTune.join(' + ')}`)
-      }
-
-      for (let i = 0; i < kvToTune.length && !this.cancelled && Date.now() <= this.deadline; i++) {
-        const kv = kvToTune[i]
-        const kvBase: LoadProfile = { ...splitBase, kvTypeK: kv, kvTypeV: kv }
-        const found = entry.moe
-          ? await this.moeSearch(entry, sys, kvBase, caps, results, headroomMb)
-          : await this.denseSearch(entry, sys, kvBase, caps, results, headroomMb)
-        if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
-        if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
-      }
+      const found = entry.moe
+        ? await this.moeSearch(entry, sys, splitBase, caps, results, headroomMb)
+        : await this.denseSearch(entry, sys, splitBase, caps, results, headroomMb)
+      if (found && (!best || betterBySpeed(found.cand, best.cand))) best = found
+      if (best) this.state = { ...this.state, bestTps: best.cand.tps ?? undefined }
     }
 
     // Engine is always left stopped at the end of a run (AC#3 for cancel; also tidy
     // for a normal finish — the user explicitly loads afterward).
-    await this.manager.stopAndWait().catch(() => {})
+    await this.stopEngine()
 
     if (best) {
       // Card-derived recommended sampling (ADR-099): read the model author's recommended
@@ -408,7 +398,7 @@ export class BenchRunner {
       let recommended: CardSampling | undefined
       if (!this.cancelled && Date.now() <= this.deadline) {
         recommended = await this.extractCardSampling(entry, best.profile, caps, sys).catch(() => undefined)
-        await this.manager.stopAndWait().catch(() => {}) // in case the LLM fallback loaded a model
+        await this.stopEngine() // in case the LLM fallback loaded a model
       }
       // A cancel DURING extraction (the LLM fallback can run for minutes) must not resurrect the
       // results dialog or re-hold a profile the user just discarded: cancel() cleared winning +
@@ -421,6 +411,10 @@ export class BenchRunner {
         recommended && hasAnySampling(recommended)
           ? { ...best.profile, sampling: { ...best.profile.sampling, ...recommended } }
           : best.profile
+      // ADR-219: note (don't auto-switch) when a smaller, faster KV-cache type is available —
+      // auto-tune no longer picks the KV type itself, so a slow result deserves a pointer to the
+      // tradeoff rather than silence.
+      const kvAdvisory = kvSpeedAdvisory(best.cand.tps, profile.kvTypeK, caps.kvTypes)
       // Hold the winner instead of auto-saving — the UI shows a Save/Cancel results dialog and
       // persists via POST /bench/save only when the user clicks Save.
       this.winning = { modelKey, profile, cand: best.cand, entry, sys, engineVersion: active?.version ?? '', engineId: active?.id ?? '' }
@@ -445,6 +439,7 @@ export class BenchRunner {
             minP: profile.sampling.minP,
           },
           ...(recommended && hasAnySampling(recommended) ? { recommendedSampling: recommended } : {}),
+          ...(kvAdvisory ? { kvAdvisory } : {}),
         },
         candidates: results,
       }
@@ -572,51 +567,6 @@ export class BenchRunner {
     return found
   }
 
-  /** Measure how much the KV-cache QUANT swings VRAM at this context — so we tune only the quant(s)
-   *  that matter instead of sweeping all. Two cheap probes (largest vs smallest candidate) at ONE
-   *  shared offload: their VRAM difference is exactly the KV-size difference (weights + overhead are
-   *  identical at the same offload), valid for any architecture. Returns that swing in MB scaled to
-   *  the full model, `Number.MAX_SAFE_INTEGER` if even the largest quant won't load (cache enormous
-   *  → definitely the big-KV regime), or -1 if it couldn't be sized at all. */
-  private async calibrateKvSpread(
-    entry: ModelEntry,
-    sys: SysInfo,
-    base: LoadProfile,
-    caps: Engine['capabilities'],
-    candidates: string[],
-    results: BenchCandidate[],
-  ): Promise<number> {
-    const big = kvLargest(candidates)
-    const small = kvSmallest(candidates)
-    if (big === small) return 0
-
-    // A shared offload where the KV is resident on the GPU (so the swing is measurable) yet the
-    // model loads even with the LARGEST cache: MoE → all experts on CPU (attention + KV stay on
-    // GPU); dense → a small fraction of layers on GPU.
-    const blocks = entry.blockCount > 0 ? entry.blockCount : 32
-    const moeMax = entry.blockCount > 0 ? entry.blockCount : deriveDefault(entry, sys).nCpuMoe || 0
-    const refNgl = Math.max(1, Math.floor(blocks / 4))
-    const refOffload: Partial<LoadProfile> = entry.moe ? { nCpuMoe: moeMax, ngl: 99 } : { ngl: refNgl }
-    const knob: 'ngl' | 'nCpuMoe' = entry.moe ? 'nCpuMoe' : 'ngl'
-    const knobVal = entry.moe ? moeMax : refNgl
-
-    this.state = { ...this.state, step: `Sizing the KV cache (${big} vs ${small})…`, candidates: results }
-    const pBig = await this.probeVram(entry, sys, { ...base, kvTypeK: big, kvTypeV: big, ...refOffload }, caps)
-    this.pushProbe(results, { ...base, kvTypeK: big, ...refOffload }, knob, knobVal, pBig)
-    await this.settleGpu(sys)
-    const pSmall = await this.probeVram(entry, sys, { ...base, kvTypeK: small, kvTypeV: small, ...refOffload }, caps)
-    this.pushProbe(results, { ...base, kvTypeK: small, ...refOffload }, knob, knobVal, pSmall)
-    await this.settleGpu(sys)
-
-    if (pBig.outcome !== 'ok' || pBig.vramAbsMb === null) return Number.MAX_SAFE_INTEGER // huge cache
-    if (pSmall.outcome !== 'ok' || pSmall.vramAbsMb === null) return -1 // couldn't size it
-    let spread = pBig.vramAbsMb - pSmall.vramAbsMb
-    // Dense: only the GPU layers' KV is resident at refNgl, so scale the partial swing up to the
-    // whole model. (MoE keeps every attention layer's KV on GPU already → no scaling.)
-    if (!entry.moe) spread = spread * (blocks / refNgl)
-    return Math.max(0, spread)
-  }
-
   /** A cheap VRAM probe (Phase 1 of a search): load the candidate, wait for readiness — by which
    *  point the weights, the full KV cache, AND the compute buffers are all allocated — read the
    *  absolute GPU VRAM in use, then stop. NO prefill, NO generation. The offload param is decided
@@ -648,7 +598,7 @@ export class BenchRunner {
       await sleep(800) // let the allocator settle so the VRAM reading is final
       vramAbsMb = await readGpuVramMb(sys)
     }
-    await this.manager.stopAndWait().catch(() => {})
+    await this.stopEngine()
     return { outcome, vramAbsMb }
   }
 
@@ -757,13 +707,13 @@ export class BenchRunner {
     // Wait for ready / detect crash / OOM within the readiness window (and per-test cap).
     const outcome = await this.awaitReady(testDeadline)
     if (outcome !== 'ok') {
-      await this.manager.stopAndWait().catch(() => {})
+      await this.stopEngine()
       return fail(outcome)
     }
 
     const target = this.manager.target()
     if (!target) {
-      await this.manager.stopAndWait().catch(() => {})
+      await this.stopEngine()
       return fail('crash')
     }
     const logPath = this.manager.logPath()
@@ -778,13 +728,13 @@ export class BenchRunner {
     phase('warming up…')
     const warm = await this.prefillProbe(target, benchMessages, remaining(), logPath, stepPrefix)
     if (warm !== 'ok') {
-      await this.manager.stopAndWait().catch(() => {})
+      await this.stopEngine()
       return fail(warm.fault)
     }
     phase('measuring t/s…')
     const measured = await this.runChatWatched(target, benchMessages, 128, remaining(), logPath)
     const vramAfter = await readGpuVramMb(sys)
-    await this.manager.stopAndWait().catch(() => {})
+    await this.stopEngine()
 
     if ('fault' in measured) return fail(measured.fault)
     const vramMb = vramBefore !== null && vramAfter !== null ? Math.max(0, vramAfter - vramBefore) : vramAfter
@@ -1074,11 +1024,11 @@ export class BenchRunner {
     const ready = await this.awaitReady(Date.now() + READY_TIMEOUT_MS)
     const target = ready === 'ok' ? this.manager.target() : null
     if (!target) {
-      await this.manager.stopAndWait().catch(() => {})
+      await this.stopEngine()
       return undefined
     }
     const text = await this.chatText(target, buildCardExtractionPrompt(card), 200, 60_000).catch(() => null)
-    await this.manager.stopAndWait().catch(() => {})
+    await this.stopEngine()
     return text ? parseLlmSampling(text) : undefined
   }
 
@@ -1409,31 +1359,49 @@ export function betterBySpeed(
   return (a.prefillTps ?? 0) > (b.prefillTps ?? 0)
 }
 
-/** Bytes per cached element for a KV-cache type (defaults to f16's 2 for unknown types). */
+/** Bytes per cached element for a KV-cache type (defaults to f16's 2 for unknown types). Note:
+ *  this is a nominal/declared size, not a measured one — ADR-219 found turbo4's REAL VRAM and
+ *  compute cost is higher than its 0.5-bytes-per-element entry here implies (it runs a Walsh-
+ *  Hadamard rotation + InnerQ calibration per cached token, plus extra rotation-tensor VRAM, none
+ *  of which this table accounts for) — treat comparisons using this table as directional only. */
 function kvBytes(t: string): number {
   return KV_BYTES[t] ?? 2
 }
-/** The largest / smallest KV-cache type in a candidate set (by bytes per element). */
-function kvLargest(c: string[]): string {
-  return c.reduce((a, b) => (kvBytes(b) > kvBytes(a) ? b : a), c[0])
-}
+/** The smallest KV-cache type in a candidate set (by nominal bytes per element). */
 function kvSmallest(c: string[]): string {
   return c.reduce((a, b) => (kvBytes(b) < kvBytes(a) ? b : a), c[0])
 }
 
-/** Decide which quality-preserving KV-cache type(s) to actually tune, from the measured VRAM swing
- *  (see {@link calibrateKvSpread}). Tiny swing → the cache is small, so the quant barely changes
- *  the fit and the highest-precision/fastest-kernel type (f16) wins → tune only it. Big (or
- *  un-sizable, spread < 0) swing → the smallest type frees real VRAM for more of the model on the
- *  GPU, but its kernel can be slower (turbo4), so tune BOTH the smallest and the q8_0 stock fallback
- *  and let the measured prefill + t/s pick the winner. */
-export function decideKvToBench(spreadMb: number, candidates: string[]): string[] {
-  const has = (t: string) => candidates.includes(t)
-  const largest = kvLargest(candidates)
-  if (spreadMb >= 0 && spreadMb <= KV_SPREAD_MIN) return [largest]
-  const smallest = has('turbo4') ? 'turbo4' : kvSmallest(candidates)
-  const stock = has('q8_0') ? 'q8_0' : largest
-  return [...new Set([smallest, stock])]
+/** TurboQuant's rotation-based KV types (ADR-219). Confirmed from the fork's own source
+ *  (turbo-wht.cu/.cuh, InnerQ calibration state, "+3 rotation tensor overhead" in its merge
+ *  notes): these run a Walsh-Hadamard rotation + variance-equalizing calibration on every cached
+ *  token, plus real extra rotation-tensor VRAM — none of which `KV_BYTES`'s nominal bytes-per-
+ *  element accounts for. That's WHY turbo4 and q4_0 show the identical "0.5" in `KV_BYTES` (both
+ *  nominally 4-bit) yet turbo4 measured meaningfully slower and higher-VRAM in real testing: the
+ *  table only captures the raw quantized size, not this extra cost. It's a deliberate trade for
+ *  better quality at low bit-widths (the fork's own notes: "turbo4/turbo3 match f16 quality"),
+ *  not a bug — see {@link kvSpeedAdvisory}. */
+const TURBO_KV_TYPES = new Set(['turbo2', 'turbo3', 'turbo4'])
+
+/** ADR-219: auto-tune no longer sweeps KV-cache type — it tunes offload on whatever type the user
+ *  already selected, since the quality/speed tradeoff (confirmed real via ADR-217/219's live
+ *  testing: turbo4 vs. q4_0 on the same offload, then root-caused in TurboQuant's own source — see
+ *  {@link TURBO_KV_TYPES}) belongs to the user, not a silent auto-pick. This surfaces that tradeoff
+ *  instead of hiding it: when the winner is slow (<20 tok/s), find the smallest available type that
+ *  is NOT a turbo type (whose real cost `KV_BYTES` understates) and no bigger, nominally, than the
+ *  one tuned — note it without switching anything. A same-size non-turbo alternative still counts
+ *  (that's exactly the turbo4-vs-q4_0 case that motivated this), which a plain "strictly smaller
+ *  bytes" comparison would miss. Null when already fast enough, no such alternative exists, or the
+ *  engine wasn't probed. `20` is a blunt heuristic, not a guarantee. */
+export function kvSpeedAdvisory(tps: number | null, currentKv: string, supportedKvTypes: string[]): string | null {
+  if ((tps ?? 0) >= 20 || supportedKvTypes.length === 0) return null
+  const isTurbo = TURBO_KV_TYPES.has(currentKv)
+  const candidates = supportedKvTypes.filter(
+    (t) => t !== currentKv && kvBytes(t) <= kvBytes(currentKv) && (!isTurbo || !TURBO_KV_TYPES.has(t)),
+  )
+  if (candidates.length === 0) return null
+  const smallest = kvSmallest(candidates)
+  return `This result used the "${currentKv}" KV cache type. A different type (e.g. "${smallest}") may run faster, at some output-quality cost — try it manually if you want the extra speed.`
 }
 
 /** Best-effort current NVIDIA VRAM use in MB (sum across GPUs). Null on non-NVIDIA

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -680,8 +680,9 @@ export class BenchRunner {
     const active = this.registry.active()
     if (!active) return fail('crash')
 
-    // Per-test cap (3 min): the whole trial — load + warmup + measured request — must finish
-    // within this, else it's recorded 'timeout' and the sweep continues. Also bounded by the
+    // Per-test cap (PER_TEST_TIMEOUT_MS, 10 min — raised from 3 for deep-ctx trials, ADR-217
+    // round 2): the whole trial — load + warmup + measured request — must finish within this,
+    // else it's recorded 'timeout' and the sweep continues. Also bounded by the
     // global deadline so a near-budget start can't overrun.
     const testDeadline = Math.min(Date.now() + PER_TEST_TIMEOUT_MS, this.deadline)
     const remaining = () => Math.max(1_000, testDeadline - Date.now())
@@ -1395,10 +1396,15 @@ const TURBO_KV_TYPES = new Set(['turbo2', 'turbo3', 'turbo4'])
  *  engine wasn't probed. `20` is a blunt heuristic, not a guarantee. */
 export function kvSpeedAdvisory(tps: number | null, currentKv: string, supportedKvTypes: string[]): string | null {
   if ((tps ?? 0) >= 20 || supportedKvTypes.length === 0) return null
-  const isTurbo = TURBO_KV_TYPES.has(currentKv)
-  const candidates = supportedKvTypes.filter(
-    (t) => t !== currentKv && kvBytes(t) <= kvBytes(currentKv) && (!isTurbo || !TURBO_KV_TYPES.has(t)),
-  )
+  // Turbo types are ALWAYS excluded from the recommendation candidates, regardless of whether
+  // `currentKv` itself is turbo — they're exactly the types whose real cost KV_BYTES understates
+  // (ADR-219/220), so they can never be the "faster, standard" alternative this advisory offers.
+  // A prior version of this filter incorrectly gated the exclusion on `TURBO_KV_TYPES.has(currentKv)`,
+  // which — because `(!isTurbo || ...)` short-circuits true whenever isTurbo is false — meant the
+  // exclusion silently did nothing for the common case (a non-turbo current type), letting the
+  // smallest-nominal-size turbo type (turbo2, 0.25 bytes) win every time. Caught in independent
+  // review before merge (ADR-222) — see the regression test covering exactly this combination.
+  const candidates = supportedKvTypes.filter((t) => t !== currentKv && kvBytes(t) <= kvBytes(currentKv) && !TURBO_KV_TYPES.has(t))
   if (candidates.length === 0) return null
   const smallest = kvSmallest(candidates)
   return `This result used the "${currentKv}" KV cache type. A different type (e.g. "${smallest}") may run faster, at some output-quality cost — try it manually if you want the extra speed.`

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -117,20 +117,25 @@ export interface BenchState {
 const READY_TIMEOUT_MS = 150_000
 // Per-candidate cap: load + warmup + the measured request must all finish within this window,
 // else the candidate is recorded 'timeout' and the sweep moves on — one hung config can't stall
-// the run.
-const PER_TEST_TIMEOUT_MS = 3 * 60_000
+// the run. Raised from 3 to 10 minutes (ADR-217 round 2): the bench prompt now targets depth near
+// the CONFIGURED ctx (see benchPromptTokens) instead of an 8k cap, so a deep-ctx candidate does
+// TWO full prefills at that depth (the warmup prefill-gate, then the measured request re-processes
+// from scratch on purpose — see the `cache_prompt: false` comment in `chat`) — 10 min covers that
+// at realistic prefill speeds with margin; the existing prefill-overrun projection in
+// `prefillProbe` still fails a genuinely-too-slow config fast rather than waiting out the cap.
+const PER_TEST_TIMEOUT_MS = 10 * 60_000
 // Grace before judging prefill speed — give the first tokens time to flow before projecting.
 const PREFILL_GRACE_MS = 8_000
 // Overall budget — sized to fit a full binary search of per-test-capped trials (~log2(layers)).
-const TOTAL_BUDGET_MS = 20 * 60_000
+// Raised from 20 to 45 minutes alongside PER_TEST_TIMEOUT_MS (ADR-217 round 2) — deep-ctx bench
+// trials are slower by design now, and a run can measure 2+ KV types plus a headroom-backoff
+// retry, each up to PER_TEST_TIMEOUT_MS.
+const TOTAL_BUDGET_MS = 45 * 60_000
 // Memory-pressure / GPU-exhaustion signatures. Beyond a clean "out of memory", a config that
 // overflows VRAM often surfaces a secondary CUDA fault (failed allocation, or "device not ready"
 // during graph capture once the allocation failed). Treat all of these as OOM so the search
 // offloads more and the result reads as a fit problem rather than a mystery crash.
 const OOM_RE = /out of memory|cudaMalloc|failed to allocate|unable to allocate|device not ready|CUDA error/i
-
-// English text is roughly 4 characters per token — used to size the bench prompt.
-const CHARS_PER_TOKEN = 4
 
 // Auto-tune may also sweep the KV-cache quant — but only ever SELECTS a quality-preserving type:
 // full-precision f16, near-lossless q8_0, and (on TurboQuant forks) turbo4 (≈ q8_0 quality). This
@@ -477,12 +482,14 @@ export class BenchRunner {
     if (base.nglFit) return this.benchAt(entry, sys, base, caps, results, 'auto-fit')
 
     let bestNgl: number | null = 0 // CPU-only box → everything on CPU, no probing needed.
+    // The VRAM this split is allowed to use: all cards for a layer/row split, ONE card for a
+    // single-GPU 'none' split (ADR-054). The headroom gate must judge against THIS, not the summed
+    // pool — else a 14 GB single-GPU load looks safe against a 30 GB total when it's at one card's
+    // edge. Computed unconditionally (0 on a CPU-only box) so the Phase-2 re-check below can reuse
+    // it too (ADR-217) — `overHeadroom` treats a ≤0 budget as "never over".
+    const budgetMb = gpuBudgetMb(sys, base)
 
     if (sys.gpus.length > 0) {
-      // The VRAM this split is allowed to use: all cards for a layer/row split, ONE card for a
-      // single-GPU 'none' split (ADR-054). The headroom gate must judge against THIS, not the summed
-      // pool — else a 14 GB single-GPU load looks safe against a 30 GB total when it's at one card's edge.
-      const budgetMb = gpuBudgetMb(sys, base)
       // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with enough headroom VRAM.
       const hi0 = entry.blockCount > 0 ? entry.blockCount : 99
       let lo = 0, hi = hi0
@@ -492,7 +499,7 @@ export class BenchRunner {
         this.state = { ...this.state, step: `KV ${base.kvTypeK}: probing ngl=${mid} (range ${lo}–${hi})…`, candidates: results }
         const probe = await this.probeVram(entry, sys, { ...base, ngl: mid }, caps)
         this.pushProbe(results, base, 'ngl', mid, probe)
-        await this.settleGpu()
+        await this.settleGpu(sys)
         if (probe.outcome === 'ok' && !overHeadroom(probe.vramAbsMb, budgetMb, headroomMb)) {
           bestNgl = mid // fits with headroom → record, try MORE GPU layers
           lo = mid + 1
@@ -503,7 +510,16 @@ export class BenchRunner {
     }
 
     if (bestNgl === null) return null
-    return this.benchAt(entry, sys, { ...base, ngl: bestNgl }, caps, results, `ngl=${bestNgl}`)
+    let found = await this.benchAt(entry, sys, { ...base, ngl: bestNgl }, caps, results, `ngl=${bestNgl}`)
+    // Phase 2 (the actual timed run) can allocate more VRAM than Phase 1's load-only probe did
+    // (lazy cuBLAS/graph-capture scratch buffers) — re-validate against the REAL post-generation
+    // VRAM and back off one layer if it silently blew through the user's headroom (ADR-217).
+    if (found && overHeadroom(found.cand.vramAbsMb, budgetMb, headroomMb) && bestNgl > 0) {
+      this.emit(`ngl=${bestNgl} exceeded headroom after generation (${found.cand.vramAbsMb} MB) — retrying at ngl=${bestNgl - 1}`)
+      const safer = await this.benchAt(entry, sys, { ...base, ngl: bestNgl - 1 }, caps, results, `ngl=${bestNgl - 1} (headroom backoff)`)
+      if (safer) found = safer
+    }
+    return found
   }
 
   /** MoE models: pin `nCpuMoe` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
@@ -533,7 +549,7 @@ export class BenchRunner {
       this.state = { ...this.state, step: `KV ${base.kvTypeK}: probing nCpuMoe=${mid} (range ${lo}–${hi})…`, candidates: results }
       const probe = await this.probeVram(entry, sys, { ...base, nCpuMoe: mid }, caps)
       this.pushProbe(results, base, 'nCpuMoe', mid, probe)
-      await this.settleGpu()
+      await this.settleGpu(sys)
       if (probe.outcome === 'oom' || overHeadroom(probe.vramAbsMb, budgetMb, headroomMb)) {
         lo = mid + 1 // too much on GPU → more CPU experts to free VRAM / restore the headroom
       } else if (probe.outcome === 'ok') {
@@ -545,7 +561,15 @@ export class BenchRunner {
     }
 
     if (bestN === null) return null
-    return this.benchAt(entry, sys, { ...base, nCpuMoe: bestN }, caps, results, `nCpuMoe=${bestN}`)
+    let found = await this.benchAt(entry, sys, { ...base, nCpuMoe: bestN }, caps, results, `nCpuMoe=${bestN}`)
+    // Same Phase-1-vs-Phase-2 VRAM gap as denseSearch — back off (more CPU experts, less VRAM) one
+    // step if the real measured run blew through headroom (ADR-217).
+    if (found && overHeadroom(found.cand.vramAbsMb, budgetMb, headroomMb) && bestN < maxN) {
+      this.emit(`nCpuMoe=${bestN} exceeded headroom after generation (${found.cand.vramAbsMb} MB) — retrying at nCpuMoe=${bestN + 1}`)
+      const safer = await this.benchAt(entry, sys, { ...base, nCpuMoe: bestN + 1 }, caps, results, `nCpuMoe=${bestN + 1} (headroom backoff)`)
+      if (safer) found = safer
+    }
+    return found
   }
 
   /** Measure how much the KV-cache QUANT swings VRAM at this context — so we tune only the quant(s)
@@ -579,10 +603,10 @@ export class BenchRunner {
     this.state = { ...this.state, step: `Sizing the KV cache (${big} vs ${small})…`, candidates: results }
     const pBig = await this.probeVram(entry, sys, { ...base, kvTypeK: big, kvTypeV: big, ...refOffload }, caps)
     this.pushProbe(results, { ...base, kvTypeK: big, ...refOffload }, knob, knobVal, pBig)
-    await this.settleGpu()
+    await this.settleGpu(sys)
     const pSmall = await this.probeVram(entry, sys, { ...base, kvTypeK: small, kvTypeV: small, ...refOffload }, caps)
     this.pushProbe(results, { ...base, kvTypeK: small, ...refOffload }, knob, knobVal, pSmall)
-    await this.settleGpu()
+    await this.settleGpu(sys)
 
     if (pBig.outcome !== 'ok' || pBig.vramAbsMb === null) return Number.MAX_SAFE_INTEGER // huge cache
     if (pSmall.outcome !== 'ok' || pSmall.vramAbsMb === null) return -1 // couldn't size it
@@ -622,7 +646,7 @@ export class BenchRunner {
     let vramAbsMb: number | null = null
     if (outcome === 'ok') {
       await sleep(800) // let the allocator settle so the VRAM reading is final
-      vramAbsMb = await readNvidiaVramMb()
+      vramAbsMb = await readGpuVramMb(sys)
     }
     await this.manager.stopAndWait().catch(() => {})
     return { outcome, vramAbsMb }
@@ -674,7 +698,7 @@ export class BenchRunner {
     results.push(cand)
     this.emit(`bench ${label} → ${cand.outcome}${cand.tps != null ? ` (${cand.tps.toFixed(1)} tok/s)` : ''}`, cand)
     this.state = { ...this.state, candidates: results, bestTps: cand.tps ?? this.state.bestTps }
-    await this.settleGpu()
+    await this.settleGpu(sys)
     return cand.outcome === 'ok' && cand.tps !== null ? { cand, profile } : null
   }
 
@@ -722,7 +746,7 @@ export class BenchRunner {
       extraArgs: profileToArgs(profile, entry, caps, sys.cores),
     }
 
-    const vramBefore = await readNvidiaVramMb()
+    const vramBefore = await readGpuVramMb(sys)
     phase('loading model…')
     try {
       await this.manager.start(opts)
@@ -744,21 +768,22 @@ export class BenchRunner {
     }
     const logPath = this.manager.logPath()
 
-    // Bench prompt = 75% of the configured ctx, capped at 8k (see benchPromptTokens).
-    const promptContent = makeBenchContent(benchPromptTokens(profile.ctx))
+    // Bench request sized to this profile's configured ctx (ADR-217 round 2) — see
+    // buildBenchMessages for why depth matters here.
+    const benchMessages = buildBenchMessages(profile.ctx)
 
     // Prefill gate (doubles as warmup): stream the prompt and fail fast if it's spilling/crawling
     // or the engine faults — so a config that doesn't fit at this ctx is rejected in seconds and the
     // search offloads more, instead of hanging out the whole per-test budget.
     phase('warming up…')
-    const warm = await this.prefillProbe(target, promptContent, remaining(), logPath, stepPrefix)
+    const warm = await this.prefillProbe(target, benchMessages, remaining(), logPath, stepPrefix)
     if (warm !== 'ok') {
       await this.manager.stopAndWait().catch(() => {})
       return fail(warm.fault)
     }
     phase('measuring t/s…')
-    const measured = await this.runChatWatched(target, promptContent, 128, remaining(), logPath)
-    const vramAfter = await readNvidiaVramMb()
+    const measured = await this.runChatWatched(target, benchMessages, 128, remaining(), logPath)
+    const vramAfter = await readGpuVramMb(sys)
     await this.manager.stopAndWait().catch(() => {})
 
     if ('fault' in measured) return fail(measured.fault)
@@ -796,13 +821,13 @@ export class BenchRunner {
    *  in a "device not ready" state that otherwise cascades into every following trial failing — the
    *  cause of spurious "no candidate found" on large models. Returns fast when VRAM is already low
    *  (the normal success case). Best-effort; never throws. */
-  private async settleGpu(): Promise<void> {
+  private async settleGpu(sys: SysInfo): Promise<void> {
     await sleep(1500) // base: let the killed engine process release + the driver settle
-    let prev = await readNvidiaVramMb()
-    if (prev === null) return // non-NVIDIA / no nvidia-smi: the fixed wait is all we can do
+    let prev = await readGpuVramMb(sys)
+    if (prev === null) return // no live VRAM reader for this vendor: the fixed wait is all we can do
     for (let i = 0; i < 12 && !this.cancelled; i++) {
       await sleep(1000)
-      const cur = await readNvidiaVramMb()
+      const cur = await readGpuVramMb(sys)
       if (cur === null || cur >= prev - 64) return // released / stabilized (no further drop)
       prev = cur
     }
@@ -814,7 +839,7 @@ export class BenchRunner {
    *  result is classified accordingly. Returns the timing, or a `fault` outcome. */
   private async runChatWatched(
     target: string,
-    content: string,
+    messages: BenchMessage[],
     maxTokens: number,
     budgetMs: number,
     logPath: string,
@@ -838,7 +863,7 @@ export class BenchRunner {
 
     let timed: { tps: number; prefillTps: number | null; ttftMs: number } | null = null
     try {
-      timed = await this.chat(target, content, maxTokens, budgetMs, probe.signal)
+      timed = await this.chat(target, messages, maxTokens, budgetMs, probe.signal)
     } catch {
       timed = null
     } finally {
@@ -858,7 +883,7 @@ export class BenchRunner {
    *  the warm prompt cache makes the following measured request fast and accurate. */
   private async prefillProbe(
     target: string,
-    content: string,
+    messages: BenchMessage[],
     budgetMs: number,
     logPath: string,
     stepPrefix: string,
@@ -886,7 +911,7 @@ export class BenchRunner {
       const res = await fetch(`${target}/v1/chat/completions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: 'bench', messages: [{ role: 'user', content }], max_tokens: 8, temperature: 0, seed: 42, stream: true, return_progress: true }),
+        body: JSON.stringify({ model: 'bench', messages, max_tokens: 8, temperature: 0, seed: 42, stream: true, return_progress: true }),
         signal: AbortSignal.any(signals),
       })
       if (!res.ok || !res.body) throw new Error('no stream')
@@ -935,7 +960,7 @@ export class BenchRunner {
 
   /** One non-streaming /v1/chat/completions request. Returns engine-reported tps + ttftMs, or null.
    *  Aborts on the per-test timeout, the cancel kill-switch, or `extraSignal` (the fault watchdog). */
-  private async chat(target: string, content: string, maxTokens: number, timeoutMs: number, extraSignal?: AbortSignal): Promise<{ tps: number; prefillTps: number | null; ttftMs: number } | null> {
+  private async chat(target: string, messages: BenchMessage[], maxTokens: number, timeoutMs: number, extraSignal?: AbortSignal): Promise<{ tps: number; prefillTps: number | null; ttftMs: number } | null> {
     const signals: AbortSignal[] = [AbortSignal.timeout(timeoutMs)]
     if (this.abort) signals.push(this.abort.signal)
     if (extraSignal) signals.push(extraSignal)
@@ -944,7 +969,7 @@ export class BenchRunner {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         model: 'bench',
-        messages: [{ role: 'user', content }],
+        messages,
         max_tokens: maxTokens,
         temperature: 0,
         seed: 42,
@@ -1158,32 +1183,143 @@ export class BenchRunner {
 
 // ---- helpers ----------------------------------------------------------------
 
-/** Filler text for the bench prompt — varied enough to avoid tokenizer-dedup tricks. */
-const BENCH_BASE =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ' +
-  'incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ' +
-  'exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure ' +
-  'dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. ' +
-  'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt ' +
-  'mollit anim id est laborum. '
-
-/** Build a bench prompt of approximately `targetTokens` tokens by repeating BENCH_BASE.
- *  Uses a 4-chars-per-token estimate — close enough for English lorem text. */
-function makeBenchContent(targetTokens: number): string {
-  const targetChars = Math.max(BENCH_BASE.length, targetTokens * CHARS_PER_TOKEN)
-  const reps = Math.ceil(targetChars / BENCH_BASE.length)
-  return BENCH_BASE.repeat(reps).slice(0, targetChars) + '\n\nSummarize the passage above in one sentence.'
+/** A chat message for the bench request — mirrors the wire shape `/v1/chat/completions` expects. */
+export interface BenchMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string
 }
 
-/** How many prompt tokens to use for a bench trial: 75% of the configured context, capped at 8k.
- *  The cap matters for BOTH speed and accuracy. Speed: a huge model at 200K would otherwise spend
- *  the whole trial prefilling tens of thousands of tokens. Accuracy: generation t/s falls with how
- *  deep the context is, and a very deep measurement reflects a worst case, not typical use — an 8k
- *  context is representative of normal prompts and makes the per-token attention cost (which is
- *  where a low-bit KV's slower kernel shows up) realistic rather than exaggerated. KV/VRAM is
- *  allocated for the full ctx at load regardless, so this only sizes the speed measurement. */
-function benchPromptTokens(ctx: number): number {
-  return Math.max(256, Math.min(8_192, Math.floor(ctx * 0.75)))
+/** Bench system prompt: the "Default" agent's REAL injected prompt (ADR-217) — mirrors
+ *  `web/src/lib/personas.ts`'s `TURBOLLM_BASE_CAPABILITY` + `TURBOLLM_ARTIFACTS_CAPABILITY` +
+ *  date line verbatim (Default carries no persona text of its own, and a bench run has no
+ *  personalization/memory facts to inject). No shared module exists between `web/` and `src/`
+ *  (separate build targets), so this is kept in sync with personas.ts BY HAND — if one changes,
+ *  update the other. Using the real system prompt (instead of synthetic filler) means the bench
+ *  request's prefill shape matches what a real first chat message actually sends. */
+const BENCH_SYSTEM_PROMPT = `You are running inside TurboLLM, a local-first AI chat app. You can render text-based charts and graphics using Unicode characters. Use them when a visual would genuinely make the response clearer — not by default.
+
+A chart is appropriate when:
+- Comparing 3+ items by a numeric metric (rankings, benchmarks, budgets)
+- Showing a trend, distribution, or progression over time or stages
+- Presenting a hierarchy or dependency tree
+- The user asks about data that has a clear pattern hard to read in prose
+
+A chart is NOT appropriate for:
+- Conversational replies, opinions, or explanations
+- Data with only 1–2 values (just state the numbers inline)
+- Lists that are purely qualitative (no meaningful numeric comparison)
+
+When a chart is warranted:
+- Bar / column charts: use block fill characters █ ▓ ▒ ░ with a numeric scale and axis labels
+- Tables: use box-drawing characters ┌ ─ ┐ │ └ ┘ ├ ┤ ┬ ┴ ┼ for clean borders; align columns
+- Line / trend: sketch with · ╌ ╍ ╱ ╲ characters; mark key points with ●
+- Tree / hierarchy: use └─ ├─ │ connectors
+- Progress / gauge: [████████░░] style with a percentage
+
+Always include a title, axis/column labels, and the underlying numbers. Keep charts compact — no wider than ~60 characters. Wrap chart output in a plain code block (\`\`\`) so spacing is preserved.
+
+TurboLLM also live-previews three kinds of fenced code block, so you can return RENDERED visuals, not just text. When the user wants something visual or interactive, reply with ONE self-contained fenced block in the right language:
+
+- \`\`\`mermaid — diagrams: flowcharts, sequence/class/ER/state diagrams, gantt, mind maps, pie charts. Reach for this on "diagram", "flowchart", "flow", "architecture", "sequence", "how X works" (visually), "org chart", "timeline".
+- \`\`\`svg — static vector graphics: icons, logos, illustrations, simple scenes, or charts you draw by hand (bar/line/scatter). Reach for this on "draw", "icon", "logo", "illustration", "graphic".
+- \`\`\`html — interactive or animated results: a web page, UI mockup, form, canvas animation, game, calculator — anything needing live CSS/JS. Must be fully self-contained: inline CSS/JS only, NO external URLs, scripts, fonts, images, or network calls (they are blocked).
+
+When to use them:
+- ONLY when a rendered visual or runnable result is genuinely what the user asked for. Pick the simplest type that satisfies it — a flowchart is mermaid, not html; an icon is svg, not html.
+- Put any explanation BEFORE or AFTER the block, never inside it. At most one artifact per response.
+
+Keep the syntax valid (a diagram that fails to parse is worse than a simpler one that renders):
+- mermaid: prefer simple flowcharts/graphs. Wrap any node or message label that contains spaces, parentheses, slashes, or punctuation in double quotes. In sequence diagrams, do NOT use activate/deactivate unless every activate has a matching deactivate — when in doubt, leave them out.
+- svg/html: self-contained only — no external URLs, CDNs, fonts, or images.
+
+When NOT to use them (important — do not over-render):
+- Plain questions, opinions, explanations, or conversation → normal prose.
+- Code meant to be read, copied, or used in a project (a function, a script, a config) → a normal code block in its real language, NOT an artifact. Wrapping ordinary code in html/svg/mermaid is wrong.
+- A 1–2 number comparison → just say the numbers. Small text tables/sparklines → the Unicode style above.
+
+Today's date is ${new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}.`
+
+/** Fixed bench question (ADR-217) — one realistic, medium-length technical question, held
+ *  constant across every bench run so results stay comparable run-to-run. Deterministic sampling
+ *  (`temperature: 0`, `seed: 42` in {@link BenchRunner.chat}) means the same question always
+ *  measures the same thing. Always the LAST message — see {@link buildBenchMessages}. */
+const BENCH_QUESTION = 'Explain the main differences between TCP and UDP, and give a couple of real-world scenarios where each one is the better choice.'
+
+// English text is roughly 4 characters per token — used only to size how much filler content
+// {@link buildBenchMessages} needs to add to reach the target depth; the real prefill then reports
+// the real token count.
+const CHARS_PER_TOKEN = 4
+
+// Fraction of the configured ctx the bench prompt targets, before the depth cap below — see
+// {@link benchPromptTokens}.
+const BENCH_CTX_FRACTION = 0.75
+// Depth cap (ADR-217 round 3): a founder live test at the UNCAPPED 150k depth (0.75 × their
+// 200k ctx) measured 3.2 tok/s (127s just for first token) — MORE pessimistic than their real
+// ~11 tok/s chat experience, not just slower to bench. A mid-depth test at 22k tokens measured
+// 10.4 tok/s, matching real chat almost exactly. So depth beyond ~20-30k tokens isn't just
+// expensive to bench, it's actively LESS representative of typical real usage — real
+// conversations rarely sustain tens of thousands of tokens of *dense* back-and-forth before a
+// user would have started a fresh chat or the context reset. 32k is the founder-directed cap:
+// deep enough to capture the real depth-dependent slowdown (validated: 22k already tracked real
+// chat within ~5%), capped low enough that bench time stays close to the original ~8k-depth
+// runtime instead of scaling unboundedly with ctx.
+const BENCH_MAX_PROMPT_TOKENS = 32_000
+
+/** How many prompt tokens the bench trial should target: {@link BENCH_CTX_FRACTION} of the
+ *  configured context, capped at {@link BENCH_MAX_PROMPT_TOKENS} (ADR-217 round 3 — see that
+ *  constant's comment for why the cap is correctness, not just speed). Floored at 256 so a tiny
+ *  ctx still gets a minimally-realistic bench. */
+export function benchPromptTokens(ctx: number): number {
+  return Math.max(256, Math.min(BENCH_MAX_PROMPT_TOKENS, Math.floor(ctx * BENCH_CTX_FRACTION)))
+}
+
+/** Deterministic filler topics used to pad the bench prompt out toward the target depth (ADR-217
+ *  round 2) — realistic technical prose, not Lorem-ipsum repetition, so the attention pattern isn't
+ *  degenerate. Cycled in a fixed order (never random / never Date/Math.random-seeded) so a bench
+ *  run stays exactly reproducible. */
+const FILLER_TOPICS = [
+  'the history and evolution of relational databases, from IBM System R through modern distributed SQL engines',
+  'how modern CPUs use branch prediction and speculative execution to hide pipeline stalls',
+  'the tradeoffs between microservices and monolithic architectures for a mid-sized SaaS company',
+  'how TCP congestion control algorithms like Reno, Cubic, and BBR differ in their approach to bandwidth estimation',
+  "the design philosophy behind Rust's ownership and borrowing system compared to garbage collection",
+  'how content delivery networks use anycast routing and edge caching to reduce latency',
+  'the tradeoffs between REST, GraphQL, and gRPC for building internal service APIs',
+  'how modern GPUs pipeline shader execution across thousands of parallel cores',
+]
+
+/** One filler assistant answer for {@link FILLER_TOPICS}. `round` distinguishes repeated cycles
+ *  through the topic list (needed once the target depth exceeds one pass) so the prompt isn't
+ *  made of byte-identical repeated blocks. */
+function fillerAnswer(topic: string, round: number): string {
+  const sentences: string[] = []
+  for (let i = 0; i < 40; i++) {
+    sentences.push(
+      `Regarding ${topic} (pass ${round}, point ${i + 1}), the underlying tradeoffs depend heavily on the specific ` +
+        'workload, the scale of the system, and the operational constraints the team is working under, which is ' +
+        'why experienced engineers tend to reach for established patterns before inventing something bespoke.',
+    )
+  }
+  return sentences.join(' ')
+}
+
+/** Build the bench request for `ctx`: the real Default-agent system prompt, deterministic
+ *  realistic filler exchanges padded out to ~{@link benchPromptTokens}(ctx) tokens (ADR-217 round
+ *  2 — matches the depth a real, substantially-filled conversation reaches at this ctx), then the
+ *  fixed {@link BENCH_QUESTION} as the final turn so every run asks the identical last question. */
+export function buildBenchMessages(ctx: number): BenchMessage[] {
+  const targetChars = benchPromptTokens(ctx) * CHARS_PER_TOKEN
+  const messages: BenchMessage[] = [{ role: 'system', content: BENCH_SYSTEM_PROMPT }]
+  let chars = BENCH_SYSTEM_PROMPT.length
+  for (let round = 0; chars < targetChars; round++) {
+    const topic = FILLER_TOPICS[round % FILLER_TOPICS.length]
+    const q = `Can you explain ${topic}?`
+    const a = fillerAnswer(topic, Math.floor(round / FILLER_TOPICS.length) + 1)
+    messages.push({ role: 'user', content: q }, { role: 'assistant', content: a })
+    chars += q.length + a.length
+  }
+  messages.push({ role: 'user', content: BENCH_QUESTION })
+  return messages
 }
 
 /** True when a candidate's ABSOLUTE VRAM use leaves less than `headroomMb` free within `budgetMb`
@@ -1324,6 +1460,55 @@ function readNvidiaVramMb(): Promise<number | null> {
       resolve(null)
     }
   })
+}
+
+/** Pure parser for `rocm-smi --showmeminfo vram --json` output, split out for direct testing
+ *  (mirrors `sysinfo.ts`'s `parseRocmSmi`). Sums "VRAM Total Used Memory (B)" across every card.
+ *  Null on unparseable JSON or when no card reports a positive used-memory figure. */
+export function parseRocmVramUsed(memJson: string): number | null {
+  try {
+    const mem = JSON.parse(memJson) as Record<string, Record<string, string>>
+    let total = 0
+    for (const fields of Object.values(mem)) {
+      const usedKey = Object.keys(fields).find((k) => /VRAM Total Used Memory/i.test(k))
+      const bytes = usedKey ? parseInt(String(fields[usedKey]).trim(), 10) || 0 : 0
+      total += bytes
+    }
+    const mb = Math.round(total / 1e6)
+    return mb > 0 ? mb : null
+  } catch {
+    return null
+  }
+}
+
+/** Best-effort current AMD VRAM use in MB (sum across cards) via ROCm's rocm-smi. Null when
+ *  rocm-smi is absent (ROCm not installed) or its output can't be parsed — never throws.
+ *  Mirrors `sysinfo.ts`'s `parseRocmSmi` (same `--showmeminfo vram --json` call), reading
+ *  "VRAM Total Used Memory (B)" instead of "VRAM Total Memory (B)" (ADR-217: before this, the
+ *  headroom gate had zero VRAM protection on AMD — {@link readNvidiaVramMb} silently returned
+ *  null on every AMD box and {@link overHeadroom} treats unknown VRAM as "never over"). */
+function readRocmVramMb(): Promise<number | null> {
+  return new Promise((resolve) => {
+    try {
+      execFile('rocm-smi', ['--showmeminfo', 'vram', '--json'], { timeout: 8000, windowsHide: true }, (err, stdout) => {
+        resolve(err || !stdout ? null : parseRocmVramUsed(stdout))
+      })
+    } catch {
+      resolve(null)
+    }
+  })
+}
+
+/** Best-effort current GPU VRAM use in MB (sum across GPUs), vendor-aware (ADR-217). Tries
+ *  nvidia-smi first (unconditionally — cheap to attempt, and correct even without `sys`), then
+ *  falls back to rocm-smi only when the box has a known AMD GPU. Null when neither applies
+ *  (Intel/Apple/CPU-only, or no live VRAM reader for that vendor) — matches
+ *  {@link overHeadroom}'s "unknown VRAM never blocks" contract. Never throws. */
+async function readGpuVramMb(sys: SysInfo): Promise<number | null> {
+  const nv = await readNvidiaVramMb()
+  if (nv !== null) return nv
+  if (sys.gpus.some((g) => g.vendor === 'amd')) return readRocmVramMb()
+  return null
 }
 
 function sleep(ms: number): Promise<void> {

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -144,6 +144,12 @@ export interface AgentRun {
    *  hides messages at/before this point too, with a banner offering /resume to un-hide them —
    *  the underlying messages are never deleted, so resuming restores them exactly. */
   clearedUpToMessageId?: string
+  // ── Manual-rename persistence (v32) ─────────────────────────────────────────────────────
+  /** True once the auto-generated title has been mirrored from conversations.title onto this
+   *  run's own title exactly once (code-run-manager.ts's pump()) — gates that mirror to fire
+   *  only at the session's first successful turn, never again, so a later manual rename of the
+   *  session sticks instead of reverting on the next completed turn. */
+  titleAutoSynced?: boolean
 }
 
 /** One per-Hitman track-record row (spec 13 §12.3). */
@@ -411,7 +417,7 @@ export interface Message {
 }
 
 interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; agent_id: string | null; completed_at: string | null; read_scope: string | null; agent_mode: string | null; skill_ids: string | null; allowed_tools: string | null; preserve_thinking: number; created_at: string; updated_at: string }
-interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null; repo_root: string | null; repo_branch: string | null; use_worktree: number | null; worktree_branch: string | null; worktree_base: string | null; lines_added: number | null; lines_removed: number | null; compaction_summary: string | null; compaction_upto_message_id: string | null; compaction_tokens_before: number | null; cleared_upto_message_id: string | null }
+interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null; repo_root: string | null; repo_branch: string | null; use_worktree: number | null; worktree_branch: string | null; worktree_base: string | null; lines_added: number | null; lines_removed: number | null; compaction_summary: string | null; compaction_upto_message_id: string | null; compaction_tokens_before: number | null; cleared_upto_message_id: string | null; title_auto_synced: number | null }
 interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; timeline: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string; variant_group: string | null; is_active: number; branch_of: string | null; edited: number }
 
@@ -461,6 +467,7 @@ function rowToAgentRun(r: AgentRunRow): AgentRun {
     compactionUpToMessageId: r.compaction_upto_message_id ?? undefined,
     compactionTokensBefore: r.compaction_tokens_before ?? undefined,
     clearedUpToMessageId: r.cleared_upto_message_id ?? undefined,
+    titleAutoSynced: r.title_auto_synced === 1,
   }
 }
 
@@ -825,6 +832,20 @@ export class ConversationStore {
     if (v < 31) {
       if (!this.hasColumn('messages', 'timeline')) this.db.exec(`ALTER TABLE messages ADD COLUMN timeline TEXT;`)
       this.db.exec(`PRAGMA user_version = 31;`)
+    }
+    // v32 (Code, founder-reported gap 2026-07-14): a manual session rename used to silently
+    // revert on the next completed turn — code-run-manager.ts's pump() unconditionally mirrored
+    // conversations.title onto agent_runs.title after EVERY successful turn (auto-title's own
+    // regeneration guard only stops conversations.title from changing again, not the mirror
+    // re-applying that now-frozen value over a manual rename). Fix (founder-decided): the mirror
+    // should only ever run ONCE, at the session's first successful turn, never again after,
+    // regardless of any rename in between. 0/NULL = not yet synced; existing rows default to
+    // NULL (their title may already have been mirrored under the old unconditional behavior —
+    // treated as "not yet synced" is harmless, it just allows exactly one more mirror before
+    // this fix's guard takes over for good).
+    if (v < 32) {
+      if (!this.hasColumn('agent_runs', 'title_auto_synced')) this.db.exec(`ALTER TABLE agent_runs ADD COLUMN title_auto_synced INTEGER;`)
+      this.db.exec(`PRAGMA user_version = 32;`)
     }
   }
 
@@ -1389,12 +1410,12 @@ export class ConversationStore {
       const placeholders = opts.statuses.map((_, i) => `$s${i}`).join(',')
       const params: Record<string, SQLInputValue> = {}
       opts.statuses.forEach((s, i) => { params[`$s${i}`] = s })
-      return (this.db.prepare(`SELECT * FROM agent_runs WHERE status IN (${placeholders}) ORDER BY created_at DESC LIMIT 200`).all(params) as unknown as AgentRunRow[]).map(rowToAgentRun)
+      return (this.db.prepare(`SELECT * FROM agent_runs WHERE status IN (${placeholders}) ORDER BY updated_at DESC LIMIT 200`).all(params) as unknown as AgentRunRow[]).map(rowToAgentRun)
     }
-    return (this.db.prepare(`SELECT * FROM agent_runs ORDER BY created_at DESC LIMIT 200`).all() as unknown as AgentRunRow[]).map(rowToAgentRun)
+    return (this.db.prepare(`SELECT * FROM agent_runs ORDER BY updated_at DESC LIMIT 200`).all() as unknown as AgentRunRow[]).map(rowToAgentRun)
   }
 
-  updateAgentRun(id: string, patch: Partial<Pick<AgentRun, 'status' | 'error' | 'startedAt' | 'endedAt' | 'title' | 'compactionSummary' | 'compactionUpToMessageId' | 'compactionTokensBefore'>>): boolean {
+  updateAgentRun(id: string, patch: Partial<Pick<AgentRun, 'status' | 'error' | 'startedAt' | 'endedAt' | 'title' | 'compactionSummary' | 'compactionUpToMessageId' | 'compactionTokensBefore' | 'titleAutoSynced'>>): boolean {
     const now = new Date().toISOString()
     const sets: string[] = ['updated_at = $now']
     const params: Record<string, SQLInputValue> = { $id: id, $now: now }
@@ -1406,6 +1427,7 @@ export class ConversationStore {
     if (patch.compactionSummary        !== undefined) { sets.push('compaction_summary = $csum');    params.$csum = patch.compactionSummary }
     if (patch.compactionUpToMessageId  !== undefined) { sets.push('compaction_upto_message_id = $cupto'); params.$cupto = patch.compactionUpToMessageId }
     if (patch.compactionTokensBefore   !== undefined) { sets.push('compaction_tokens_before = $ctok'); params.$ctok = patch.compactionTokensBefore }
+    if (patch.titleAutoSynced          !== undefined) { sets.push('title_auto_synced = $tas'); params.$tas = patch.titleAutoSynced ? 1 : 0 }
     return ((this.db.prepare(`UPDATE agent_runs SET ${sets.join(', ')} WHERE id = $id`).run(params) as unknown) as Changes).changes > 0
   }
 

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -373,6 +373,16 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     return c.json({ ok: true })
   })
 
+  // ── "Send now" on a queued follow-up: stop the active turn, promote this one to run next ──
+  // Unlike /stop, this does NOT drop the rest of the queue — see CodeRunManager.sendNow's own
+  // comment for why a naive stop-then-requeue can't do this atomically with 2+ queued turns.
+  app.post('/api/v1/code/sessions/:id/queue/:userMsgId/send-now', (c) => {
+    const id = c.req.param('id')
+    const userMsgId = c.req.param('userMsgId')
+    const ok = runs.sendNow(id, userMsgId)
+    return c.json({ ok })
+  })
+
   // ── start / queue a turn (daemon-owned; returns JSON, NOT a stream) ────────────
   // This ONLY starts (or queues) the run in CodeRunManager and returns immediately. The event
   // stream is fetched separately via GET /stream, so the run's lifetime is decoupled from any

--- a/turbollm/src/code/code-run-manager.reconnect.test.ts
+++ b/turbollm/src/code/code-run-manager.reconnect.test.ts
@@ -180,11 +180,11 @@ test('a queued follow-up survives a mid-run disconnect and runs in order server-
   const u2 = store.addMessage(convId, 'user', 'second')
   const r2 = mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
   assert.equal(r2.queued, true, 'the follow-up queued behind the active turn')
-  assert.deepEqual(mgr.queued(sessionId), ['second'], 'server-side queue holds the follow-up')
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second' }], 'server-side queue holds the follow-up')
 
   // DISCONNECT mid-run. The queue is server-side, so it must survive.
   sub1.close()
-  assert.deepEqual(mgr.queued(sessionId), ['second'], 'queue survived the client disconnect')
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second' }], 'queue survived the client disconnect')
 
   // Reconnect and watch everything to the end.
   const sub2 = mgr.subscribe(sessionId, 0)
@@ -203,6 +203,61 @@ test('a queued follow-up survives a mid-run disconnect and runs in order server-
   assert.equal(mgr.isActive(sessionId), false, 'session idle after both turns')
 })
 
+// ── sendNow() promotes one queued turn without dropping the rest ───────────────────────
+
+test('sendNow() stops the active turn and promotes the target queued turn, keeping the rest queued', async () => {
+  const { d, store } = makeDeps()
+  const runner: CodeSessionRunner = (params) => {
+    const marker = params.task === 'first' ? 'r1' : params.task === 'second' ? 'r2' : 'r3'
+    return pacedRunner(marker)(params)
+  }
+  const mgr = new CodeRunManager(d, { runner })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+
+  // Turn 1 active; queue turns 2 and 3 behind it, in that order.
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  const sub1 = mgr.subscribe(sessionId, 0)
+  await collect(sub1, (ev) => ev.event === 'tool_call')
+  const u2 = store.addMessage(convId, 'user', 'second')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
+  const u3 = store.addMessage(convId, 'user', 'third')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'third', userMsgId: u3.id })
+  assert.deepEqual(mgr.queued(sessionId).map((t) => t.task), ['second', 'third'], 'FIFO order before sendNow')
+
+  // "Send now" on the THIRD turn — must stop turn 1 AND move turn 3 to the FRONT, without
+  // dropping turn 2 (a naive stop()-then-requeue would either drop turn 2 or run turn 2 first).
+  const ok = mgr.sendNow(sessionId, u3.id)
+  assert.equal(ok, true)
+  assert.deepEqual(mgr.queued(sessionId).map((t) => t.task), ['third', 'second'], 'target promoted to front, the rest survives')
+
+  sub1.close()
+  const all = await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.equal(all.ended, true)
+
+  // Turn 1 aborted (no file). Turn 3 ran BEFORE turn 2 (promoted), and turn 2 still ran after.
+  assert.equal(existsSync(join(repoRoot, 'r1.txt')), false, 'turn 1 was stopped before finishing')
+  assert.equal(existsSync(join(repoRoot, 'r2.txt')), true, 'turn 2 (demoted) still ran eventually')
+  assert.equal(existsSync(join(repoRoot, 'r3.txt')), true, 'turn 3 (promoted) ran')
+  assert.equal(mgr.queued(sessionId).length, 0, 'queue drained')
+  assert.equal(mgr.isActive(sessionId), false)
+})
+
+test('sendNow() on an unknown/already-run userMsgId is a harmless no-op', async () => {
+  const { d, store } = makeDeps()
+  const mgr = new CodeRunManager(d, { runner: pacedRunner('delta') })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'do delta')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'do delta', userMsgId })
+
+  assert.equal(mgr.sendNow(sessionId, 'not-a-real-id'), false, 'unknown userMsgId returns false')
+  assert.equal(mgr.sendNow('not-a-real-session', userMsgId), false, 'unknown session returns false')
+  assert.equal(mgr.isActive(sessionId), true, 'the real active turn was untouched by either no-op call')
+
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.equal(existsSync(join(repoRoot, 'delta.txt')), true, 'the active turn completed normally')
+})
+
 // ── stop() aborts the active run AND clears the queue ─────────────────────────────────
 
 test('stop() aborts the active run and drops everything queued behind it', async () => {
@@ -214,7 +269,7 @@ test('stop() aborts the active run and drops everything queued behind it', async
   mgr.enqueue(sessionId, { convId, repoRoot, task: 'do gamma', userMsgId })
   const u2 = store.addMessage(convId, 'user', 'queued one')
   mgr.enqueue(sessionId, { convId, repoRoot, task: 'queued one', userMsgId: u2.id })
-  assert.deepEqual(mgr.queued(sessionId), ['queued one'])
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'queued one' }])
 
   const sub1 = mgr.subscribe(sessionId, 0)
   await collect(sub1, (ev) => ev.event === 'tool_call') // early return closes sub1 (a disconnect)
@@ -280,6 +335,36 @@ test('an aborted turn that reports a HIGHER ctxUsed than before is trusted as-is
 
   const last = store.getConversation(convId, true)?.messages?.findLast((m) => m.role === 'assistant')
   assert.equal(last?.stats.ctxUsed, 9000, 'a real higher value is trusted, not clamped')
+})
+
+// ── a manual rename survives a later successful turn (founder-reported gap, 2026-07-14) ─
+
+test('a manual session rename is not reverted by a later successful turn\'s auto-title mirror', async () => {
+  const { d, store } = makeDeps()
+  const repoRoot = tmp('tllm-code-repo-')
+  const okRunner: CodeSessionRunner = (async () => ({ finalText: 'ok', contextUsed: 100, contextMax: 8192, aborted: false })) as CodeSessionRunner
+  const mgr = new CodeRunManager(d, { runner: okRunner })
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+
+  // Simulate an already-generated conversation title (bypasses needing to mock the real
+  // title-generation completions call — autoTitleFromConversation's own guard short-circuits
+  // once conv.title isn't 'New chat', exactly as it would after a real generation).
+  store.updateConversation(convId, { title: 'Auto Generated Title' })
+
+  // Turn 1: the mirror fires for the first time — agent_runs.title picks up the generated name.
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.equal(store.getAgentRun(sessionId)?.title, 'Auto Generated Title')
+  assert.equal(store.getAgentRun(sessionId)?.titleAutoSynced, true, 'mirror marks itself synced after the first successful turn')
+
+  // The user renames the session (PATCH .../title route, mirrored here directly).
+  store.updateAgentRun(sessionId, { title: 'My Custom Name' })
+
+  // Turn 2: a second successful turn must NOT re-mirror conversations.title over the rename.
+  const u2 = store.addMessage(convId, 'user', 'second')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.equal(store.getAgentRun(sessionId)?.title, 'My Custom Name', 'manual rename survives a later completed turn')
 })
 
 test('a runner that THROWS AbortError also floors ctxUsed at the last confirmed value', async () => {

--- a/turbollm/src/code/code-run-manager.ts
+++ b/turbollm/src/code/code-run-manager.ts
@@ -137,10 +137,12 @@ export class CodeRunManager {
     return !!s && (s.active !== null || s.queue.length > 0)
   }
 
-  /** The tasks currently WAITING behind the active turn (not the running one) — the server-side
-   *  message queue, surfaced to the UI so its "Queued" chips survive a disconnect. */
-  queued(sessionId: string): string[] {
-    return this.sessions.get(sessionId)?.queue.map((t) => t.task) ?? []
+  /** The turns currently WAITING behind the active turn (not the running one) — the server-side
+   *  message queue, surfaced to the UI so its "Queued" chips survive a disconnect. `userMsgId`
+   *  (not just index) identifies each entry so a per-chip action (sendNow) can target one
+   *  specific queued turn even if two queued tasks have identical text. */
+  queued(sessionId: string): { userMsgId: string; task: string }[] {
+    return this.sessions.get(sessionId)?.queue.map((t) => ({ userMsgId: t.userMsgId, task: t.task })) ?? []
   }
 
   /** The in-flight turn's message ids, so a reconnecting stream can synthesize a `meta` frame
@@ -212,7 +214,7 @@ export class CodeRunManager {
   private emitQueue(sessionId: string): void {
     const s = this.sessions.get(sessionId)
     if (!s) return
-    const ev = s.buffer.push('queue', { queued: s.queue.map((t) => t.task) })
+    const ev = s.buffer.push('queue', { queued: this.queued(sessionId) })
     s.emitter.emit('event', ev)
   }
 
@@ -327,11 +329,15 @@ export class CodeRunManager {
       // autoTitleFromConversation's own guard). It writes conversations.title, but the
       // sidebar/session list reads agent_runs.title (set to the raw task text at session
       // creation) — mirror the generated title onto the session record too, or the sidebar
-      // never sees it.
-      if (!result.aborted) {
+      // never sees it. Gated on titleAutoSynced (founder-reported gap, 2026-07-14): this used
+      // to re-mirror unconditionally on EVERY successful turn, silently reverting a manual
+      // rename on the very next completed turn — the auto-generated name is a first-run
+      // convenience and should only ever assert itself once, never again after.
+      if (!result.aborted && !this.d.db.getAgentRun(sessionId)?.titleAutoSynced) {
         void autoTitleFromConversation(this.d, s.convId).then(() => {
+          if (this.d.db.getAgentRun(sessionId)?.titleAutoSynced) return
           const title = this.d.db.getConversation(s.convId)?.title
-          if (title && title !== 'New chat') this.d.db.updateAgentRun(sessionId, { title })
+          if (title && title !== 'New chat') this.d.db.updateAgentRun(sessionId, { title, titleAutoSynced: true })
         })
       }
     } catch (e) {
@@ -391,6 +397,26 @@ export class CodeRunManager {
     if (s.queue.length > 0) { s.queue = []; this.emitQueue(sessionId) }
     s.active?.ac.abort()
     return had
+  }
+
+  /** Atomically stop the currently active turn AND promote a specific queued turn to run next —
+   *  the "Send now" action on a queued chip. Unlike stop(), this does NOT drop the rest of the
+   *  queue: only the target turn is moved to the front, the remaining queued turns still run
+   *  afterward in their original relative order. A naive "stop() then re-enqueue" would race the
+   *  abort against pump()'s own re-entrant call and, with 2+ queued turns, could let whichever
+   *  was already first run instead of the one the user actually clicked. Returns false if
+   *  userMsgId isn't currently in the queue (already running, already finished, unknown session)
+   *  — the caller should treat that as a harmless no-op, not an error. */
+  sendNow(sessionId: string, userMsgId: string): boolean {
+    const s = this.sessions.get(sessionId)
+    if (!s) return false
+    const idx = s.queue.findIndex((t) => t.userMsgId === userMsgId)
+    if (idx === -1) return false
+    const [turn] = s.queue.splice(idx, 1)
+    s.queue.unshift(turn)
+    this.emitQueue(sessionId)
+    s.active?.ac.abort()
+    return true
   }
 
   /**

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -17,6 +17,7 @@ import { readFile } from 'node:fs/promises'
 import { Type, Unsafe, type TSchema } from 'typebox'
 import {
   createAgentSession,
+  createBashTool,
   DefaultResourceLoader,
   ModelRegistry,
   AuthStorage,
@@ -29,6 +30,7 @@ import {
   type ToolResultEvent,
   type AgentSessionEvent,
 } from '@earendil-works/pi-coding-agent'
+import { createRobustBashOperations } from './robust-bash'
 import type { TextContent, ToolCall as PiToolCall, Usage } from '@earendil-works/pi-ai'
 import type { Deps } from '../deps'
 import type { Message as DbMessage } from '../chat/db'
@@ -295,30 +297,27 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     if (summaryText) sm.appendMessage({ role: 'user', content: summaryText, timestamp: Date.now() })
     if (priorMessages.length > 0) seedPriorHistory(sm, priorMessages, modelId)
   }
-  let sessionManager = SessionManager.inMemory(repoRoot)
+  const sessionManager = SessionManager.inMemory(repoRoot)
   seedHistoryInto(sessionManager)
-  // Defensive check + retry + text fallback: live testing of a founder-reported "Code forgot my
-  // last message" bug (2026-07-13) caught this exact seed silently registering FEWER entries
+  // Defensive check + text fallback: live testing of a founder-reported "Code forgot my last
+  // message" bug (2026-07-13, ADR-194) caught this exact seed silently registering FEWER entries
   // than it should have — sometimes zero, sometimes only a partial subset (e.g. the user's
   // message but not the assistant's reply) — in roughly 1 of every 5-6 turns, and occasionally
-  // in a long unbroken streak. Reproduced repeatedly with instrumented logging, but the root
-  // cause inside pi's SessionManager/tree-building couldn't be pinned down (the seeding code
-  // itself is fully synchronous with no plausible interleaving). A fresh SessionManager +
-  // re-seed recovers MOST of the time but not always — when it doesn't, fall back to prepending
-  // a plain-text transcript onto the prompt itself: session.prompt(task) is the one path proven
-  // reliable in every single trial (it's the actual turn — always exercised), so it can't fail
-  // the same way appendMessage() apparently can. Always log so a recurrence leaves forensic
-  // evidence (session id, expected vs actual count) instead of a silent wrong answer.
+  // in a long unbroken streak. The root cause inside pi's SessionManager/tree-building was never
+  // pinned down. This used to retry on a second fresh SessionManager before falling back to text;
+  // removed 2026-07-15 (ADR-210) after confirming, by reading pi's own SessionManager.appendMessage/
+  // getEntries source, that seedHistoryInto is fully synchronous, in-memory, and has no I/O — so
+  // re-running it on the SAME unmutated priorMessages/summaryText can never produce a different
+  // entry count than the first attempt did. The retry was dead weight; the plain-text fallback
+  // below is the one path proven reliable in every trial (it's the actual turn — always
+  // exercised), so it can't fail the same way appendMessage() apparently can. Always log so a
+  // recurrence leaves forensic evidence (session id, expected vs actual count) instead of a
+  // silent wrong answer.
   const expectedEntries = (summaryText ? 1 : 0) + countReplayEntries(priorMessages)
   let task = rawTask
   if (expectedEntries > 0 && sessionManager.getEntries().length < expectedEntries) {
-    console.warn(`[code-session] history seed for session ${sessionId} produced ${sessionManager.getEntries().length}/${expectedEntries} expected entries — retrying on a fresh SessionManager`)
-    sessionManager = SessionManager.inMemory(repoRoot)
-    seedHistoryInto(sessionManager)
-    if (sessionManager.getEntries().length < expectedEntries) {
-      console.warn(`[code-session] retry for session ${sessionId} still only produced ${sessionManager.getEntries().length}/${expectedEntries} — falling back to a plain-text history prefix on this turn's prompt`)
-      task = `${HISTORY_FALLBACK_PREFIX}${renderHistoryFallbackText(summaryText, priorMessages)}${HISTORY_FALLBACK_SUFFIX}${rawTask}`
-    }
+    console.warn(`[code-session] history seed for session ${sessionId} produced ${sessionManager.getEntries().length}/${expectedEntries} expected entries — falling back to a plain-text history prefix on this turn's prompt`)
+    task = `${HISTORY_FALLBACK_PREFIX}${renderHistoryFallbackText(summaryText, priorMessages)}${HISTORY_FALLBACK_SUFFIX}${rawTask}`
   }
   // Isolated, shippable agent-config dir under TurboLLM's own data dir (never an arbitrary
   // system path). It's a fresh empty dir, so no user global extensions/skills are discovered.
@@ -509,6 +508,10 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
 
     // No invoke_skill tool registered here — a skill cannot invoke another skill (v1 scope).
     const skillTools = toolsForMode(skillMode)
+    // Same verified-kill bash tool the main session uses (see its own registration above for the
+    // full root-cause writeup) — a skill sub-session runs real bash calls too and deserves the
+    // same reliable Stop behavior, not just the outer session.
+    const skillBash = createBashTool(repoRoot, { operations: createRobustBashOperations({ sessionLabel: `${sessionId}:skill:${skill.id}` }) })
     const { session: skillSession } = await createAgentSession({
       cwd: repoRoot,
       agentDir: skillAgentDir,
@@ -518,6 +521,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       resourceLoader: skillResourceLoader,
       sessionManager: SessionManager.inMemory(repoRoot),
       settingsManager: SettingsManager.inMemory(),
+      customTools: [skillBash],
       ...(skillTools ? { tools: skillTools } : {}),
     })
 
@@ -939,6 +943,18 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // (read/bash/edit/write) — toolsForMode returns undefined so `tools` is omitted below.
   const tools = toolsForMode(mode)
 
+  // Stop-button reliability (founder-reported gap, 2026-07-17): a customTool with the same name
+  // as a built-in cleanly REPLACES it (confirmed in pi-coding-agent's own source,
+  // agent-session.js's _refreshToolRegistry — built-ins populate the registry first, then
+  // customTools Map.set() over them by name), and is filtered by the SAME tools/excludeTools
+  // allowlist as built-ins — so passing this unconditionally is safe: plan mode's toolsForMode
+  // allowlist already excludes 'bash', so this customTool simply never activates there, no mode
+  // check needed here. See robust-bash.ts's own header for the full root-cause writeup (verified
+  // live, repeated, timed testing): pi's own bash tool already wires abort correctly, but its
+  // Windows kill (taskkill /F /T against a Git-Bash-rooted process tree) intermittently fails to
+  // actually kill the spawned process — this swaps in a verified, escalating kill instead.
+  const robustBash = createBashTool(repoRoot, { operations: createRobustBashOperations({ sessionLabel: sessionId }) })
+
   const { session } = await createAgentSession({
     cwd: repoRoot,
     agentDir,
@@ -948,6 +964,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     resourceLoader,
     sessionManager,
     settingsManager,
+    customTools: [robustBash],
     ...(tools ? { tools } : {}),
   })
 
@@ -967,6 +984,15 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       } else if (ame.type === 'thinking_delta') {
         void sink({ event: 'reasoning', data: { delta: ame.delta } })
       }
+    } else if (ev.type === 'compaction_start') {
+      // pi's own AUTO-compaction (distinct from the manual /compact route below, which only
+      // ever calls session.compact() on demand) — a real first-class pi feature this session
+      // registered no listener for until now, so it fired with zero UI feedback: the transcript
+      // just went quiet while pi silently summarized history mid-turn. Forwarded so the
+      // frontend can show a real "Compacting conversation…" state instead of a generic/blank gap.
+      void sink({ event: 'compaction', data: { phase: 'start', reason: ev.reason } })
+    } else if (ev.type === 'compaction_end') {
+      void sink({ event: 'compaction', data: { phase: 'end', reason: ev.reason, aborted: ev.aborted, tokensBefore: ev.result?.tokensBefore } })
     }
   })
 

--- a/turbollm/src/code/robust-bash.test.ts
+++ b/turbollm/src/code/robust-bash.test.ts
@@ -1,0 +1,78 @@
+// Unit tests for robust-bash.ts's Stop-button reliability fix (founder-reported gap,
+// 2026-07-17). Exercises real spawned processes and real abort signals — not mocks — matching
+// this codebase's own testing discipline for exactly this class of timing/process-lifecycle bug
+// (see the module's own header for the live, timed testing that found the original bug).
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRobustBashOperations } from './robust-bash'
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), 'tllm-robust-bash-'))
+}
+
+test('exec: runs a real command and returns its output + exit code', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-basic' })
+  const chunks: string[] = []
+  const result = await ops.exec('echo hello-robust-bash', tmp(), {
+    onData: (d) => chunks.push(d.toString()),
+  })
+  assert.equal(result.exitCode, 0)
+  assert.match(chunks.join(''), /hello-robust-bash/)
+})
+
+test('exec: a nonzero exit code is reported, not thrown', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-exit-code' })
+  const result = await ops.exec('exit 7', tmp(), { onData: () => {} })
+  assert.equal(result.exitCode, 7)
+})
+
+test('exec: throws "Working directory does not exist" for a missing cwd, without spawning', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-missing-cwd' })
+  await assert.rejects(
+    () => ops.exec('echo unreachable', join(tmp(), 'does-not-exist'), { onData: () => {} }),
+    /Working directory does not exist/,
+  )
+})
+
+test('exec: an already-aborted signal rejects immediately without spawning', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-preaborted' })
+  const ac = new AbortController()
+  ac.abort()
+  await assert.rejects(
+    () => ops.exec('echo unreachable', tmp(), { onData: () => {}, signal: ac.signal }),
+    /aborted/,
+  )
+})
+
+test('exec: aborting mid-command kills the real process within a bounded time (the actual bug this fixes)', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-live-abort' })
+  const ac = new AbortController()
+  const chunks: string[] = []
+  const start = Date.now()
+  const execPromise = ops.exec('sleep 30', tmp(), { onData: (d) => chunks.push(d.toString()), signal: ac.signal })
+  // Give the shell a moment to actually spawn and start `sleep` before aborting — aborting
+  // instantly would only prove the pre-spawn fast path (already covered above).
+  await new Promise((r) => setTimeout(r, 300))
+  ac.abort()
+  await assert.rejects(() => execPromise, /aborted/)
+  const elapsedMs = Date.now() - start
+  // Must resolve well before `sleep 30` would naturally finish — this is the actual regression
+  // test for "most of the time it doesn't work and waits for completion." Generous bound (the
+  // module's own VERIFY_GRACE_MS + FINAL_VERIFY_MS ceiling plus scheduling slack), still an order
+  // of magnitude under the 30s the unfixed bug could leave a process running for.
+  assert.ok(elapsedMs < 10_000, `expected abort to resolve in well under 10s, took ${elapsedMs}ms`)
+})
+
+test('exec: a timeout kills the real process the same way an abort does', async () => {
+  const ops = createRobustBashOperations({ sessionLabel: 'test-timeout' })
+  const start = Date.now()
+  await assert.rejects(
+    () => ops.exec('sleep 30', tmp(), { onData: () => {}, timeout: 1 }),
+    /timeout:1/,
+  )
+  const elapsedMs = Date.now() - start
+  assert.ok(elapsedMs < 10_000, `expected timeout-triggered kill to resolve in well under 10s, took ${elapsedMs}ms`)
+})

--- a/turbollm/src/code/robust-bash.ts
+++ b/turbollm/src/code/robust-bash.ts
@@ -1,0 +1,253 @@
+// Robust bash tool operations for Code (founder-reported gap, 2026-07-17: "the stop button in
+// code is very weak. most of the time it doesn't work and waits for completion").
+//
+// Root cause, confirmed via live, repeated, timed testing against a real running daemon (not
+// just code reading): pi-coding-agent's own built-in bash tool (createLocalBashOperations,
+// @earendil-works/pi-coding-agent/dist/core/tools/bash.js) already wires the abort signal
+// correctly all the way from CodeRunManager.stop() through AgentSession.abort() to a REAL
+// killProcessTree(child.pid) call on the spawned shell — the whole chain is genuinely fast when
+// it works (~300ms, verified with GPU/process-tree telemetry). But it is NOT reliable: on
+// Windows, pi's bash tool spawns commands through Git Bash's bash.exe (an MSYS2-based POSIX
+// emulation layer — see getShellConfig()'s own preference order), and Windows' native
+// `taskkill /F /T /PID <pid>` (pi's own kill mechanism, utils/shell.js's killProcessTree) does
+// not always correctly walk descendants spawned through that layer. Measured live: 3 of 4
+// identical trials killed the full process tree in ~300ms; one trial left the spawned process
+// (and its own children) running for 10+ seconds past the "aborted" state already showing in the
+// UI/DB — a real orphaned process silently still consuming resources while TurboLLM had already
+// told the user the turn stopped. That intermittency ("most of the time") is the founder's exact
+// report.
+//
+// Fix: a drop-in replacement for pi's bash tool operations (BashOperations — the same public
+// extension point createCodingTools/createBashTool already accept) that does everything pi's own
+// implementation does, but VERIFIES the kill actually took effect instead of firing-and-trusting,
+// and escalates to an independent, WMI-based descendant enumeration (proven reliable in the same
+// live testing — it correctly reported the full bash.exe -> bash.exe -> ping.exe ancestry in
+// every trial, including the one where taskkill's own internal tree-walk silently failed) when
+// the first attempt doesn't verify within a bounded grace window. Never silently reports success
+// it didn't confirm — logs a warning on the rare case even the escalation can't confirm, so a
+// recurrence leaves forensic evidence instead of a silent lie (same discipline as this codebase's
+// other defensive fallbacks, e.g. code-session.ts's history-seed retry).
+//
+// waitForChildProcess below is adapted verbatim from pi-coding-agent's own
+// utils/child-process.js (MIT-licensed, same package already a direct dependency here) — NOT
+// reimplemented from scratch, since it defends against a real, specific, already-fixed upstream
+// bug (earendil-works/pi#5303: a detached descendant holding stdout/stderr open past its parent's
+// own exit must not have its trailing output truncated by a naive fixed-deadline wait). Copied
+// rather than imported because pi-coding-agent's package.json restricts `exports` to its public
+// entry point only — this utility isn't reachable via a subpath import.
+import { access as fsAccess } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { spawn, type ChildProcess } from 'node:child_process'
+import { getShellConfig } from '@earendil-works/pi-coding-agent'
+import type { BashOperations } from '@earendil-works/pi-coding-agent'
+
+const EXIT_STDIO_GRACE_MS = 100
+
+/** Adapted from pi-coding-agent's utils/child-process.js — see module comment above. */
+function waitForChildProcess(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let exited = false
+    let exitCode: number | null = null
+    let postExitTimer: ReturnType<typeof setTimeout> | undefined
+    let stdoutEnded = child.stdout === null
+    let stderrEnded = child.stderr === null
+    const cleanup = () => {
+      if (postExitTimer) { clearTimeout(postExitTimer); postExitTimer = undefined }
+      child.removeListener('error', onError)
+      child.removeListener('exit', onExit)
+      child.removeListener('close', onClose)
+      child.stdout?.removeListener('end', onStdoutEnd)
+      child.stderr?.removeListener('end', onStderrEnd)
+      child.stdout?.removeListener('data', onData)
+      child.stderr?.removeListener('data', onData)
+    }
+    const finalize = (code: number | null) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      child.stdout?.destroy()
+      child.stderr?.destroy()
+      resolve(code)
+    }
+    const maybeFinalizeAfterExit = () => {
+      if (!exited || settled) return
+      if (stdoutEnded && stderrEnded) finalize(exitCode)
+    }
+    const armIdleTimer = () => {
+      if (postExitTimer) clearTimeout(postExitTimer)
+      postExitTimer = setTimeout(() => finalize(exitCode), EXIT_STDIO_GRACE_MS)
+    }
+    const onData = () => { if (exited && !settled) armIdleTimer() }
+    const onStdoutEnd = () => { stdoutEnded = true; maybeFinalizeAfterExit() }
+    const onStderrEnd = () => { stderrEnded = true; maybeFinalizeAfterExit() }
+    const onError = (err: Error) => { if (settled) return; settled = true; cleanup(); reject(err) }
+    const onExit = (code: number | null) => {
+      exited = true
+      exitCode = code
+      maybeFinalizeAfterExit()
+      if (!settled) armIdleTimer()
+    }
+    const onClose = (code: number | null) => finalize(code)
+    child.stdout?.once('end', onStdoutEnd)
+    child.stderr?.once('end', onStderrEnd)
+    child.stdout?.on('data', onData)
+    child.stderr?.on('data', onData)
+    child.once('error', onError)
+    child.once('exit', onExit)
+    child.once('close', onClose)
+  })
+}
+
+/** Portable "is this pid still alive" check — signal 0 is a no-op existence probe on every
+ *  platform Node supports, including Windows. ESRCH = gone; EPERM = alive but unsignalable
+ *  (still counts as alive — an unrelated permission boundary, not evidence of death). */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Windows-only escalation: enumerate every live descendant of `rootPid` via WMI (reliable in
+ *  live testing even in the exact trial where taskkill's own internal /T tree-walk silently
+ *  failed to reach the same processes) and kill each one individually with a plain, non-tree
+ *  taskkill — sidestepping whatever /T's own walk gets wrong for an MSYS2-rooted tree. Returns
+ *  the pids it attempted to kill, for logging. */
+async function killDescendantsViaWmi(rootPid: number): Promise<number[]> {
+  const psScript =
+    `$all = Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId; ` +
+    `$ids = @(${rootPid}); $frontier = @(${rootPid}); ` +
+    `for ($i = 0; $i -lt 8; $i++) { ` +
+    `  $children = $all | Where-Object { $frontier -contains $_.ParentProcessId } | Select-Object -ExpandProperty ProcessId; ` +
+    `  if (-not $children) { break }; $ids += $children; $frontier = $children ` +
+    `}; ` +
+    `$ids | Select-Object -Unique | ForEach-Object { Write-Output $_ }`
+  const pids = await new Promise<number[]>((resolve) => {
+    const proc = spawn('powershell', ['-NoProfile', '-NonInteractive', '-Command', psScript], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    })
+    let out = ''
+    proc.stdout.on('data', (d: Buffer) => { out += d.toString() })
+    proc.on('close', () => {
+      const found = out.split(/\r?\n/).map((l) => Number(l.trim())).filter((n) => Number.isInteger(n) && n > 0)
+      resolve([...new Set(found)])
+    })
+    proc.on('error', () => resolve([]))
+  })
+  for (const pid of pids) {
+    try { spawn('taskkill', ['/F', '/PID', String(pid)], { stdio: 'ignore', detached: true, windowsHide: true }) } catch { /* best-effort */ }
+  }
+  return pids
+}
+
+/** First attempt — same mechanism pi's own killProcessTree uses (fast, works most of the time,
+ *  per live testing: ~300ms in 3 of 4 trials). Kept identical to pi's own approach here rather
+ *  than skipping straight to the WMI escalation on every call, since that escalation costs a real
+ *  process spawn (~100-300ms) this fast path avoids on the common case. */
+function killProcessTreeFast(pid: number): void {
+  if (process.platform === 'win32') {
+    try { spawn('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore', detached: true, windowsHide: true }) } catch { /* best-effort */ }
+  } else {
+    try { process.kill(-pid, 'SIGKILL') } catch {
+      try { process.kill(pid, 'SIGKILL') } catch { /* already dead */ }
+    }
+  }
+}
+
+const VERIFY_GRACE_MS = 800
+const VERIFY_POLL_MS = 100
+const FINAL_VERIFY_MS = 1500
+
+/** Kill `pid`'s whole process tree and VERIFY it actually died instead of firing-and-trusting —
+ *  see the module comment for why: pi's own equivalent (killProcessTree) is correct in mechanism
+ *  but intermittently ineffective against a Git-Bash-rooted tree on Windows. Escalates to a
+ *  WMI-based descendant kill only when the fast path doesn't verify within `VERIFY_GRACE_MS`. */
+async function killProcessTreeVerified(pid: number, sessionLabel: string): Promise<void> {
+  killProcessTreeFast(pid)
+  const deadline = Date.now() + VERIFY_GRACE_MS
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return
+    await sleep(VERIFY_POLL_MS)
+  }
+  if (!isAlive(pid)) return
+  console.warn(`[code-session:${sessionLabel}] bash process ${pid} still alive ${VERIFY_GRACE_MS}ms after abort — escalating to WMI-based descendant kill`)
+  if (process.platform === 'win32') {
+    const killed = await killDescendantsViaWmi(pid)
+    console.warn(`[code-session:${sessionLabel}] WMI escalation targeted ${killed.length} process(es): ${killed.join(', ')}`)
+  } else {
+    try { process.kill(pid, 'SIGKILL') } catch { /* already dead */ }
+  }
+  await sleep(FINAL_VERIFY_MS)
+  if (isAlive(pid)) {
+    console.warn(`[code-session:${sessionLabel}] bash process ${pid} SURVIVED the WMI escalation — giving up, it may still be running orphaned`)
+  }
+}
+
+/** Drop-in replacement for pi-coding-agent's createLocalBashOperations with a verified,
+ *  escalating kill on abort/timeout instead of a fire-and-forget one. Everything else (shell
+ *  resolution, spawn shape, streaming, stdio wiring, exit-vs-close draining) matches pi's own
+ *  implementation — only the kill path changes. `sessionLabel` is purely for the warning logs
+ *  above (a Code session id), so a recurrence is traceable to which session hit it. */
+export function createRobustBashOperations(options?: { shellPath?: string; sessionLabel: string }): BashOperations {
+  return {
+    exec: async (command, cwd, { onData, signal, timeout, env }) => {
+      if (signal?.aborted) throw new Error('aborted')
+      const shellConfig = getShellConfig(options?.shellPath)
+      try {
+        await fsAccess(cwd, constants.F_OK)
+      } catch {
+        throw new Error(`Working directory does not exist: ${cwd}\nCannot execute bash commands.`)
+      }
+      const commandFromStdin = shellConfig.commandTransport === 'stdin'
+      const child = spawn(
+        shellConfig.shell,
+        commandFromStdin ? shellConfig.args : [...shellConfig.args, command],
+        {
+          cwd,
+          detached: process.platform !== 'win32',
+          env: env ?? process.env,
+          stdio: [commandFromStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+        },
+      )
+      if (commandFromStdin) {
+        child.stdin?.on('error', () => { /* best-effort */ })
+        child.stdin?.end(command)
+      }
+
+      let timedOut = false
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+      const onAbort = () => { if (child.pid) void killProcessTreeVerified(child.pid, options?.sessionLabel ?? 'unknown') }
+
+      try {
+        if (timeout !== undefined && timeout > 0) {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true
+            if (child.pid) void killProcessTreeVerified(child.pid, options?.sessionLabel ?? 'unknown')
+          }, timeout * 1000)
+        }
+        child.stdout?.on('data', onData)
+        child.stderr?.on('data', onData)
+        if (signal) {
+          if (signal.aborted) onAbort()
+          else signal.addEventListener('abort', onAbort, { once: true })
+        }
+        const exitCode = await waitForChildProcess(child)
+        if (signal?.aborted) throw new Error('aborted')
+        if (timedOut) throw new Error(`timeout:${timeout}`)
+        return { exitCode }
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle)
+        if (signal) signal.removeEventListener('abort', onAbort)
+      }
+    },
+  }
+}

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -317,11 +317,18 @@ export class Manager {
     const exited = this.exited
     if (this.state === 'running' || this.state === 'starting') {
       // force: SIGKILL immediately rather than the graceful TERM→8s-then-kill path.
-      // Used by the ComfyUI guard, which needs the VRAM freed NOW before ComfyUI runs.
+      // Used by the ComfyUI guard, which needs the VRAM freed NOW before ComfyUI runs, and by
+      // auto-tune's cancel (ADR-220).
       if (opts?.force) this.forceStop()
       else this.stop()
       await this.waitForExit(exited)
     } else if (this.state === 'stopping') {
+      // A force request landing while a graceful stop is ALREADY in flight (e.g. auto-tune's
+      // cancel arriving in the narrow window right after a probe's own non-forced stop already
+      // started) must not just passively wait out the remainder of that graceful timer — kill
+      // now. Bypasses forceStop()'s running/starting-only guard by calling the module-level
+      // forceKill directly, since state is already 'stopping' (ADR-220).
+      if (opts?.force && this.child) forceKill(this.child)
       await this.waitForExit(exited)
     } else if (this.state === 'error') {
       this.state = 'stopped'

--- a/turbollm/src/engines/probe.test.ts
+++ b/turbollm/src/engines/probe.test.ts
@@ -1,7 +1,7 @@
 // Capability-flag extraction from --help output (GitHub #43 regression).
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { extractFlags } from './probe'
+import { extractFlags, detectKvTypes } from './probe'
 
 test('captures a normally-documented flag', () => {
   const help = `--cache-type-k TYPE     KV cache data type for K\n--parallel N            number of parallel sequences\n`
@@ -33,4 +33,47 @@ test('a flag genuinely supported elsewhere is captured even if also named inside
     `--mtp-head FNAME                       path to the MTP head GGUF\n`
   const flags = extractFlags(help)
   assert.ok(flags.includes('--mtp-head'))
+})
+
+// ---- detectKvTypes: turbo2/3/4 detection scoped to --cache-type-k's own help block, not a
+// whole-document "turbo" substring search (a real false-positive bug — see probe.ts) ----------
+
+test('detectKvTypes: TurboQuant fork — turbo2/3/4 genuinely listed in --cache-type-k\'s allowed values', () => {
+  const help =
+    `-ctk,  --cache-type-k TYPE              KV cache data type for K\n` +
+    `                                        allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1,\n` +
+    `                                        turbo2, turbo3, turbo4\n` +
+    `                                        (default: f16)\n` +
+    `-ctv,  --cache-type-v TYPE              KV cache data type for V\n`
+  const kvTypes = detectKvTypes(help, true)
+  assert.ok(kvTypes.includes('turbo2'))
+  assert.ok(kvTypes.includes('turbo3'))
+  assert.ok(kvTypes.includes('turbo4'))
+  assert.ok(kvTypes.includes('f16')) // base KNOWN_KV set still present
+})
+
+test('detectKvTypes: ik_llama.cpp — mentions "turbo" nowhere near --cache-type-k, must NOT claim turbo support (the regression this fix targets)', () => {
+  const help =
+    `  -ctk,  --cache-type-k TYPE      KV cache data type for K (default: f16)\n` +
+    `  -ictk, --indexer-cache-type-k TYPE\n` +
+    `                                  indexer K-cache data type (default: f16)\n` +
+    `  -ctv,  --cache-type-v TYPE      KV cache data type for V (default: f16)\n` +
+    `some unrelated later line mentioning turbo boost or a defer-experts turbo scheduler\n`
+  const kvTypes = detectKvTypes(help, true)
+  assert.ok(!kvTypes.includes('turbo2'))
+  assert.ok(!kvTypes.includes('turbo3'))
+  assert.ok(!kvTypes.includes('turbo4'))
+})
+
+test('detectKvTypes: no --cache-type-k flag at all → f16-only, unprobed-safe default', () => {
+  const kvTypes = detectKvTypes('--parallel N   number of parallel sequences\n', false)
+  assert.deepEqual(kvTypes, ['f16'])
+})
+
+test('detectKvTypes: -draft/-first/-last sibling flags never confused for the main --cache-type-k enum', () => {
+  const help =
+    `--cache-type-k-draft TYPE   KV cache data type for K for the draft model, includes turbo4 talk unrelated\n` +
+    `--cache-type-k TYPE         KV cache data type for K (default: f16)\n`
+  const kvTypes = detectKvTypes(help, true)
+  assert.ok(!kvTypes.includes('turbo4'), 'the -draft flag\'s text must not leak turbo4 into the main enum')
 })

--- a/turbollm/src/engines/probe.ts
+++ b/turbollm/src/engines/probe.ts
@@ -99,8 +99,7 @@ export async function probe(bin: string): Promise<ProbeResult> {
   if (!version) version = 'unknown'
 
   const flags = extractFlags(h.out)
-  const kvTypes = flags.includes('--cache-type-k') ? [...KNOWN_KV] : ['f16']
-  if (combined.toLowerCase().includes('turbo')) kvTypes.push('turbo2', 'turbo3', 'turbo4')
+  const kvTypes = detectKvTypes(h.out, flags.includes('--cache-type-k'))
 
   // Capture the accepted `--spec-type` enum values (e.g. `none,draft-mtp,nextn`)
   // as `spec-type:<value>` pseudo-flags. The enum differs by engine — official
@@ -169,6 +168,25 @@ export function extractFlags(helpText: string): string[] {
     for (const f of line.match(RE_FLAG) ?? []) flagSet.add(f)
   }
   return [...flagSet].sort()
+}
+
+/** Detect which KV-cache types --cache-type-k actually accepts, from that flag's OWN help
+ *  block — not a blind "does 'turbo' appear anywhere in --help" search across the whole output
+ *  (a real false-positive bug: an unrelated engine — e.g. ik_llama.cpp — can mention "turbo"
+ *  somewhere in its help text with no connection to KV cache types, and used to get turbo2/3/4
+ *  added to its capabilities, which either silently degrades in `profileToArgs`'s `kvOk` gate or
+ *  can leak an unsupported --cache-type-k value into a launch on an engine that doesn't
+ *  understand it). `\s+\S+\b` right after the flag (not `-`) excludes the -draft/-first/-last
+ *  sibling flags, whose text is unrelated to the main K-cache type enum. Split out for direct
+ *  testing — confirmed against the TurboQuant fork's real --help output ("allowed values: ...
+ *  turbo2, turbo3, turbo4") and ik_llama.cpp's (no such list near --cache-type-k at all). */
+export function detectKvTypes(helpText: string, hasCacheTypeFlag: boolean): string[] {
+  const kvTypes = hasCacheTypeFlag ? [...KNOWN_KV] : ['f16']
+  const kvFlagBlock = /--cache-type-k\s+\S+\b([\s\S]{0,400}?)(?=\n\s*\(default|\n\s{2,}-[a-zA-Z]|\n\n|$)/i.exec(helpText)
+  if (kvFlagBlock) {
+    for (const t of ['turbo2', 'turbo3', 'turbo4']) if (kvFlagBlock[1].includes(t) && !kvTypes.includes(t)) kvTypes.push(t)
+  }
+  return kvTypes
 }
 
 function firstNonEmptyLine(s: string): string {

--- a/turbollm/web/src/components/ThinkingBudgetSlider.tsx
+++ b/turbollm/web/src/components/ThinkingBudgetSlider.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
 import { Brain } from 'lucide-react'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from './ui/dropdown-menu'
 
 // ── Thinking budget control ──────────────────────────────────────────────────
 //
@@ -13,6 +13,17 @@ import { Brain } from 'lucide-react'
 // The far-right slider position is deliberately "Unlimited", not a literal MAX-token
 // ceiling — dragging all the way right must reproduce today's always-on-thinking default
 // exactly (no cap sent), not silently introduce a new cap for users who never asked for one.
+//
+// Built on the shared portaled DropdownMenu primitive (same one ModelLoadMenu/CodeComposer's
+// mode picker already use) rather than a hand-rolled `position: absolute` popover. The old
+// version lived directly inside CodeComposer.tsx's toolbar row, which has `overflow-x-auto` as
+// a narrow-viewport safety net — per the CSS Overflow spec, a container can't mix
+// `overflow-x: auto` with `overflow-y: visible` (the browser forces the other axis to `auto`
+// too), which silently clipped the popover's `bottom-full` panel to zero visible height. That
+// read exactly like "the slider doesn't open" (confirmed live 2026-07-15), not a positioning
+// bug. Rendering into `document.body` via Radix's Portal escapes that ancestor's clipping
+// entirely, and Radix's Popper collision detection positions the panel automatically (matching
+// how the mode picker already avoids the viewport edge) instead of a hardcoded `bottom-full`.
 
 const MAX_BUDGET = 16_000
 const STEP = 500
@@ -24,63 +35,46 @@ function formatBudget(value: number): string {
 }
 
 export function ThinkingBudgetSlider({ value, onChange }: { value: number; onChange: (v: number) => void }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const onDocClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
-    }
-    document.addEventListener('mousedown', onDocClick)
-    return () => document.removeEventListener('mousedown', onDocClick)
-  }, [open])
-
   const sliderValue = value < 0 ? MAX_BUDGET : Math.min(value, MAX_BUDGET)
   const active = value !== -1
 
   return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        title={`Thinking: ${formatBudget(value)} — click to adjust`}
-        aria-label="Thinking budget"
-        className="grid h-8 w-8 place-items-center rounded-md transition-colors hover:bg-panel-2"
-        style={{ color: active ? 'var(--accent)' : 'var(--faint)' }}
-      >
-        <Brain size={15} />
-      </button>
-      {open && (
-        // Opens UPWARD (bottom-full), not downward: this control lives in a composer toolbar
-        // docked at the bottom of the screen (Chat + Code), so top-full used to push the panel
-        // off the bottom of the viewport / behind the OS taskbar. Mirrors CodeComposer's own
-        // slash-command picker, which already opens upward for the same reason.
-        <div className="absolute right-0 bottom-full z-20 mb-2 w-64 rounded-[var(--radius-lg)] border border-border bg-panel p-3 shadow-[var(--shadow-2)]">
-          <div className="mb-2 flex items-center justify-between text-[12px]">
-            <span className="font-medium text-ink">Thinking budget</span>
-            <span className="text-muted">{formatBudget(value)}</span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={MAX_BUDGET}
-            step={STEP}
-            value={sliderValue}
-            onChange={(e) => {
-              const n = Number(e.target.value)
-              onChange(n >= MAX_BUDGET ? -1 : n)
-            }}
-            className="w-full"
-            style={{ accentColor: 'var(--accent)' }}
-            aria-label="Thinking token budget"
-          />
-          <div className="mt-1 flex justify-between text-[10px] text-faint">
-            <span>Off</span>
-            <span>Unlimited</span>
-          </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          title={`Thinking: ${formatBudget(value)} — click to adjust`}
+          aria-label="Thinking budget"
+          className="grid h-8 w-8 shrink-0 place-items-center rounded-md transition-colors hover:bg-panel-2"
+          style={{ color: active ? 'var(--accent)' : 'var(--faint)' }}
+        >
+          <Brain size={15} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64 p-3">
+        <div className="mb-2 flex items-center justify-between text-[12px]">
+          <span className="font-medium text-ink">Thinking budget</span>
+          <span className="text-muted">{formatBudget(value)}</span>
         </div>
-      )}
-    </div>
+        <input
+          type="range"
+          min={0}
+          max={MAX_BUDGET}
+          step={STEP}
+          value={sliderValue}
+          onChange={(e) => {
+            const n = Number(e.target.value)
+            onChange(n >= MAX_BUDGET ? -1 : n)
+          }}
+          className="w-full"
+          style={{ accentColor: 'var(--accent)' }}
+          aria-label="Thinking token budget"
+        />
+        <div className="mt-1 flex justify-between text-[10px] text-faint">
+          <span>Off</span>
+          <span>Unlimited</span>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -61,6 +61,16 @@ export function useConversation(id: string | null) {
     queryFn: () => getConversation(id!),
     enabled: !!id,
     retry: false,
+    // Multi-device/multi-tab live sync (founder-reported gap, 2026-07-15): a message sent from
+    // one device/tab has no push channel to any OTHER client viewing the same conversation — the
+    // SSE stream in chat-routes.ts's POST .../messages is the direct HTTP response to the ONE
+    // request that sent it, not a subscribable broadcast (unlike Code's RingBuffer+EventEmitter,
+    // which genuinely fans out to multiple subscribers). A passive second client previously had
+    // zero mechanism (no poll, and refetchOnWindowFocus is off globally, main.tsx) to ever notice
+    // a new message short of a manual reload. Polling is the minimal fix — matches the cadence
+    // Code's own session list already uses (code-queries.ts, refetchInterval: 5000).
+    refetchInterval: 4000,
+    refetchIntervalInBackground: false,
   })
 }
 

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -1,7 +1,7 @@
 // Code launchpad API client — mirrors chat-api.ts's conventions (req() helper, the
 // hand-rolled SSE line parser) against turbollm/src/code/code-routes.ts.
 import type { Conversation } from './chat-types'
-import type { CodeSession, CodeSessionFilter, CodeStats, CodeStatsRange, CodeStreamEvent, CreateCodeSessionParams } from './code-types'
+import type { CodeSession, CodeSessionFilter, CodeStats, CodeStatsRange, CodeStreamEvent, CreateCodeSessionParams, QueuedTurn } from './code-types'
 import { ApiError, authHeaders } from './api'
 import { markCodeAuthNeeded, clearCodeAuthNeeded } from './auth-signal'
 
@@ -83,9 +83,9 @@ export interface CodeSessionDetail {
   /** True when a run is live in the daemon right now — the frontend reconnects the stream when
    *  this is set on load, instead of assuming a fresh page has nothing in flight. */
   running: boolean
-  /** Tasks waiting behind the active turn (server-side queue) — restores the "Queued" chips
+  /** Turns waiting behind the active one (server-side queue) — restores the "Queued" chips
    *  after a reload/reconnect. */
-  queued: string[]
+  queued: QueuedTurn[]
 }
 export function getCodeSession(id: string): Promise<CodeSessionDetail> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}`)
@@ -93,6 +93,12 @@ export function getCodeSession(id: string): Promise<CodeSessionDetail> {
 
 export function stopCodeSession(id: string): Promise<{ ok: true }> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/stop`, { method: 'POST', json: {} })
+}
+
+/** "Send now" on a queued follow-up chip: stops the active turn and promotes this specific
+ *  queued turn to run next, keeping the rest of the queue intact (see CodeRunManager.sendNow). */
+export function sendCodeQueuedTurnNow(id: string, userMsgId: string): Promise<{ ok: boolean }> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/queue/${encodeURIComponent(userMsgId)}/send-now`, { method: 'POST', json: {} })
 }
 
 /** Changes a session's mode (auto/plan/ask) for its NEXT run — the mode picker is

--- a/turbollm/web/src/lib/code-queries.ts
+++ b/turbollm/web/src/lib/code-queries.ts
@@ -92,6 +92,16 @@ export function useCodeSession(id: string | null) {
     // some unrelated action happens to fail with a 404. Refetching on focus catches it as soon
     // as the user comes back to this tab, before they try to act on a session that's gone.
     refetchOnWindowFocus: true,
+    // Multi-device/multi-tab live sync (founder-reported gap, 2026-07-15): the multi-subscriber
+    // SSE infrastructure (CodeRunManager's RingBuffer+EventEmitter) already fans out correctly to
+    // any client that calls connect() — the gap was that a PASSIVE second device/tab (one that
+    // didn't start the run) never learned `running` flipped to true, since this query never
+    // polled: CodeSessionScreen.tsx only calls connect() from a useEffect keyed on
+    // detailQ.data?.running changing, and refetchOnWindowFocus alone only catches it on
+    // blur/refocus, never on a second monitor / never-blurred tab. Plain polling, matching the
+    // cadence useCodeSessions already uses for the sidebar list.
+    refetchInterval: 6000,
+    refetchIntervalInBackground: false,
   })
 }
 

--- a/turbollm/web/src/lib/code-types.ts
+++ b/turbollm/web/src/lib/code-types.ts
@@ -43,6 +43,14 @@ export interface CreateCodeSessionParams {
   contextFiles?: string[]
 }
 
+/** One entry in the server-side message queue (turns waiting behind the active one).
+ *  `userMsgId` identifies the entry (not just its text) so a per-chip action — e.g. "Send now"
+ *  — can target one specific queued turn even if two queued tasks have identical text. */
+export interface QueuedTurn {
+  userMsgId: string
+  task: string
+}
+
 // SSE event payloads for GET /api/v1/code/sessions/:id/stream (code-routes.ts). Reuses
 // chat's tool_call/reasoning/delta wire shape verbatim (same sink), but 'meta'/'done' carry
 // different fields than chat's — a real, separate type, not a reuse of ChatSseEvent.
@@ -53,7 +61,8 @@ export type CodeSseEvent =
   | { event: 'reasoning'; data: { delta: string } }
   | { event: 'delta';     data: { delta: string } }
   | { event: 'tool_call'; data: { id: string; name: string; args: Record<string, unknown>; status: 'pending' | 'done' | 'error' | 'awaiting_approval'; result?: string; diff?: string; patch?: string; firstChangedLine?: number } }
-  | { event: 'queue';     data: { queued: string[] } }
+  | { event: 'queue';     data: { queued: QueuedTurn[] } }
+  | { event: 'compaction'; data: { phase: 'start' | 'end'; reason: 'manual' | 'threshold' | 'overflow'; aborted?: boolean; tokensBefore?: number } }
   | { event: 'done';      data: { contextUsed: number; contextMax: number; aborted: boolean } }
   | { event: 'error';     data: { code: string; message: string } }
 

--- a/turbollm/web/src/lib/utils.ts
+++ b/turbollm/web/src/lib/utils.ts
@@ -22,6 +22,17 @@ export function folderName(repoRoot: string): string {
   return parts.at(-1) ?? repoRoot
 }
 
+/** "+1234 −567" — matches the sidebar's own per-session diff-stat chip style. Omits a zero
+ *  side entirely rather than printing "+0" for a diff that only ever removed (or only ever
+ *  added) lines. "—" when there's genuinely no diff activity at all yet. */
+export function formatDiff(added: number, removed: number): string {
+  if (added === 0 && removed === 0) return '—'
+  const parts: string[] = []
+  if (added > 0) parts.push(`+${added.toLocaleString()}`)
+  if (removed > 0) parts.push(`−${removed.toLocaleString()}`)
+  return parts.join(' ')
+}
+
 // ── Last-opened id per Workspace mode ──────────────────────────────────────────
 //
 // The Chat|Code pill in ConversationSidebar.tsx used to always link to the bare

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type RefObject } from 'react'
-import { Check, ChevronDown, CircleDot, FileText, FolderGit2, FolderOpen, GitBranch, ListTodo, Plus, SendHorizontal, Square, Wand2, X } from 'lucide-react'
+import { Check, ChevronDown, CircleDot, FileText, FolderGit2, FolderOpen, GitBranch, ListTodo, Loader2, Plus, SendHorizontal, Square, Wand2, X } from 'lucide-react'
 import { Button } from '../../components/ui/button'
 import {
   DropdownMenu,
@@ -478,7 +478,17 @@ export function CodeComposer({
         </div>
       </div>
       </div>
-      <p className="mt-2 text-center text-[11px] text-faint">{hintText}</p>
+      {/* Persistent, always-visible busy indicator (founder-reported gap, 2026-07-13): the only
+          "is the agent busy" signal near the composer used to be this hint's plain STRING swap
+          (idle text ↔ running text) — no icon, no animation. The inline CodeThinking/
+          CodeStreamingEntry activity live INSIDE the scrolling transcript body and can be
+          scrolled out of view during a long run; this lives in the composer itself, so it's
+          visible regardless of scroll position. Reuses CodeThinking's own spinner styling
+          (Loader2, accent color) rather than inventing a new motion language. */}
+      <p className="mt-2 flex items-center justify-center gap-1.5 text-center text-[11px] text-faint">
+        {live && <Loader2 size={11} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
+        <span>{hintText}</span>
+      </p>
     </div>
   )
 }

--- a/turbollm/web/src/screens/code/CodeHomeScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeHomeScreen.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../components/ui/button'
 import { toast } from '../../components/ui/sonner'
 import { getPersonalization } from '../../lib/personas'
 import { useIsDesktop } from '../../lib/useIsDesktop'
-import { cn } from '../../lib/utils'
+import { cn, formatDiff } from '../../lib/utils'
 import { ApiError } from '../../lib/api'
 import { useGitBranch, useModelActions, useModels, useStatus } from '../../lib/queries'
 import { createCodeSession } from '../../lib/code-api'
@@ -120,17 +120,6 @@ function StatTile({ label, value, loading }: { label: string; value: string; loa
         : <div className="mt-1 truncate text-[20px] font-semibold tracking-[-0.01em] text-ink tabular-nums">{value}</div>}
     </div>
   )
-}
-
-/** "+1234 −567" — matches the sidebar's own per-session diff-stat chip style. Omits a zero
- *  side entirely rather than printing "+0" for a diff that only ever removed (or only ever
- *  added) lines. "—" when there's genuinely no diff activity at all yet. */
-function formatDiff(added: number, removed: number): string {
-  if (added === 0 && removed === 0) return '—'
-  const parts: string[] = []
-  if (added > 0) parts.push(`+${added.toLocaleString()}`)
-  if (removed > 0) parts.push(`−${removed.toLocaleString()}`)
-  return parts.join(' ')
 }
 
 export function CodeHomeScreen() {

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowDown, Clock, Eraser, FolderOpen, GitBranch, PanelLeft, Pencil, RotateCcw } from 'lucide-react'
+import { ArrowDown, Clock, Diff, Eraser, FolderOpen, GitBranch, PanelLeft, Pencil, RotateCcw, SendHorizontal } from 'lucide-react'
 import { ApiError } from '../../lib/api'
 import { skillKeys, fetchSkills } from '../../lib/agent-api'
 import { useModelActions, useModels, useStatus } from '../../lib/queries'
-import { compactCodeSession, revertCodeSession, startCodeRun, streamCodeSession, stopCodeSession } from '../../lib/code-api'
+import { compactCodeSession, revertCodeSession, sendCodeQueuedTurnNow, startCodeRun, streamCodeSession, stopCodeSession } from '../../lib/code-api'
+import type { QueuedTurn } from '../../lib/code-types'
 import {
   codeKeys, useClearCodeSession, useCodeSession, useCodeSessionRename, useResumeCodeSession,
   useUpdateCodeSessionMode,
@@ -19,7 +20,7 @@ import {
 } from '../../components/ui/alert-dialog'
 import { toast } from '../../components/ui/sonner'
 import { useIsDesktop } from '../../lib/useIsDesktop'
-import { cn, folderName, writeLastCodeSessionId } from '../../lib/utils'
+import { cn, folderName, formatDiff, writeLastCodeSessionId } from '../../lib/utils'
 import { ToolApprovalBar } from '../chat/ToolApprovalBar'
 import { ConversationSidebar } from '../chat/ConversationSidebar'
 import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle } from '../chat/SidebarResizeHandle'
@@ -34,6 +35,10 @@ interface LiveState {
   content: string
   reasoning: string
   timeline: LiveBlock[]
+  /** True between a 'compaction' SSE event's start and end phases — pi's own AUTO-compaction
+   *  silently summarizing history mid-turn (distinct from the manual /compact command). Drives
+   *  CodeThinking's "Compacting conversation…" state instead of a blank/generic gap. */
+  compacting?: boolean
 }
 
 /** Apply `fn` to the current live block, creating one (anchored to `fallbackId`) if none exists
@@ -172,7 +177,7 @@ export function CodeSessionScreen() {
   // the daemon — `queue` SSE frames while streaming, plus the session detail on load — NOT
   // browser memory, so queued follow-ups survive a disconnect/reload and still fire in order
   // server-side. (Previously this was a client-only array that was lost on navigation.)
-  const [queued, setQueued] = useState<string[]>([])
+  const [queued, setQueued] = useState<QueuedTurn[]>([])
   // The GET /stream subscription. Aborting it only DETACHES this client from the run — the
   // daemon keeps executing it — so it never stops the run. One active stream per mounted session.
   const streamAbortRef = useRef<AbortController | null>(null)
@@ -243,6 +248,9 @@ export function CodeSessionScreen() {
             void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
           } else if (evt.event === 'queue') {
             setQueued(evt.data.queued)
+          } else if (evt.event === 'compaction') {
+            const compacting = evt.data.phase === 'start'
+            setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, compacting })))
           } else if (evt.event === 'reasoning') {
             const delta = evt.data.delta
             setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, reasoning: b.reasoning + delta })))
@@ -472,6 +480,15 @@ export function CodeSessionScreen() {
     await stopCodeSession(sessionId).catch(() => {})
   }
 
+  // "Send now" on a queued chip: stops the active turn and promotes this one to run next,
+  // WITHOUT dropping the rest of the queue (unlike handleStop above). No optimistic setQueued
+  // here — the reordered queue comes back as a fresh `queue` SSE frame moments later, and
+  // guessing the reorder client-side risks a flash of the wrong order if it doesn't match.
+  const handleSendNow = async (userMsgId: string) => {
+    if (!sessionId) return
+    await sendCodeQueuedTurnNow(sessionId, userMsgId).catch(() => {})
+  }
+
   // At most one tool call awaits interactive approval at a time (ask mode's gate is
   // sequential — same invariant ChatScreen relies on).
   const pendingApprovalBlock = live?.timeline.find((b) => b.kind === 'tool' && b.call.status === 'awaiting_approval')
@@ -612,6 +629,12 @@ export function CodeSessionScreen() {
                   <span className="max-w-[70px] truncate md:max-w-none">{session.branch}</span>
                 </span>
               )}
+              {(session.add > 0 || session.del > 0) && (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted">
+                  <Diff size={11} className="shrink-0" />
+                  <span className="max-w-[70px] truncate md:max-w-none">{formatDiff(session.add, session.del)}</span>
+                </span>
+              )}
             </>
           )}
         </div>
@@ -650,7 +673,7 @@ export function CodeSessionScreen() {
               <CodeTranscript
                 messages={transcriptMessages}
                 liveAssistantId={live?.assistantId}
-                live={live ? { timeline: live.timeline, reasoning: live.reasoning } : null}
+                live={live ? { timeline: live.timeline, reasoning: live.reasoning, compacting: live.compacting } : null}
                 onRevert={live || queued.length > 0 ? undefined : openRevertConfirm}
               />
             )}
@@ -680,12 +703,21 @@ export function CodeSessionScreen() {
               <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted">
                 <Clock size={11} className="text-faint" /> Queued
               </span>
-              {queued.map((q, i) => (
+              {queued.map((q) => (
                 <span
-                  key={i}
-                  className="inline-flex max-w-[240px] items-center gap-1 rounded-full border border-border bg-panel-2 px-2.5 py-1 text-[12px] text-muted"
+                  key={q.userMsgId}
+                  className="inline-flex max-w-[280px] items-center gap-1 rounded-full border border-border bg-panel-2 py-1 pr-1 pl-2.5 text-[12px] text-muted"
                 >
-                  <span className="min-w-0 truncate" title={q}>{q}</span>
+                  <span className="min-w-0 truncate" title={q.task}>{q.task}</span>
+                  <button
+                    type="button"
+                    onClick={() => void handleSendNow(q.userMsgId)}
+                    title="Send now — stop the current run and run this one next"
+                    aria-label="Send now"
+                    className="grid h-5 w-5 shrink-0 place-items-center rounded-full text-faint transition-colors hover:bg-panel hover:text-ink"
+                  >
+                    <SendHorizontal size={11} />
+                  </button>
                 </span>
               ))}
             </div>
@@ -724,7 +756,9 @@ export function CodeSessionScreen() {
               ...(skillsQ.data ?? []).map((s) => ({ id: s.id, description: s.description })),
             ]}
             hintText={live
-              ? (queued.length ? `${queued.length} queued · Enter to queue another` : 'Running — Enter to queue a follow-up')
+              ? (live.compacting
+                  ? 'Compacting conversation…'
+                  : queued.length ? `${queued.length} queued · Enter to queue another` : 'Running — Enter to queue a follow-up')
               : 'Enter to send · Shift+Enter for newline'}
           />
         </div>

--- a/turbollm/web/src/screens/code/CodeTranscript.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.tsx
@@ -653,17 +653,20 @@ function chunkPersistedTimeline(timeline: MessageTimelineBlock[], toolCalls: Too
  *  context, which can run many seconds with zero timeline/reasoning content.
  *  Without this, CodeStreamingEntry renders nothing at all and the turn looks
  *  stuck (chat/MessageBubble.tsx's StreamingBubble has the equivalent
- *  "always-on activity line" for the same reason). */
-function CodeThinking() {
+ *  "always-on activity line" for the same reason). `label` distinguishes pi's
+ *  auto-compaction (which silently summarizes history mid-turn with no other
+ *  signal) from ordinary "no content yet" — same spinner, different text, so a
+ *  long compaction pause doesn't read as a stuck/dead run. */
+function CodeThinking({ label = 'thinking…' }: { label?: string }) {
   return (
     <div className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
       <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />
-      <span>thinking…</span>
+      <span>{label}</span>
     </div>
   )
 }
 
-function CodeStreamingEntry({ timeline, reasoning }: { timeline: LiveBlock[]; reasoning: string }) {
+function CodeStreamingEntry({ timeline, reasoning, compacting }: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean }) {
   const chunks = chunkTimeline(timeline)
   const hasContent = !!reasoning?.trim() || chunks.length > 0
   return (
@@ -686,11 +689,17 @@ function CodeStreamingEntry({ timeline, reasoning }: { timeline: LiveBlock[]; re
               </RailEntry>
             ),
       )}
-      {!hasContent && (
-        <RailEntry icon={Terminal} tone="accent">
-          <CodeThinking />
-        </RailEntry>
-      )}
+      {compacting
+        ? (
+            <RailEntry icon={Terminal} tone="accent">
+              <CodeThinking label="Compacting conversation…" />
+            </RailEntry>
+          )
+        : !hasContent && (
+            <RailEntry icon={Terminal} tone="accent">
+              <CodeThinking />
+            </RailEntry>
+          )}
     </div>
   )
 }
@@ -700,7 +709,7 @@ export function CodeTranscript({
 }: {
   messages: Message[]
   liveAssistantId?: string
-  live?: { timeline: LiveBlock[]; reasoning: string } | null
+  live?: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean } | null
   /** Revert affordance on each user message — omitted entirely (via `undefined`) while a run
    *  is live, and never shown on the FIRST message (nothing before it to revert to; `messages`
    *  here is already cut at any existing /clear point, so index 0 is always correct). */
@@ -721,7 +730,7 @@ export function CodeTranscript({
           />
         ))}
       {live && (
-        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} />
+        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} compacting={live.compacting} />
       )}
     </div>
   )

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -166,6 +166,13 @@ export function ModelDetailDialog({
   // stop it first, then start the sweep once the engine has settled.
   const startBenchRun = () => {
     if (!detail) return
+    // Persist the current draft FIRST, before anything else (ADR-220). The draft only ever
+    // lives in this component's local state — sending it as `base` tells auto-tune to start
+    // its search from these settings, but doesn't save them. If the user cancels the run or
+    // doesn't click Save on the results dialog, their own manual edits were gone with no way
+    // back (a real founder-reported data-loss report). Save it exactly like the "Save without
+    // reloading" button would, so it's recoverable regardless of what auto-tune does next.
+    if (draft) actions.save.mutate({ key: detail.key, profile: draft, engineId: activeEngine?.id ?? '*' })
     if (detail.loaded) {
       // Stop the engine; the effect above starts the sweep once it reports stopped.
       setPendingBenchKey(detail.key)
@@ -697,6 +704,7 @@ function AutoTuneResultDialog({
     vramMb: number | null
     sampling?: CardSampling
     recommendedSampling?: CardSampling
+    kvAdvisory?: string
   }
   modelName?: string
   onSave: (downloadLog: boolean) => void
@@ -753,6 +761,10 @@ function AutoTuneResultDialog({
                   {result.vramMb != null && <ConfigRow label="VRAM used" value={`~${result.vramMb.toLocaleString()} MB`} />}
                   {result.ttftMs ? <ConfigRow label="First token" value={`${Math.round(result.ttftMs)} ms`} /> : null}
                 </div>
+              )}
+
+              {result?.kvAdvisory && (
+                <p className="text-[12px]" style={{ color: 'var(--warn)' }}>{result.kvAdvisory}</p>
               )}
 
               <span className="text-faint">

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -1,5 +1,4 @@
 ﻿import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
 import { ChevronDown, ExternalLink, Gauge, RotateCcw, Save, X, Zap } from 'lucide-react'
 import { ApiError } from '../../lib/api'
 import { useBenchActions, useBenchState, useEngines, useModelActions, useModelDetail, useStatus } from '../../lib/queries'
@@ -65,7 +64,6 @@ export function ModelDetailDialog({
   const [draft, setDraft] = useState<LoadProfile | null>(null)
   const [advanced, setAdvanced] = useState(false)
   const [remember, setRemember] = useState(true)
-  const qc = useQueryClient()
 
   const detail = detailQ.data
   const statusQ = useStatus()
@@ -188,12 +186,13 @@ export function ModelDetailDialog({
     bench.save.mutate(undefined, {
       onSuccess: () => {
         toast.success('Tuned settings saved')
-        // Refetch ONLY here — right after an actual save — so the form reflects the new
-        // settings immediately (no close/reopen needed). ADR-221: this used to fire on every
-        // `benchDone` (completion OR cancel), refetching stale server data over the user's
-        // still-unsaved local draft before they'd even decided Save vs. Cancel — the real
-        // cause of the original "my config was gone" report.
-        if (detail?.key) void qc.invalidateQueries({ queryKey: ['model', detail.key] })
+        // No explicit invalidateQueries needed here — `bench.save`'s own mutation hook
+        // (useBenchActions, queries.ts) already invalidates the `['model']` prefix on success,
+        // which covers this detail query and runs independent of this component's lifecycle.
+        // ADR-221: the bug was a `benchDone`-keyed effect that refetched on EVERY completion
+        // (cancel included), clobbering unsaved local edits before the user had even decided
+        // Save vs. Cancel — that effect is deleted; a real save is the only thing that should
+        // ever trigger a refetch, and the existing hook-level invalidation already does that.
         if (downloadLog) {
           const a = document.createElement('a')
           a.href = '/api/v1/bench/log'

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -692,6 +692,7 @@ function AutoTuneResultDialog({
   result?: {
     params: { ctx: number; ngl: number; nglFit?: boolean; nCpuMoe: number; nCpuMoeFit?: boolean; parallel: number; kvTypeK: string; flashAttn: string }
     tps: number
+    prefillTps?: number | null
     ttftMs?: number
     vramMb: number | null
     sampling?: CardSampling
@@ -747,7 +748,8 @@ function AutoTuneResultDialog({
                   )}
 
                   <ConfigSection title="Measured" />
-                  <ConfigRow label="Speed" value={`${result.tps.toFixed(1)} tok/s`} />
+                  <ConfigRow label="Generation speed" value={`${result.tps.toFixed(1)} tok/s`} />
+                  {result.prefillTps != null && <ConfigRow label="Prefill speed" value={`${result.prefillTps.toFixed(0)} tok/s`} />}
                   {result.vramMb != null && <ConfigRow label="VRAM used" value={`~${result.vramMb.toLocaleString()} MB`} />}
                   {result.ttftMs ? <ConfigRow label="First token" value={`${Math.round(result.ttftMs)} ms`} /> : null}
                 </div>

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -166,13 +166,13 @@ export function ModelDetailDialog({
   // stop it first, then start the sweep once the engine has settled.
   const startBenchRun = () => {
     if (!detail) return
-    // Persist the current draft FIRST, before anything else (ADR-220). The draft only ever
-    // lives in this component's local state — sending it as `base` tells auto-tune to start
-    // its search from these settings, but doesn't save them. If the user cancels the run or
-    // doesn't click Save on the results dialog, their own manual edits were gone with no way
-    // back (a real founder-reported data-loss report). Save it exactly like the "Save without
-    // reloading" button would, so it's recoverable regardless of what auto-tune does next.
-    if (draft) actions.save.mutate({ key: detail.key, profile: draft, engineId: activeEngine?.id ?? '*' })
+    // Use the current draft as the search's starting basis (ctx, sampling, etc.) via `base`
+    // below — but do NOT persist it (ADR-221). An earlier attempt saved the draft to the
+    // backend right here (ADR-220), which created the opposite problem: cancelling a run the
+    // founder didn't like left that pre-auto-tune draft permanently saved even though they'd
+    // never asked to commit it. The real cause of the original "my config was gone" report was
+    // the stale-refetch effect below firing on every `benchDone` (cancel included) BEFORE any
+    // save happened — fixed there instead; no defensive save needed here.
     if (detail.loaded) {
       // Stop the engine; the effect above starts the sweep once it reports stopped.
       setPendingBenchKey(detail.key)
@@ -182,21 +182,18 @@ export function ModelDetailDialog({
     }
   }
 
-  // When a sweep finishes it saves the tuned profile server-side — refetch the detail
-  // so the form reflects the new settings immediately (no close/reopen needed).
-  useEffect(() => {
-    if (benchDone && detail?.key) {
-      void qc.invalidateQueries({ queryKey: ['model', detail.key] })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [benchDone, detail?.key])
-
   // Auto-tune results dialog (shown on a finished run). Both buttons close the whole model dialog;
   // Save persists the tuned profile (POST /bench/save), Cancel discards it.
   const onTuneSave = (downloadLog: boolean) => {
     bench.save.mutate(undefined, {
       onSuccess: () => {
         toast.success('Tuned settings saved')
+        // Refetch ONLY here — right after an actual save — so the form reflects the new
+        // settings immediately (no close/reopen needed). ADR-221: this used to fire on every
+        // `benchDone` (completion OR cancel), refetching stale server data over the user's
+        // still-unsaved local draft before they'd even decided Save vs. Cancel — the real
+        // cause of the original "my config was gone" report.
+        if (detail?.key) void qc.invalidateQueries({ queryKey: ['model', detail.key] })
         if (downloadLog) {
           const a = document.createElement('a')
           a.href = '/api/v1/bench/log'


### PR DESCRIPTION
## Summary

Three batches of work, bundled into one PR:

**Code UX/reliability** (`ec0c677`)
- Fixes an intermittent (~25%) Stop-button failure in Code: bash tool calls could keep running after the UI already showed "aborted" — root cause was Windows/MSYS2 process-tree kills silently failing. Replaced with a WMI-based verified kill (`robust-bash.ts`).
- Adds live multi-device/tab sync for Chat and Code (both screens only updated on local action before).
- Adds a "Send now" action for queued follow-up turns, auto-compaction UI state, and a Radix-based rewrite of the thinking-budget slider (was a hand-rolled popover with manual outside-click handling).

**Auto-tune accuracy** (`8fbcba1`)
- Root-caused and fixed a founder-reported gap between auto-tune's reported tok/s and real chat tok/s. Went through 3 iterations, each validated on real hardware:
  - Bench request now uses the app's real "Default" agent system prompt + deterministic realistic filler, depth-targeted to the user's configured ctx (capped at 32k tokens) instead of a synthetic/shallow sample.
  - VRAM headroom gate now re-validates against real post-generation VRAM, not just the pre-generation probe.
  - AMD VRAM reading added — the headroom gate was previously silently inert on non-NVIDIA GPUs.
  - Auto-tune results dialog now shows prefill speed (was measured, never displayed).
- Result: auto-tune's number now tracks real chat within ~14%, down from a 41-71% gap depending on methodology. Founder-accepted; full real-hardware data across all iterations is in the local decision log (ADR-217).

**Auto-tune KV-type sweep removed + two more live-tested bugs fixed** (`6b4d150`)
- Live A/B testing (real, process-verified command-line flags) found auto-tune's own quality-preserving KV pick (turbo4) was ~3.8x slower AND used more VRAM than a manually-configured alternative (q4_0) at the same offload. Root-caused from TurboQuant's own C++ source: turbo2/3/4 run a real Walsh-Hadamard rotation + calibration step per cached token, plus extra rotation-tensor VRAM — a deliberate quality-for-speed trade, not a bug, and not something the old KV-selection heuristic accounted for.
- Auto-tune no longer sweeps/chooses KV-cache type at all — it tunes offload only, on whatever type is already selected. Added a non-automatic speed advisory instead: when the result is slow and a smaller, non-turbo type is available, the results dialog notes it without switching anything.
- Found and fixed along the way: engine capability probing granted turbo2/3/4 support to any engine whose `--help` text merely contained the substring "turbo" anywhere (confirmed false positive on `ik_llama.cpp`, an unrelated fork) — now scoped to the `--cache-type-k` flag's own help block.
- Two more bugs found during live re-testing: starting auto-tune could silently lose unsaved manual config edits (now persisted first, same path as "Save without reloading"); cancelling a run could take up to 8s per in-flight stop via the default graceful-TERM path (now force-kills immediately when cancelled).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 937 passing, 0 failing
- [x] `npm run build` (backend) + `npm run build:web` — both clean
- [x] Live-verified on real hardware throughout: Stop button, multi-device sync, the full auto-tune-vs-chat comparison, and the KV-type/VRAM discrepancy investigation (traced to TurboQuant's actual source), all against production builds on the founder's own machine
- [ ] Cancel-speed fix and draft-persist fix are code-verified (typecheck + existing suite) but not independently live-tested yet — no live-process test harness exists for the Manager class's real kill timing