### PR TITLE
fix(ui): spec-drift repair — implement decided spec 11/07 values the code never had

### DIFF
--- a/turbollm/web/src/components/ArtifactCard.tsx
+++ b/turbollm/web/src/components/ArtifactCard.tsx
@@ -3,6 +3,12 @@ import { Download, Loader2, ChevronDown, Maximize2, Minimize2 } from 'lucide-rea
 import { toast } from 'sonner'
 import { cn } from '../lib/utils'
 import { useUiStore, resolveDark } from '../stores/ui'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu'
 
 // Fenced-block language → artifact MIME type
 const ARTIFACT_LANGS: Record<string, string> = {
@@ -577,7 +583,6 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
   const [availW, setAvailW] = useState(0)
   const [maxH, setMaxH] = useState(screenCap)
   const [mermaid, setMermaid] = useState<{ svg?: string; error?: string; loading?: boolean }>({})
-  const [menuOpen, setMenuOpen] = useState(false)
   const [busy, setBusy] = useState(false)
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const staticRef = useRef<HTMLIFrameElement>(null)
@@ -736,13 +741,6 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [type, staticDims, fitReady, stableCode, theme])
 
-  useEffect(() => {
-    if (!menuOpen) return
-    const close = () => setMenuOpen(false)
-    document.addEventListener('mousedown', close)
-    return () => document.removeEventListener('mousedown', close)
-  }, [menuOpen])
-
   const srcdoc = type !== 'application/vnd.mermaid' ? buildSrcdoc(type, stableCode) : ''
   const mermaidSrcdoc = mermaid.svg ? buildSrcdoc('image/svg+xml', mermaid.svg) : ''
 
@@ -777,7 +775,6 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
   const formats: Fmt[] = type === 'text/html' ? ['png', 'jpeg', 'gif', 'html'] : ['png', 'jpeg', 'svg']
 
   async function download(fmt: Fmt) {
-    setMenuOpen(false)
     setBusy(true)
     try {
       if (fmt === 'svg') {
@@ -947,33 +944,28 @@ export function ArtifactCard({ lang, code }: ArtifactCardProps) {
             >
               {fitMode === 'height' ? <Maximize2 size={12} /> : <Minimize2 size={12} />}
             </button>
-            <div className="relative" onMouseDown={(e) => e.stopPropagation()}>
-              <button
-                type="button"
+            <DropdownMenu>
+              <DropdownMenuTrigger
                 title="Download"
-                onClick={() => setMenuOpen((o) => !o)}
                 className="flex items-center rounded p-1 text-faint transition-colors hover:text-ink"
               >
                 {busy ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
                 <ChevronDown size={9} className="ml-0.5" />
-              </button>
-              {menuOpen && (
-                <div className="absolute right-0 z-10 mt-1 min-w-28 overflow-hidden rounded-md border border-border bg-panel shadow-lg">
-                  {formats.map((f) => (
-                    <button
-                      key={f}
-                      type="button"
-                      onClick={() => void download(f)}
-                      className="block w-full px-3 py-1.5 text-left text-[12px] text-muted hover:bg-panel-2 hover:text-ink"
-                    >
-                      {FMT_LABEL[f]}
-                      {f === 'gif' && <span className="ml-1 text-[10px] text-faint">animation</span>}
-                      {f === 'html' && <span className="ml-1 text-[10px] text-faint">source</span>}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-28">
+                {formats.map((f) => (
+                  <DropdownMenuItem
+                    key={f}
+                    className="text-[12px]"
+                    onSelect={() => void download(f)}
+                  >
+                    {FMT_LABEL[f]}
+                    {f === 'gif' && <span className="ml-1 text-[10px] text-faint">animation</span>}
+                    {f === 'html' && <span className="ml-1 text-[10px] text-faint">source</span>}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
 

--- a/turbollm/web/src/components/UnreachableOverlay.tsx
+++ b/turbollm/web/src/components/UnreachableOverlay.tsx
@@ -10,7 +10,7 @@ export function UnreachableOverlay() {
       role="alertdialog"
       aria-label="Lost connection to daemon"
     >
-      <Loader2 size={24} className="tllm-pulse text-muted" />
+      <Loader2 size={24} className="animate-spin text-muted" />
       <p className="text-[14px] text-ink">
         Lost connection to TurboLLM daemon — retrying…
       </p>

--- a/turbollm/web/src/components/ui/input.tsx
+++ b/turbollm/web/src/components/ui/input.tsx
@@ -9,8 +9,7 @@ export const Input = React.forwardRef<
     ref={ref}
     className={cn(
       'flex h-9 w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-ink',
-      'placeholder:text-faint focus-visible:border-border-strong focus-visible:outline-none',
-      'disabled:cursor-not-allowed disabled:opacity-50',
+      'placeholder:text-faint disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -11,7 +11,7 @@
   --panel-2: #f4f2ee;
   --ink: #1a1a18;
   --muted: #6b6a66;
-  --faint: #9c9a94;
+  --faint: #6f6e69;
   --border: #e7e4de;
   --border-strong: #d6d2c8;
   --accent: #c96442;
@@ -26,6 +26,8 @@
   --radius-sm: 8px;
   --shadow-1: 0 1px 2px rgb(0 0 0 / 0.05);
   --shadow-2: 0 4px 16px rgb(0 0 0 / 0.07);
+  /* code-block surface (spec 11 §4): --panel-2 in light, its own near-black in dark. */
+  --code-bg: var(--panel-2);
   /* log panel is the same near-black in both themes (spec 11 §6); its foreground
      tokens are defined here so components never inline hex. */
   --log-bg: #0b0b0c;
@@ -51,6 +53,7 @@
   --warn: #d8a45a;
   --err: #e06c5f;
   --info: #7da3c4;
+  --code-bg: #111114;
 }
 
 /* Map design tokens to the Tailwind v4 theme so utilities like bg-panel,
@@ -71,6 +74,7 @@
   --color-warn: var(--warn);
   --color-err: var(--err);
   --color-info: var(--info);
+  --color-code-bg: var(--code-bg);
 
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius);
@@ -113,6 +117,169 @@ body {
   outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);
   outline-offset: 1px;
 }
+
+/* ── Assistant markdown prose (spec 11 §4 + spec 07 §7) ───────────────────────
+   Applied by MessageBubble/CodeTranscript around rendered assistant markdown.
+   Type is em-based so it tracks the wrapper's font-size (15px chat, 14px Code).
+   Deliberately unlayered: these must beat both the Tailwind preflight resets
+   (which strip heading/list/blockquote styling) and utility classes on the
+   renderer's element overrides. */
+.prose-tllm h1,
+.prose-tllm h2,
+.prose-tllm h3,
+.prose-tllm h4,
+.prose-tllm h5,
+.prose-tllm h6 {
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 1.2em 0 0.5em;
+}
+.prose-tllm h1 { font-size: 1.25em; }
+.prose-tllm h2 { font-size: 1.15em; }
+.prose-tllm h3,
+.prose-tllm h4,
+.prose-tllm h5,
+.prose-tllm h6 { font-size: 1.05em; }
+.prose-tllm p { margin: 0.75em 0; }
+.prose-tllm ul,
+.prose-tllm ol {
+  margin: 0.75em 0;
+  padding-left: 1.5em;
+}
+.prose-tllm ul { list-style: disc; }
+.prose-tllm ol { list-style: decimal; }
+.prose-tllm li { margin: 0.25em 0; }
+.prose-tllm li > p,
+.prose-tllm li > ul,
+.prose-tllm li > ol { margin: 0.25em 0; }
+.prose-tllm blockquote {
+  margin: 0.75em 0;
+  padding: 2px 0 2px 12px;
+  border-left: 3px solid var(--border-strong);
+  color: var(--muted);
+}
+.prose-tllm table { border-collapse: collapse; }
+.prose-tllm th,
+.prose-tllm td {
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  font-size: 13px;
+}
+.prose-tllm th { font-weight: 600; }
+.prose-tllm hr {
+  margin: 1.25em 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+/* Inline code only — scoped by parent because block code lives inside the
+   renderer's div wrapper (MessageBubble unwraps <pre>), so a bare
+   `.prose-tllm code` would also clobber block-code padding/background. */
+.prose-tllm p > code,
+.prose-tllm li > code,
+.prose-tllm td > code,
+.prose-tllm th > code,
+.prose-tllm h1 > code,
+.prose-tllm h2 > code,
+.prose-tllm h3 > code,
+.prose-tllm h4 > code,
+.prose-tllm blockquote code {
+  background: var(--panel-2);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+.prose-tllm a { color: var(--accent); text-decoration: none; }
+.prose-tllm a:hover { text-decoration: underline; text-underline-offset: 2px; }
+.prose-tllm strong { font-weight: 600; }
+.prose-tllm em { font-style: italic; }
+.prose-tllm > :first-child { margin-top: 0; }
+.prose-tllm > :last-child { margin-bottom: 0; }
+
+/* ── highlight.js palette (spec 11 §4): github / github-dark ported inline with
+   the background overridden to transparent — the block surface comes from
+   --code-bg. Hex is permitted here only: index.css is the palette home. */
+.hljs { background: transparent; color: inherit; }
+.hljs-subst,
+.hljs-tag,
+.hljs-punctuation { color: inherit; }
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ { color: #d73a49; }
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ { color: #6f42c1; }
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id { color: #005cc5; }
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string { color: #032f62; }
+.hljs-built_in,
+.hljs-symbol { color: #e36209; }
+.hljs-comment,
+.hljs-code,
+.hljs-formula { color: #6a737d; }
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo { color: #22863a; }
+.hljs-section { color: #005cc5; font-weight: 600; }
+.hljs-bullet { color: #735c0f; }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 600; }
+.hljs-addition { color: #22863a; background-color: #f0fff4; }
+.hljs-deletion { color: #b31d28; background-color: #ffeef0; }
+
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ { color: #ff7b72; }
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title.function_ { color: #d2a8ff; }
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id { color: #79c0ff; }
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string { color: #a5d6ff; }
+.dark .hljs-built_in,
+.dark .hljs-symbol { color: #ffa657; }
+.dark .hljs-comment,
+.dark .hljs-code,
+.dark .hljs-formula { color: #8b949e; }
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo { color: #7ee787; }
+.dark .hljs-section { color: #1f6feb; }
+.dark .hljs-bullet { color: #f2cc60; }
+.dark .hljs-addition { color: #aff5b4; background-color: #033a16; }
+.dark .hljs-deletion { color: #ffdcd7; background-color: #67060c; }
 
 /* Rise-in entrance used by the Code launchpad — sections stagger via inline
    animation-delay. Motion-sensitive users get an instant render instead. */

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -41,7 +41,7 @@
   --panel-2: #1d1d21;
   --ink: #ededec;
   --muted: #9a9a96;
-  --faint: #6e6e6a;
+  --faint: #8a8983;
   --border: #2a2a2e;
   --border-strong: #3a3a40;
   --accent: #e08a5f;

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -9,6 +9,13 @@ import type { ChatSseEvent, Conversation, LiveToolCall, Message } from '../lib/c
 import { appendTextDelta, upsertToolCall, type LiveBlock } from '../lib/live-timeline'
 import { ApiError, downloadChatExport, getDebugSnapshot, getShareUrl, importChat } from '../lib/api'
 import { Button } from '../components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/dropdown-menu'
 import { toast } from '../components/ui/sonner'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { skillKeys, fetchSkills } from '../lib/agent-api'
@@ -91,10 +98,8 @@ export function ChatScreen() {
   const sidebarRef = useRef<HTMLDivElement>(null)
   const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const [attachments, setAttachments] = useState<{ file: File; dataUrl: string }[]>([])
-  // Share menu state
-  const [shareMenuOpen, setShareMenuOpen] = useState(false)
+  // Share menu clipboard fallback (F-023)
   const [clipboardFallback, setClipboardFallback] = useState<{ text: string; title: string } | null>(null)
-  const shareMenuRef = useRef<HTMLDivElement>(null)
   // Import state (F-024)
   const importFileRef = useRef<HTMLInputElement>(null)
   const [importError, setImportError] = useState<string | null>(null)
@@ -308,22 +313,9 @@ export function ChatScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeId])
 
-  // Close share menu on outside click
-  useEffect(() => {
-    if (!shareMenuOpen) return
-    const handler = (e: MouseEvent) => {
-      if (shareMenuRef.current && !shareMenuRef.current.contains(e.target as Node)) {
-        setShareMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [shareMenuOpen])
-
   // ── Share handlers (F-023) ────────────────────────────────────────────────
 
   const copyText = async (text: string, successMsg: string, title: string) => {
-    setShareMenuOpen(false)
     try {
       await navigator.clipboard.writeText(text)
       toast.success(successMsg)
@@ -355,7 +347,6 @@ export function ChatScreen() {
 
   const handleExportChat = () => {
     if (!activeId) return
-    setShareMenuOpen(false)
     downloadChatExport(activeId)
   }
 
@@ -826,52 +817,40 @@ export function ChatScreen() {
 
           {/* Share / Export menu (F-023, F-024) — only when a conversation is active */}
           {activeId && (
-            <div ref={shareMenuRef} className="relative ml-auto">
-              <Button
-                size="icon"
-                variant="ghost"
-                className="h-8 w-8"
-                onClick={() => setShareMenuOpen((o) => !o)}
-                title="Share or export this chat"
-              >
-                <Share2 size={15} />
-              </Button>
-              {shareMenuOpen && (
-                <div className="absolute right-0 top-9 z-50 min-w-[180px] rounded-md border border-border bg-panel shadow-[var(--shadow-2)] py-1">
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyLink()}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-[13px] text-ink hover:bg-panel-2"
-                  >
-                    <Copy size={13} className="text-muted" />
-                    Copy link (LAN)
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void handleCopyDebugInfo()}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-[13px] text-ink hover:bg-panel-2"
-                  >
-                    <Copy size={13} className="text-muted" />
-                    Copy debug info
-                  </button>
-                  <div className="my-1 border-t border-border" />
-                  <button
-                    type="button"
-                    onClick={handleExportChat}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-[13px] text-ink hover:bg-panel-2"
-                  >
-                    <Download size={13} className="text-muted" />
-                    Export chat
-                  </button>
-                </div>
-              )}
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="ml-auto h-8 w-8"
+                  title="Share or export this chat"
+                >
+                  <Share2 size={15} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                <DropdownMenuItem className="text-[13px]" onSelect={() => void handleCopyLink()}>
+                  <Copy size={13} className="text-muted" />
+                  Copy link (LAN)
+                </DropdownMenuItem>
+                <DropdownMenuItem className="text-[13px]" onSelect={() => void handleCopyDebugInfo()}>
+                  <Copy size={13} className="text-muted" />
+                  Copy debug info
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-[13px]" onSelect={handleExportChat}>
+                  <Download size={13} className="text-muted" />
+                  Export chat
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
 
         {/* Message list — always visible; empty state shown only when no messages */}
         <div ref={scrollerRef} className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
-          <div className="flex w-full flex-col gap-6 px-4 py-4 md:px-8 md:py-6">
+          {/* 768px thread measure (spec 11 §2) — must match the composer wrapper below */}
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-4 md:px-8 md:py-6">
             {/* Hidden import file input (F-024) */}
             <input
               ref={importFileRef}
@@ -884,7 +863,7 @@ export function ChatScreen() {
             {/* Model mismatch banner (F-024): shown after a successful import when the
                 exported model isn't available on this machine. Inline, not a toast. */}
             {importModelMismatch && (
-              <div className="mb-2 flex items-start gap-2 rounded-md border border-[color:var(--warn,#ca8a04)] bg-[color-mix(in_srgb,var(--warn,#ca8a04)_8%,transparent)] px-3 py-2 text-[13px]">
+              <div className="mb-2 flex items-start gap-2 rounded-md border border-[color:var(--warn)] bg-[color-mix(in_srgb,var(--warn)_8%,transparent)] px-3 py-2 text-[13px]">
                 <span className="flex-1">
                   <span className="font-medium">Model not found:</span>{' '}
                   <span className="font-mono">{importModelMismatch}</span> is not available on this machine.
@@ -960,12 +939,13 @@ export function ChatScreen() {
           </div>
         </div>
 
-        {/* Scroll-to-bottom pill */}
+        {/* Scroll-to-bottom pill (spec 07 §7) — fades in over 150ms via the shared
+            tllm-rise-in keyframe (index.css), suppressed for motion-sensitive users */}
         {showScrollBtn && (
           <button
             type="button"
             onClick={() => { userScrolledUp.current = false; scrollToBottom(true) }}
-            className="absolute bottom-28 left-1/2 -translate-x-1/2 flex items-center gap-1.5 rounded-full border border-border bg-panel px-3 py-1.5 text-[12px] text-muted shadow-[var(--shadow-1)] hover:text-ink"
+            className="absolute bottom-28 left-1/2 -translate-x-1/2 flex animate-[tllm-rise-in_150ms_ease-out] items-center gap-1.5 rounded-full border border-border bg-panel px-3 py-1.5 text-[13px] text-muted shadow-[var(--shadow-2)] transition-colors hover:text-ink motion-reduce:animate-none"
           >
             <ArrowDown size={13} /> Jump to latest
           </button>
@@ -995,11 +975,13 @@ export function ChatScreen() {
             the transcript). Rendered just above the composer while a background tool
             call awaits interactive approval. */}
         {!readonly && activeId && pendingApproval && (
-          <ToolApprovalBar key={pendingApproval.id} pending={pendingApproval} convId={activeId} onResolved={() => {}} />
+          <div className="mx-auto w-full max-w-3xl">
+            <ToolApprovalBar key={pendingApproval.id} pending={pendingApproval} convId={activeId} onResolved={() => {}} />
+          </div>
         )}
 
         {/* Composer area (always visible; disabled when no model; hidden in readonly) */}
-        {readonly ? null : <div className="px-3 pb-3 md:px-8 md:pb-5">
+        {readonly ? null : <div className="mx-auto w-full max-w-3xl px-3 pb-3 md:px-8 md:pb-5">
           <div className="relative w-full">
             {/* '/' skill picker */}
             {skillPickerOpen && (
@@ -1098,9 +1080,12 @@ export function ChatScreen() {
                 )}
               </div>
             </div>
-            <p className="mt-1.5 px-1 text-[11px] text-faint">
-              {model ? `${model.name} · Enter to send · Shift+Enter for newline` : 'Load a model above to start chatting'}
-            </p>
+            {/* No-model hint lives in the textarea placeholder above — don't repeat it here. */}
+            {model && (
+              <p className="mt-1.5 px-1 text-[11px] text-faint">
+                {model.name} · Enter to send · Shift+Enter for newline
+              </p>
+            )}
           </div>
         </div>}
       </div>

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -145,8 +145,8 @@ export const Markdown = memo(function Markdown({ children, streaming }: { childr
             return <ArtifactCard lang={lang} code={childrenToString(children).replace(/\n$/, '')} />
           }
           return (
-            <div className="relative my-2 overflow-hidden rounded-lg border border-border">
-              <div className="flex items-center justify-between border-b border-border bg-panel-2 px-3 py-1 font-mono text-[11px] text-muted">
+            <div className="relative my-2 overflow-hidden rounded-md border border-border bg-[var(--code-bg)]">
+              <div className="flex items-center justify-between border-b border-border bg-panel-2 px-3 py-1 font-mono text-[12px] text-muted">
                 <span>{lang}</span>
                 <CopyButton text={childrenToString(children)} size={12} />
               </div>
@@ -218,7 +218,7 @@ function ToolCallCard({ call }: { call: CardCall }) {
   return (
     <div
       className="overflow-hidden rounded-lg border bg-panel-2"
-      style={awaitingApproval ? { borderColor: 'var(--warn,#ca8a04)', background: 'color-mix(in srgb, var(--warn,#ca8a04) 6%, transparent)' } : { borderColor: 'var(--border)' }}
+      style={awaitingApproval ? { borderColor: 'var(--warn)', background: 'color-mix(in srgb, var(--warn) 6%, transparent)' } : { borderColor: 'var(--border)' }}
     >
       <button
         type="button"
@@ -227,9 +227,9 @@ function ToolCallCard({ call }: { call: CardCall }) {
         style={{ cursor: hasOutput ? 'pointer' : 'default' }}
       >
         {call.status === 'pending'            && <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
-        {call.status === 'done'               && <CheckCircle2 size={12} className="shrink-0" style={{ color: '#4ade80' }} />}
+        {call.status === 'done'               && <CheckCircle2 size={12} className="shrink-0" style={{ color: 'var(--ok)' }} />}
         {call.status === 'error'              && <XCircle size={12} className="shrink-0" style={{ color: 'var(--err)' }} />}
-        {call.status === 'awaiting_approval'  && <HelpCircle size={12} className="shrink-0" style={{ color: 'var(--warn,#ca8a04)' }} />}
+        {call.status === 'awaiting_approval'  && <HelpCircle size={12} className="shrink-0" style={{ color: 'var(--warn)' }} />}
         <span className="font-mono text-[12px] font-medium text-ink">{friendlyName(call.name)}</span>
         <span className="text-[11px] text-faint">
           {call.status === 'pending' ? 'running…' : call.status === 'error' ? 'error' : call.status === 'awaiting_approval' ? 'waiting on you' : 'done'}
@@ -293,7 +293,7 @@ function InlineToolStep({ call }: { call: LiveToolCall }) {
         style={{ cursor: hasOutput ? 'pointer' : 'default' }}
       >
         {pending && <Loader2 size={13} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />}
-        {call.status === 'done'  && <CheckCircle2 size={13} className="shrink-0" style={{ color: '#4ade80' }} />}
+        {call.status === 'done'  && <CheckCircle2 size={13} className="shrink-0" style={{ color: 'var(--ok)' }} />}
         {call.status === 'error' && <XCircle size={13} className="shrink-0" style={{ color: 'var(--err)' }} />}
         <span className="font-mono text-[12px] font-medium text-ink">{friendlyName(call.name)}</span>
         <span className="text-[11px]" style={{ color: pending ? 'var(--accent)' : 'var(--faint)' }}>
@@ -664,7 +664,7 @@ export function MessageBubble({
           </div>
         </div>
       ) : hasError ? (
-        <div className="rounded-lg border px-4 py-3 text-[14px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)' }}>
+        <div className="rounded-lg border px-4 py-3 text-[13px]" style={{ borderColor: 'var(--err)', color: 'var(--err)', background: 'color-mix(in srgb, var(--err) 10%, transparent)' }}>
           {message.stats.aborted ? 'Generation failed or was stopped.' : 'This message is empty.'}
           {isLast && onRegenerate && <button type="button" className="ml-3 underline" onClick={onRegenerate}>Regenerate</button>}
         </div>

--- a/turbollm/web/src/screens/chat/ToolApprovalBar.tsx
+++ b/turbollm/web/src/screens/chat/ToolApprovalBar.tsx
@@ -46,7 +46,7 @@ export function ToolApprovalBar({
   if (dismissed) return null
 
   return (
-    <div className="mx-3 mb-3 rounded-md border border-[color:var(--warn,#ca8a04)] bg-[color-mix(in_srgb,var(--warn,#ca8a04)_8%,transparent)] px-3 py-2.5 text-[13px] md:mx-8">
+    <div className="mx-3 mb-3 rounded-md border border-[color:var(--warn)] bg-[color-mix(in_srgb,var(--warn)_8%,transparent)] px-3 py-2.5 text-[13px] md:mx-8">
       <div className="flex flex-wrap items-baseline gap-x-2">
         <span className="font-medium text-ink">Tool call needs your approval:</span>
         <span className="font-mono text-[12px] text-ink">{friendlyName(pending.name)}</span>


### PR DESCRIPTION
## What

Founder-approved "spec-drift repair" batch (ADR-227): implements design-spec requirements that were **already decided** (spec 11 / spec 07) but never built. Zero requirement changes — every item was vetted against the decision log first; audit suggestions that contradicted settled ADRs were struck and recorded.

- **`.prose-tllm` content styles authored** (spec 11 §4 / 07 §7) — assistant markdown headings/lists/blockquotes/tables/inline-code no longer render as flat preflight-reset text
- **highlight.js github/github-dark palette** in `index.css`, transparent background — code was highlighted-but-colorless
- **Code blocks** on a new `--code-bg` token (`--panel-2` light / spec-sanctioned `#111114` dark), header row polish
- **768px centered thread measure** (spec 11 §2) on message column + composer + approval bar
- **Share + artifact download menus** ported to the shared Radix `DropdownMenu` (ADR-211 pattern) — contents preserved exactly 1:1 per ADR-070 / ADR-114
- **Input focus ring restored** (spec 11 §8, 2px accent at 40%) — `input.tsx` was suppressing it
- **Scroll-pill + error-alert polish** to exact spec values; **stray-hex sweep**; UnreachableOverlay spinner actually spins
- **Dark + light `--faint` WCAG AA fixes** (ADR-226/227): dark `#6e6e6a→#8a8983` (3.3→4.8:1 min), light `#9c9a94→#6f6e69` (2.5→4.6:1 min)

## Verification

- `tsc --noEmit` + full `vite build` clean
- Adversarial diff review: no critical/major findings; locked menu contents verified byte-identical
- Live-verified on the real daemon (port 6996) in both themes: computed prose/table styles, hljs binding, 768px cap, exact focus-ring formula on real input focus, Radix share menu contents

## Refs

ADR-226, ADR-227 (decision log): approved scope, struck items, and open follow-ups.