### PR TITLE
Fix Windows VRAM detection when registry enumeration exits non-zero

### DIFF
--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -210,18 +210,26 @@ function readWindowsVramRegistry(): RegistryVram[] {
   try {
     const ps =
       `Get-ChildItem 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Class\\${DISPLAY_CLASS_GUID}' -ErrorAction SilentlyContinue | ` +
-      "ForEach-Object { $p = Get-ItemProperty -Path $_.PSPath -ErrorAction SilentlyContinue; " +
-      "if ($p.'HardwareInformation.qwMemorySize') { \"$($p.DriverDesc)|$($p.'HardwareInformation.qwMemorySize')\" } }"
+      "Where-Object { $_.PSChildName -match '^\\d{4}$' } | " +
+      "ForEach-Object { " +
+      "try { " +
+      "$p = Get-ItemProperty -Path $_.PSPath -ErrorAction Stop; " +
+      "if ($p.'HardwareInformation.qwMemorySize') { " +
+      "\"$($p.DriverDesc)|$($p.'HardwareInformation.qwMemorySize')\" " +
+      "} " +
+      "} catch { } " +
+      "}; exit 0"
+
     const out = execFileSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', ps], {
       timeout: 8000,
       windowsHide: true,
     }).toString()
+
     return parseWindowsVramRegistry(out)
   } catch {
     return []
   }
 }
-
 /** Pure parser for {@link readWindowsVramRegistry}'s PowerShell output, split out for direct
  *  testing (mirrors {@link parseRocmSmi}). Each line is "DriverDesc|qwMemorySize(bytes)". */
 export function parseWindowsVramRegistry(psOutput: string): RegistryVram[] {


### PR DESCRIPTION
## Summary

Fixes Windows VRAM detection for discrete GPUs when PowerShell successfully reads `HardwareInformation.qwMemorySize` but exits with a non-zero status after encountering a protected display-class registry key.

## Problem

On Windows 11, the display-adapter registry contains the correct 64-bit value:

`AMD Radeon RX 9070 XT|17095983104`

However, enumerating the display class also encounters protected sibling keys. PowerShell still writes the valid adapter results to stdout, but exits with status `1`.

Because `execFileSync()` throws on a non-zero exit status, `readWindowsVramRegistry()` discarded the valid stdout and returned an empty array. TurboLLM then fell back to the 32-bit-capped WMI `AdapterRAM` value:

`4293918720`

This caused a 16 GB RX 9070 XT to be displayed as 4.3 GB.

## Fix

- Restrict registry processing to numbered adapter keys.
- Ignore inaccessible individual registry entries.
- Explicitly exit PowerShell with status 0 after emitting valid adapter results.

## Verification

Before:

`AMD Radeon RX 9070 XT · 4.3 GB VRAM`

After:

`AMD Radeon RX 9070 XT · 17.1 GB VRAM`

Tested on:

- Windows 11 Pro
- AMD Radeon RX 9070 XT 16 GB
- AMD driver 32.0.31021.5001
- TurboLLM v1.8.1

## Validation

- `npm run typecheck`: passed
- `src/sysinfo/sysinfo.test.ts`: 15 passed
- Production build: passed
- Full test suite: 994 passed, 1 unrelated process-reaping test failed under WSL

Related to #63.

<img width="1902" height="756" alt="vramFix" src="https://github.com/user-attachments/assets/cb004dfb-53d0-4e93-8c75-e49bf1bb0b20" />
