### PR TITLE
fix: auto-tune single-GPU gating, AMD VRAM, build error messaging, Code context/crash, chat title bugs, custom-engine parity

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -915,7 +915,11 @@ export function registerApi(app: Hono, d: Deps): void {
   // Registered BEFORE the :id route below — Hono matches in registration order, and :id would
   // otherwise swallow "custom-sources" as its own param value.
   app.delete('/api/v1/engines/custom-sources/:key', (c) => {
-    d.registry.forgetCustomSource(decodeURIComponent(c.req.param('key')))
+    // c.req.param() already URL-decodes path segments (Hono) — decoding again corrupts any
+    // key containing a literal '%' (the binPath fallback key can) and throws on an invalid
+    // escape, since a normal key's second decode is a harmless no-op that hid this on the
+    // happy path.
+    d.registry.forgetCustomSource(c.req.param('key'))
     return c.json({ ok: true })
   })
 
@@ -926,8 +930,19 @@ export function registerApi(app: Hono, d: Deps): void {
       return err(c, 409, 'engine_in_use', 'Stop the engine before removing it.')
     }
     const purge = c.req.query('purge') === '1'
+    // Set by the frontend's custom-engine Disable (never alongside purge): a custom engine
+    // added before customEngineSources tracking existed has no recorded identity, so a plain
+    // Disable would otherwise vanish it with no Enable path back. recordCustomSource is a
+    // record-or-refresh, so this is a no-op when a record already exists.
+    const recordSource = c.req.query('recordSource') === '1'
     try {
       const eng = d.registry.get(id)
+      if (recordSource && !purge && eng) {
+        d.registry.recordCustomSource({
+          name: eng.name, binPath: eng.binPath, kind: eng.kind,
+          sourceRepo: eng.sourceRepo, sourceBranch: eng.sourceBranch, sourceCommit: eng.sourceCommit,
+        })
+      }
       d.registry.remove(id)
       // ?purge=1: also delete the engine's installed files from disk.
       // Only removes dirs under {dataDir}/engines/ — never touches model dirs.

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -11,7 +11,7 @@ import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, VRAM_
 import type { Deps } from '../deps'
 import { type ModelInfo, type StartOpts } from '../engines/manager'
 import { abortAllInFlightChats } from '../chat/chat-routes'
-import { NameTakenError, NotFoundError } from '../engines/registry'
+import { NameTakenError, NotFoundError, customSourceKey } from '../engines/registry'
 import { ProbeError, probe } from '../engines/probe'
 import { resolveServerBinary, suggestEngineName } from '../engines/scan'
 import { generateApiKey, isLocalRequest } from '../auth'
@@ -154,7 +154,17 @@ export function registerApi(app: Hono, d: Deps): void {
   // ---- engine registry (A1) ----
   app.get('/api/v1/engines', (c) => {
     const { engines, activeEngineId } = d.registry.list()
-    return c.json({ engines, activeEngineId })
+    // Custom (non-catalog) engines that are currently DISABLED — recorded (recordCustomSource)
+    // when added, kept across a plain Disable, dropped only on purge. Cross-referenced against
+    // the LIVE registry by customSourceKey so a re-enabled/rebuilt entry doesn't show twice.
+    // binPathExists lets the UI offer a real "Enable" (re-register, no rebuild) vs. a
+    // "build no longer on disk, rebuild from source" state for one the user deleted by hand.
+    const liveKeys = new Set(engines.map((e) => customSourceKey(e)))
+    const customDisabled = d.registry
+      .customSources()
+      .filter((s) => !liveKeys.has(customSourceKey(s)))
+      .map((s) => ({ ...s, binPathExists: existsSync(s.binPath) }))
+    return c.json({ engines, activeEngineId, customDisabled })
   })
 
   // ---- engine backends (ADR-025): hardware-aware default + override ----
@@ -589,6 +599,13 @@ export function registerApi(app: Hono, d: Deps): void {
           sourceCommit: commit,
         })).engine
         d.registry.activate(eng.id)
+        // A genuinely custom repo (not one of the catalog's own known projects) needs its
+        // identity remembered independent of the live registration — see recordCustomSource's
+        // own doc comment. A catalog repo already gets equivalent treatment from the /catalog
+        // endpoint's own disk scan, so it's deliberately excluded here.
+        if (!isCatalogRepo(repoUrl)) {
+          d.registry.recordCustomSource({ name: eng.name, binPath: eng.binPath, kind: eng.kind, sourceRepo: repoUrl, sourceBranch: branch, sourceCommit: commit })
+        }
         d.build.log(`Registered "${eng.name}" — built from ${out.commit.slice(0, 8)}.`)
         d.build.done()
       } catch (e) {
@@ -816,13 +833,20 @@ export function registerApi(app: Hono, d: Deps): void {
     // Refuse it from non-loopback callers even with a key (defense in depth).
     if (!isLocalRequest(c, d))
       return err(c, 403, 'forbidden', 'Engines can only be added from the machine running TurboLLM.')
-    const b = await body<{ name?: string; binPath?: string; sourceRepo?: string; sourceBranch?: string }>(c)
+    const b = await body<{ name?: string; binPath?: string; sourceRepo?: string; sourceBranch?: string; sourceCommit?: string }>(c)
     if (!b.binPath || !b.binPath.trim()) return err(c, 400, 'invalid_config_value', 'binPath is required.')
     try {
       const { engine, warning } = await d.registry.add(b.name ?? '', b.binPath, {
         sourceRepo: b.sourceRepo,
         sourceBranch: b.sourceBranch,
+        sourceCommit: b.sourceCommit,
       })
+      // Same custom-source tracking as the 1-click build completion above — a manually
+      // pointed-at binary (with or without a sourceRepo) is just as much a "custom engine"
+      // as a self-service build, and deserves the same Disable-survives-as-Enable treatment.
+      if (!isCatalogRepo(b.sourceRepo)) {
+        d.registry.recordCustomSource({ name: engine.name, binPath: engine.binPath, kind: engine.kind, sourceRepo: b.sourceRepo, sourceBranch: b.sourceBranch, sourceCommit: b.sourceCommit })
+      }
       // `probe_no_version` is non-blocking (spec 03 §2): the engine is saved, but
       // the response carries a warning flag so the dialog can prompt the user.
       return c.json({ ...engine, warning: warning ?? null }, 201)
@@ -885,6 +909,16 @@ export function registerApi(app: Hono, d: Deps): void {
     }
   })
 
+  // Forget a DISABLED custom engine's remembered identity (customEngineSources) — no live
+  // registry entry to delete (that's the whole point: it's disabled, not registered), so this
+  // is distinct from DELETE /api/v1/engines/:id?purge=1 below. Never touches files on disk.
+  // Registered BEFORE the :id route below — Hono matches in registration order, and :id would
+  // otherwise swallow "custom-sources" as its own param value.
+  app.delete('/api/v1/engines/custom-sources/:key', (c) => {
+    d.registry.forgetCustomSource(decodeURIComponent(c.req.param('key')))
+    return c.json({ ok: true })
+  })
+
   app.delete('/api/v1/engines/:id', (c) => {
     const id = c.req.param('id')
     const { activeEngineId } = d.registry.list()
@@ -903,6 +937,11 @@ export function registerApi(app: Hono, d: Deps): void {
         if (purgeDir && existsSync(purgeDir)) {
           rmSync(purgeDir, { recursive: true, force: true })
         }
+        // A purge is a real delete, not a Disable — drop any remembered custom-engine
+        // identity too, so a purged engine doesn't linger as a "disabled" card with a
+        // now-broken Enable (its files are gone). A plain Disable (no purge) leaves this
+        // record alone; that's the whole point of recordCustomSource.
+        d.registry.forgetCustomSource(customSourceKey(eng))
       }
       return c.json({ ok: true })
     } catch (e) {
@@ -2244,6 +2283,16 @@ function benchError(c: Context, e: unknown) {
 function engineBusy(d: Deps): boolean {
   const s = d.manager.status().state
   return s === 'running' || s === 'starting' || s === 'stopping'
+}
+
+/** True when `repoUrl` matches a known catalog engine's homepage (llama.cpp, TurboQuant, …).
+ *  Gates {@link Registry.recordCustomSource}: a catalog repo already gets its own re-enable
+ *  detection (the /catalog endpoint's `sourceBuildBinary(enginesRoot, e.homepage)` scan, keyed
+ *  by that fixed, hardcoded URL) — recording it as a "custom" source too would just duplicate
+ *  that, and could show the SAME build as two different cards. */
+function isCatalogRepo(repoUrl: string | undefined): boolean {
+  if (!repoUrl) return false
+  return catalogForPlatform().some((e) => sameRepo(repoUrl, e.homepage))
 }
 
 function regErr(c: Context, e: unknown) {

--- a/turbollm/src/bench/bench.split.test.ts
+++ b/turbollm/src/bench/bench.split.test.ts
@@ -61,11 +61,23 @@ test('multi-GPU, model fits one card → single-GPU FIRST, then layer-split', ()
 
 test('multi-GPU, model too big for one card even at smallest KV → layer-split only', () => {
   const s = sys([24000, 24000])
-  // ~60 GB weights: overflows a single 24 GB card no matter the KV quant, but the summed pool is
-  // its only hope — so single-GPU is not offered, layer-split is kept.
+  // ~60 GB weights: even fully on CPU (ngl=0) plus KV/overhead this barely clears one 24 GB card,
+  // and any real GPU residency overflows it fast — so single-GPU is well under 50% and skipped.
   const strats = pickSplitStrategies(model({ sizeBytes: 60_000_000_000 }), s, base(s), caps)
   assert.equal(strats.length, 1)
   assert.equal(strats[0].splitMode, 'layer')
+})
+
+test('multi-GPU, model just barely exceeds one card at FULL offload → single-GPU still offered (GitHub #62)', () => {
+  // 15 GB weights on a 16 GB card: doesn't fit at ngl=32 (full offload) but easily fits at a
+  // partial ngl (CPU covering only the tail) — the search should get a shot at that, instead of
+  // being forced straight into a slower cross-GPU layer-split the way GitHub #62 reported (a model
+  // that easily fit fully split across two cards, with VRAM to spare, was never tried on one card
+  // alone even though the vast majority of it would sit there fine).
+  const s = sys([16000, 16000])
+  const strats = pickSplitStrategies(model({ sizeBytes: 15_000_000_000, blockCount: 32, nativeCtx: 8192 }), s, base(s, { ctx: 8192 }), caps)
+  assert.ok(strats.some((g) => g.splitMode === 'none'), 'single-GPU strategy should be offered')
+  assert.equal(strats[0].splitMode, 'none', 'tried first — the likely winner')
 })
 
 test('single-GPU is offered thanks to the smallest-KV fit estimate (turbo4), not the base f16', () => {

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1301,16 +1301,26 @@ export function pickSplitStrategies(
   if (sys.gpus.length <= 1 || !has('--split-mode') || !has('--main-gpu')) return [base.gpu]
 
   const strategies: GpuProfile[] = []
-  // Single-GPU: whole model on one card. Judge feasibility with the SMALLEST quality-preserving KV
-  // the engine offers (the inner KV sweep can pick it to fit), so a model that only fits one card
-  // with turbo4 still gets the single-GPU branch it would win on.
+  // Single-GPU: as much of the model as this ONE card can hold. Judge feasibility with the SMALLEST
+  // quality-preserving KV the engine offers (the inner KV sweep can pick it to fit), so a model that
+  // only fits one card with turbo4 still gets the single-GPU branch it would win on.
   const kvOpts = pickKvQuants(base.kvTypeK, caps.kvTypes)
   const bestFitKv = kvOpts.reduce((a, b) => (kvBytes(b) < kvBytes(a) ? b : a), kvOpts[0] ?? base.kvTypeK)
   const mainGpu = base.gpu.mainGpu >= 0 ? base.gpu.mainGpu : 0
   const single: GpuProfile = { ...base.gpu, splitMode: 'none', mainGpu, tensorSplit: [] }
-  const singleFits =
-    estimateVram({ ...base, gpu: single, kvTypeK: bestFitKv, kvTypeV: bestFitKv }, entry, sys).verdict !== 'overflow'
-  if (singleFits) strategies.push(single)
+  // Feasibility is NOT "does the model fit at FULL GPU offload" — the inner offload search
+  // (denseSearch/moeSearch) already handles PARTIAL residency just fine, and a single card holding
+  // most of the model (CPU covering only the tail) still beats a cross-GPU layer-split, which pays a
+  // PCIe activation-copy tax at every layer boundary — worse yet with mismatched card speeds. Gating
+  // on "fits fully" skipped single-GPU whenever a model exceeded one card's capacity by even a
+  // little, forcing the slower split even when 90%+ of the model would happily sit on one GPU
+  // (GitHub #62: a model whose weights just missed a 16 GB card only ever got tried as a 2-GPU
+  // layer-split — comfortably fitting with VRAM to spare — and that came in at 4.8 tok/s). Instead,
+  // find the largest GPU-resident fraction this ONE card can hold and offer single-GPU only when
+  // CPU wouldn't end up doing the majority of the work — below that, the summed multi-GPU pool
+  // (kept as today's fallback either way) is the sounder bet.
+  const singleFrac = maxGpuFraction(entry, sys, { ...base, gpu: single, kvTypeK: bestFitKv, kvTypeV: bestFitKv })
+  if (singleFrac >= 0.5) strategies.push(single)
 
   // The profile's current split (default: layer across all GPUs) — always kept, as the fallback for
   // models too big for one card and so a tuned result can never be worse than today's default.
@@ -1324,6 +1334,33 @@ export function pickSplitStrategies(
     seen.add(key)
     return true
   })
+}
+
+/** The largest GPU-resident fraction (0..1) of `entry` that fits under `profile.gpu`'s own VRAM
+ *  budget, per {@link estimateVram}'s math — a cheap deterministic binary search (no real probing).
+ *  Dense: highest ngl/blockCount that isn't 'overflow'. MoE: complement of the lowest nCpuMoe/blockCount
+ *  that isn't 'overflow' (more CPU experts = less GPU residency, so the search direction inverts).
+ *  Used to decide whether single-GPU is even worth trying — see {@link pickSplitStrategies}. */
+function maxGpuFraction(entry: ModelEntry, sys: SysInfo, profile: LoadProfile): number {
+  const blocks = entry.blockCount > 0 ? entry.blockCount : 1
+  const fits = (n: number) =>
+    estimateVram(entry.moe ? { ...profile, nCpuMoe: n } : { ...profile, ngl: n }, entry, sys).verdict !== 'overflow'
+  let lo = 0
+  let hi = blocks
+  if (entry.moe) {
+    let best = blocks // worst case: every expert on CPU
+    while (lo <= hi) {
+      const mid = Math.floor((lo + hi) / 2)
+      if (fits(mid)) { best = mid; hi = mid - 1 } else { lo = mid + 1 }
+    }
+    return 1 - best / blocks
+  }
+  let best = 0
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    if (fits(mid)) { best = mid; lo = mid + 1 } else { hi = mid - 1 }
+  }
+  return best / blocks
 }
 
 /** Human-readable label for a split strategy, for the live step / bench log. */

--- a/turbollm/src/chat/chat-routes.test.ts
+++ b/turbollm/src/chat/chat-routes.test.ts
@@ -7,6 +7,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { stripThinkingBlocks, needsExtraPass } from './think-utils.js'
+import { recentTitleTurns } from './chat-routes.js'
 
 // ── stripThinkingBlocks ───────────────────────────────────────────────────────
 
@@ -69,4 +70,46 @@ test('needsExtraPass: returns false for plain text with no thinking tokens', () 
 
 test('needsExtraPass: returns false when think block is followed by non-whitespace', () => {
   assert.equal(needsExtraPass('<think>step</think>\n\nActual answer here.'), false)
+})
+
+// ── recentTitleTurns ──────────────────────────────────────────────────────────
+// GitHub: "the AI generated chat title is broken. It gets title based on memory and not based
+// on msg I send." For a brand-new conversation (exactly when auto-title fires), engineMessages
+// is just [system, user] — a plain slice(-2) grabbed the memory-stuffed system prompt right
+// alongside the real first message.
+
+test('recentTitleTurns: excludes the injected system prompt for a brand-new conversation', () => {
+  const engineMessages = [
+    { role: 'system', content: 'You are TurboLLM...\n\nWhat you know about the user from past conversations:\n- Likes cats\n- Works in finance' },
+    { role: 'user', content: 'How do I center a div in CSS?' },
+  ]
+  const turns = recentTitleTurns(engineMessages)
+  assert.equal(turns.length, 1)
+  assert.equal(turns[0].role, 'user')
+  assert.equal(turns[0].content, 'How do I center a div in CSS?')
+})
+
+test('recentTitleTurns: still takes the last N when there IS real history (no system message present)', () => {
+  const engineMessages = [
+    { role: 'user', content: 'first turn' },
+    { role: 'assistant', content: 'first reply' },
+    { role: 'user', content: 'second turn' },
+  ]
+  const turns = recentTitleTurns(engineMessages)
+  assert.deepEqual(turns.map((t) => t.content), ['first reply', 'second turn'])
+})
+
+test('recentTitleTurns: a system message is excluded even when mixed in with real history', () => {
+  const engineMessages = [
+    { role: 'system', content: 'hidden capability + memory block' },
+    { role: 'user', content: 'first turn' },
+    { role: 'assistant', content: 'first reply' },
+  ]
+  const turns = recentTitleTurns(engineMessages)
+  assert.ok(turns.every((t) => t.role !== 'system'))
+  assert.deepEqual(turns.map((t) => t.content), ['first turn', 'first reply'])
+})
+
+test('recentTitleTurns: empty input yields empty output, no throw', () => {
+  assert.deepEqual(recentTitleTurns([]), [])
 })

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -1324,6 +1324,17 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
 
 // ── auto title generation ──────────────────────────────────────────────────
 
+/** PURE: the last `n` actual conversation turns to ground title generation in — excludes the
+ *  injected system prompt (capability boilerplate + persona + personalization + auto-memory
+ *  facts, see buildSystemPrompt). For a BRAND NEW conversation — exactly when auto-title fires —
+ *  engineMessages is just [system, user], so a plain `.slice(-n)` grabs the memory-stuffed
+ *  system message right alongside the real first message. A model handed a hefty "what I know
+ *  about you" block next to one short user turn often titled the chat off THAT instead of what
+ *  was actually asked (GitHub: "gets title based on memory and not based on msg I send"). */
+export function recentTitleTurns(messages: { role: string; content: unknown }[], n = 2): { role: string; content: unknown }[] {
+  return messages.filter((m) => m.role !== 'system').slice(-n)
+}
+
 async function autoTitle(
   d: Deps,
   convId: string,
@@ -1335,7 +1346,7 @@ async function autoTitle(
     const ms = d.manager.status()
     if (ms.state !== 'running') return
     const titleMessages = [
-      ...prevMessages.slice(-2),
+      ...recentTitleTurns(prevMessages),
       { role: 'assistant', content: assistantReply.slice(0, 500) },
       {
         role: 'user',

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -763,14 +763,19 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
         })
       : undefined
     // Custom chat Agent tool allow-list (Customize → Agents), baked in at conversation
-    // creation. Undefined/empty = unrestricted — every built-in persona's conversations
-    // take this branch, so their tool list is byte-identical to before this feature.
+    // creation. Undefined (never set) = unrestricted — every untouched built-in persona's
+    // conversations take this branch, so their tool list is byte-identical to before this
+    // feature. An EXPLICIT empty array is different from unset, though — it means a
+    // built-in deliberately fixed its tool list to none (e.g. the Blank persona: "raw model
+    // output, no instructions injected" has to mean no tool-calling preamble too, not just
+    // an empty system prompt — GitHub #52) — so it must actually filter down to zero tools,
+    // not fall through to unrestricted the way a merely-absent list does.
     // Applied ONLY to the base (built-in + MCP) registry: skill-granted tools like
     // save_skill are never enumerated by /api/v1/tools (they only exist once their
     // skill is enabled), so they can never appear in the allow-list checklist — gating
     // them a second time here would silently strip save_skill from any agent that has
     // 'skill-creator' enabled. Enabling the skill IS the allow decision for its tools.
-    const scopedBaseToolDefs = conv.allowedTools?.length
+    const scopedBaseToolDefs = conv.allowedTools !== undefined
       ? baseToolDefs.filter((t) => conv.allowedTools!.includes(t.function.name))
       : baseToolDefs
     const toolDefs = skillTools ? [...scopedBaseToolDefs, ...skillTools.defs] : scopedBaseToolDefs
@@ -1218,13 +1223,23 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
   const thinkMs = thinkStart && thinkEnd ? thinkEnd - thinkStart : 0
   const ctxMax = ms.model?.ctx ?? 4096
 
+  // An aborted stream (Stop clicked, or the client disconnected mid-generation) can be cut off
+  // before the engine's final usage/timings chunk ever arrives, leaving completion_tokens at its
+  // default 0 — even though real output WAS generated, IS persisted (fullContent below), and WILL
+  // sit in context for the next turn. liveOut (incremented per streamed delta, above) is the one
+  // number we still have in that case; fall back to it instead of silently reporting "0 tokens"
+  // for a message that plainly has content (GitHub #52: "when you interrupt a model's response,
+  // the token count remains as 0+0, yet the model still sees the message in context, and the
+  // total token count remains unchanged").
+  const genTokensFallback = finalUsage.completion_tokens || liveOut
+
   const stats: Partial<MessageStats> = {
     ttftMs,
     totalMs,
     thinkMs,
     // Full context occupancy: cache-reused prompt tokens still sit in the KV cache / context
     // window (they're skipped only for recomputation), so they must stay counted here.
-    ctxUsed: (finalUsage.prompt_tokens ?? 0) + (finalUsage.completion_tokens ?? 0),
+    ctxUsed: (finalUsage.prompt_tokens ?? 0) + genTokensFallback,
     ctxMax,
     model: ms.model?.name ?? '',
     aborted,
@@ -1242,7 +1257,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
     stats.cachedTokens = cachedExplicit ?? Math.max(0, (fullPrompt || processed) - processed)
   } else {
     stats.promptTokens = fullPrompt
-    stats.genTokens    = finalUsage.completion_tokens ?? 0
+    stats.genTokens    = genTokensFallback
     stats.genMs        = totalMs - ttftMs
     stats.tps          = stats.genMs > 0 ? Math.round((stats.genTokens / stats.genMs) * 1000 * 10) / 10 : 0
     stats.cachedTokens = cachedExplicit ?? 0

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
 import { toSessionStatus } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand } from './code-session'
+import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor } from './code-session'
 import { ConversationStore } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
@@ -61,6 +61,41 @@ test('PATH_TOOLS: path-checked tools include the fs tools but NOT bash', () => {
   assert.deepEqual([...PATH_TOOLS].sort(), ['edit', 'find', 'grep', 'ls', 'read', 'write'])
   // bash takes `command`, not `path` — it must not be containment-checked by path.
   assert.ok(!PATH_TOOLS.has('bash'))
+})
+
+// GitHub #60: "ran out of context... it just failed, no attempt to roll up context." pi's own
+// auto-compaction defaults (reserve 16384 + keep-recent 20000 = 36384 tokens) assume a large
+// hosted model — unscaled, that alone can exceed a typical local model's real context window,
+// making compaction self-defeating (it "succeeds" but the result still doesn't fit, and pi only
+// retries an overflow once before giving up for good).
+test('compactionSettingsFor: scales down for a small local context window (8K)', () => {
+  const s = compactionSettingsFor(8192)
+  assert.equal(s.enabled, true)
+  assert.ok(s.reserveTokens + s.keepRecentTokens < 8192, 'reserve+keepRecent must leave real headroom')
+})
+
+test('compactionSettingsFor: reserve+keepRecent stays a bounded fraction of ctx (32K)', () => {
+  const s = compactionSettingsFor(32768)
+  assert.ok(s.reserveTokens + s.keepRecentTokens <= 32768 * 0.6)
+})
+
+test('compactionSettingsFor: never below a sane floor, even for a tiny context', () => {
+  const s = compactionSettingsFor(2048)
+  assert.ok(s.reserveTokens >= 512)
+  assert.ok(s.keepRecentTokens >= 1024)
+})
+
+test('compactionSettingsFor: caps at pi\'s own defaults for a large-context local build (200K)', () => {
+  const s = compactionSettingsFor(200_000)
+  assert.equal(s.reserveTokens, 16384)
+  assert.equal(s.keepRecentTokens, 20000)
+})
+
+test('compactionSettingsFor: monotonically non-decreasing with contextWindow (below the cap)', () => {
+  const small = compactionSettingsFor(8192)
+  const big = compactionSettingsFor(65536)
+  assert.ok(big.reserveTokens >= small.reserveTokens)
+  assert.ok(big.keepRecentTokens >= small.keepRecentTokens)
 })
 
 test('isDependencyAddCommand: detects install/add commands across common package managers', () => {

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -167,6 +167,27 @@ export function resolveEffectiveHistory(d: Deps, convId: string, sessionId: stri
   return { summaryText: `${COMPACTION_PREFIX}${run.compactionSummary}${COMPACTION_SUFFIX}`, messages: rest }
 }
 
+// pi's own auto-compaction defaults (reserveTokens: 16384, keepRecentTokens: 20000 — 36384 total)
+// assume a large HOSTED model's context window (100K+ tokens). A local model's real context is
+// often far smaller — 8K-32K is common on consumer GPUs — and left unscaled, reserve+keepRecent
+// ALONE can exceed the model's whole window. That makes compaction self-defeating: pi "compacts"
+// but still aims to keep ~20000 tokens of recent history, which the very next request can't fit
+// under either, immediately overflowing again — and pi only auto-retries an overflow ONCE before
+// giving up for good with "Context overflow recovery failed..." (GitHub #60: "ran out of
+// context... it just failed", with no attempt to roll up context that could actually succeed).
+const PI_DEFAULT_RESERVE_TOKENS = 16384
+const PI_DEFAULT_KEEP_RECENT_TOKENS = 20000
+
+/** Auto-compaction settings scaled to the REAL loaded model's context window instead of pi's
+ *  hosted-model-sized defaults — reserve ~15% and keep-recent ~35% of `contextWindow` (leaving
+ *  the other ~50% for the compaction summary, system prompt/skills, and the new turn), capped at
+ *  pi's own defaults so a large-context local setup (e.g. a 200K-ctx build) is unaffected. */
+export function compactionSettingsFor(contextWindow: number): { enabled: boolean; reserveTokens: number; keepRecentTokens: number } {
+  const reserveTokens = Math.max(512, Math.min(PI_DEFAULT_RESERVE_TOKENS, Math.round(contextWindow * 0.15)))
+  const keepRecentTokens = Math.max(1024, Math.min(PI_DEFAULT_KEEP_RECENT_TOKENS, Math.round(contextWindow * 0.35)))
+  return { enabled: true, reserveTokens, keepRecentTokens }
+}
+
 /** A minimal SSE sink — matches the chat wire shape so the existing frontend parser works. */
 export type CodeSseSink = (ev: { event: string; data: unknown }) => void | Promise<void>
 
@@ -284,7 +305,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // ── in-memory pi services (no global pi config on disk) ──────────────────────
   const authStorage = AuthStorage.inMemory()
   const modelRegistry = ModelRegistry.inMemory(authStorage)
-  const settingsManager = SettingsManager.inMemory()
+  // Auto-compaction settings scaled to THIS model's real ctx (see compactionSettingsFor) — pi's
+  // own hosted-model-sized defaults would otherwise make auto-compaction self-defeating here.
+  const settingsManager = SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) })
   // Seed prior turns (see seedPriorHistory's own comment), respecting any existing manual
   // /compact — everything up to but NOT including the current turn's user message.
   // code-run-manager.ts's pump() has already appended both `task`'s own user message AND an
@@ -520,7 +543,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       modelRegistry: skillRegistry,
       resourceLoader: skillResourceLoader,
       sessionManager: SessionManager.inMemory(repoRoot),
-      settingsManager: SettingsManager.inMemory(),
+      // Same ctx-scaled auto-compaction settings as the outer session (compactionSettingsFor) —
+      // a skill sub-session shares the same model/contextWindow, so the same defaults apply.
+      settingsManager: SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) }),
       customTools: [skillBash],
       ...(skillTools ? { tools: skillTools } : {}),
     })
@@ -1124,7 +1149,10 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
     authStorage,
     modelRegistry,
     sessionManager,
-    settingsManager: SettingsManager.inMemory(),
+    // Ctx-scaled settings (compactionSettingsFor) — pi's hosted-model-sized defaults could ask
+    // to keep more "recent" tokens than this model's real context window even has room for,
+    // producing a compacted result that still doesn't fit.
+    settingsManager: SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) }),
     resourceLoader: compactResourceLoader,
     tools: [], // pure summarization — no tool needs to run, and none should be able to.
   })

--- a/turbollm/src/code/lsp-client.ts
+++ b/turbollm/src/code/lsp-client.ts
@@ -157,7 +157,11 @@ export class LspClient {
       const result = await Promise.race([initialize.then(() => 'ok' as const), spawnFailure.then((e) => `error:${e}` as const), timeout])
       if (result === 'timeout') throw new Error(`${this.spec.language} language server did not initialize within ${INITIALIZE_TIMEOUT_MS}ms`)
       if (result.startsWith('error:')) throw new Error(result.slice('error:'.length))
-      conn.sendNotification('initialized', {})
+      // sendNotification returns a Promise that can reject ASYNCHRONOUSLY (e.g. ERR_STREAM_DESTROYED
+      // if the server process's stdin already closed) — fire-and-forget without a .catch() turns
+      // that into an unhandled rejection that crashes the whole daemon process (see dispose()'s own
+      // comment below for the exact stack this produces — GitHub #60's attached log).
+      conn.sendNotification('initialized', {}).catch(() => {})
       this.ready = true
       return { ok: true }
     } catch (e) {
@@ -186,9 +190,9 @@ export class LspClient {
     })
 
     if (version === 1) {
-      this.conn.sendNotification('textDocument/didOpen', { textDocument: { uri, languageId: this.spec.languageId, version, text } })
+      this.conn.sendNotification('textDocument/didOpen', { textDocument: { uri, languageId: this.spec.languageId, version, text } }).catch(() => {})
     } else {
-      this.conn.sendNotification('textDocument/didChange', { textDocument: { uri, version }, contentChanges: [{ text }] })
+      this.conn.sendNotification('textDocument/didChange', { textDocument: { uri, version }, contentChanges: [{ text }] }).catch(() => {})
     }
 
     await Promise.race([waitForPush, new Promise<void>((resolve) => setTimeout(resolve, DIAGNOSTICS_WAIT_MS))])
@@ -197,7 +201,14 @@ export class LspClient {
 
   dispose(): void {
     this.ready = false
-    try { this.conn?.sendNotification('exit') } catch { /* best-effort */ }
+    // sendNotification returns a Promise, and it can reject ASYNCHRONOUSLY — after this
+    // synchronous try/catch has already exited — when the server process's stdin is already
+    // closed (ERR_STREAM_DESTROYED: "Cannot call write after a stream was destroyed"). Without
+    // the .catch() below, that becomes an unhandled rejection that crashes the whole daemon
+    // process (GitHub #60's attached log: this exact stack, from vscode-jsonrpc's
+    // StreamMessageWriter → Writable.write). 'exit' is a courtesy notification either way —
+    // dispose() proceeds to kill the process regardless of whether it's delivered.
+    try { this.conn?.sendNotification('exit').catch(() => {}) } catch { /* best-effort */ }
     this.conn?.dispose()
     this.conn = null
     if (this.proc && !this.proc.killed) this.proc.kill()

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -48,6 +48,29 @@ export interface Engine {
    *  repo (registration would silently replace one with the other). */
   sourceCommit?: string
 }
+
+/** A custom (non-catalog) engine's identity, remembered independent of its live
+ *  {@link Engine} registration (GitHub: "custom engine treated as an outsider").
+ *
+ *  A catalog engine (llama.cpp, TurboQuant, …) can be disabled then re-enabled instantly
+ *  because its fixed, hardcoded homepage URL lets the backend re-scan disk for a still-built
+ *  binary. A custom repo has no such fixed identity anywhere else in the system — once its
+ *  {@link Engine} row is removed (Disable), nothing remembers which repo it came from. This
+ *  record is that memory: written when a non-catalog engine is added, kept across a Disable
+ *  (registry.remove), and only dropped on an explicit purge/delete — so Enable can re-detect
+ *  the still-built binary and re-register it with no rebuild, the same as a catalog engine. */
+export interface CustomEngineSource {
+  name: string
+  /** Binary path at the time this was recorded. Still valid after a Disable (files are only
+   *  removed on purge) — used to both re-register on Enable and to check the build still
+   *  exists on disk before offering that. */
+  binPath: string
+  kind: string
+  sourceRepo?: string
+  sourceBranch?: string
+  sourceCommit?: string
+  addedAt: string
+}
 export interface Daemon {
   host: string
   port: number
@@ -294,6 +317,8 @@ export interface Config {
   telemetry: Telemetry
   apiKeys: ApiKey[]
   engines: Engine[]
+  /** Custom (non-catalog) engine identities, kept across Disable — see {@link CustomEngineSource}. */
+  customEngineSources: CustomEngineSource[]
   activeEngineId: string
   modelDirs: string[]
   /** The folder downloads/imports land in (spec 01 §3, ADR-035). When '' or not in
@@ -437,6 +462,7 @@ export function defaultConfig(): Config {
     telemetry: { level: 'unset', machineId: '' },
     apiKeys: [],
     engines: [],
+    customEngineSources: [],
     activeEngineId: '',
     modelDirs: [],
     primaryModelDir: '',
@@ -599,6 +625,7 @@ function normalize(c: Config): void {
   c.lastLoaded = { ...d.lastLoaded, ...(c.lastLoaded ?? {}) }
   c.apiKeys ??= []
   c.engines ??= []
+  c.customEngineSources ??= []
   c.modelDirs ??= []
   // Primary model dir (spec 01 §3, ADR-035): absent in old files → '' (effective
   // default falls back to the first modelDir). Never throw on an old config.

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildDirName, CMAKE_CONFIGURE_ARGS, isIncompleteMetalBackendError, pickGenerator, vcvarsBatch, stripGenericAsmLanguage, sameRepo, sourceBuildDirOf } from './build-runner'
+import { buildDirName, CMAKE_CONFIGURE_ARGS, isIncompleteMetalBackendError, pickGenerator, vcvarsBatch, stripGenericAsmLanguage, sameRepo, sourceBuildDirOf, notCmakeProjectError } from './build-runner'
 import { join } from 'node:path'
 
 test('buildDirName: repo name from a .git URL, branch appended', () => {
@@ -148,4 +148,16 @@ test('sourceBuildDirOf: derives the build dir from a source-built binPath', () =
 test('sourceBuildDirOf: null for a non-source-build binary path', () => {
   const root = join('C:', 'e')
   assert.equal(sourceBuildDirOf(join(root, 'turboquant', 'llama-server.exe'), root), null)
+})
+
+// GitHub #61: exllamav3 (a pure-Python engine, no CMakeLists.txt) failed 1-click build with a
+// bare "cmake exited with code 1" and no explanation. notCmakeProjectError fails fast instead.
+test('notCmakeProjectError: null (no error) when CMakeLists.txt is present', () => {
+  assert.equal(notCmakeProjectError(true), null)
+})
+
+test('notCmakeProjectError: actionable message when CMakeLists.txt is absent', () => {
+  const msg = notCmakeProjectError(false)
+  assert.ok(msg && /CMakeLists\.txt/.test(msg))
+  assert.ok(msg && /llama\.cpp/.test(msg))
 })

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -116,6 +116,21 @@ export function isIncompleteMetalBackendError(log: string[]): boolean {
   return log.some((line) => /undeclared identifier 'ggml_backend_(is_metal|metal_\w+)'/.test(line))
 }
 
+/** PURE: the actionable failure message when the cloned repo isn't a llama.cpp-family CMake
+ *  project — null when it is. Checked right after cloning: without it, a Python-only engine
+ *  (e.g. exllamav3, GitHub #61) burns through the toolchain checks and clone, then dies on a
+ *  bare "cmake exited with code 1" with the real reason (no CMakeLists.txt) buried in the
+ *  scrolled build log instead of the headline error. */
+export function notCmakeProjectError(hasCMakeLists: boolean): string | null {
+  if (hasCMakeLists) return null
+  return (
+    "This repository doesn't look like a llama.cpp-based (CMake) project — no CMakeLists.txt was " +
+    'found at its root. 1-click build currently only supports llama.cpp-family engines built with ' +
+    'CMake. If this project exposes a llama-server-compatible binary some other way, add it as a ' +
+    'custom engine by pointing TurboLLM directly at that binary instead of building from source.'
+  )
+}
+
 // CMAKE_CONFIGURE_ARGS now lives in build-prereqs.ts (re-exported below) — it's shared with
 // that module's `buildCommands`, the manual-build command list, so the two can never drift.
 export { CMAKE_CONFIGURE_ARGS }
@@ -497,6 +512,11 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
 
   // Record the built commit (ADR-088 provenance / rebuild comparison).
   const commit = (await runStep('git', ['-C', srcDir, 'rev-parse', 'HEAD'], { env, signal, onLine: () => {} })).trim()
+
+  // Fail fast with an actionable reason when this isn't a llama.cpp-family CMake project at all
+  // (GitHub #61) — before sinking minutes into a configure/compile that can only die cryptically.
+  const notCmake = notCmakeProjectError(existsSync(join(srcDir, 'CMakeLists.txt')))
+  if (notCmake) throw new Error(notCmake)
 
   // Drop a gratuitous ASM-language declaration some forks ship (no assembly sources) so the
   // MSVC build doesn't die on "No CMAKE_ASM_COMPILER could be found" for a language nothing uses.

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -71,16 +71,22 @@ export function buildDirName(repoUrl: string, branch?: string, commit?: string):
  *  a `github.com/` host prefix, a trailing `.git`/slash, and case. Lets us match a catalog
  *  entry's homepage to a source-built engine's stored `sourceRepo`. */
 export function sameRepo(a?: string, b?: string): boolean {
-  const norm = (s?: string) =>
-    (s ?? '')
-      .trim()
-      .toLowerCase()
-      .replace(/^https?:\/\//, '')
-      .replace(/^github\.com\//, '')
-      .replace(/\.git$/, '')
-      .replace(/\/+$/, '')
-  const na = norm(a)
-  return na !== '' && na === norm(b)
+  const na = normRepoUrl(a)
+  return na !== '' && na === normRepoUrl(b)
+}
+
+/** PURE: normalize a repo identifier (full URL or `owner/repo`) to a comparable/keyable form —
+ *  strips scheme, a `github.com/` host prefix, a trailing `.git`/slash, and case. Exported (not
+ *  just {@link sameRepo}'s internal helper) so a stable per-repo KEY can be built the same way
+ *  a match is judged — e.g. {@link customSourceKey} in registry.ts. */
+export function normRepoUrl(s?: string): string {
+  return (s ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^github\.com\//, '')
+    .replace(/\.git$/, '')
+    .replace(/\/+$/, '')
 }
 
 /** The built `llama-server` for a repo (+optional branch) under `enginesRoot`, or null. Used

--- a/turbollm/src/engines/registry.custom-source.test.ts
+++ b/turbollm/src/engines/registry.custom-source.test.ts
@@ -1,0 +1,139 @@
+// Custom-engine identity persistence (GitHub: "a custom engine added from git url is treated
+// as an outsider... should get the same UI as catalogue engines with disable/enable/delete/
+// rebuild"). A catalog engine survives Disable→Enable because its fixed, hardcoded homepage
+// URL lets the backend re-scan disk for a still-built binary; a custom repo has no such fixed
+// identity anywhere else, so customSourceKey/recordCustomSource/forgetCustomSource are that
+// memory instead. These tests cover the identity key and the record/forget lifecycle;
+// GET /api/v1/engines' derived customDisabled list is exercised at the route level.
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { ConfigStore } from '../config/config'
+import { Registry, customSourceKey } from './registry'
+
+function freshRegistry(): { reg: Registry; store: ConfigStore } {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-custom-src-'))
+  const store = ConfigStore.load(join(dir, 'config.json'))
+  return { reg: new Registry(store), store }
+}
+
+// ---- customSourceKey ---------------------------------------------------------
+
+test('customSourceKey: git-sourced identity is keyed by repo+branch+commit, not binPath', () => {
+  const a = { binPath: '/build/a/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  const b = { binPath: '/build/b/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  // A rebuild lands at a DIFFERENT binPath each time — the key must still match.
+  assert.equal(customSourceKey(a), customSourceKey(b))
+})
+
+test('customSourceKey: repo URL normalization matches regardless of scheme/.git/case/slash', () => {
+  const forms = [
+    { binPath: 'x', sourceRepo: 'https://github.com/User/Fork', sourceBranch: '' },
+    { binPath: 'x', sourceRepo: 'https://github.com/user/fork.git', sourceBranch: '' },
+    { binPath: 'x', sourceRepo: 'https://github.com/user/fork/', sourceBranch: '' },
+    { binPath: 'x', sourceRepo: 'HTTPS://GITHUB.COM/user/fork', sourceBranch: '' },
+  ]
+  const keys = forms.map(customSourceKey)
+  assert.ok(keys.every((k) => k === keys[0]))
+})
+
+test('customSourceKey: different branches of the SAME repo get different keys', () => {
+  const main = { binPath: 'x', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  const dev = { binPath: 'x', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'dev' }
+  assert.notEqual(customSourceKey(main), customSourceKey(dev))
+})
+
+test('customSourceKey: a commit-pinned build is a DISTINCT identity from the plain branch build', () => {
+  const branch = { binPath: 'x', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  const pinned = { binPath: 'x', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main', sourceCommit: 'abc1234' }
+  assert.notEqual(customSourceKey(branch), customSourceKey(pinned))
+})
+
+test('customSourceKey: no sourceRepo falls back to binPath itself', () => {
+  assert.equal(customSourceKey({ binPath: '/opt/my-server' }), '/opt/my-server')
+  assert.notEqual(customSourceKey({ binPath: '/opt/a' }), customSourceKey({ binPath: '/opt/b' }))
+})
+
+// ---- recordCustomSource / customSources / forgetCustomSource -----------------
+
+test('recordCustomSource: appears in customSources() with the given fields', () => {
+  const { reg } = freshRegistry()
+  reg.recordCustomSource({ name: 'My Fork', binPath: '/build/my-fork/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })
+  const sources = reg.customSources()
+  assert.equal(sources.length, 1)
+  assert.equal(sources[0].name, 'My Fork')
+  assert.equal(sources[0].sourceRepo, 'https://github.com/user/fork')
+  assert.ok(sources[0].addedAt)
+})
+
+test('recordCustomSource: recording the SAME identity twice overwrites in place, no duplicate', () => {
+  const { reg } = freshRegistry()
+  reg.recordCustomSource({ name: 'My Fork', binPath: '/build/v1/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })
+  // A rebuild: same repo+branch, new binPath (fresh compile output), possibly renamed.
+  reg.recordCustomSource({ name: 'My Fork (renamed)', binPath: '/build/v2/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })
+  const sources = reg.customSources()
+  assert.equal(sources.length, 1)
+  assert.equal(sources[0].name, 'My Fork (renamed)')
+  assert.equal(sources[0].binPath, '/build/v2/llama-server')
+})
+
+test('recordCustomSource: two DIFFERENT repos both persist as separate entries', () => {
+  const { reg } = freshRegistry()
+  reg.recordCustomSource({ name: 'Fork A', binPath: '/build/a/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork-a' })
+  reg.recordCustomSource({ name: 'Fork B', binPath: '/build/b/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork-b' })
+  assert.equal(reg.customSources().length, 2)
+})
+
+test('forgetCustomSource: removes exactly the matching entry, leaves others', () => {
+  const { reg } = freshRegistry()
+  reg.recordCustomSource({ name: 'Fork A', binPath: '/build/a/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork-a' })
+  reg.recordCustomSource({ name: 'Fork B', binPath: '/build/b/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork-b' })
+  reg.forgetCustomSource(customSourceKey({ binPath: '/build/a/llama-server', sourceRepo: 'https://github.com/user/fork-a' }))
+  const sources = reg.customSources()
+  assert.equal(sources.length, 1)
+  assert.equal(sources[0].name, 'Fork B')
+})
+
+test('forgetCustomSource: forgetting an unknown key is a harmless no-op', () => {
+  const { reg } = freshRegistry()
+  reg.recordCustomSource({ name: 'Fork A', binPath: '/build/a/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork-a' })
+  reg.forgetCustomSource('nothing-matches-this-key')
+  assert.equal(reg.customSources().length, 1)
+})
+
+test('recordCustomSource: survives being re-loaded from disk (real persistence, not in-memory only)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tllm-custom-src-'))
+  const configPath = join(dir, 'config.json')
+  const reg1 = new Registry(ConfigStore.load(configPath))
+  reg1.recordCustomSource({ name: 'My Fork', binPath: '/build/my-fork/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork' })
+  // A fresh Registry/ConfigStore instance over the SAME file — simulates a daemon restart.
+  const reg2 = new Registry(ConfigStore.load(configPath))
+  assert.equal(reg2.customSources().length, 1)
+  assert.equal(reg2.customSources()[0].name, 'My Fork')
+})
+
+test('the whole point: Disable (registry.remove) does NOT erase the recorded custom source', () => {
+  const { reg, store } = freshRegistry()
+  reg.recordCustomSource({ name: 'My Fork', binPath: '/build/my-fork/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })
+  // Seed a matching LIVE registry entry directly (bypassing add()'s real probe() call, which
+  // would fail on a fake binPath) — mirrors what actually happens: build completion / manual
+  // add calls both registry.add AND recordCustomSource, so a live entry normally coexists.
+  const engineId = 'test-engine-id'
+  store.update((c) => {
+    c.engines.push({
+      id: engineId, name: 'My Fork', binPath: '/build/my-fork/llama-server', kind: 'llama-server',
+      version: '1.0', capabilities: { kvTypes: [], flags: [] }, addedAt: new Date().toISOString(),
+      sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main',
+    })
+  })
+  reg.remove(engineId) // Disable
+  // The remembered identity must survive — this is the record a catalog engine gets for free
+  // from its fixed homepage URL; a custom repo has no other memory of it.
+  const sources = reg.customSources()
+  assert.equal(sources.length, 1)
+  assert.equal(sources[0].sourceRepo, 'https://github.com/user/fork')
+  // And the live engine is genuinely gone (Disable did its job).
+  assert.equal(reg.list().engines.length, 0)
+})

--- a/turbollm/src/engines/registry.ts
+++ b/turbollm/src/engines/registry.ts
@@ -2,8 +2,9 @@
 // enforced by the API layer using the Manager's live state.
 import { existsSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { ConfigStore, Engine, UpdatePolicy, ValueError, findEngine } from '../config/config'
+import { ConfigStore, CustomEngineSource, Engine, UpdatePolicy, ValueError, findEngine } from '../config/config'
 import { probe } from './probe'
+import { normRepoUrl } from './build-runner'
 
 /** Auto-provisioned official builds live under `<dataDir>/engines/llama.cpp-…/`.
  *  User forks are arbitrary paths and are never auto-removed. */
@@ -283,6 +284,31 @@ export class Registry {
     })
   }
 
+  /** Record (or refresh) a custom engine's identity so it survives a later Disable —
+   *  see {@link CustomEngineSource}. Idempotent: a second call for the same identity
+   *  (customSourceKey) overwrites in place rather than accumulating duplicates. */
+  recordCustomSource(entry: Omit<CustomEngineSource, 'addedAt'>): void {
+    this.store.update((c) => {
+      const key = customSourceKey(entry)
+      const record: CustomEngineSource = { ...entry, addedAt: new Date().toISOString() }
+      const i = c.customEngineSources.findIndex((s) => customSourceKey(s) === key)
+      if (i >= 0) c.customEngineSources[i] = record
+      else c.customEngineSources.push(record)
+    })
+  }
+
+  customSources(): CustomEngineSource[] {
+    return this.store.snapshot().customEngineSources
+  }
+
+  /** Drop a custom engine's remembered identity — called on an explicit purge/delete
+   *  (never on a plain Disable, which is exactly what this record is meant to survive). */
+  forgetCustomSource(key: string): void {
+    this.store.update((c) => {
+      c.customEngineSources = c.customEngineSources.filter((s) => customSourceKey(s) !== key)
+    })
+  }
+
   activate(id: string): void {
     this.store.update((c) => {
       if (!findEngine(c.engines, id)) throw new NotFoundError()
@@ -350,6 +376,17 @@ export class Registry {
       }
     }
   }
+}
+
+/** PURE: stable identity key for a custom engine source — sourceRepo+branch+commit when
+ *  git-built (a rebuild lands at a different binPath each time, so binPath alone can't be the
+ *  key), else the binPath itself (a plain "point at a binary" add has nothing else to key by).
+ *  Shared between {@link Registry.recordCustomSource}/{@link Registry.forgetCustomSource} and
+ *  a live {@link Engine} so the two can be cross-referenced (same shape: sourceRepo?/
+ *  sourceBranch?/sourceCommit?/binPath). */
+export function customSourceKey(s: { sourceRepo?: string; sourceBranch?: string; sourceCommit?: string; binPath: string }): string {
+  if (!s.sourceRepo) return s.binPath
+  return `${normRepoUrl(s.sourceRepo)}#${(s.sourceBranch ?? '').trim().toLowerCase()}#${(s.sourceCommit ?? '').trim().toLowerCase()}`
 }
 
 /** True when a saved `capabilities.flags` list was captured by a daemon predating a

--- a/turbollm/src/sysinfo/sysinfo.test.ts
+++ b/turbollm/src/sysinfo/sysinfo.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseRocmSmi, isIntegratedGpuName } from './sysinfo'
+import { parseRocmSmi, isIntegratedGpuName, parseWindowsVramRegistry } from './sysinfo'
 
 // rocm-smi --showmeminfo vram --json output for an RX 7900 XTX (24GB). The WMI
 // AdapterRAM fallback would cap this at ~4GB; rocm-smi reports the true total.
@@ -95,4 +95,32 @@ test('isIntegratedGpuName: discrete AMD cards are NOT integrated', () => {
 test('isIntegratedGpuName: NVIDIA and unrelated names are NOT integrated', () => {
   assert.equal(isIntegratedGpuName('NVIDIA GeForce RTX 5070 Ti'), false)
   assert.equal(isIntegratedGpuName('Apple M3 Max'), false)
+})
+
+// ---- parseWindowsVramRegistry: true VRAM via the registry's 64-bit qwMemorySize, unlike WMI's
+// 32-bit-capped AdapterRAM (GitHub #63: a real 16 GB AMD card was detected as "4.3 GB") --------
+
+test('parseWindowsVramRegistry: reports true 16GB VRAM the 4GB WMI cap would miss', () => {
+  const out = 'AMD Radeon RX 9070 XT|17179869184' // exactly 16 GiB, in bytes
+  const entries = parseWindowsVramRegistry(out)
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].name, 'AMD Radeon RX 9070 XT')
+  assert.equal(entries[0].vramMb, 17180)
+  assert.ok(entries[0].vramMb > 4300, 'must be well above the ~4.3GB WMI AdapterRAM cap')
+})
+
+test('parseWindowsVramRegistry: multiple adapters each parse', () => {
+  const out = 'AMD Radeon RX 9070 XT|17179869184\nIntel(R) UHD Graphics 770|0'
+  const entries = parseWindowsVramRegistry(out)
+  // The iGPU's qwMemorySize of 0 is dropped — isIntegratedGpuName already handles iGPU sizing
+  // via the shared-memory heuristic, so a zero/missing registry entry is simply skipped.
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].name, 'AMD Radeon RX 9070 XT')
+})
+
+test('parseWindowsVramRegistry: blank/malformed lines are skipped, not crashed on', () => {
+  assert.deepEqual(parseWindowsVramRegistry(''), [])
+  assert.deepEqual(parseWindowsVramRegistry('\n\n'), [])
+  assert.deepEqual(parseWindowsVramRegistry('no pipe here'), [])
+  assert.deepEqual(parseWindowsVramRegistry('Some Card|not-a-number'), [])
 })

--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -136,25 +136,29 @@ function detectGpus(): GpuInfo[] {
 
 function enumWindowsGpus(): GpuInfo[] {
   // AMD first: ROCm's rocm-smi reports true VRAM, unlike WMI's 4GB-capped
-  // AdapterRAM below. Only present when ROCm is installed; falls through if not.
+  // AdapterRAM below. Only present when ROCm is installed; falls through if not —
+  // which is the COMMON case for consumer Radeon cards (ROCm's Windows support is
+  // limited and doesn't cover most gaming GPUs, e.g. the RX 9000 series), so most
+  // AMD users still hit the WMI path below.
   try {
     const amd = rocmSmiGpus()
     if (amd.length) return amd
   } catch {
-    /* no rocm-smi (ROCm not installed) — fall back to WMI */
+    /* no rocm-smi (ROCm not installed, or unsupported on this card) — fall back to WMI */
   }
 
   // Win32_VideoController: Name + AdapterRAM (AdapterRAM caps at 4GB for larger
   // cards and is unreliable — used only as a weak hint). This mis-sizes AMD cards
-  // >4GB (e.g. RX 7900 XTX reports ~4GB, not 24GB), which is why AMD is tried via
-  // rocm-smi first above.
+  // >4GB (e.g. RX 7900 XTX / RX 9070 XT report ~4GB, not their real 16-24GB —
+  // GitHub #63), which is why AMD is tried via rocm-smi first above, and why the
+  // registry is cross-checked below for whatever falls through to here.
   const ps =
     'Get-CimInstance Win32_VideoController | ForEach-Object { "$($_.Name)|$($_.AdapterRAM)" }'
   const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
     timeout: 8000,
     windowsHide: true,
   }).toString()
-  return out
+  const wmiGpus = out
     .trim()
     .split('\n')
     .map((line) => {
@@ -174,6 +178,69 @@ function enumWindowsGpus(): GpuInfo[] {
       return { name: nm, vramMb, vendor: classifyVendor(nm) }
     })
     .filter((g) => g.name && g.vendor !== 'unknown')
+
+  // AdapterRAM is a 32-bit DWORD — it silently caps/wraps for ANY card past ~4 GB, not just
+  // AMD (the exact "4.3 GB" GitHub #63 reported for a real 16 GB card). The registry keeps the
+  // SAME total as a proper 64-bit value under each display adapter's driver key — this is how
+  // GPU-Z/HWiNFO get it right too — so read it and prefer it over AdapterRAM whenever it's
+  // bigger, for every discrete card. rocm-smi above already covers the ROCm-equipped AMD case;
+  // this covers everyone who fell through to WMI (most consumer AMD/Intel dGPU owners).
+  const registryVram = readWindowsVramRegistry()
+  return wmiGpus.map((g) => {
+    if (isIntegratedGpuName(g.name)) return g
+    const fromRegistry = findRegistryVram(registryVram, g.name)
+    return fromRegistry !== undefined && fromRegistry > g.vramMb ? { ...g, vramMb: fromRegistry } : g
+  })
+}
+
+/** A display adapter's true VRAM as read from the registry, before matching to a WMI entry. */
+export interface RegistryVram {
+  name: string
+  vramMb: number
+}
+
+// Display-adapter driver class GUID (stable across all Windows versions) — each installed
+// adapter gets a numbered subkey here with its driver-reported HardwareInformation.qwMemorySize.
+const DISPLAY_CLASS_GUID = '{4d36e968-e325-11ce-bfc1-08002be10318}'
+
+/** Best-effort read of every display adapter's true VRAM from the Windows registry — a proper
+ *  64-bit value, unlike WMI's 32-bit-capped AdapterRAM (see enumWindowsGpus). Empty array on any
+ *  failure (missing key, no permission, non-Windows): the caller just keeps the AdapterRAM value. */
+function readWindowsVramRegistry(): RegistryVram[] {
+  try {
+    const ps =
+      `Get-ChildItem 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Class\\${DISPLAY_CLASS_GUID}' -ErrorAction SilentlyContinue | ` +
+      "ForEach-Object { $p = Get-ItemProperty -Path $_.PSPath -ErrorAction SilentlyContinue; " +
+      "if ($p.'HardwareInformation.qwMemorySize') { \"$($p.DriverDesc)|$($p.'HardwareInformation.qwMemorySize')\" } }"
+    const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
+      timeout: 8000,
+      windowsHide: true,
+    }).toString()
+    return parseWindowsVramRegistry(out)
+  } catch {
+    return []
+  }
+}
+
+/** Pure parser for {@link readWindowsVramRegistry}'s PowerShell output, split out for direct
+ *  testing (mirrors {@link parseRocmSmi}). Each line is "DriverDesc|qwMemorySize(bytes)". */
+export function parseWindowsVramRegistry(psOutput: string): RegistryVram[] {
+  const out: RegistryVram[] = []
+  for (const line of psOutput.trim().split('\n')) {
+    const [name, bytes] = line.split('|')
+    const nm = (name ?? '').trim()
+    const b = parseInt((bytes ?? '').trim(), 10)
+    if (nm && Number.isFinite(b) && b > 0) out.push({ name: nm, vramMb: Math.round(b / 1e6) })
+  }
+  return out
+}
+
+/** Loose GPU-name match between WMI's Name and the registry's DriverDesc — normally identical,
+ *  but can differ in trademark symbols/punctuation/whitespace/case, so compare a normalized form. */
+function findRegistryVram(entries: RegistryVram[], wmiName: string): number | undefined {
+  const norm = (s: string) => s.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim()
+  const target = norm(wmiName)
+  return entries.find((e) => norm(e.name) === target)?.vramMb
 }
 
 // AMD VRAM on Windows via ROCm's rocm-smi. `--showmeminfo vram --json` returns an

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -149,6 +149,26 @@ body {
   animation: tllm-pulse 1.2s ease-in-out infinite;
 }
 
+/* Hover-reveal row actions (message copy/edit/regenerate/delete, conversation rename/delete,
+   Code transcript step actions): hidden until `.group:hover` on a device that actually HAS hover
+   (a mouse) — but on a touchscreen there's no hover state to ever trigger, so these stayed
+   permanently invisible and the buttons were completely unreachable (GitHub #52: "in a phone,
+   it is impossible to edit, delete, or copy any messages"). `(hover: none)` covers touch input;
+   `(pointer: coarse)` also catches devices that technically report hover but whose primary
+   input is imprecise (some hybrid tablets). */
+.hover-actions {
+  opacity: 0;
+  transition: opacity 150ms;
+}
+.group:hover .hover-actions {
+  opacity: 1;
+}
+@media (hover: none), (pointer: coarse) {
+  .hover-actions {
+    opacity: 1;
+  }
+}
+
 /* Code transcript entries: a quiet fade + slight rise on arrival, one-shot (not looping like
    tllm-pulse above) — new rail entries used to just pop in instantly. */
 @keyframes tllm-rise-in {

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -131,8 +131,19 @@ export function addEngine(input: {
    *  notify-only "newer source available → rebuild" check. Omitted when empty. */
   sourceRepo?: string
   sourceBranch?: string
+  /** Set only when re-registering a build pinned to an exact historical commit. */
+  sourceCommit?: string
 }): Promise<AddEngineResult> {
   return request<AddEngineResult>('/api/v1/engines', { method: 'POST', json: input })
+}
+
+/** Forget a DISABLED custom engine's remembered identity (backend CustomEngineSource) — no
+ *  live registered engine to purge, so this is distinct from {@link purgeEngine}. Never
+ *  touches files on disk; `key` is the same identity string the entry carries as `customSourceKey`. */
+export function forgetCustomEngineSource(key: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/v1/engines/custom-sources/${encodeURIComponent(key)}`, {
+    method: 'DELETE',
+  })
 }
 
 /** Guided Add-engine scan (engine overhaul, Phase 3): given a chosen FOLDER or a

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -278,6 +278,15 @@ export function removeEngine(id: string): Promise<{ ok: true }> {
   })
 }
 
+/** Disable a CUSTOM (non-catalog) engine — same DELETE as removeEngine, but tells the
+ *  backend to backfill its customEngineSources record first if one doesn't exist yet, so a
+ *  build added before that tracking existed doesn't vanish on Disable with no way back. */
+export function disableCustomEngine(id: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/v1/engines/${encodeURIComponent(id)}?recordSource=1`, {
+    method: 'DELETE',
+  })
+}
+
 /** Unregister a catalog engine AND delete its installed files from disk.
  *  Models are never touched — only the engine's install dir under engines/. */
 export function purgeEngine(id: string): Promise<{ ok: true }> {

--- a/turbollm/web/src/lib/chat-queries.ts
+++ b/turbollm/web/src/lib/chat-queries.ts
@@ -43,6 +43,15 @@ export function useConversations(q?: string) {
     queryFn: () => listConversations(q),
     staleTime: 0,
     retry: false,
+    // Same live-sync gap as useConversation below, for the sidebar's list instead of one open
+    // conversation: autoTitle (chat-routes.ts) runs ~1s+ AFTER the SSE stream's 'done' event has
+    // already closed, entirely out-of-band from the response the frontend is watching — nothing
+    // ever told this query the title changed, so the sidebar (and the still-"New chat" active
+    // conversation's header) was stuck showing the old title until a manual reload remounted it
+    // (GitHub: "the auto generated chat title doesn't update until i refresh"). Same 4s cadence
+    // as useConversation's own multi-device poll.
+    refetchInterval: 4000,
+    refetchIntervalInBackground: false,
   })
 }
 

--- a/turbollm/web/src/lib/engine-groups.test.ts
+++ b/turbollm/web/src/lib/engine-groups.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  customSourceIsLive,
+  customSourceKey,
   engineGroupKey,
   groupEngines,
   latestMemberId,
@@ -119,4 +121,33 @@ test('memberToActivate prefers the active member, then latest, then first', () =
   assert.equal(memberToActivate(g, null)?.id, 'b') // none active → latest
   const noTags = groupEngines([turboquant, mlx]).find((x) => x.key === 'turboquant')!
   assert.equal(memberToActivate(noTags, null)?.id, 'c') // no latest → first
+})
+
+// customSourceKey MUST mirror the backend's registry.ts version exactly — it's used to match a
+// "Forget" request against the same record the backend keyed it under (GitHub: custom-engine
+// parity for disable/enable/rebuild).
+
+test('customSourceKey: matches the backend registry.ts test vectors byte-for-byte', () => {
+  const a = { binPath: '/build/a/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  const b = { binPath: '/build/b/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' }
+  assert.equal(customSourceKey(a), customSourceKey(b)) // rebuild → different binPath, same key
+  const forms = [
+    { binPath: 'x', sourceRepo: 'https://github.com/User/Fork', sourceBranch: '' },
+    { binPath: 'x', sourceRepo: 'https://github.com/user/fork.git', sourceBranch: '' },
+    { binPath: 'x', sourceRepo: 'https://github.com/user/fork/', sourceBranch: '' },
+  ]
+  assert.ok(forms.every((f) => customSourceKey(f) === customSourceKey(forms[0])))
+  assert.notEqual(
+    customSourceKey({ binPath: 'x', sourceRepo: 'r', sourceBranch: 'main' }),
+    customSourceKey({ binPath: 'x', sourceRepo: 'r', sourceBranch: 'main', sourceCommit: 'abc' }),
+  )
+  assert.equal(customSourceKey({ binPath: '/opt/my-server' }), '/opt/my-server')
+})
+
+test('customSourceIsLive: true when a live engine shares the same identity, false otherwise', () => {
+  const source = { name: 'My Fork', binPath: '/build/v1/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main', addedAt: '', binPathExists: true }
+  const liveSameRepo = eng({ id: 'live', binPath: '/build/v2/llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })
+  assert.equal(customSourceIsLive(source, [liveSameRepo]), true)
+  assert.equal(customSourceIsLive(source, [userFork]), false)
+  assert.equal(customSourceIsLive(source, []), false)
 })

--- a/turbollm/web/src/lib/engine-groups.ts
+++ b/turbollm/web/src/lib/engine-groups.ts
@@ -5,7 +5,7 @@
 // than one installed variant, surface a second "version" dropdown to pick the build.
 //
 // Pure + framework-free so it is unit-testable on its own (imported by EnginesScreen).
-import type { Engine } from './types'
+import type { CustomEngineSource, Engine } from './types'
 
 /** Official llama.cpp builds auto-downloaded by TurboLLM live in
  *  `<config>/engines/llama.cpp-<tag>-<backend>/`. Matches EnginesScreen.isOfficialLlama. */
@@ -22,6 +22,31 @@ export function repoSlug(sourceRepo: string | undefined): string | undefined {
     ?.replace(/^https?:\/\/github\.com\//i, '')
     .replace(/\.git$/i, '')
     .toLowerCase()
+}
+
+/** PURE: MUST mirror the backend's registry.ts `customSourceKey` exactly (down to the
+ *  normalization steps) — this is used to look up a "Forget" request against the SAME record
+ *  the backend keyed it under, and a mismatch here means the request silently matches nothing.
+ *  Deliberately not built on `repoSlug` above, which normalizes slightly differently (no
+ *  trailing-slash strip) — a divergence there wouldn't matter for its own display purpose but
+ *  would break this identity match. */
+export function customSourceKey(s: { sourceRepo?: string; sourceBranch?: string; sourceCommit?: string; binPath: string }): string {
+  if (!s.sourceRepo) return s.binPath
+  const normRepoUrl = s.sourceRepo
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/^github\.com\//, '')
+    .replace(/\.git$/, '')
+    .replace(/\/+$/, '')
+  return `${normRepoUrl}#${(s.sourceBranch ?? '').trim().toLowerCase()}#${(s.sourceCommit ?? '').trim().toLowerCase()}`
+}
+
+/** True when a live registered `Engine` corresponds to a recorded `CustomEngineSource` —
+ *  i.e. the custom engine is currently ENABLED, not disabled. */
+export function customSourceIsLive(source: CustomEngineSource, liveEngines: Engine[]): boolean {
+  const key = customSourceKey(source)
+  return liveEngines.some((e) => customSourceKey(e) === key)
 }
 
 /** A logical-engine grouping key. Engines that share a key collapse into one row.

--- a/turbollm/web/src/lib/personas.test.ts
+++ b/turbollm/web/src/lib/personas.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveAgents, buildSystemPrompt } from './personas'
+
+// GitHub #52: "the model still is being fed tool instructions even in the blank template
+// (which should not include a thing for 'raw' model response)". Blank's whole point is zero
+// injected instructions — that has to include the tool-calling preamble many chat templates
+// render whenever ANY tools are offered, not just the system prompt text.
+
+test('resolveAgents: Blank resolves to an explicit empty tool list, not unrestricted', () => {
+  const agents = resolveAgents([], {})
+  const blank = agents.find((a) => a.id === 'blank')
+  assert.ok(blank)
+  assert.deepEqual(blank!.tools, [])
+})
+
+test('resolveAgents: an untouched built-in (e.g. Concise) stays unrestricted (tools undefined)', () => {
+  const agents = resolveAgents([], {})
+  const concise = agents.find((a) => a.id === 'concise')
+  assert.ok(concise)
+  assert.equal(concise!.tools, undefined)
+})
+
+test('resolveAgents: a saved override wins over the built-in default, even for Blank', () => {
+  const agents = resolveAgents([], { blank: { tools: ['read', 'grep'] } })
+  const blank = agents.find((a) => a.id === 'blank')
+  assert.deepEqual(blank!.tools, ['read', 'grep'])
+})
+
+test('resolveAgents: an override that explicitly restricts to zero tools stays zero (not undefined)', () => {
+  const agents = resolveAgents([], { concise: { tools: [] } })
+  const concise = agents.find((a) => a.id === 'concise')
+  assert.deepEqual(concise!.tools, [])
+})
+
+test('buildSystemPrompt: blank agent still returns an empty system prompt (unchanged)', () => {
+  assert.equal(buildSystemPrompt('blank', 'ignored', { assistantName: '', userName: '', customInstructions: '' }), '')
+})

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -5,6 +5,11 @@ export interface Persona {
   name: string
   description: string
   systemPrompt: string
+  /** Fixed tool allow-list for a built-in whose definition REQUIRES a specific tool set,
+   *  independent of any user override — currently only 'blank' (empty array: raw model output
+   *  means no tool-calling instructions either, not just an empty system prompt). Absent for
+   *  every other built-in, which stays unrestricted by default (see resolveAgents). */
+  tools?: string[]
 }
 
 const MAX_INJECTED_MEMORY_FACTS = 50
@@ -244,6 +249,10 @@ export const PERSONAS: readonly Persona[] = [
     name: 'Blank',
     description: 'Zero system prompt — raw model output, no instructions injected',
     systemPrompt: '',
+    // "No instructions injected" must also mean no tool-calling preamble — many chat templates
+    // render one whenever ANY tools are offered, regardless of the (blank) system prompt text
+    // (GitHub #52: "the model still is being fed tool instructions even in the blank template").
+    tools: [],
   },
   {
     id: 'concise',
@@ -468,7 +477,9 @@ export function resolveAgents(customAgents: MinimalCustomAgent[], overrides: Rec
       builtin: true,
       overridden: !!o,
       skillIds: o?.skillIds,
-      tools: o?.tools,
+      // Override wins when present (even an explicit []); otherwise fall through to the
+      // built-in's OWN fixed tools (e.g. Blank's []), not straight to undefined/unrestricted.
+      tools: o?.tools ?? p.tools,
     }
   })
   const customs: ResolvedAgent[] = customAgents.map((a) => ({ ...a, builtin: false }))

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -32,6 +32,7 @@ import {
   deleteEngineBackend,
   enableBackend,
   purgeEngine,
+  forgetCustomEngineSource,
   updateBackend,
   updateVllm,
   updateMlx,
@@ -402,6 +403,11 @@ export function useEngineMutations() {
     /** Purge: unregister + delete files from disk (catalog engines only, never models). */
     purge: useMutation({
       mutationFn: (id: string) => purgeEngine(id),
+      onSuccess: invalidate,
+    }),
+    /** Forget a DISABLED custom engine's remembered identity — no live engine to purge. */
+    forgetCustomSource: useMutation({
+      mutationFn: (key: string) => forgetCustomEngineSource(key),
       onSuccess: invalidate,
     }),
     activate: useMutation({

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -70,6 +70,7 @@ import {
   loadModel,
   removeDownload,
   removeEngine,
+  disableCustomEngine,
   removeModelDir,
   renameEngine,
   scanEngineFolder,
@@ -398,6 +399,12 @@ export function useEngineMutations() {
     }),
     remove: useMutation({
       mutationFn: (id: string) => removeEngine(id),
+      onSuccess: invalidate,
+    }),
+    /** Disable a CUSTOM (non-catalog) engine — backfills its customEngineSources record
+     *  first if one doesn't exist yet, so Disable never silently forgets it. */
+    disableCustom: useMutation({
+      mutationFn: (id: string) => disableCustomEngine(id),
       onSuccess: invalidate,
     }),
     /** Purge: unregister + delete files from disk (catalog engines only, never models). */

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -216,11 +216,31 @@ export type Engine = {
   sourceRepo?: string
   /** Optional branch to compare commits against (ADR-088). Empty → default branch. */
   sourceBranch?: string
+  /** Set only when this build was pinned to an exact historical commit. */
+  sourceCommit?: string
+}
+
+/** A custom (non-catalog) engine remembered even while disabled (see backend
+ *  CustomEngineSource) — lets Enable re-register the still-built binary with no rebuild. */
+export type CustomEngineSource = {
+  name: string
+  binPath: string
+  kind?: string
+  sourceRepo?: string
+  sourceBranch?: string
+  sourceCommit?: string
+  addedAt: string
+  /** Whether `binPath` still exists on disk — false means the user removed the build
+   *  folder by hand; Enable can't work until it's rebuilt. */
+  binPathExists: boolean
 }
 
 export type EnginesList = {
   engines: Engine[]
   activeEngineId: string
+  /** Custom engines the user has added before but are not currently registered
+   *  (Disabled, or never re-enabled since) — see {@link CustomEngineSource}. */
+  customDisabled: CustomEngineSource[]
 }
 
 /** POST /api/v1/engines/scan result (engine overhaul, Phase 3). Read-only preflight

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -631,7 +631,10 @@ export function ChatScreen() {
           systemPrompt: finalSystemPrompt || undefined,
           toolPolicy: selectedPersonaId === 'research' ? 'force_web_search' : undefined,
           skillIds: initialSkillIds.length ? initialSkillIds : undefined,
-          allowedTools: resolved?.tools?.length ? resolved.tools : undefined,
+          // Pass an explicit empty array through as-is (e.g. Blank's fixed []) — collapsing it
+          // to undefined here would silently turn "zero tools" back into "unrestricted" before
+          // the request ever reaches the backend (GitHub #52).
+          allowedTools: resolved?.tools,
           sampling: Object.keys(pendingSampling).length ? pendingSampling : undefined,
           preserveThinking: pendingPreserveThinking,
         })

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -690,6 +690,7 @@ function EngineGallery({
     install.updateKoboldcpp.isPending ||
     install.updateLlamafile.isPending ||
     engineMut.remove.isPending ||
+    engineMut.disableCustom.isPending ||
     engineMut.purge.isPending
 
   // ── lifecycle (unchanged behavior; mirrors ManagedEngines.DiscoverEngines) ──
@@ -779,7 +780,7 @@ function EngineGallery({
   // lookup needed, unlike a catalog engine (which has to be re-matched via binPath/sourceRepo
   // conventions since it has no single fixed id of its own).
   const doDisableCustom = (eng: Engine) => {
-    engineMut.remove.mutate(eng.id, {
+    engineMut.disableCustom.mutate(eng.id, {
       onSuccess: () => toast.success(`${eng.name} disabled`),
       onError: (err) => toast.error(err instanceof ApiError ? err.message : `Could not disable ${eng.name}.`),
     })

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -39,6 +39,7 @@ import { ApiError } from '../lib/api'
 import { primaryVendorSummary } from '../lib/vram'
 import type {
   CatalogEngine,
+  CustomEngineSource,
   Engine,
   EngineBackends,
   EngineFit,
@@ -78,6 +79,7 @@ import { EngineStatusHeader } from './engines/EngineStatusHeader'
 import { EngineLogPanel } from './engines/EngineLogPanel'
 import { LlamaCppBackendRows } from './engines/ManagedEngines'
 import {
+  customSourceKey,
   groupEngines,
   memberToActivate,
   repoSlug,
@@ -772,6 +774,33 @@ function EngineGallery({
     setDeleteTarget({ name: e.name, registryId })
   }
   const requestDeleteCustom = (eng: Engine) => setDeleteTarget({ name: eng.name, registryId: eng.id })
+  // Custom-engine parity (GitHub: "treated as an outsider... same UI as catalogue engines"):
+  // Disable is just registry.remove keyed by the LIVE engine's own id — no registryEngineId
+  // lookup needed, unlike a catalog engine (which has to be re-matched via binPath/sourceRepo
+  // conventions since it has no single fixed id of its own).
+  const doDisableCustom = (eng: Engine) => {
+    engineMut.remove.mutate(eng.id, {
+      onSuccess: () => toast.success(`${eng.name} disabled`),
+      onError: (err) => toast.error(err instanceof ApiError ? err.message : `Could not disable ${eng.name}.`),
+    })
+  }
+  // Enable re-registers using the SAME identity that was remembered (recordCustomSource) —
+  // instant, no rebuild, exactly like a catalog engine's sourceBuilt Enable.
+  const doEnableCustom = (source: CustomEngineSource) => {
+    engineMut.add.mutate(
+      { name: source.name, binPath: source.binPath, sourceRepo: source.sourceRepo, sourceBranch: source.sourceBranch, sourceCommit: source.sourceCommit },
+      {
+        onSuccess: () => toast.success(`${source.name} enabled`),
+        onError: (err) => toast.error(err instanceof ApiError ? err.message : `Could not enable ${source.name}.`),
+      },
+    )
+  }
+  const doForgetCustom = (source: CustomEngineSource) => {
+    engineMut.forgetCustomSource.mutate(customSourceKey(source), {
+      onSuccess: () => toast.success(`${source.name} removed`),
+      onError: (err) => toast.error(err instanceof ApiError ? err.message : `Could not remove ${source.name}.`),
+    })
+  }
   const doDelete = () => {
     if (!deleteTarget) return
     engineMut.purge.mutate(deleteTarget.registryId, {
@@ -809,6 +838,18 @@ function EngineGallery({
   const customEngines = (registry?.engines ?? []).filter(
     (e) => !matchedRegistryIds.has(e.id) && !isOfficialLlama(e.binPath),
   )
+  // GitHub: "a custom engine added from git url is treated as an outsider — it should get the
+  // same UI as catalogue engines with disable/enable/delete/rebuild." Unlike a catalog engine
+  // (re-enabled via its own fixed, hardcoded homepage URL), a disabled custom engine has no
+  // other identity anywhere in the system — customDisabled (backend customEngineSources) is
+  // that memory, so Enable can re-register the still-built binary instead of the entry just
+  // vanishing. Already excludes anything matching a currently-live engine (backend-computed).
+  const customDisabled = registry?.customDisabled ?? []
+  // Reuses engineMut.add (the same mutation catalog Enable/Install already use) — a disabled
+  // custom engine's Enable is exactly that: re-register the still-built binary, no rebuild.
+  // engineMut.add is shared with AddEngineDialog/catalog Enable too, so this key just won't
+  // match any customDisabled entry while one of THOSE is in flight — harmless, no false spinner.
+  const enablingKey = engineMut.add.isPending ? customSourceKey(engineMut.add.variables ?? { binPath: '' }) : null
 
   return (
     <section className="flex flex-col gap-3">
@@ -839,30 +880,40 @@ function EngineGallery({
         })}
       </div>
 
-      {customEngines.length > 0 && (
+      {(customEngines.length > 0 || customDisabled.length > 0) && (
         <div className="flex flex-col gap-2">
           {customEngines.map((eng) => (
-            <div
+            <CustomEngineCard
               key={eng.id}
-              className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-panel px-4 py-3"
-            >
-              <div className="flex min-w-0 items-center gap-2">
-                <Wrench size={15} className="shrink-0 text-accent" />
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="truncate text-sm font-medium text-ink">{eng.name}</span>
-                    <Badge>Custom</Badge>
-                  </div>
-                  <div className="truncate text-[12px] text-muted" title={eng.binPath}>{eng.binPath}</div>
-                </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                {eng.version && <span className="text-[12px] text-faint">{eng.version}</span>}
-                <Button variant="outline" size="sm" onClick={() => requestDeleteCustom(eng)}>
-                  Delete
-                </Button>
-              </div>
-            </div>
+              name={eng.name}
+              binPath={eng.binPath}
+              version={eng.version}
+              sourceRepo={eng.sourceRepo}
+              sourceBranch={eng.sourceBranch}
+              disabled={false}
+              binPathExists
+              anyPending={anyPending}
+              enabling={false}
+              onDisable={() => doDisableCustom(eng)}
+              onEnable={() => {}}
+              onDelete={() => requestDeleteCustom(eng)}
+            />
+          ))}
+          {customDisabled.map((source) => (
+            <CustomEngineCard
+              key={customSourceKey(source)}
+              name={source.name}
+              binPath={source.binPath}
+              sourceRepo={source.sourceRepo}
+              sourceBranch={source.sourceBranch}
+              disabled
+              binPathExists={source.binPathExists}
+              anyPending={anyPending}
+              enabling={enablingKey === customSourceKey(source)}
+              onDisable={() => {}}
+              onEnable={() => doEnableCustom(source)}
+              onDelete={() => doForgetCustom(source)}
+            />
           ))}
         </div>
       )}
@@ -1158,6 +1209,95 @@ function EngineCard({
         <div className="mt-2">
           <CatalogUpdateStatusLine st={updateStatus} />
         </div>
+      )}
+    </div>
+  )
+}
+
+/** One custom (non-catalog) engine — either currently live (`disabled: false`) or remembered
+ *  but not registered (`disabled: true`, from backend customEngineSources). Gives a custom
+ *  engine the SAME lifecycle actions a catalog card gets (Rebuild/Disable/Enable/Delete),
+ *  not just a name + a single Delete button (GitHub: "treated as an outsider"). */
+function CustomEngineCard({
+  name,
+  binPath,
+  version,
+  sourceRepo,
+  sourceBranch,
+  disabled,
+  binPathExists,
+  anyPending,
+  enabling,
+  onDisable,
+  onEnable,
+  onDelete,
+}: {
+  name: string
+  binPath: string
+  version?: string
+  sourceRepo?: string
+  sourceBranch?: string
+  disabled: boolean
+  binPathExists: boolean
+  anyPending: boolean
+  enabling: boolean
+  onDisable: () => void
+  onEnable: () => void
+  onDelete: () => void
+}) {
+  const [rebuildOpen, setRebuildOpen] = useState(false)
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border bg-panel px-4 py-3">
+      <div className="flex min-w-0 items-center gap-2">
+        <Wrench size={15} className="shrink-0 text-accent" />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-ink">{name}</span>
+            <Badge>Custom</Badge>
+            {disabled && <Badge variant="mono">Disabled</Badge>}
+          </div>
+          <div className="truncate text-[12px] text-muted" title={binPath}>{binPath}</div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {version && <span className="text-[12px] text-faint">{version}</span>}
+        {disabled && !binPathExists && (
+          <span
+            className="text-[11px] text-faint"
+            title="The build folder for this engine no longer exists on disk — rebuild from the repo to bring it back."
+          >
+            Build not found on disk
+          </span>
+        )}
+        {sourceRepo && (
+          <Button size="sm" variant="outline" disabled={anyPending} onClick={() => setRebuildOpen(true)}>
+            <RefreshCw size={13} /> Rebuild
+          </Button>
+        )}
+        {disabled ? (
+          binPathExists && (
+            <Button size="sm" disabled={anyPending || enabling} onClick={onEnable}>
+              {enabling ? <Loader2 size={13} className="animate-spin" /> : <Download size={13} />} Enable
+            </Button>
+          )
+        ) : (
+          <Button variant="outline" size="sm" disabled={anyPending} onClick={onDisable}>
+            Disable
+          </Button>
+        )}
+        <Button variant="outline" size="sm" onClick={onDelete}>
+          {disabled ? 'Remove' : 'Delete'}
+        </Button>
+      </div>
+      {sourceRepo && (
+        <BuildGuideDialog
+          open={rebuildOpen}
+          onOpenChange={setRebuildOpen}
+          repoUrl={sourceRepo}
+          branch={sourceBranch || undefined}
+          engineName={name}
+          mode="rebuild"
+        />
       )}
     </div>
   )

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -139,7 +139,7 @@ function CodeSessionItem({
       {/* Hover reveal: diff stats + actions menu + open affordance — same interaction
           language as ConvItem's hover-revealed folder-move/rename buttons. */}
       {!rename.editing && (
-        <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-1.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-1.5">
           {session.status !== 'aborted' && (session.add > 0 || session.del > 0) && (
             <span className="rounded bg-panel-2 px-1 py-0.5 font-mono text-[10px] tabular-nums">
               <span style={{ color: 'var(--ok)' }}>+{session.add}</span>{' '}
@@ -930,7 +930,7 @@ function ConvItem({
       )}
       <span className="text-[11px] text-faint">{relTime(conv.updatedAt)}</span>
       {!editing && (
-        <div className="absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="hover-actions absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center gap-0.5">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -605,7 +605,7 @@ export function MessageBubble({
           {!isEditing && (
             <div className="flex items-center gap-0.5">
               {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
-              <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+              <div className="hover-actions flex items-center gap-0.5">
                 <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
                 {onEdit && <ActionBtn icon={<Pencil size={12} />}  label="Edit"   onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
                 {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
@@ -692,9 +692,15 @@ export function MessageBubble({
       {!isEditing && (
         <div className="mt-1 flex items-center gap-0.5">
           {convId && message.variantGroup && <VariantSwitcher convId={convId} message={message} />}
-          <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-            <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />
-            {onEdit && <ActionBtn icon={<Pencil size={12} />} label="Edit" onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
+          <div className="hover-actions flex items-center gap-0.5">
+            {/* GitHub #52 (v1.7.5 fix was incomplete): Copy/Edit make no sense on a message
+                with no content to copy or edit — hasError already replaces the content area
+                with "This message is empty."/"Generation failed…", but this action row still
+                rendered all four buttons underneath regardless, which is the "block" the
+                follow-up report was pointing at. Delete/Regenerate stay: both are genuinely
+                useful on a failed/empty message. */}
+            {!hasError && <CopyButton text={message.content} className="rounded p-1 hover:bg-panel-2" />}
+            {!hasError && onEdit && <ActionBtn icon={<Pencil size={12} />} label="Edit" onClick={() => { setEditDraft(message.content); onEdit(message) }} />}
             {isLast && onRegenerate && <ActionBtn icon={<RefreshCw size={12} />} label="Regenerate" onClick={onRegenerate} />}
             {onDelete && <ActionBtn icon={<Trash2 size={12} />} label="Delete" onClick={() => onDelete(message)} destructive />}
           </div>

--- a/turbollm/web/src/screens/code/CodeTranscript.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.tsx
@@ -439,7 +439,7 @@ function CodeInstructionEntry({
         </div>
       )}
       <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{content}</p>
-      <div className="mt-1 flex items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="hover-actions mt-1 flex items-center justify-end gap-0.5">
         <CopyButton text={content} size={12} />
         {onRevert && (
           <button
@@ -495,7 +495,7 @@ function CodeCommentary({ content, streaming }: { content: string; streaming?: b
         <Markdown streaming={streaming}>{content}</Markdown>
       </div>
       {!streaming && (
-        <div className="opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="hover-actions">
           <CopyButton text={content} size={12} />
         </div>
       )}


### PR DESCRIPTION
## Summary

Eight fixes, spanning the reported auto-tune/chat t/s issue, three other open bug reports, and a few more found while investigating them.

**#62 — auto-tune wrongly skips single-GPU whenever a model exceeds one card by any amount** (`0981948`)
`pickSplitStrategies` gated the single-GPU strategy on "does the model fit at FULL GPU offload" — a model whose weights just missed one card's VRAM was forced straight into a slower cross-GPU layer-split even when the split it picked had several GB of headroom to spare. Now judges feasibility by the largest GPU-resident fraction the card can actually hold, and lets the existing offload search + measured t/s decide, same as it already does for KV-quant choice. (Main independently landed a much deeper t/s-accuracy fix for the same root complaint in `8fbcba1`/`6b4d150` — this is the one gap that work didn't touch.)

**#63 — AMD/Intel dGPUs on Windows report ~4GB VRAM instead of their real size** (`f4ac2ab`)
WMI's `AdapterRAM` is a 32-bit DWORD that caps/wraps past ~4GB. Cross-checks the registry's `HardwareInformation.qwMemorySize` (a real 64-bit value — the same source GPU-Z/HWiNFO use) and prefers it whenever bigger.

**#61 — 1-click build fails with a bare "Code 1" for a non-CMake repo** (`9f673d1`)
Building a non-llama.cpp-family repo (e.g. exllamav3) burned through toolchain checks and cloning only to die on an unexplained `cmake exited with code 1`. Now checks for `CMakeLists.txt` right after cloning and fails fast with an actionable message.

**#60 — Code: context overflow with no recovery, and a crash on cleanup** (`0c83ab0`)
Two bugs: (1) pi's auto-compaction defaults (reserve+keep-recent ≈ 36K tokens) assume a large hosted model — for a typical local model's 8K–32K context, that alone can exceed the whole window, making compaction self-defeating. Now scaled to the real loaded model's context. (2) The exact `ERR_STREAM_DESTROYED` crash from the report's attached log — an LSP client `sendNotification()` call with no `.catch()`, whose promise could reject asynchronously and crash the daemon.

**#52 batch — Blank persona tools, empty-message actions, token count, mobile hover-actions** (`092b5a1`)
Four independent fixes from the same thread: Blank persona ("no instructions injected") wasn't suppressing the tools offered to the model; an aborted/empty message's action row still showed Copy/Edit; an interrupted generation could show 0+0 tokens even though real output was persisted; and message/conversation/Code-transcript hover actions were pure-CSS `:hover`, unreachable on touch devices.

**Custom-engine parity** (`812d8f1`)
A custom engine added via git-URL build or arbitrary binPath only ever got a bare row with a single Delete button — no Rebuild/Disable/Enable, unlike catalog engines. Added a small persisted record so Disable→Enable round-trips instantly (re-registers the still-built binary, no rebuild), matching catalog-engine parity. Live-verified end-to-end in the browser.

**Auto-title derailed by memory facts, and stale until refresh** (`0779389`, `18861dc`)
Two follow-on bugs found live-testing the above: auto-generated chat titles were being generated from the injected memory-facts system prompt instead of the actual first message (for a brand-new conversation, `.slice(-2)` grabbed the system message right alongside the real one); and the sidebar's conversation list had no refetch mechanism at all, so a freshly-generated title never appeared without a manual page reload.

## Test plan
- [x] Full backend test suite (948 tests) and typecheck clean
- [x] Full frontend test suite (27 tests) and typecheck clean
- [x] Custom-engine parity live-verified end-to-end in-browser (register → full card → Disable → Enable → Rebuild dialog)
- [x] Built, globally installed, and running against real data for manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)