### PR TITLE
fix(code): revert-to-message, /compact, and MoE auto-tune VRAM-spill guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ the detail:
   overwrites another engine's tuning for the same model.
 - **Configurable VRAM headroom** (Settings → Models & loading → Advanced, 300 MB–2 GB, default
   1 GB) — tell auto-tune how much VRAM to keep free for other GPU workloads instead of a fixed margin.
+  Drag it to 0 to opt into an experimental **MoE "VRAM-spill" search** — auto-tune keeps pushing more
+  experts onto the GPU past the safe margin as long as both generation and prompt-processing speed
+  keep improving.
 
 </details>
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,66 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.1] - 2026-07-17
+
+**A large batch of reliability fixes — auto-tune accuracy, Code's revert-to-message and /compact,
+and a real VRAM-detection bug — plus an opt-in MoE auto-tune "VRAM-spill" search.**
+
+### Added
+- **MoE auto-tune "VRAM-spill" search** (opt-in) — set VRAM headroom to 0 (Settings → Models &
+  loading → Advanced) to let auto-tune keep pushing more experts onto the GPU past its normal
+  safety margin, as long as both generation AND prompt-processing speed keep improving. Off by
+  default; your configured headroom is otherwise always honored exactly as before.
+- Auto-tune's results dialog now also shows prefill (prompt-processing) speed, not just generation
+  speed.
+
+### Fixed
+- **Auto-tune vs. real chat speed gap** — the benchmark now uses a representative prompt and depth
+  instead of a short generic one, so the tok/s it reports is much closer to what you'll actually
+  see in a real conversation.
+- **Auto-tune no longer picks the KV-cache type for you** — it tunes GPU/CPU offload on whichever
+  KV type you already have selected, and shows an advisory note (not an automatic switch) when a
+  faster type is available. Fixes a case where the "quality-preserving" pick auto-tune made was
+  measurably slower and used more VRAM than a manual choice.
+- Auto-tune wrongly skipped single-GPU placement whenever a model missed fitting fully on one card
+  by even a hair, forcing a slower cross-GPU split even when the split had plenty of room to spare
+  (#62). A related fix stops a noisy VRAM reading from silently ruling out a smaller KV-cache type.
+- Auto-tune could lose an unsaved manual config edit when a run started, and Cancel could take up
+  to 8 seconds to actually stop.
+- **AMD/Intel dedicated GPUs on Windows could be reported as ~4 GB VRAM** regardless of their real
+  size, due to a 32-bit limit in the Windows API used to read it (#63).
+- **1-click engine build failed with a bare "Code 1"** for a repo that isn't a CMake project (e.g.
+  exllamav3) — now fails fast with a clear explanation instead (#61).
+- **Code: long sessions that ran out of context just failed** instead of compacting, with no way
+  to continue; a related crash from a background language-server message race is also fixed (#60).
+- **Code: revert-to-message was fundamentally broken** — reverting to an earlier message could
+  leave it (and its reply) still showing, or in some cases hide the wrong part of the conversation
+  entirely. Reverting now correctly discards the reverted message and everything after it, and
+  `/resume` still brings it back exactly as before.
+- **Code: manual `/compact` always said "nothing to compact,"** no matter how long the real
+  conversation was — root-caused to how a session's most recent turn interacted with the
+  underlying compaction logic. Also added a real "Compacting conversation…" indicator; previously
+  the composer just went blank with no feedback while it worked.
+- Code: Blank persona could still leak tool instructions into the model despite promising none; an
+  aborted/empty message kept showing Copy/Edit controls; an interrupted generation could show 0
+  tokens even though real output was saved; and hover-only actions in chat/Code were unreachable on
+  touch devices — all fixed.
+- Code: custom-added engines (via "Add via git repo" or a manual path) now get the same
+  Disable/Enable/Delete/Rebuild controls a built-in catalog engine has.
+- Sidebar conversation titles now update live without a page reload; an auto-generated title no
+  longer gets derailed by injected memory facts on a brand-new chat.
+- macOS engine parity fixes (Metal builds, Rapid-MLX, and other cross-engine fixes) (#50).
+
+### Discord
+- Fixed a real VRAM-detection bug that showed some AMD/Intel GPUs as ~4 GB regardless of their
+  actual size.
+- Auto-tune is noticeably more accurate now — it no longer silently picks a slower KV-cache type
+  or skips single-GPU placement when it shouldn't, and its benchmark better matches real chat speed.
+- Code's revert-to-message and manual `/compact` were both broken in ways that made long coding
+  sessions painful — both are fixed, and `/compact` now shows real progress instead of going silent.
+- New opt-in "VRAM-spill" search for MoE models — trade a configurable safety margin for extra
+  speed, only if you turn it on.
+
 ## [1.8.0] - 2026-07-14
 
 **Code — a local coding agent that reads, edits, and runs commands in a real project directory,

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -218,6 +218,9 @@ the detail:
   overwrites another engine's tuning for the same model.
 - **Configurable VRAM headroom** (Settings → Models & loading → Advanced, 300 MB–2 GB, default
   1 GB) — tell auto-tune how much VRAM to keep free for other GPU workloads instead of a fixed margin.
+  Drag it to 0 to opt into an experimental **MoE "VRAM-spill" search** — auto-tune keeps pushing more
+  experts onto the GPU past the safe margin as long as both generation and prompt-processing speed
+  keep improving.
 
 </details>
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -7,7 +7,7 @@ import { basename, dirname, join, resolve } from 'node:path'
 import { GATE_VERSION, gateNodeSource } from '../comfyui/gate-template'
 import { randomUUID } from 'node:crypto'
 import { homedir, networkInterfaces } from 'node:os'
-import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, VRAM_HEADROOM_MIN_MB, VRAM_HEADROOM_MAX_MB, type ApiKey, type Engine, type McpServer } from '../config/config'
+import { ValueError, getModelProfile, setModelProfile, deleteModelProfile, VRAM_HEADROOM_MIN_MB, VRAM_HEADROOM_MAX_MB, VRAM_HEADROOM_SPILL_MB, type ApiKey, type Engine, type McpServer } from '../config/config'
 import type { Deps } from '../deps'
 import { type ModelInfo, type StartOpts } from '../engines/manager'
 import { abortAllInFlightChats } from '../chat/chat-routes'
@@ -1565,8 +1565,11 @@ export function registerApi(app: Hono, d: Deps): void {
     let vramHeadroomMb: number | undefined
     if (b.vramHeadroomMb !== undefined) {
       const v = Number(b.vramHeadroomMb)
-      if (!Number.isFinite(v) || v < VRAM_HEADROOM_MIN_MB || v > VRAM_HEADROOM_MAX_MB) {
-        return err(c, 400, 'invalid_config_value', `vramHeadroomMb must be ${VRAM_HEADROOM_MIN_MB}–${VRAM_HEADROOM_MAX_MB}.`)
+      // VRAM_HEADROOM_SPILL_MB (0) is a distinct, valid opt-in value — not part of the
+      // MIN_MB–MAX_MB safety-margin range, but not out-of-range either.
+      const valid = v === VRAM_HEADROOM_SPILL_MB || (v >= VRAM_HEADROOM_MIN_MB && v <= VRAM_HEADROOM_MAX_MB)
+      if (!Number.isFinite(v) || !valid) {
+        return err(c, 400, 'invalid_config_value', `vramHeadroomMb must be ${VRAM_HEADROOM_SPILL_MB} (allow VRAM spill) or ${VRAM_HEADROOM_MIN_MB}–${VRAM_HEADROOM_MAX_MB}.`)
       }
       vramHeadroomMb = Math.round(v)
     }

--- a/turbollm/src/bench/bench.test.ts
+++ b/turbollm/src/bench/bench.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { pickKvQuants, betterBySpeed, kvSpeedAdvisory, parseRocmVramUsed, benchPromptTokens, buildBenchMessages } from './bench'
+import { pickKvQuants, betterBySpeed, spillImproves, kvSpeedAdvisory, parseRocmVramUsed, benchPromptTokens, buildBenchMessages } from './bench'
 
 // ---- pickKvQuants: quality-preserving KV sweep, base-first ------------------
 
@@ -62,6 +62,46 @@ test('betterBySpeed: 27B reality — turbo4 wins on both', () => {
 test('betterBySpeed: null / zero handling', () => {
   assert.equal(betterBySpeed({ tps: 10, prefillTps: null }, { tps: 0, prefillTps: null }), true)
   assert.equal(betterBySpeed({ tps: null, prefillTps: null }, { tps: null, prefillTps: null }), false)
+})
+
+// ---- spillImproves: MoE VRAM-spill hill-climb decision (founder-directed, 2026-07-17; extended
+// same day to also guard prefill speed) ----------------------------------------------------------
+
+test('spillImproves: both generation and prefill hold up (no decrease) — keeps climbing', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: 22, prefillTps: 950 }), true)
+  // Equal counts as "not decreased", not just a strict increase.
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: 20, prefillTps: 900 }), true)
+})
+
+test('spillImproves: generation t/s decreases — stops the climb even if prefill improved', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: 19.9, prefillTps: 1200 }), false)
+})
+
+test('spillImproves: prefill decreases — stops the climb even if generation t/s improved', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: 25, prefillTps: 899 }), false)
+})
+
+test('spillImproves: a candidate with no prefill reading is treated as a decrease (fail-safe)', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: 25, prefillTps: null }), false)
+})
+
+test('spillImproves: the PREVIOUS step having no prefill reading skips the prefill check entirely', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: null }, { outcome: 'ok', tps: 22, prefillTps: null }), true)
+  assert.equal(spillImproves({ tps: 20, prefillTps: null }, { outcome: 'ok', tps: 22, prefillTps: 5 }), true)
+})
+
+test('spillImproves: a failed spill step (oom/crash/timeout) is never "an increase"', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'oom', tps: null, prefillTps: null }), false)
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'crash', tps: null, prefillTps: null }), false)
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'timeout', tps: null, prefillTps: null }), false)
+})
+
+test('spillImproves: null candidate (benchAt itself returned null) stops the climb', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, null), false)
+})
+
+test('spillImproves: an "ok" outcome with a null tps (shouldn\'t happen, but defensively) stops the climb', () => {
+  assert.equal(spillImproves({ tps: 20, prefillTps: 900 }, { outcome: 'ok', tps: null, prefillTps: 950 }), false)
 })
 
 // ---- kvSpeedAdvisory: ADR-219 — auto-tune no longer picks the KV type, just notes when a

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -12,7 +12,7 @@ import { execFile } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { setModelProfile, getModelProfile, type BenchResult, type ConfigStore } from '../config/config'
+import { setModelProfile, getModelProfile, VRAM_HEADROOM_SPILL_MB, type BenchResult, type ConfigStore } from '../config/config'
 import type { Manager, StartOpts } from '../engines/manager'
 import type { Registry } from '../engines/registry'
 import type { Engine } from '../config/config'
@@ -520,7 +520,16 @@ export class BenchRunner {
   /** MoE models: pin `nCpuMoe` by VRAM probing (Phase 1), then run the full bench once (Phase 2).
    *  Fewer CPU experts = more on GPU = faster, so the best is the LOWEST nCpuMoe whose absolute VRAM
    *  still leaves the configured headroom. Found with cheap load-and-read-VRAM probes (no generation);
-   *  t/s is measured only at the winner. */
+   *  t/s is measured only at the winner. Then (founder-directed, 2026-07-17, gated to an explicit
+   *  headroom=0 opt-in after live testing showed the unconditional version silently overriding
+   *  the user's own configured safety margin): the headroom-safe winner isn't always the fastest
+   *  config for a MoE model — some real VRAM spill can still net a higher t/s. When (and ONLY
+   *  when) the user has set VRAM headroom to {@link VRAM_HEADROOM_SPILL_MB}, hill-climbs past the
+   *  safe winner, one nCpuMoe step at a time, for as long as each further step measures BOTH
+   *  generation AND prefill speed holding up (see `spillImproves`) — a step that trades away
+   *  prompt-processing speed for a small generation gain, or vice versa, isn't a real win. At any
+   *  real (non-zero) headroom this is skipped entirely — the
+   *  configured margin is honored as-is, exactly like every other search in this file. */
   private async moeSearch(
     entry: ModelEntry,
     sys: SysInfo,
@@ -563,6 +572,35 @@ export class BenchRunner {
       this.emit(`nCpuMoe=${bestN} exceeded headroom after generation (${found.cand.vramAbsMb} MB) — retrying at nCpuMoe=${bestN + 1}`)
       const safer = await this.benchAt(entry, sys, { ...base, nCpuMoe: bestN + 1 }, caps, results, `nCpuMoe=${bestN + 1} (headroom backoff)`)
       if (safer) found = safer
+    }
+    // VRAM-spill hill-climb (founder-directed, 2026-07-17) — ONLY when the user has explicitly
+    // opted in via VRAM_HEADROOM_SPILL_MB (0, Settings → Engine → Advanced). At any real headroom
+    // value this is skipped outright: live-testing the unconditional version showed it silently
+    // overriding the user's own configured safety margin, which this app never does anywhere else
+    // in the search (see the headroom-backoff check just above, which always honors it).
+    // From whatever the headroom-safe step landed on, keep moving MORE experts to the GPU one at
+    // a time — spilling past the configured headroom on purpose — for as long as each further
+    // step measures strictly faster. Stops (keeping the previous, better step) the instant a spill
+    // step measures no faster, OR fails outright (oom/crash/timeout) — a failed step is never
+    // treated as "an increase". Anchored on the ACTUAL nCpuMoe of `found` (not the pre-backoff
+    // `bestN`), since the headroom backoff above may have already moved off it. Floors at
+    // nCpuMoe=0 (every expert already on GPU).
+    if (headroomMb === VRAM_HEADROOM_SPILL_MB && found && found.cand.tps !== null) {
+      let current = found
+      while (current.cand.params.nCpuMoe > 0 && !this.cancelled && Date.now() <= this.deadline) {
+        const spillN = current.cand.params.nCpuMoe - 1
+        const prev = { tps: current.cand.tps as number, prefillTps: current.cand.prefillTps }
+        const prevLabel = `${prev.tps.toFixed(1)} tok/s (prefill ${prev.prefillTps !== null ? prev.prefillTps.toFixed(1) : 'n/a'} tok/s)`
+        this.emit(`nCpuMoe=${current.cand.params.nCpuMoe} measured ${prevLabel} — trying VRAM-spill nCpuMoe=${spillN}`)
+        const spillFound = await this.benchAt(entry, sys, { ...base, nCpuMoe: spillN }, caps, results, `nCpuMoe=${spillN} (VRAM-spill hill-climb)`)
+        if (!spillImproves(prev, spillFound?.cand ?? null)) {
+          this.emit(`nCpuMoe=${spillN} spill did not improve on ${prevLabel} (generation or prefill speed decreased) — stopping climb, keeping nCpuMoe=${current.cand.params.nCpuMoe}`)
+          break
+        }
+        current = spillFound as { cand: BenchCandidate; profile: LoadProfile }
+        this.state = { ...this.state, bestTps: current.cand.tps ?? undefined }
+      }
+      found = current
     }
     return found
   }
@@ -1395,6 +1433,27 @@ export function betterBySpeed(
   if (rel > OUTPUT_TIE) return true
   if (rel < -OUTPUT_TIE) return false
   return (a.prefillTps ?? 0) > (b.prefillTps ?? 0)
+}
+
+/** MoE VRAM-spill hill-climb decision (founder-directed, 2026-07-17; extended same day, after live
+ *  testing, to also guard prefill speed): should auto-tune keep moving another MoE expert onto the
+ *  GPU past the safe-headroom point? Stops (keeping the previous, better step) the instant EITHER
+ *  generation t/s OR prefill t/s decreases — a spill that trades away prompt-processing speed for
+ *  a small generation gain (or vice versa) isn't a real win. A failed candidate (null, or any
+ *  non-'ok' outcome) is never treated as an improvement. A candidate with no prefill reading is
+ *  treated the same as a decrease (fail-safe: this feature already trades away a real safety
+ *  margin for speed, so an unverifiable metric should never wave a spill step through) — but a
+ *  missing reading on the PREVIOUS step (nothing to compare against) just skips the prefill check
+ *  rather than blocking on it. No tie band here (unlike `betterBySpeed`): this is a
+ *  one-directional search for "still climbing", not a final-winner comparison. */
+export function spillImproves(
+  previous: { tps: number; prefillTps: number | null },
+  candidate: { outcome: BenchCandidate['outcome']; tps: number | null; prefillTps: number | null } | null,
+): boolean {
+  if (!candidate || candidate.outcome !== 'ok' || candidate.tps === null) return false
+  if (candidate.tps < previous.tps) return false
+  if (previous.prefillTps !== null && (candidate.prefillTps === null || candidate.prefillTps < previous.prefillTps)) return false
+  return true
 }
 
 /** Bytes per cached element for a KV-cache type (defaults to f16's 2 for unknown types). Note:

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -144,6 +144,20 @@ export interface AgentRun {
    *  hides messages at/before this point too, with a banner offering /resume to un-hide them —
    *  the underlying messages are never deleted, so resuming restores them exactly. */
   clearedUpToMessageId?: string
+  // ── Revert to a user message (v33) — a real, resumable deactivation, NOT a clearedUpToMessageId
+  // reuse. ─────────────────────────────────────────────────────────────────────────────────────
+  /** The id of the message a revert cut FROM (inclusive) — that message and everything after it
+   *  (at the moment of the revert) were deactivated (is_active=0, the same mechanism Chat's own
+   *  branching uses — see Message.isActive), not merely hidden by a movable cursor. getMessages()
+   *  filters is_active=1 unconditionally, so deactivated messages disappear from every consumer
+   *  (transcript, resolveEffectiveHistory, revertFileEdits) with no separate cut-logic needed —
+   *  unlike clearedUpToMessageId, this correctly supports reverting to ANY earlier user message,
+   *  not just the most recent one, since messages BEFORE this id are never touched. Undefined =
+   *  never reverted, or resumed back from one. /resume reactivates (is_active=1) every message
+   *  from this id onward and clears this field — nothing is ever deleted. Mutually exclusive with
+   *  clearedUpToMessageId (each blocks starting the other; /resume undoes whichever is active) —
+   *  two independent hidden-and-resumable states on one session would be genuinely confusing. */
+  revertedFromMessageId?: string
   // ── Manual-rename persistence (v32) ─────────────────────────────────────────────────────
   /** True once the auto-generated title has been mirrored from conversations.title onto this
    *  run's own title exactly once (code-run-manager.ts's pump()) — gates that mirror to fire
@@ -417,7 +431,7 @@ export interface Message {
 }
 
 interface ConvRow { id: string; title: string; system_prompt: string; model_key: string; sampling: string; expert_mode: number; tool_policy: string | null; kind: string | null; folder_id: string | null; tool_overrides: string | null; agent_id: string | null; completed_at: string | null; read_scope: string | null; agent_mode: string | null; skill_ids: string | null; allowed_tools: string | null; preserve_thinking: number; created_at: string; updated_at: string }
-interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null; repo_root: string | null; repo_branch: string | null; use_worktree: number | null; worktree_branch: string | null; worktree_base: string | null; lines_added: number | null; lines_removed: number | null; compaction_summary: string | null; compaction_upto_message_id: string | null; compaction_tokens_before: number | null; cleared_upto_message_id: string | null; title_auto_synced: number | null }
+interface AgentRunRow { id: string; conv_id: string; title: string; status: string; allowed_tools: string; agent_id: string | null; error: string | null; created_at: string; updated_at: string; started_at: string | null; ended_at: string | null; archived_at: string | null; completion: string | null; repo_root: string | null; repo_branch: string | null; use_worktree: number | null; worktree_branch: string | null; worktree_base: string | null; lines_added: number | null; lines_removed: number | null; compaction_summary: string | null; compaction_upto_message_id: string | null; compaction_tokens_before: number | null; cleared_upto_message_id: string | null; reverted_from_message_id: string | null; title_auto_synced: number | null }
 interface FolderRow { id: string; name: string; sort_order: number; created_at: string; updated_at: string }
 interface MsgRow  { id: string; conv_id: string; seq: number; role: 'user' | 'assistant'; content: string; reasoning: string; attachments: string; text_attachments: string | null; tool_calls: string | null; timeline: string | null; stats: string; model_key: string | null; research_meta: string | null; created_at: string; variant_group: string | null; is_active: number; branch_of: string | null; edited: number }
 
@@ -467,6 +481,7 @@ function rowToAgentRun(r: AgentRunRow): AgentRun {
     compactionUpToMessageId: r.compaction_upto_message_id ?? undefined,
     compactionTokensBefore: r.compaction_tokens_before ?? undefined,
     clearedUpToMessageId: r.cleared_upto_message_id ?? undefined,
+    revertedFromMessageId: r.reverted_from_message_id ?? undefined,
     titleAutoSynced: r.title_auto_synced === 1,
   }
 }
@@ -846,6 +861,18 @@ export class ConversationStore {
     if (v < 32) {
       if (!this.hasColumn('agent_runs', 'title_auto_synced')) this.db.exec(`ALTER TABLE agent_runs ADD COLUMN title_auto_synced INTEGER;`)
       this.db.exec(`PRAGMA user_version = 32;`)
+    }
+    // v33 (Code, founder-reported bug 2026-07-17, found live against a real 40-message session):
+    // revert-to-message previously reused clearedUpToMessageId (a movable prefix cursor), which
+    // can only hide "everything before X, show everything after" — backwards from what a revert
+    // needs (discard the reverted message and everything after it, keep everything before it),
+    // and structurally incapable of that for any message that isn't already at the tail. Real
+    // deactivation (is_active=0, the same mechanism Chat's branching already uses — getMessages()
+    // filters is_active=1 unconditionally) fixes both: it needs a marker of its own so /resume
+    // knows what to reactivate. Nullable — existing rows get NULL (never reverted).
+    if (v < 33) {
+      if (!this.hasColumn('agent_runs', 'reverted_from_message_id')) this.db.exec(`ALTER TABLE agent_runs ADD COLUMN reverted_from_message_id TEXT;`)
+      this.db.exec(`PRAGMA user_version = 33;`)
     }
   }
 
@@ -1447,6 +1474,35 @@ export class ConversationStore {
     const now = new Date().toISOString()
     return ((this.db.prepare(`UPDATE agent_runs SET cleared_upto_message_id = $mid, updated_at = $now WHERE id = $id`)
       .run({ $id: id, $mid: messageId, $now: now } as P) as unknown) as Changes).changes > 0
+  }
+
+  /** Set or clear (`null`) a Code session's revert marker — see AgentRun.revertedFromMessageId. */
+  setRevertedFromMessageId(id: string, messageId: string | null): boolean {
+    const now = new Date().toISOString()
+    return ((this.db.prepare(`UPDATE agent_runs SET reverted_from_message_id = $mid, updated_at = $now WHERE id = $id`)
+      .run({ $id: id, $mid: messageId, $now: now } as P) as unknown) as Changes).changes > 0
+  }
+
+  /** Revert-to-message (v33): deactivates `fromMessageId` and every message after it (by `seq`,
+   *  within the same conversation) — is_active=0, same mechanism Chat's branching uses. Unlike
+   *  clearedUpToMessageId's movable cursor, this correctly discards a range starting anywhere in
+   *  history while leaving everything BEFORE it untouched and visible. Returns the number of rows
+   *  deactivated (0 if `fromMessageId` doesn't exist). */
+  deactivateMessagesFrom(convId: string, fromMessageId: string): number {
+    const from = this.db.prepare(`SELECT seq FROM messages WHERE id = $id AND conv_id = $cid`).get({ $id: fromMessageId, $cid: convId } as P) as unknown as { seq: number } | undefined
+    if (!from) return 0
+    return ((this.db.prepare(`UPDATE messages SET is_active = 0 WHERE conv_id = $cid AND seq >= $seq`)
+      .run({ $cid: convId, $seq: from.seq } as P) as unknown) as Changes).changes
+  }
+
+  /** Undoes {@link deactivateMessagesFrom} — reactivates `fromMessageId` and every message after
+   *  it (by `seq`). Safe to call even if `fromMessageId` itself no longer exists (a no-op, 0
+   *  rows) — mirrors deactivateMessagesFrom's own lookup-then-range-update shape. */
+  reactivateMessagesFrom(convId: string, fromMessageId: string): number {
+    const from = this.db.prepare(`SELECT seq FROM messages WHERE id = $id AND conv_id = $cid`).get({ $id: fromMessageId, $cid: convId } as P) as unknown as { seq: number } | undefined
+    if (!from) return 0
+    return ((this.db.prepare(`UPDATE messages SET is_active = 1 WHERE conv_id = $cid AND seq >= $seq`)
+      .run({ $cid: convId, $seq: from.seq } as P) as unknown) as Changes).changes
   }
 
   /** Permanently delete a Code session: its messages, working doc, and the agent_run +

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -20,7 +20,7 @@
 import type { Context, Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { Deps } from '../deps'
-import type { AgentRun } from '../chat/db'
+import type { AgentRun, Message } from '../chat/db'
 import { CodeRunManager } from './code-run-manager'
 import { compactCodeSession, disposeLspClientsForConv } from './code-session'
 import { revertFileEdits } from './revert'
@@ -31,6 +31,24 @@ function err(c: Context, s: S, code: string, msg: string) { return c.json({ erro
 async function body<T>(c: Context): Promise<T> { try { return await c.req.json() as T } catch { return {} as T } }
 
 const VALID_MODES = new Set<CodeMode>(['auto', 'plan', 'ask'])
+
+/** Pure validation for POST .../revert (founder bug report, 2026-07-17; corrected same day after
+ *  live-testing against a real 40-message session — see the route below for the full story): is
+ *  `messageId` a valid revert target in `messages`? Exported for direct unit testing without a
+ *  live route/DB/CodeRunManager. Deliberately does NOT decide any cut point — a revert deactivates
+ *  (is_active=0) `messageId` and everything after it (ConversationStore.deactivateMessagesFrom),
+ *  which correctly discards the reverted range while leaving everything BEFORE it untouched,
+ *  unlike the old clearedUpToMessageId-cursor approach this replaces. */
+export function resolveRevertCut(
+  messages: Message[],
+  messageId: string,
+): { ok: true; revertText: string } | { ok: false; error: 'not_found' | 'not_a_user_message' | 'no_earlier_message' } {
+  const idx = messages.findIndex((m) => m.id === messageId)
+  if (idx === -1) return { ok: false, error: 'not_found' }
+  if (messages[idx].role !== 'user') return { ok: false, error: 'not_a_user_message' }
+  if (idx === 0) return { ok: false, error: 'no_earlier_message' }
+  return { ok: true, revertText: messages[idx].content }
+}
 
 /** Formats attached context-file paths (the composer's "Add context" file picker) as a prompt
  *  instruction — PATHS only, never fetched/inlined content: the agent already has a real `read`
@@ -87,6 +105,7 @@ function toSidebarRow(run: AgentRun) {
     error: run.error,
     archivedAt: run.archivedAt,
     clearedUpToMessageId: run.clearedUpToMessageId,
+    revertedFromMessageId: run.revertedFromMessageId,
   }
 }
 
@@ -302,12 +321,15 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
   // that marker back to null — the messages were never deleted, so resuming restores the
   // conversation exactly as it was. Both blocked while a run is active, same rationale as
   // /compact: clearing/resuming out from under a turn mid-flight against the OLD history frame
-  // is confusing regardless of whether it would technically corrupt anything.
+  // is confusing regardless of whether it would technically corrupt anything. ALSO blocked while
+  // reverted (v33) — /clear and revert are two independent resumable hidden-states; stacking them
+  // on one session would leave /resume ambiguous about which one it's undoing.
   app.post('/api/v1/code/sessions/:id/clear', (c) => {
     const id = c.req.param('id')
     const run = db.getAgentRun(id)
     if (!run) return err(c, 404, 'not_found', 'Session not found.')
     if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before clearing.')
+    if (run.revertedFromMessageId) return err(c, 409, 'session_reverted', 'Resume this session before clearing — it currently has a reverted message pending.')
     const conv = db.getConversation(run.convId, true)
     const lastMsg = (conv?.messages ?? []).at(-1)
     if (!lastMsg) return err(c, 400, 'nothing_to_clear', 'Nothing to clear yet.')
@@ -321,17 +343,41 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     const run = db.getAgentRun(id)
     if (!run) return err(c, 404, 'not_found', 'Session not found.')
     if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before resuming.')
+    // Undoes whichever of the two independent resumable hidden-states is active (v33) — they're
+    // mutually exclusive (see /clear and /revert's own guards), so at most one is ever set.
+    if (run.revertedFromMessageId) {
+      db.reactivateMessagesFrom(run.convId, run.revertedFromMessageId)
+      db.setRevertedFromMessageId(id, null)
+      return c.json({ ok: true })
+    }
     if (!run.clearedUpToMessageId) return err(c, 400, 'not_cleared', 'This session has not been cleared.')
     db.setClearedUpToMessageId(id, null)
     return c.json({ ok: true })
   })
 
   // ── revert to a user message ──────────────────────────────────────────────────
-  // Rewinds the transcript to just before `messageId` (reusing the SAME clearedUpToMessageId
-  // mechanism /clear + /resume already use — nothing is deleted, /resume still un-hides it) and
-  // returns that message's original text so the caller can refill the composer with it.
+  // Rewinds the transcript to just before `messageId` by DEACTIVATING (is_active=0) it and every
+  // message after it — ConversationStore.deactivateMessagesFrom, the same mechanism Chat's own
+  // branching already relies on (getMessages() filters is_active=1 unconditionally, so a
+  // deactivated message disappears from every consumer — transcript, resolveEffectiveHistory,
+  // revertFileEdits below — with no separate cut-logic needed anywhere). Nothing is deleted;
+  // /resume reactivates the same range. Returns messageId's original text so the caller can
+  // refill the composer with it.
+  //
+  // Corrected 2026-07-17 (same day, live-tested against a real 40-message session): a first pass
+  // reused clearedUpToMessageId (the /clear + /resume cursor) instead. That mechanism can only
+  // express "hide everything BEFORE a point, show everything after" — backwards from what revert
+  // needs (discard the reverted message and everything AFTER it, keep everything before), and
+  // structurally incapable of that for any message that isn't already at the very end: reverting
+  // to the session's actual last user message left that message's own reply orphaned and visible
+  // with nothing above it, and reverting to an EARLIER message (the revert affordance appears on
+  // every user message, not just the last — CodeTranscript.tsx) would have hidden the wrong half
+  // of history entirely. Real per-message deactivation fixes both, and generalizes correctly to
+  // any revert target, not just the last message.
+  //
   // Optionally (revertFiles) also reverse-applies every 'edit' tool call's stored patch for the
   // discarded messages, walking any touched file back to its pre-edit content — see revert.ts.
+  // ALSO blocked while cleared (v33) — same mutual-exclusion rationale as /clear's own guard.
   app.post('/api/v1/code/sessions/:id/revert', async (c) => {
     const id = c.req.param('id')
     const b = await body<{ messageId?: string; revertFiles?: boolean }>(c)
@@ -342,28 +388,31 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     if (!run) return err(c, 404, 'not_found', 'Session not found.')
     if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
     if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before reverting.')
+    if (run.clearedUpToMessageId) return err(c, 409, 'session_cleared', 'Resume this session before reverting — it currently has cleared messages pending.')
+    if (run.revertedFromMessageId) return err(c, 409, 'session_reverted', 'Resume this session before reverting again — it already has a reverted message pending.')
     const conv = db.getConversation(run.convId, true)
     if (!conv) return err(c, 404, 'not_found', 'Session conversation not found.')
 
     const messages = conv.messages ?? []
-    const idx = messages.findIndex((m) => m.id === messageId)
-    if (idx === -1) return err(c, 404, 'not_found', 'Message not found.')
-    if (messages[idx].role !== 'user') return err(c, 400, 'invalid_input', 'Can only revert to a user message.')
-    if (idx === 0) return err(c, 400, 'invalid_input', 'This is the first message in the session — nothing before it to revert to.')
-
-    const cutMessage = messages[idx - 1]
-    const revertText = messages[idx].content
+    const cut = resolveRevertCut(messages, messageId)
+    if (!cut.ok) {
+      if (cut.error === 'not_found') return err(c, 404, 'not_found', 'Message not found.')
+      if (cut.error === 'not_a_user_message') return err(c, 400, 'invalid_input', 'Can only revert to a user message.')
+      return err(c, 400, 'invalid_input', 'This is the first message in the session — nothing before it to revert to.')
+    }
 
     let revertedFiles: string[] = []
     let failedFiles: string[] = []
     if (b.revertFiles) {
+      const idx = messages.findIndex((m) => m.id === messageId)
       const result = revertFileEdits(messages.slice(idx), run.repoRoot)
       revertedFiles = result.reverted
       failedFiles = result.failed
     }
 
-    db.setClearedUpToMessageId(id, cutMessage.id)
-    return c.json({ ok: true, clearedUpToMessageId: cutMessage.id, revertText, revertedFiles, failedFiles })
+    db.deactivateMessagesFrom(run.convId, messageId)
+    db.setRevertedFromMessageId(id, messageId)
+    return c.json({ ok: true, revertedFromMessageId: messageId, revertText: cut.revertText, revertedFiles, failedFiles })
   })
 
   // ── stop the in-flight run (+ drop the queue) ─────────────────────────────────

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -12,9 +12,9 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
-import { toSessionStatus } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor } from './code-session'
-import { ConversationStore } from '../chat/db'
+import { toSessionStatus, resolveRevertCut } from './code-routes'
+import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor } from './code-session'
+import { ConversationStore, type Message } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
 
@@ -47,6 +47,127 @@ test('toSessionStatus: failed / cancelled / interrupted → aborted', () => {
 test('toSessionStatus: running / queued → review', () => {
   assert.equal(toSessionStatus('running'), 'review')
   assert.equal(toSessionStatus('queued'), 'review')
+})
+
+// ── resolveRevertCut (code-routes.ts) — validation only; the actual hide/show behavior is now
+// ConversationStore.deactivateMessagesFrom (below), not a clearedUpToMessageId cut point ---------
+
+function makeRevertConv(): { store: ConversationStore; convId: string } {
+  const store = new ConversationStore(mkdtempSync(join(tmpdir(), 'tllm-revert-cut-')))
+  const conv = store.createConversation({ kind: 'code' })
+  return { store, convId: conv.id }
+}
+
+test('resolveRevertCut: a valid target returns its original text', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'first task')
+  store.addMessage(convId, 'assistant', 'first reply')
+  const m1 = store.addMessage(convId, 'user', 'second task')
+  store.addMessage(convId, 'assistant', 'second reply')
+
+  const messages = store.getConversation(convId, true)!.messages!
+  assert.deepEqual(resolveRevertCut(messages, m1.id), { ok: true, revertText: 'second task' })
+})
+
+test('resolveRevertCut: reverting to a non-user message is rejected', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'task')
+  const reply = store.addMessage(convId, 'assistant', 'reply')
+  const messages = store.getConversation(convId, true)!.messages!
+  assert.deepEqual(resolveRevertCut(messages, reply.id), { ok: false, error: 'not_a_user_message' })
+})
+
+test('resolveRevertCut: reverting to the FIRST message is rejected (nothing earlier to keep)', () => {
+  const { store, convId } = makeRevertConv()
+  const first = store.addMessage(convId, 'user', 'first task')
+  const messages = store.getConversation(convId, true)!.messages!
+  assert.deepEqual(resolveRevertCut(messages, first.id), { ok: false, error: 'no_earlier_message' })
+})
+
+test('resolveRevertCut: unknown message id is rejected', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'task')
+  const messages = store.getConversation(convId, true)!.messages!
+  assert.deepEqual(resolveRevertCut(messages, 'does-not-exist'), { ok: false, error: 'not_found' })
+})
+
+// ── ConversationStore.deactivateMessagesFrom / reactivateMessagesFrom (db.ts) — the real
+// revert-to-message mechanism (v33), replacing the clearedUpToMessageId reuse the founder caught
+// live-testing against a real 40-message session (AMOLEDBurnFix): reverting to the session's
+// actual LAST user message left that message's own reply orphaned and visible with nothing above
+// it, since clearedUpToMessageId can only hide a PREFIX and show a SUFFIX — backwards from what a
+// revert needs. Real per-message deactivation fixes this generally, for any revert target -------
+
+test('deactivateMessagesFrom: hides the target message AND everything after it, but nothing before', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'first task')
+  store.addMessage(convId, 'assistant', 'first reply')
+  const m1 = store.addMessage(convId, 'user', 'second task')
+  store.addMessage(convId, 'assistant', 'second reply')
+
+  const affected = store.deactivateMessagesFrom(convId, m1.id)
+  assert.equal(affected, 2, 'the reverted message + its own reply')
+  const visible = store.getMessages(convId)
+  assert.deepEqual(visible.map((m) => m.content), ['first task', 'first reply'], 'everything before the reverted message stays visible; nothing orphaned after it')
+})
+
+test('deactivateMessagesFrom: reverting to the actual LAST user message hides its own reply too (the exact reported bug)', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'go do the thing')
+  const lastUser = store.addMessage(convId, 'user', 'delete them no needed')
+  store.addMessage(convId, 'assistant', 'Done. The store-assets/ directory has been deleted.')
+
+  store.deactivateMessagesFrom(convId, lastUser.id)
+  const visible = store.getMessages(convId)
+  assert.deepEqual(visible.map((m) => m.content), ['go do the thing'])
+  assert.ok(!visible.some((m) => m.id === lastUser.id))
+})
+
+test('deactivateMessagesFrom: reverting to an EARLY message preserves everything before it, unlike a clearedUpToMessageId cut', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'm0')
+  store.addMessage(convId, 'assistant', 'r0')
+  const early = store.addMessage(convId, 'user', 'm1') // revert target, well before the end
+  store.addMessage(convId, 'assistant', 'r1')
+  store.addMessage(convId, 'user', 'm2')
+  store.addMessage(convId, 'assistant', 'r2')
+
+  store.deactivateMessagesFrom(convId, early.id)
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['m0', 'r0'])
+})
+
+test('deactivateMessagesFrom: unknown message id is a no-op (0 rows), never throws', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'task')
+  assert.equal(store.deactivateMessagesFrom(convId, 'does-not-exist'), 0)
+  assert.equal(store.getMessages(convId).length, 1, 'untouched')
+})
+
+test('reactivateMessagesFrom: undoes deactivateMessagesFrom exactly, restoring full history (the /resume contract)', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'first task')
+  const m1 = store.addMessage(convId, 'user', 'second task')
+  store.addMessage(convId, 'assistant', 'second reply')
+
+  store.deactivateMessagesFrom(convId, m1.id)
+  assert.equal(store.getMessages(convId).length, 1)
+  const restored = store.reactivateMessagesFrom(convId, m1.id)
+  assert.equal(restored, 2)
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['first task', 'second task', 'second reply'])
+})
+
+test('reactivateMessagesFrom: a NEW message sent after a revert is unaffected by a later /resume of that revert', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'first task')
+  const m1 = store.addMessage(convId, 'user', 'second task (attempt 1)')
+  store.deactivateMessagesFrom(convId, m1.id)
+  // Resend after the revert — appended fresh, same as the real /messages route would do.
+  store.addMessage(convId, 'user', 'second task (attempt 2)')
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['first task', 'second task (attempt 2)'])
+
+  // Resuming (undoing) the revert brings attempt 1 back WITHOUT disturbing attempt 2.
+  store.reactivateMessagesFrom(convId, m1.id)
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['first task', 'second task (attempt 1)', 'second task (attempt 2)'])
 })
 
 // ── tool-set contracts ──────────────────────────────────────────────────────────────
@@ -96,6 +217,74 @@ test('compactionSettingsFor: monotonically non-decreasing with contextWindow (be
   const big = compactionSettingsFor(65536)
   assert.ok(big.reserveTokens >= small.reserveTokens)
   assert.ok(big.keepRecentTokens >= small.keepRecentTokens)
+})
+
+// ── keepRecentTokensFor (code-session.ts) — founder-reported, 2026-07-17 ("I have never yet
+// successfully compacted... keeps saying conversation is short"). Root-caused live against a
+// real 272K-token AMOLEDBurnFix session: pi's own bundled findCutPoint has a genuine bug where a
+// trailing tool-call-only run bigger than keepRecentTokens makes it silently keep EVERYTHING
+// instead of falling back to the last real cut point. This guards against it by ensuring
+// keepRecentTokens is never smaller than the conversation's own last turn -----------------------
+
+function fakeTurnMsg(role: 'user' | 'assistant', content: string, toolResults: string[] = []): Message {
+  return {
+    role,
+    content,
+    toolCalls: toolResults.map((result, i) => ({ id: `tc${i}`, name: 'read', args: {}, result })),
+  } as unknown as Message
+}
+
+test('keepRecentTokensFor: leaves the base value untouched when the last turn is small', () => {
+  const messages = [fakeTurnMsg('user', 'hi'), fakeTurnMsg('assistant', 'hello')]
+  assert.equal(keepRecentTokensFor(messages, 20000), 20000)
+})
+
+test('keepRecentTokensFor: bumps keepRecentTokens past a large trailing tool-call-only turn', () => {
+  const bigResult = 'x'.repeat(40000) // ~10,000 tokens each
+  const messages = [
+    fakeTurnMsg('user', 'first task'),
+    fakeTurnMsg('assistant', 'reply', ['small']),
+    fakeTurnMsg('user', 'do something big'),
+    fakeTurnMsg('assistant', 'working on it', [bigResult, bigResult]),
+  ]
+  const bumped = keepRecentTokensFor(messages, 2867) // compactionSettingsFor(8192)'s own value
+  assert.ok(bumped > 2867, 'should be bumped above the small base')
+  assert.ok(bumped >= Math.ceil((bigResult.length * 2) / 4), "should cover the last turn's real size")
+})
+
+test('keepRecentTokensFor: reproduces the exact reported bug scenario and confirms the fix covers it', () => {
+  // Mirrors the real AMOLEDBurnFix session that reproduced this: the LAST turn alone (one
+  // assistant message + ~30 tool results) summed to ~12K estimated tokens — bigger than
+  // compactionSettingsFor's own scaled keepRecentTokens for an 8K or 32K local context (2867 /
+  // 11469), which is exactly what made pi's findCutPoint fail every time.
+  const toolResults = Array.from({ length: 30 }, () => 'y'.repeat(1600)) // ~12,000 tokens total
+  const messages = [
+    fakeTurnMsg('user', 'first task'),
+    fakeTurnMsg('assistant', 'first reply'),
+    fakeTurnMsg('user', 'delete them no needed'),
+    fakeTurnMsg('assistant', 'Done.', toolResults),
+  ]
+  const lastTurnTokens = toolResults.reduce((sum, r) => sum + Math.ceil(r.length / 4), 0)
+  assert.ok(lastTurnTokens > 11469, 'sanity: the synthetic last turn must exceed the 32K-ctx scaled threshold to reproduce the bug')
+  const bumped = keepRecentTokensFor(messages, 11469)
+  assert.ok(bumped > lastTurnTokens, 'bumped keepRecentTokens must exceed the whole last turn, not just be somewhat bigger')
+})
+
+test('keepRecentTokensFor: no user message at all returns the base unchanged', () => {
+  const messages = [fakeTurnMsg('assistant', 'just a reply, no user turn')]
+  assert.equal(keepRecentTokensFor(messages, 5000), 5000)
+})
+
+test('keepRecentTokensFor: only counts the LAST turn, not the whole conversation', () => {
+  const bigOldResult = 'z'.repeat(400000) // huge, but from an EARLIER turn
+  const messages = [
+    fakeTurnMsg('user', 'old big task'),
+    fakeTurnMsg('assistant', 'huge old reply', [bigOldResult]),
+    fakeTurnMsg('user', 'small recent task'),
+    fakeTurnMsg('assistant', 'small recent reply'),
+  ]
+  // The last turn (small recent task + reply) is tiny — the huge earlier turn must NOT inflate it.
+  assert.equal(keepRecentTokensFor(messages, 20000), 20000)
 })
 
 test('isDependencyAddCommand: detects install/add commands across common package managers', () => {

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -188,6 +188,46 @@ export function compactionSettingsFor(contextWindow: number): { enabled: boolean
   return { enabled: true, reserveTokens, keepRecentTokens }
 }
 
+/** Rough chars/4 token estimate for one DB message + its tool calls' args/results — mirrors pi's
+ *  own heuristic (compaction.js's estimateTokens) closely enough to size a safety margin against
+ *  (see keepRecentTokensFor below), not to reproduce pi's count exactly. */
+export function estimateMessageTokensRough(m: DbMessage): number {
+  let chars = m.content.length
+  for (const tc of m.toolCalls) {
+    chars += tc.name.length + JSON.stringify(tc.args).length // the assistant's own toolCall block
+    chars += (tc.result ?? tc.error ?? '').length // the separate toolResult entry
+  }
+  return Math.ceil(chars / 4)
+}
+
+/** Founder-reported, 2026-07-17 ("I have never yet successfully compacted... keeps saying
+ *  conversation is short") — root-caused against a real 272K-token AMOLEDBurnFix session: pi's
+ *  bundled findCutPoint (compaction.js) has a genuine bug. It walks backward from the newest
+ *  entry accumulating token estimates until `keepRecentTokens` is reached, then searches for the
+ *  closest valid cut point AT OR AFTER that position — but a "cut point" can only be a user/
+ *  assistant/etc. message, never a tool result (pi's own rule: never cut a tool call apart from
+ *  its result). When a session's LAST turn is a heavy tool-call turn (common in agentic coding —
+ *  a single turn easily has dozens of tool results with no later user/assistant message), and
+ *  `keepRecentTokens` is smaller than that whole trailing run's size, the threshold gets crossed
+ *  entirely INSIDE that run — where there is no valid cut point at or after the crossing position
+ *  — so the search comes up empty and silently falls back to keeping EVERYTHING (cutIndex 0)
+ *  instead of the last real cut point, reporting "nothing to compact" no matter how large the
+ *  actual conversation is. Reproduced directly: a real session's trailing tool-call run alone
+ *  summed to ~12K estimated tokens; keepRecentTokens=2867/11469 (compactionSettingsFor's own
+ *  scaled values for an 8K/32K local context — ADR-224) both hit the bug, 12000+ did not.
+ *  Can't patch the bundled dependency, so work around it here: never let keepRecentTokens end up
+ *  smaller than the conversation's own last turn, so pi's threshold-crossing walk always lands at
+ *  or before a real cut point instead of running past every one of them. `messages` should be
+ *  whatever pi is about to have seeded (repriorMessages for auto-compaction, the full
+ *  effectiveMessages for manual /compact) — NOT the live in-flight turn, which isn't seeded yet. */
+export function keepRecentTokensFor(messages: DbMessage[], baseKeepRecentTokens: number): number {
+  const lastUserIdx = messages.map((m) => m.role).lastIndexOf('user')
+  if (lastUserIdx === -1) return baseKeepRecentTokens
+  let lastTurnTokens = 0
+  for (let i = lastUserIdx; i < messages.length; i++) lastTurnTokens += estimateMessageTokensRough(messages[i])
+  return Math.max(baseKeepRecentTokens, lastTurnTokens + 512) // margin past the exact boundary
+}
+
 /** A minimal SSE sink — matches the chat wire shape so the existing frontend parser works. */
 export type CodeSseSink = (ev: { event: string; data: unknown }) => void | Promise<void>
 
@@ -305,17 +345,23 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // ── in-memory pi services (no global pi config on disk) ──────────────────────
   const authStorage = AuthStorage.inMemory()
   const modelRegistry = ModelRegistry.inMemory(authStorage)
-  // Auto-compaction settings scaled to THIS model's real ctx (see compactionSettingsFor) — pi's
-  // own hosted-model-sized defaults would otherwise make auto-compaction self-defeating here.
-  const settingsManager = SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) })
   // Seed prior turns (see seedPriorHistory's own comment), respecting any existing manual
   // /compact — everything up to but NOT including the current turn's user message.
   // code-run-manager.ts's pump() has already appended both `task`'s own user message AND an
   // empty assistant placeholder for THIS turn by the time we get here, so the current turn is
-  // excluded by cutting at the last user message, not by seq.
+  // excluded by cutting at the last user message, not by seq. Computed BEFORE settingsManager
+  // below (moved up from its original spot) since keepRecentTokensFor needs priorMessages.
   const { summaryText, messages: effectiveMessages } = resolveEffectiveHistory(d, convId, sessionId)
   const lastUserIdx = effectiveMessages.findLastIndex((m) => m.role === 'user')
   const priorMessages = lastUserIdx > 0 ? effectiveMessages.slice(0, lastUserIdx) : []
+  // Auto-compaction settings scaled to THIS model's real ctx (see compactionSettingsFor) — pi's
+  // own hosted-model-sized defaults would otherwise make auto-compaction self-defeating here.
+  // keepRecentTokens further guarded by keepRecentTokensFor — see its doc comment for the real
+  // pi-side bug this works around (a heavy-tool-call-ending turn otherwise makes pi's own
+  // findCutPoint silently keep everything and report nothing left to compact).
+  const autoCompactionSettings = compactionSettingsFor(contextWindow)
+  autoCompactionSettings.keepRecentTokens = keepRecentTokensFor(priorMessages, autoCompactionSettings.keepRecentTokens)
+  const settingsManager = SettingsManager.inMemory({ compaction: autoCompactionSettings })
   const seedHistoryInto = (sm: SessionManager): void => {
     if (summaryText) sm.appendMessage({ role: 'user', content: summaryText, timestamp: Date.now() })
     if (priorMessages.length > 0) seedPriorHistory(sm, priorMessages, modelId)
@@ -1090,6 +1136,8 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
 
   const { summaryText, messages: effectiveMessages } = resolveEffectiveHistory(d, convId, sessionId)
   if (effectiveMessages.length === 0) throw new Error('nothing_to_compact')
+  const compactionSettings = compactionSettingsFor(contextWindow)
+  compactionSettings.keepRecentTokens = keepRecentTokensFor(effectiveMessages, compactionSettings.keepRecentTokens)
 
   const authStorage = AuthStorage.inMemory()
   const modelRegistry = ModelRegistry.inMemory(authStorage)
@@ -1149,10 +1197,13 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
     authStorage,
     modelRegistry,
     sessionManager,
-    // Ctx-scaled settings (compactionSettingsFor) — pi's hosted-model-sized defaults could ask
-    // to keep more "recent" tokens than this model's real context window even has room for,
-    // producing a compacted result that still doesn't fit.
-    settingsManager: SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) }),
+    // Ctx-scaled settings (compactionSettingsFor), keepRecentTokens further guarded by
+    // keepRecentTokensFor — pi's hosted-model-sized defaults could ask to keep more "recent"
+    // tokens than this model's real context window even has room for, producing a compacted
+    // result that still doesn't fit; the guard fixes a real bug in pi's own findCutPoint (see its
+    // doc comment) that otherwise makes manual /compact report "nothing to compact" on a
+    // heavy-tool-call-ending session, no matter how large the real conversation is.
+    settingsManager: SettingsManager.inMemory({ compaction: compactionSettings }),
     resourceLoader: compactResourceLoader,
     tools: [], // pure summarization — no tool needs to run, and none should be able to.
   })

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -14,6 +14,14 @@ export const SCHEMA_VERSION = 3
 export const VRAM_HEADROOM_MIN_MB = 300
 export const VRAM_HEADROOM_MAX_MB = 2048
 export const VRAM_HEADROOM_DEFAULT_MB = 1024
+/** Special sentinel, distinct from the {@link VRAM_HEADROOM_MIN_MB}–{@link VRAM_HEADROOM_MAX_MB}
+ *  safety-margin range: an explicit opt-in to let auto-tune spill PAST all VRAM headroom during
+ *  its MoE hill-climb search (`bench.ts`'s `moeSearch`), trading the safety margin for a real
+ *  measured tok/s gain when one exists. Founder call, 2026-07-17 (after live-testing the
+ *  hill-climb unconditionally): the hill-climb must never silently override a user's configured
+ *  safety margin, so it's gated on this exact value — anything in 1–299 is invalid, same as
+ *  before. The Settings slider snaps straight from {@link VRAM_HEADROOM_MIN_MB} to this value. */
+export const VRAM_HEADROOM_SPILL_MB = 0
 
 export interface Capabilities {
   kvTypes: string[]
@@ -342,8 +350,9 @@ export interface Config {
    *  ComfyUI VRAM grab can't tip the chosen config into a sysmem spill (bench.ts's
    *  `overHeadroom`). User-configurable via a Settings slider,
    *  {@link VRAM_HEADROOM_MIN_MB}–{@link VRAM_HEADROOM_MAX_MB}, default
-   *  {@link VRAM_HEADROOM_DEFAULT_MB}. Absent in pre-this-feature configs → normalize
-   *  seeds the default. */
+   *  {@link VRAM_HEADROOM_DEFAULT_MB} — OR the {@link VRAM_HEADROOM_SPILL_MB} sentinel (0), an
+   *  explicit opt-in to let auto-tune's MoE hill-climb spill past all headroom for more t/s.
+   *  Absent in pre-this-feature configs → normalize seeds the default. */
   vramHeadroomMb: number
   lastLoaded: LastLoaded
   autoLoadOnStart: boolean
@@ -652,8 +661,11 @@ function normalize(c: Config): void {
   c.benchResults ??= {}
   // VRAM headroom slider: absent/garbage (pre-feature config, or a stale out-of-range
   // value) → the default, never thrown on load — mirrors the gateway.keepN clamp below.
+  // VRAM_HEADROOM_SPILL_MB (0) is a valid, distinct value — the explicit "allow spill" opt-in —
+  // not an out-of-range value to normalize away.
   c.vramHeadroomMb =
-    typeof c.vramHeadroomMb === 'number' && c.vramHeadroomMb >= VRAM_HEADROOM_MIN_MB && c.vramHeadroomMb <= VRAM_HEADROOM_MAX_MB
+    typeof c.vramHeadroomMb === 'number' &&
+    (c.vramHeadroomMb === VRAM_HEADROOM_SPILL_MB || (c.vramHeadroomMb >= VRAM_HEADROOM_MIN_MB && c.vramHeadroomMb <= VRAM_HEADROOM_MAX_MB))
       ? c.vramHeadroomMb
       : VRAM_HEADROOM_DEFAULT_MB
   c.autoLoadOnStart ??= false
@@ -853,8 +865,8 @@ function validate(c: Config): void {
   if (c.activeEngineId && !c.engines.some((e) => e.id === c.activeEngineId)) {
     throw new ValueError('activeEngineId', 'unknown engine id')
   }
-  if (c.vramHeadroomMb < VRAM_HEADROOM_MIN_MB || c.vramHeadroomMb > VRAM_HEADROOM_MAX_MB) {
-    throw new ValueError('vramHeadroomMb', `must be between ${VRAM_HEADROOM_MIN_MB} and ${VRAM_HEADROOM_MAX_MB} MB`)
+  if (c.vramHeadroomMb !== VRAM_HEADROOM_SPILL_MB && (c.vramHeadroomMb < VRAM_HEADROOM_MIN_MB || c.vramHeadroomMb > VRAM_HEADROOM_MAX_MB)) {
+    throw new ValueError('vramHeadroomMb', `must be ${VRAM_HEADROOM_SPILL_MB} (allow VRAM spill) or between ${VRAM_HEADROOM_MIN_MB} and ${VRAM_HEADROOM_MAX_MB} MB`)
   }
   // ComfyUI reverse-gate origin (F-011): empty is allowed (reverse gate just stays off);
   // if set, it must be an http(s):// origin so the `POST {url}/free` call is well-formed.

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -549,9 +549,9 @@ export type DaemonSettings = {
   autoMemoryEnabled: boolean
   openBrowserOnStart: boolean
   autoLoadOnStart: boolean
-  /** VRAM to keep free during auto-tune's offload search, MB (300–2048, default 1024). A
-   *  later desktop / ComfyUI VRAM grab can't tip a config tuned with less headroom into a
-   *  sysmem spill. */
+  /** VRAM to keep free during auto-tune's offload search, MB (300–2048, default 1024) — OR 0, an
+   *  explicit opt-in letting the MoE hill-climb spill past all headroom for more t/s. A later
+   *  desktop / ComfyUI VRAM grab can't tip a config tuned with less headroom into a sysmem spill. */
   vramHeadroomMb: number
   /** Expose the API on the local network (spec 08 §2). Changing this requires a
    *  daemon restart to take effect (POST /api/v1/daemon/restart). */

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -72,7 +72,7 @@ export function revertCodeSession(
   id: string,
   messageId: string,
   revertFiles?: boolean,
-): Promise<{ ok: true; clearedUpToMessageId: string; revertText: string; revertedFiles: string[]; failedFiles: string[] }> {
+): Promise<{ ok: true; revertedFromMessageId: string; revertText: string; revertedFiles: string[]; failedFiles: string[] }> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/revert`, { method: 'POST', json: { messageId, revertFiles } })
 }
 

--- a/turbollm/web/src/lib/code-types.ts
+++ b/turbollm/web/src/lib/code-types.ts
@@ -24,6 +24,10 @@ export interface CodeSession {
   /** Set when this session has been /clear'd — the last message id everything at/before is
    *  hidden. Undefined = never cleared, or resumed back from one. */
   clearedUpToMessageId?: string
+  /** Set when a message has been reverted-to — that message id and everything after it is
+   *  deactivated (not deleted; /resume reactivates it). Mutually exclusive with
+   *  clearedUpToMessageId. Undefined = never reverted, or resumed back from one. */
+  revertedFromMessageId?: string
 }
 
 export type CodeSessionFilter = 'active' | 'archived' | 'all'

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -87,7 +87,7 @@ const TURBOLLM_KNOWLEDGE =
 
   '**Settings** — a two-pane layout, six categories in the left rail, one sticky Save bar:\n' +
   '- **General**: theme (light/dark/system), enable-thinking-by-default, confirm-before-delete, personalization (assistant name / your name), **Memory** — its toggle now lives in Experimental (see below); when on, the reviewable/deletable fact list still shows here, auto-generate chat titles, open browser on start.\n' +
-  '- **Models & loading**: idle timeout (auto-stop after N minutes), default context length, Gateway (auto model-swap + Keep-N pool, 1–4 models), model folders, Hugging Face token, and an **Advanced** collapsible for expert knobs — default GPU layers, VRAM headroom (300 MB–2 GB, default 1 GB), and image/response token caps.\n' +
+  '- **Models & loading**: idle timeout (auto-stop after N minutes), default context length, Gateway (auto model-swap + Keep-N pool, 1–4 models), model folders, Hugging Face token, and an **Advanced** collapsible for expert knobs — default GPU layers, VRAM headroom (300 MB–2 GB, default 1 GB, or drag to 0 to opt into MoE auto-tune\'s "VRAM-spill" search — see Auto-Tune below), and image/response token caps.\n' +
   '- **Tools & safety**: per-tool Ask/Allow/Deny defaults for every tool the model can call (web_search, fetch_url, run_code, MCP tools).\n' +
   '- **Network & sharing**: LAN exposure (bind to 0.0.0.0 vs loopback-only), port, require-API-key auth, and ComfyUI integration (URL, Reverse GPU gate, update banner).\n' +
   '- **Experimental**: still-in-progress features, off by default — a single on/off row each for **Memory** (silently extracts durable facts from chat using the loaded model; its own settings stay in General, unlocked once this is on), **Code** (the Workspace → Code tab; disabling this removes the tab entirely, not just its content), and **Cloud Launch/RunPod** (earliest-stage of the three — turning it on doesn\'t yet unlock a built UI).\n' +
@@ -118,11 +118,10 @@ const TURBOLLM_KNOWLEDGE =
 
   '## Auto-Tune\n\n' +
   'Auto-tune finds the best GPU-offload config for a model given available VRAM. It runs a binary search, not a fixed candidate list. Triggered from the Model Detail panel.\n\n' +
-  '**Phase 1 — KV quant sweep** (VRAM probes, no generation):\n' +
-  'Tests quality-preserving KV cache types from best to smaller: f16 → q8_0 → turbo4 (TurboQuant only) / q4_0. Picks the highest-quality type that fits within the configured VRAM headroom buffer (Settings → Models & loading → Advanced, default 1 GB, adjustable 300 MB–2 GB). Lower-quality types (q4_0, q4_1) are never auto-selected — quality floor is enforced.\n\n' +
-  '**Phase 2 — Binary search for GPU offload** (~log₂(blockCount) probes, VRAM-only):\n' +
-  '- Dense models: search ngl ∈ [0, blockCount] — finds highest ngl that doesn\'t exceed the VRAM headroom.\n' +
-  '- MoE models: search nCpuMoe ∈ [0, nExpertsTotal] — ngl stays maxed, finds minimum nCpuMoe (router experts on CPU) that fits. Reducing nCpuMoe pushes more MoE routing onto the GPU.\n\n' +
+  '**Phase 1 — Offload search** (VRAM probes, no generation), on whatever KV-cache type you already have selected — auto-tune no longer picks the KV type for you:\n' +
+  '- Dense models: search ngl ∈ [0, blockCount] — finds highest ngl that doesn\'t exceed the configured VRAM headroom buffer (Settings → Models & loading → Advanced, default 1 GB, adjustable 300 MB–2 GB).\n' +
+  '- MoE models: search nCpuMoe ∈ [0, nExpertsTotal] — ngl stays maxed, finds minimum nCpuMoe (router experts on CPU) that fits the headroom. Reducing nCpuMoe pushes more MoE routing onto the GPU. If VRAM headroom is set to 0 (an explicit opt-in, not the default), MoE models then hill-climb PAST that safe point — pushing nCpuMoe lower still, for as long as each further step measures both generation AND prompt-processing speed still improving.\n' +
+  '- If the winning config is slow (under 20 tok/s) and a smaller, non-lossy KV type would fit, the results dialog shows an advisory naming it — it never switches the type automatically.\n\n' +
   '**Phase 3 — Real benchmark at winner config**:\n' +
   'One real prefill + generation run. Bench prompt: `min(50,000 tokens, ctx × 75%)`. Per-test cap: 3 minutes. Stop/restart/load cancel a running auto-tune. Records prefill t/s, generation t/s, TTFT ms, and VRAM delta.\n\n' +
   '**Phase 4 — Recommended sampling extraction**:\n' +

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -212,7 +212,9 @@ export function SettingsScreen() {
     // Clamp defensively: NumberField commits unclamped while editing and only
     // snaps to range on blur, so guard the final ranges here too (spec 08 §2).
     idleTtlMinutes: clampN(ttl, 0, 1440),
-    vramHeadroomMb: clampN(vramHeadroom, 300, 2048),
+    // 0 is the distinct "allow VRAM spill" opt-in (VRAM_HEADROOM_SPILL_MB), not a smaller safety
+    // margin — clampN(v, 300, 2048) would otherwise clamp it up to 300 and silently discard it.
+    vramHeadroomMb: vramHeadroom === 0 ? 0 : clampN(vramHeadroom, 300, 2048),
     port: clampN(port, 1024, 65535),
     autoGenerateTitles: autoTitle,
     openBrowserOnStart: openBrowser,
@@ -531,13 +533,20 @@ export function SettingsScreen() {
                   <div className="mt-3 border-t border-border pt-1">
                     <Slider
                       label="VRAM headroom"
-                      hint="VRAM to keep free during auto-tune, so a later app switch or render job doesn't spill the model into slower shared memory"
+                      hint={
+                        vramHeadroom === 0
+                          ? "VRAM spill allowed. For MoE models, auto-tune will keep moving experts onto the GPU past this point as long as it measures a real speed gain — even if that spills the model into slower shared memory. Drag right to restore a safety margin."
+                          : "VRAM to keep free during auto-tune, so a later app switch or render job doesn't spill the model into slower shared memory. Drag all the way to the left to instead let auto-tune spill on purpose for more speed."
+                      }
                       value={vramHeadroom}
-                      min={300}
+                      min={0}
                       max={2048}
                       step={1}
-                      onChange={setVramHeadroom}
-                      fmt={(v) => (v >= 1024 ? `${(v / 1024).toFixed(1)} GB` : `${v} MB`)}
+                      // Snaps straight from 300 to 0 — 0 is a distinct "allow VRAM spill" opt-in
+                      // (VRAM_HEADROOM_SPILL_MB), not a smaller safety margin, so 1–299 isn't a
+                      // real intermediate value: only the literal minimum position drops to 0.
+                      onChange={(v) => setVramHeadroom(v === 0 ? 0 : Math.max(300, v))}
+                      fmt={(v) => (v === 0 ? '0 MB — spill allowed' : v >= 1024 ? `${(v / 1024).toFixed(1)} GB` : `${v} MB`)}
                     />
                   </div>
 

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -109,6 +109,13 @@ export interface CodeComposerProps {
   contextFiles?: string[]
   onRemoveContextFile?: (path: string) => void
   hintText: string
+  /** A real, in-progress state (running / compacting) — founder feedback, 2026-07-17: the old
+   *  approach folded this into `hintText` as tiny 11px faint-gray text below the composer,
+   *  identical in weight to the boring "Enter to send" keyboard hint, so an actual in-flight
+   *  operation (especially manual /compact, which disables the whole composer) was easy to miss
+   *  entirely. Rendered instead as its own prominent, accent-colored banner directly ABOVE the
+   *  textarea when present; `hintText` stays reserved for the idle keyboard-shortcut copy. */
+  statusText?: string
 
   /** -1 = unlimited (default), 0 = off, N>0 = a real token cap — same control/semantics as
    *  ChatScreen's own thinking budget slider (chat-routes.ts's `thinkingBudget`), applied to
@@ -129,7 +136,7 @@ export function CodeComposer({
   repo, mode, onModeChange,
   models, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
   ctxUsed, ctxMax, live, onStop, sendDisabled,
-  onAddContext, contextFiles, onRemoveContextFile, hintText, slashCommands = [],
+  onAddContext, contextFiles, onRemoveContextFile, hintText, statusText, slashCommands = [],
   thinkingBudget, onThinkingBudgetChange,
 }: CodeComposerProps) {
   const ModeIcon = MODE_ICONS[mode.id]
@@ -357,6 +364,22 @@ export function CodeComposer({
           </div>
         )}
 
+        {/* Prominent in-progress banner (running / compacting) — directly above the textarea,
+            accent-colored, its own row (not folded into the faint keyboard-hint text below). */}
+        {statusText && (
+          <div
+            className="flex items-center gap-2 border-b px-3 py-2 text-[13px] font-medium"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent) 35%, var(--border))',
+              background: 'color-mix(in srgb, var(--accent) 12%, transparent)',
+              color: 'var(--accent)',
+            }}
+          >
+            <Loader2 size={14} className="shrink-0 animate-spin" />
+            <span>{statusText}</span>
+          </div>
+        )}
+
         {/* Task input */}
         <textarea
           ref={inputRef}
@@ -478,17 +501,16 @@ export function CodeComposer({
         </div>
       </div>
       </div>
-      {/* Persistent, always-visible busy indicator (founder-reported gap, 2026-07-13): the only
-          "is the agent busy" signal near the composer used to be this hint's plain STRING swap
-          (idle text ↔ running text) — no icon, no animation. The inline CodeThinking/
-          CodeStreamingEntry activity live INSIDE the scrolling transcript body and can be
-          scrolled out of view during a long run; this lives in the composer itself, so it's
-          visible regardless of scroll position. Reuses CodeThinking's own spinner styling
-          (Loader2, accent color) rather than inventing a new motion language. */}
-      <p className="mt-2 flex items-center justify-center gap-1.5 text-center text-[11px] text-faint">
-        {live && <Loader2 size={11} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
-        <span>{hintText}</span>
-      </p>
+      {/* Persistent, always-visible busy indicator (founder-reported gap, 2026-07-13; moved to
+          its own prominent banner ABOVE the textarea, 2026-07-17 — a second founder report that
+          folding it into this tiny 11px faint-gray hint made it too easy to miss for a real
+          in-progress state like manual /compact, which disables the whole composer). This line is
+          now ONLY the idle keyboard-shortcut copy — hidden entirely while `statusText` is
+          showing, since "Enter to send" is irrelevant (and wrong) while the composer is
+          disabled. */}
+      {!statusText && (
+        <p className="mt-2 text-center text-[11px] text-faint">{hintText}</p>
+      )}
     </div>
   )
 }

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -372,11 +372,19 @@ export function CodeSessionScreen() {
     return skill && task ? `Use the invoke_skill tool with skillId "${skill.id}" for this task: ${task}` : undefined
   }
 
+  // Founder-reported UX gap, 2026-07-17: manual /compact showed NO progress indication at all
+  // while compactCodeSession awaited (a real LLM summarization call, easily several seconds to a
+  // minute+) — the composer just went blank with nothing to show for it until a toast finally
+  // landed. `live.compacting` (driving the SAME "Compacting conversation…" hint text below) only
+  // ever fires for AUTO-compaction's SSE event mid-turn; the manual command is a separate,
+  // non-streaming POST with no live state of its own until now.
+  const [manualCompacting, setManualCompacting] = useState(false)
   const COMPACT_RE = /^\/compact\b\s*(.*)$/i
   const runCompact = async (text: string) => {
     if (!sessionId) return
     const instructions = COMPACT_RE.exec(text)?.[1]?.trim() || undefined
     setInput('')
+    setManualCompacting(true)
     try {
       const result = await compactCodeSession(sessionId, instructions)
       void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
@@ -385,6 +393,8 @@ export function CodeSessionScreen() {
       setInput(text) // restore so the command isn't lost
       if (e instanceof ApiError && e.code === 'nothing_to_compact') toast.info('Nothing to compact yet — history is already short enough.')
       else toast.error(e instanceof ApiError ? e.message : 'Could not compact.')
+    } finally {
+      setManualCompacting(false)
     }
   }
 
@@ -417,12 +427,12 @@ export function CodeSessionScreen() {
     }
   }
 
-  // Revert-to-message: rewinds the transcript to just before a user message (same underlying
-  // clearedUpToMessageId mechanism as /clear — /resume still un-hides it) and refills the
-  // composer with that message's ORIGINAL text. When the discarded range touched real files
-  // (any edit-tool call with a stored patch), asks whether to ALSO reverse-apply those edits —
-  // reverting the transcript alone is always safe/reversible; reverting files is a real,
-  // separate, less-reversible action the user should explicitly opt into.
+  // Revert-to-message: rewinds the transcript to just before a user message — deactivating it
+  // and everything after it (v33; independent of /clear's clearedUpToMessageId cursor — /resume
+  // still un-hides it) — and refills the composer with that message's ORIGINAL text. When the
+  // discarded range touched real files (any edit-tool call with a stored patch), asks whether to
+  // ALSO reverse-apply those edits — reverting the transcript alone is always safe/reversible;
+  // reverting files is a real, separate, less-reversible action the user should explicitly opt into.
   const [pendingRevert, setPendingRevert] = useState<{ messageId: string; hasFileEdits: boolean } | null>(null)
   const openRevertConfirm = (messageId: string) => {
     const idx = messages.findIndex((m) => m.id === messageId)
@@ -668,6 +678,22 @@ export function CodeSessionScreen() {
                 </button>
               </div>
             )}
+            {/* Revert banner — same non-destructive framing as /clear's: the reverted-from
+                message and everything after it are deactivated, never deleted (v33). */}
+            {!notFound && session?.revertedFromMessageId && (
+              <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2 text-[12px] text-muted">
+                <RotateCcw size={13} className="shrink-0 text-faint" />
+                <span className="flex-1">Reverted to an earlier message — later messages hidden.</span>
+                <button
+                  type="button"
+                  onClick={() => void runResume()}
+                  disabled={resumeMut.isPending}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 font-medium text-ink transition-colors hover:bg-panel"
+                >
+                  <RotateCcw size={12} /> Resume
+                </button>
+              </div>
+            )}
             {initialLoading && <CodeTranscriptSkeleton />}
             {!notFound && !initialLoading && (
               <CodeTranscript
@@ -728,7 +754,7 @@ export function CodeSessionScreen() {
             onValueChange={setInput}
             onSubmit={() => void send()}
             placeholder={live ? 'Queue a follow-up…' : 'Send a follow-up…'}
-            textareaDisabled={false}
+            textareaDisabled={manualCompacting}
             mode={modeInfo}
             onModeChange={handleModeChange}
             models={allModels}
@@ -745,21 +771,28 @@ export function CodeSessionScreen() {
             ctxMax={ctxMax}
             live={!!live}
             onStop={() => void handleStop()}
-            sendDisabled={!input.trim()}
+            sendDisabled={!input.trim() || manualCompacting}
             onAddContext={() => setContextBrowserOpen(true)}
             contextFiles={contextFiles}
             onRemoveContextFile={(p) => setContextFiles((cf) => cf.filter((x) => x !== p))}
             slashCommands={[
               { id: 'compact', description: 'Summarize the conversation so far into one summary, to free up context' },
               { id: 'clear', description: 'Clear the chat — repo, worktree, and branch stay as they are' },
-              ...(session?.clearedUpToMessageId ? [{ id: 'resume', description: 'Bring back a cleared chat' }] : []),
+              ...(session?.clearedUpToMessageId || session?.revertedFromMessageId ? [{ id: 'resume', description: 'Bring back a cleared or reverted chat' }] : []),
               ...(skillsQ.data ?? []).map((s) => ({ id: s.id, description: s.description })),
             ]}
-            hintText={live
-              ? (live.compacting
-                  ? 'Compacting conversation…'
-                  : queued.length ? `${queued.length} queued · Enter to queue another` : 'Running — Enter to queue a follow-up')
-              : 'Enter to send · Shift+Enter for newline'}
+            // Prominent, accent-colored banner above the textarea for any real in-progress
+            // state (founder feedback, 2026-07-17: folding this into the tiny faint hint text
+            // below made an actual busy state — especially manual /compact, which disables the
+            // whole composer — too easy to miss). hintText stays reserved for the idle case.
+            statusText={
+              manualCompacting || live?.compacting
+                ? 'Compacting conversation…'
+                : live
+                  ? (queued.length ? `${queued.length} queued · Enter to queue another` : 'Running — Enter to queue a follow-up')
+                  : undefined
+            }
+            hintText="Enter to send · Shift+Enter for newline"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Three founder-reported issues from live testing, root-caused and fixed:

- **Code revert-to-message** was fundamentally broken beyond an earlier `clearedUpToMessageId`-based patch: that mechanism can only hide a prefix and show a suffix, backwards from what revert needs, and left the reverted message's own reply orphaned/visible (or hid the wrong half of history for a non-last message). Replaced with real per-message deactivation (`is_active=0`) — the same mechanism Chat's own branching already uses — correctly generalizing to any revert target. New `AgentRun.revertedFromMessageId` field (migration v33), independent of `/clear`'s cursor; `/resume` undoes either.
- **Manual `/compact`** always reported "Nothing to compact yet" regardless of conversation size. Root cause: pi's bundled `findCutPoint` has a real bug — when `keepRecentTokens` is crossed entirely inside a trailing run of tool-result-only entries (a heavy tool-call turn with no later user/assistant message), its cut-point search comes up empty and silently keeps everything. Fixed by ensuring `keepRecentTokens` is never smaller than the conversation's own last turn. Also added a real "Compacting conversation…" progress indicator (previously nothing showed while the command was in flight).
- **MoE auto-tune's VRAM-spill hill-climb** (added this cycle) was running unconditionally, overriding the user's configured VRAM headroom. Gated behind an explicit `VRAM_HEADROOM_SPILL_MB=0` opt-in (Settings slider snaps 300→0), and extended to also guard prefill speed.
- The running/compacting busy-state indicator moved from a tiny faint hint line to its own prominent, accent-colored banner above the composer.

## Test plan

- [x] Typecheck clean
- [x] Full backend suite: 971 tests, 968 pass, 0 fail, 3 skipped
- [x] Root-caused and reproduced the `/compact` bug against real session data (direct diagnostic scripts against pi's bundled compaction logic)
- [x] Live browser E2E test against this repo: real Code session, real model, `/compact` confirmed working + progress indicator confirmed showing
- [x] Live-verified revert-to-message against the real reported session (AMOLEDBurnFix), both the last-message case and an early-message case
- [x] Live-verified the VRAM headroom slider's snap-to-0 behavior and copy