### PR TITLE
release: v1.8.3 — usage tracking, tool/model config batch, mmproj + CORS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,12 @@ the detail:
 - **Real measured tokens/sec** in the model list — **live** while generating, **last-session**
   when idle (never a synthetic estimate).
 - **Full load-parameter UI**, a superset of what other tools expose: context length, GPU offload
-  (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **KV-cache quant type** (incl.
-  low-bit on supporting forks), CPU threads, flash attention, and **speculative decoding (NextN /
-  MTP / draft, with a configurable draft min/max window)**.
+  (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **independent K and V cache-quant
+  type** (incl. low-bit on supporting forks), CPU threads, flash attention, **speculative decoding
+  (NextN / MTP / draft, with a configurable draft min/max window)**, a **pinned engine port** per
+  model, and a **custom/raw flags** field for anything not exposed as its own control.
+- **Copy the exact launch command** for a loaded model — runs the same config standalone with
+  llama.cpp/the fork directly, no TurboLLM required.
 - **Auto-fit GPU layers / MoE offload** — an optional toggle (off by default) that hands the
   GPU/CPU split decision to llama.cpp's own memory-fitting logic at load time instead of a fixed
   number, honored by Auto-tune too. Useful when a large context or model doesn't fit your usual
@@ -266,10 +269,12 @@ the detail:
   in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
 - **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
   with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
-  composer. Set per-tool defaults globally from Settings → Tools & safety.
+  composer. Set per-tool defaults globally from Settings → Tools & safety, or flip **Auto-allow
+  all** to skip prompts entirely — a tool set to Deny still stays blocked either way.
 - **Usage dashboard** — a GitHub-style activity heatmap of your local generation history (adaptive
   1h/12h/24h boxes for the 7-day/30-day/all-time views), streaks, peak hour, a per-model
-  breakdown, and a lifetime token-milestone tracker.
+  breakdown, a lifetime token-milestone tracker, and a separate **API tab** tracking tokens hitting
+  the gateway from external tools like Claude Code — not just in-app chat.
 - **Auto-memory** *(experimental, off by default)* — silently extracts durable facts you mention
   in chat (name, preferences, hardware) using your own loaded model, and carries them into future
   new conversations. Nothing leaves your device; the full fact list is reviewable and deletable

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,46 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.3] - 2026-07-22
+
+**API token tracking, tool/model config batch, and two real bug fixes (mmproj pairing, an
+`/api/*` CORS hole).**
+
+### Added
+- **Usage → API tab** — tracks tokens hitting the OpenAI/Anthropic-compatible gateway from
+  external tools (Claude Code, other CLIs/extensions), separately from in-app chat, split by
+  source and model. (#71)
+- **Auto-allow-all tools toggle** (Settings → Tools & safety) — skip the approval prompt for every
+  tool set to Ask; a tool explicitly set to Deny still stays blocked.
+- **Custom/raw engine flags** — a field in the model config panel to append arbitrary
+  command-line flags to the launch command.
+- **Per-model engine port** — pin a model's engine to a specific port instead of always
+  auto-assigning the first free one.
+- **Independent K/V cache quant** — the KV cache type is now two selects (K and V) instead of one
+  combined dropdown, so you can e.g. keep K at full quality while quantizing V.
+- **Copy launch command** — copies the exact command to run the loaded model standalone with
+  llama.cpp/the fork directly, no TurboLLM required.
+
+### Fixed
+- **Security: `/api/*` had wildcard CORS**, letting any website silently read a loopback user's
+  GPU/CPU/RAM via unauthenticated `/api/v1/sysinfo` while the daemon ran. Tightened to an origin
+  allowlist; the OpenAI/Anthropic gateway (`/v1/*`) stays fully open, as it needs to be.
+- **A folder with more than one vision model could load the wrong image projector** onto a model,
+  which then failed to start. Projector pairing now matches by filename correlation, falling back
+  to closest-modified-time, instead of always picking the directory's largest file.
+- **VRAM estimate assumed the V cache quant always matched K** — now weighted independently, so an
+  asymmetric K/V setting (e.g. K=q8_0, V=f16) reads correctly instead of over- or under-estimating.
+- Two token-tracking gaps found while building the API tab above: a non-streaming OpenAI-compatible
+  request could silently record zero usage, and a streaming one omitted usage entirely without an
+  explicit opt-in flag.
+
+### Discord
+- New Usage → API tab shows how many tokens Claude Code and other external tools are pulling through TurboLLM — not just in-app chat.
+- Auto-allow-all toggle to skip tool approval prompts when you want; Deny always still blocks.
+- Model config: pin a model to a specific port, add custom launch flags, set K and V cache quant separately, and copy a ready-to-run llama.cpp command.
+- Fixed a bug where a folder with more than one vision model could load the wrong image projector.
+- Closed a security hole where any website could quietly read your GPU info while TurboLLM was running.
+
 ## [1.8.2] - 2026-07-21
 
 **Research mode that works to stay current, correct VRAM estimates for modern models, and a batch

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -31,9 +31,10 @@ _Nothing yet._
 `/api/*` CORS hole).**
 
 ### Added
-- **Usage → API tab** — tracks tokens hitting the OpenAI/Anthropic-compatible gateway from
-  external tools (Claude Code, other CLIs/extensions), separately from in-app chat, split by
-  source and model. (#71)
+- **Usage tracking now covers the gateway, not just in-app chat** — tokens hitting the
+  OpenAI/Anthropic-compatible gateway from external tools (Claude Code, other CLIs/extensions)
+  now count toward the Overview totals and lifetime milestone, with a dedicated API tab for the
+  breakdown by source and model. (#71)
 - **Auto-allow-all tools toggle** (Settings → Tools & safety) — skip the approval prompt for every
   tool set to Ask; a tool explicitly set to Deny still stays blocked.
 - **Custom/raw engine flags** — a field in the model config panel to append arbitrary

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -202,9 +202,12 @@ the detail:
 - **Real measured tokens/sec** in the model list — **live** while generating, **last-session**
   when idle (never a synthetic estimate).
 - **Full load-parameter UI**, a superset of what other tools expose: context length, GPU offload
-  (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **KV-cache quant type** (incl.
-  low-bit on supporting forks), CPU threads, flash attention, and **speculative decoding (NextN /
-  MTP / draft, with a configurable draft min/max window)**.
+  (`-ngl`), **MoE CPU-offload (`--n-cpu-moe`)**, parallel slots, **independent K and V cache-quant
+  type** (incl. low-bit on supporting forks), CPU threads, flash attention, **speculative decoding
+  (NextN / MTP / draft, with a configurable draft min/max window)**, a **pinned engine port** per
+  model, and a **custom/raw flags** field for anything not exposed as its own control.
+- **Copy the exact launch command** for a loaded model — runs the same config standalone with
+  llama.cpp/the fork directly, no TurboLLM required.
 - **Auto-fit GPU layers / MoE offload** — an optional toggle (off by default) that hands the
   GPU/CPU split decision to llama.cpp's own memory-fitting logic at load time instead of a fixed
   number, honored by Auto-tune too. Useful when a large context or model doesn't fit your usual
@@ -266,10 +269,12 @@ the detail:
   in every chat with no restart. A **Research** persona forces multi-step web search and cites sources inline.
 - **Tool-call approval gate** — every tool call asks for your approval by default before it runs,
   with **Deny**, **Allow**, **Allow for this chat**, or **Always Allow** on an inline bar above the
-  composer. Set per-tool defaults globally from Settings → Tools & safety.
+  composer. Set per-tool defaults globally from Settings → Tools & safety, or flip **Auto-allow
+  all** to skip prompts entirely — a tool set to Deny still stays blocked either way.
 - **Usage dashboard** — a GitHub-style activity heatmap of your local generation history (adaptive
   1h/12h/24h boxes for the 7-day/30-day/all-time views), streaks, peak hour, a per-model
-  breakdown, and a lifetime token-milestone tracker.
+  breakdown, a lifetime token-milestone tracker, and a separate **API tab** tracking tokens hitting
+  the gateway from external tools like Claude Code — not just in-app chat.
 - **Auto-memory** *(experimental, off by default)* — silently extracts durable facts you mention
   in chat (name, preferences, hardware) using your own loaded model, and carries them into future
   new conversations. Nothing leaves your device; the full fact list is reviewable and deletable

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -83,6 +83,8 @@ export function registerApi(app: Hono, d: Deps): void {
       pid: ms.pid,
     }
     if (ms.err) engine.error = ms.err
+    const launchCommand = d.manager.launchCommand()
+    if (launchCommand) engine.launchCommand = launchCommand
     const model = ms.model
       ? { key: ms.model.key, name: ms.model.name, quant: ms.model.quant, ctx: ms.model.ctx, vision: ms.model.vision, loadElapsedMs: ms.loadElapsedMs }
       : null
@@ -1188,6 +1190,7 @@ export function registerApi(app: Hono, d: Deps): void {
           modelPath: entry.path,
           extraArgs,
           tensorParallelSize: savedProfile?.gpu?.tensorParallelSize,
+          preferredPort: savedProfile?.port,
         }
       } else {
         const saved = getModelProfile(cfg, entry.key, active.id) as Partial<LoadProfile> | undefined
@@ -1204,6 +1207,7 @@ export function registerApi(app: Hono, d: Deps): void {
           model: { key: entry.key, name: entry.name, quant: entry.quant, ctx: profile.ctx, vision: entry.vision },
           modelPath: entry.path,
           extraArgs,
+          preferredPort: profile.port,
         }
       }
       // Single chokepoint (rule 3): load() stops the current model, runs the reverse

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1533,6 +1533,7 @@ export function registerApi(app: Hono, d: Deps): void {
       search?: { provider?: string; tavilyApiKey?: string; kagiApiKey?: string; searxngUrl?: string }
       build?: { toolchainDirs?: string[] }
       toolPolicies?: Record<string, string>
+      autoAllowAll?: boolean
       cloudDeploy?: { runpodTemplateId?: string }
       experimental?: { memory?: boolean; code?: boolean; cloudDeploy?: boolean }
     }>(c)
@@ -1686,6 +1687,7 @@ export function registerApi(app: Hono, d: Deps): void {
       Object.assign(cfg.gateway, gwUpdates)
       if (toolchainDirs !== undefined) cfg.build.toolchainDirs = toolchainDirs
       if (toolPolicies !== undefined) cfg.tools.toolPolicies = toolPolicies
+      if (b.autoAllowAll !== undefined) cfg.tools.autoAllowAll = !!b.autoAllowAll
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
       if (vramHeadroomMb !== undefined) cfg.vramHeadroomMb = vramHeadroomMb
       if (telemetryLevel !== undefined) cfg.telemetry.level = telemetryLevel
@@ -2192,6 +2194,7 @@ function settingsPayload(d: Deps) {
     // Tool-call approval gate: global per-tool policy ('ask' | 'allow' | 'deny').
     // Not secret — echoed back directly so Settings can render Tool Permissions.
     toolPolicies: cfg.tools.toolPolicies ?? {},
+    autoAllowAll: cfg.tools.autoAllowAll ?? false,
   }
 }
 

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -1078,6 +1078,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
               // start) — otherwise a same-turn repeat tool call misses an "Allow for this
               // chat" decision the user just made via POST .../tool-calls/:id/approve.
               convOverrides: d.db.getToolOverrides(convId),
+              autoAllowAll: d.store.snapshot().tools.autoAllowAll ?? false,
               signal: ac.signal,
               interactive: true,
             })

--- a/turbollm/src/chat/db.tokenusage.test.ts
+++ b/turbollm/src/chat/db.tokenusage.test.ts
@@ -1,0 +1,90 @@
+// Regression tests for tokenUsageStats' Overview totals including API/gateway usage
+// (founder-directed, 2026-07-22): the headline "Total tokens" / "Lifetime tokens" / milestone
+// ladder must reflect ALL usage, not just in-app chat — a heavy Claude Code / extension user was
+// seeing a total that silently excluded most of their real usage, with the API figures only
+// visible on a separate tab. sessions/messages/streak/peak-hour/favorite-model stay chat-only:
+// those are chat-conversation-shaped concepts a gateway request doesn't participate in.
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { ConversationStore } from './db'
+
+function makeTmpRoot(): string {
+  const dir = join(tmpdir(), `turbollm-tokenusage-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+test('tokenUsageStats: Total tokens and Lifetime tokens are chat + API combined', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    const conv = db.createConversation()
+    db.addMessage(conv.id, 'assistant', 'hi', { stats: { promptTokens: 100, genTokens: 50 } })
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 300, genTokens: 200 })
+
+    const stats = db.tokenUsageStats('all')
+    assert.equal(stats.totalTokens, 650, 'chat 150 + api 500')
+    assert.equal(stats.lifetimeTotalTokens, 650)
+    // The isolated API breakdown is still exposed separately, unchanged.
+    assert.equal(stats.api.totalTokens, 500)
+    assert.equal(stats.api.requests, 1)
+  } finally {
+    db.close() // node:sqlite keeps the file handle open — Windows can't rmSync while it's held
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('tokenUsageStats: milestone reflects the COMBINED total, crossing a threshold chat alone would not', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    const conv = db.createConversation()
+    // Chat alone (700) stays under the 1,000 milestone; API (400) pushes the combined total over it.
+    db.addMessage(conv.id, 'assistant', 'hi', { stats: { promptTokens: 500, genTokens: 200 } })
+    db.recordApiUsage({ source: 'openai', modelKey: 'm1', promptTokens: 300, genTokens: 100 })
+
+    const stats = db.tokenUsageStats('all')
+    assert.equal(stats.lifetimeTotalTokens, 1100)
+    assert.equal(stats.milestone.achieved, 1_000, 'should have crossed 1,000 only once API is included')
+  } finally {
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('tokenUsageStats: zero in-app chat but real API traffic still gets a real milestone (not stuck at null)', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 800, genTokens: 300 })
+
+    const stats = db.tokenUsageStats('all')
+    assert.equal(stats.firstMessageAt, null, 'no chat history')
+    assert.equal(stats.totalTokens, 1100)
+    assert.equal(stats.lifetimeTotalTokens, 1100)
+    assert.equal(stats.milestone.achieved, 1_000)
+    assert.equal(stats.sessions, 0, 'chat-only concept — a gateway request is not a session')
+  } finally {
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('tokenUsageStats: no chat and no API traffic stays fully empty', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    const stats = db.tokenUsageStats('all')
+    assert.equal(stats.firstMessageAt, null)
+    assert.equal(stats.totalTokens, 0)
+    assert.equal(stats.lifetimeTotalTokens, 0)
+    assert.equal(stats.milestone.achieved, null)
+    assert.equal(stats.api.requests, 0)
+  } finally {
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -250,10 +250,12 @@ export interface TokenUsageStats {
   activity: TokenActivity
   dailyByModel: DailyModelBreakdown[]
   byModel: ModelUsage[]
-  /** Tokens from gateway (external client) traffic — Claude Code, other CLIs/extensions —
-   *  kept as a separate bucket rather than merged into the fields above (GitHub #71): those
-   *  fields' "sessions"/streak/milestone semantics are chat-conversation concepts that gateway
-   *  requests don't participate in (no conv_id, no role). */
+  /** Tokens from gateway (external client) traffic — Claude Code, other CLIs/extensions
+   *  (GitHub #71). This isolated breakdown (by source, by model) is separate, but `totalTokens`/
+   *  `lifetimeTotalTokens`/`milestone` above already INCLUDE it (founder-directed, 2026-07-22 —
+   *  Overview must reflect all usage, not just chat). Only `sessions`/`messages`/streak/
+   *  peak-hour/favorite-model stay chat-only: those are chat-conversation concepts (a gateway
+   *  request has no conv_id, isn't a "session") with no clean API equivalent. */
   api: ApiUsageStats
 }
 
@@ -321,6 +323,19 @@ const TOKEN_MILESTONES = [
   1_000, 10_000, 100_000, 500_000, 1_000_000, 5_000_000,
   10_000_000, 50_000_000, 100_000_000, 500_000_000, 1_000_000_000,
 ]
+
+/** Where a lifetime token total sits on the milestone ladder. Shared by both branches of
+ *  tokenUsageStats (empty-rows and the real computation) — as of 2026-07-22 the lifetime
+ *  total fed in is the COMBINED chat+API figure, so this only ever computes, never decides
+ *  which figure to use. */
+function milestoneFor(lifetimeTotalTokens: number): { achieved: number | null; next: number | null; progressPct: number | null } {
+  const achieved = [...TOKEN_MILESTONES].reverse().find((m) => m <= lifetimeTotalTokens) ?? null
+  const next = TOKEN_MILESTONES.find((m) => m > lifetimeTotalTokens) ?? null
+  const progressPct = next !== null
+    ? Math.round(((lifetimeTotalTokens - (achieved ?? 0)) / (next - (achieved ?? 0))) * 1000) / 10
+    : null
+  return { achieved, next, progressPct }
+}
 
 /** "gemma 4 e4b|Q6_K|6217256480" -> "Gemma 4 E4b". Good enough for a dashboard label —
  *  the model may since have been renamed/deleted, so this derives purely from the stored
@@ -1082,14 +1097,20 @@ export class ConversationStore {
     `).all() as unknown as { conv_id: string; created_at: string; stats: string; model_key: string | null }[]
 
     if (rows.length === 0) {
+      // Computed independently — a user with zero in-app chats but real gateway (Claude
+      // Code / extension) traffic still has something to show here. "Total tokens" /
+      // "Lifetime tokens" (below and in the main branch) are the founder-directed
+      // combined figure (2026-07-22) — Overview must reflect ALL usage, not just chat,
+      // so a chat-less API-only user still gets a real milestone reading instead of a
+      // permanently-stuck-at-zero one.
+      const api = this.apiUsageStats(range)
+      const milestone = milestoneFor(api.lifetimeTotalTokens)
       return {
-        range, sessions: 0, messages: 0, totalTokens: 0, activeDays: 0,
+        range, sessions: 0, messages: 0, totalTokens: api.totalTokens, activeDays: 0,
         currentStreak: 0, longestStreak: 0, peakHour: null, favoriteModel: null,
-        firstMessageAt: null, lifetimeTotalTokens: 0, milestone: { achieved: null, next: null, progressPct: null },
+        firstMessageAt: null, lifetimeTotalTokens: api.lifetimeTotalTokens, milestone,
         activity: { granularityHours: 24, buckets: [] }, dailyByModel: [], byModel: [],
-        // Computed independently — a user with zero in-app chats but real gateway (Claude
-        // Code / extension) traffic still has something to show here.
-        api: this.apiUsageStats(range),
+        api,
       }
     }
 
@@ -1234,21 +1255,29 @@ export class ConversationStore {
       activity = { granularityHours, buckets }
     }
 
-    let lifetimeTotalTokens = 0
-    for (const b of dayBuckets.values()) lifetimeTotalTokens += b.promptTokens + b.genTokens
-    const achieved = [...TOKEN_MILESTONES].reverse().find((m) => m <= lifetimeTotalTokens) ?? null
-    const next = TOKEN_MILESTONES.find((m) => m > lifetimeTotalTokens) ?? null
-    const progressPct = next !== null
-      ? Math.round(((lifetimeTotalTokens - (achieved ?? 0)) / (next - (achieved ?? 0))) * 1000) / 10
-      : null
+    let chatLifetimeTotalTokens = 0
+    for (const b of dayBuckets.values()) chatLifetimeTotalTokens += b.promptTokens + b.genTokens
+
+    // Founder-directed (2026-07-22): Overview's "Total tokens" / "Lifetime tokens" / milestone
+    // ladder must reflect ALL usage, not just in-app chat — a heavy Claude Code / extension user
+    // was seeing a headline total that silently excluded most of their real usage, with the API
+    // figures only visible by switching to a separate tab. `sessions`/`messages`/streak/peak-hour/
+    // favorite-model stay chat-only below: those are chat-conversation-shaped concepts (a gateway
+    // request has no conv_id, isn't a "session") with no clean 1:1 API equivalent, and the founder
+    // asked specifically about "usage" totals, not those. The isolated `api` breakdown (by source,
+    // by model) remains available in its own tab for anyone who wants the split.
+    const api = this.apiUsageStats(range)
+    const combinedTotalTokens = totalTokens + api.totalTokens
+    const combinedLifetimeTotalTokens = chatLifetimeTotalTokens + api.lifetimeTotalTokens
+    const milestone = milestoneFor(combinedLifetimeTotalTokens)
 
     return {
-      range, sessions: convIds.size, messages: scopedRows.length, totalTokens, activeDays,
+      range, sessions: convIds.size, messages: scopedRows.length, totalTokens: combinedTotalTokens, activeDays,
       currentStreak, longestStreak, peakHour,
       favoriteModel: byModel[0]?.displayName ?? null,
-      firstMessageAt, lifetimeTotalTokens, milestone: { achieved, next, progressPct },
+      firstMessageAt, lifetimeTotalTokens: combinedLifetimeTotalTokens, milestone,
       activity, dailyByModel, byModel,
-      api: this.apiUsageStats(range),
+      api,
     }
   }
 

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -250,6 +250,35 @@ export interface TokenUsageStats {
   activity: TokenActivity
   dailyByModel: DailyModelBreakdown[]
   byModel: ModelUsage[]
+  /** Tokens from gateway (external client) traffic — Claude Code, other CLIs/extensions —
+   *  kept as a separate bucket rather than merged into the fields above (GitHub #71): those
+   *  fields' "sessions"/streak/milestone semantics are chat-conversation concepts that gateway
+   *  requests don't participate in (no conv_id, no role). */
+  api: ApiUsageStats
+}
+
+/** One request source recorded against `api_usage` — the two gateway entry points
+ *  (gateway.ts): the Anthropic-protocol translation and the OpenAI-compatible pass-through. */
+export type ApiUsageSource = 'anthropic' | 'openai'
+
+export interface ApiModelUsage {
+  modelKey: string
+  displayName: string
+  requests: number
+  promptTokens: number
+  genTokens: number
+  totalTokens: number
+}
+
+/** Token usage from external (gateway) clients — Claude Code, other CLIs/extensions hitting
+ *  /v1/messages or /v1/chat/completions — as opposed to in-app chat (`TokenUsageStats`). */
+export interface ApiUsageStats {
+  range: TokenUsageRange
+  requests: number
+  totalTokens: number
+  lifetimeTotalTokens: number
+  bySource: { source: ApiUsageSource; requests: number; totalTokens: number }[]
+  byModel: ApiModelUsage[]
 }
 
 export type CodeStatsRange = 'all' | '30d' | '7d'
@@ -874,6 +903,26 @@ export class ConversationStore {
       if (!this.hasColumn('agent_runs', 'reverted_from_message_id')) this.db.exec(`ALTER TABLE agent_runs ADD COLUMN reverted_from_message_id TEXT;`)
       this.db.exec(`PRAGMA user_version = 33;`)
     }
+    // v34 (GitHub #71): tokens hitting the gateway (/v1/messages, /v1/chat/completions) from
+    // external clients — Claude Code, other CLIs/extensions — never landed in `messages` (that
+    // table is chat-conversation rows only; gateway requests create no conversation). Usage was
+    // silently invisible to the Tokens dashboard. One row per completed gateway request, kept
+    // deliberately separate from `messages` (no conv_id/role — it isn't a chat turn) rather than
+    // merged into the existing streak/session semantics there, which are chat-specific concepts.
+    if (v < 34) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS api_usage (
+          id             TEXT PRIMARY KEY,
+          created_at     TEXT NOT NULL,
+          source         TEXT NOT NULL,
+          model_key      TEXT,
+          prompt_tokens  INTEGER NOT NULL DEFAULT 0,
+          gen_tokens     INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_api_usage_created ON api_usage(created_at);
+        PRAGMA user_version = 34;
+      `)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -1038,6 +1087,9 @@ export class ConversationStore {
         currentStreak: 0, longestStreak: 0, peakHour: null, favoriteModel: null,
         firstMessageAt: null, lifetimeTotalTokens: 0, milestone: { achieved: null, next: null, progressPct: null },
         activity: { granularityHours: 24, buckets: [] }, dailyByModel: [], byModel: [],
+        // Computed independently — a user with zero in-app chats but real gateway (Claude
+        // Code / extension) traffic still has something to show here.
+        api: this.apiUsageStats(range),
       }
     }
 
@@ -1196,6 +1248,75 @@ export class ConversationStore {
       favoriteModel: byModel[0]?.displayName ?? null,
       firstMessageAt, lifetimeTotalTokens, milestone: { achieved, next, progressPct },
       activity, dailyByModel, byModel,
+      api: this.apiUsageStats(range),
+    }
+  }
+
+  /** Insert one completed gateway request (GitHub #71) — called from the two gateway entry
+   *  points (gateway.ts) right where in-app chat already records into `messages`. Fully
+   *  additive/fail-safe: callers wrap this the same way `recordCompletion` is wrapped. */
+  recordApiUsage(rec: { source: ApiUsageSource; modelKey: string | null; promptTokens: number; genTokens: number }): void {
+    this.db.prepare(`
+      INSERT INTO api_usage (id, created_at, source, model_key, prompt_tokens, gen_tokens)
+      VALUES ($id, $createdAt, $source, $modelKey, $promptTokens, $genTokens)
+    `).run({
+      $id: randomUUID(),
+      $createdAt: new Date().toISOString(),
+      $source: rec.source,
+      $modelKey: rec.modelKey,
+      $promptTokens: Math.max(0, Math.floor(rec.promptTokens) || 0),
+      $genTokens: Math.max(0, Math.floor(rec.genTokens) || 0),
+    } as P)
+  }
+
+  /** Gateway (external-client) token usage — see `ApiUsageStats`'s doc comment for why this
+   *  is a separate bucket from `tokenUsageStats`. Same local-day range scoping as the chat
+   *  stats above, but no streak/session concepts (a gateway request isn't a chat turn). */
+  apiUsageStats(range: TokenUsageRange = 'all'): ApiUsageStats {
+    const rows = this.db.prepare(`
+      SELECT created_at, source, model_key, prompt_tokens, gen_tokens FROM api_usage
+      ORDER BY created_at ASC
+    `).all() as unknown as { created_at: string; source: ApiUsageSource; model_key: string | null; prompt_tokens: number; gen_tokens: number }[]
+
+    let lifetimeTotalTokens = 0
+    for (const r of rows) lifetimeTotalTokens += r.prompt_tokens + r.gen_tokens
+
+    if (rows.length === 0) {
+      return { range, requests: 0, totalTokens: 0, lifetimeTotalTokens: 0, bySource: [], byModel: [] }
+    }
+
+    const todayKey = dayKey(new Date().toISOString())
+    const heatStart = range === 'all' ? null : addDays(todayKey, -(RANGE_WINDOW_DAYS[range] - 1))
+    const scoped = heatStart === null ? rows : rows.filter((r) => dayKey(r.created_at) >= heatStart)
+
+    const sourceTally = new Map<ApiUsageSource, { requests: number; totalTokens: number }>()
+    const modelTally = new Map<string, { requests: number; promptTokens: number; genTokens: number }>()
+    let totalTokens = 0
+    for (const r of scoped) {
+      const tokens = r.prompt_tokens + r.gen_tokens
+      totalTokens += tokens
+      const st = sourceTally.get(r.source) ?? { requests: 0, totalTokens: 0 }
+      st.requests++; st.totalTokens += tokens
+      sourceTally.set(r.source, st)
+      if (r.model_key) {
+        const mt = modelTally.get(r.model_key) ?? { requests: 0, promptTokens: 0, genTokens: 0 }
+        mt.requests++; mt.promptTokens += r.prompt_tokens; mt.genTokens += r.gen_tokens
+        modelTally.set(r.model_key, mt)
+      }
+    }
+
+    const byModel: ApiModelUsage[] = [...modelTally.entries()]
+      .map(([modelKey, m]) => ({
+        modelKey, displayName: titleCaseModelName(modelKey),
+        requests: m.requests, promptTokens: m.promptTokens, genTokens: m.genTokens,
+        totalTokens: m.promptTokens + m.genTokens,
+      }))
+      .sort((a, b) => b.totalTokens - a.totalTokens)
+
+    return {
+      range, requests: scoped.length, totalTokens, lifetimeTotalTokens,
+      bySource: [...sourceTally.entries()].map(([source, s]) => ({ source, ...s })),
+      byModel,
     }
   }
 

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -170,6 +170,11 @@ export interface ToolsConfig {
    *  to 'ask' unless explicitly set here to 'allow' or 'deny'. A per-conversation
    *  override (Conversation.toolOverrides) takes precedence over this map. */
   toolPolicies?: Record<string, 'ask' | 'allow' | 'deny'>
+  /** Master toggle (Settings → Tool permissions), default OFF: when true, every tool
+   *  call that would otherwise show an "awaiting approval" prompt runs immediately
+   *  instead. Only silences a resolved 'ask' — an explicit 'deny' (global or
+   *  per-conversation) is still honored; see resolveToolPolicy. */
+  autoAllowAll?: boolean
 }
 
 /** One MCP server the daemon manages as a tool provider (v0.7.0). */
@@ -725,6 +730,7 @@ function normalize(c: Config): void {
     toolPolicies.run_code = 'allow'
   }
   c.tools.toolPolicies = toolPolicies
+  c.tools.autoAllowAll = tl.autoAllowAll === true
   // MCP host (v0.7.0): absent in pre-v0.7.0 configs → empty server list.
   const mc = (c.mcp ?? {}) as Partial<McpConfig>
   c.mcp = {

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -37,6 +37,9 @@ export interface StartOpts {
   /** vLLM multi-GPU shard count (ADR-054). Only consumed by the vllm branch of
    *  {@link engineCommand}; llama.cpp carries its GPU flags in extraArgs instead. */
   tensorParallelSize?: number
+  /** Per-model pinned port (LoadProfile.port), engine-agnostic. Tried first by
+   *  allocPort(); falls back to the normal 8081+ walk if unset or already taken. */
+  preferredPort?: number
 }
 export interface Status {
   state: State
@@ -146,6 +149,7 @@ export class Manager {
   private child: ChildProcess | null = null
   private startedAt = 0
   private errInfo: ErrInfo | null = null
+  private lastCommand: { cmd: string; args: string[] } | null = null
   private lastActivity = 0
   private logPathStr = ''
   private exited: Promise<void> = Promise.resolve()
@@ -233,7 +237,7 @@ export class Manager {
       }
     }
 
-    const port = await allocPort()
+    const port = await allocPort(opts.preferredPort)
     const logPath = join(this.store.dir(), 'logs', `engine-${opts.engine.id}.log`)
     mkdirSync(dirname(logPath), { recursive: true })
     const logStream = createWriteStream(logPath) // truncates
@@ -262,6 +266,11 @@ export class Manager {
     }
 
     const { cmd, args } = engineCommand(opts, port, slotSavePath)
+    // The UNWRAPPED command (before the POSIX-llamafile shell-quoting workaround below) is
+    // what a human would actually type in their own terminal — stored for "copy exact launch
+    // command" (GitHub Discord ask). Not logged before now: the file only ever had a port-only
+    // header line, never the real argv.
+    this.lastCommand = { cmd, args }
     const spawned = needsShellWrapper(opts.engine.kind) ? shellWrapped(cmd, args) : { cmd, args }
     const child = spawn(spawned.cmd, spawned.args, { cwd: dirname(cmd), windowsHide: true, env: pyEngineEnv(opts.engine.kind, this.store.dir(), opts.engine.binPath) })
     // end:false — otherwise whichever of stdout/stderr closes first would end the
@@ -361,6 +370,28 @@ export class Manager {
     // load() stops the current engine (if any) and starts the same opts again, all
     // under the global load gate — so a restart can't race a concurrent swap.
     await this.load(opts)
+  }
+
+  /** The exact command last spawned, formatted for copy-paste into a terminal
+   *  (GitHub Discord ask — "copy exact launch command"). Only meaningful while this
+   *  engine is the one actually running; null once stopped/swapped so a stale
+   *  command from a PREVIOUS model can never be copied as if it were current.
+   *
+   *  Deliberately NOT byte-identical to what TurboLLM itself spawned: the point of
+   *  copying it is running the SAME model+config standalone, with llama.cpp/the fork
+   *  directly and TurboLLM out of the picture entirely — so `--no-webui` (added only
+   *  because TurboLLM serves its own frontend and doesn't want llama-server's built-in
+   *  one competing with it, `buildArgs` in this file) is stripped here: for a standalone
+   *  run it's the only UI available, so silently carrying it over would hand the user a
+   *  server with no way to talk to it. Everything else (model path, offload, KV type,
+   *  sampling, extra flags) is copied verbatim — it's what makes the command reproduce
+   *  the exact same config. */
+  launchCommand(): string | null {
+    if (this.state !== 'running' && this.state !== 'starting') return null
+    if (!this.lastCommand) return null
+    const args = this.lastCommand.args.filter((a) => a !== '--no-webui')
+    const quote = (s: string) => (/[\s"]/.test(s) ? `"${s.replace(/"/g, '\\"')}"` : s)
+    return [this.lastCommand.cmd, ...args].map(quote).join(' ')
   }
 
   status(): Status {
@@ -700,7 +731,19 @@ function buildArgs(opts: StartOpts, port: number, slotSavePath?: string): string
   return args
 }
 
-function allocPort(): Promise<number> {
+/** Checks a single port for availability without the 8081+ walk — used to try a
+ *  user-pinned {@link StartOpts.preferredPort} first, falling back to the normal
+ *  walk (never rejecting) if it's already taken. */
+function portFree(p: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer()
+    srv.once('error', () => resolve(false))
+    srv.listen(p, '127.0.0.1', () => srv.close(() => resolve(true)))
+  })
+}
+
+async function allocPort(preferredPort?: number): Promise<number> {
+  if (preferredPort && preferredPort > 0 && (await portFree(preferredPort))) return preferredPort
   return new Promise((resolve, reject) => {
     const tryPort = (p: number) => {
       if (p > 8181) return reject(new Error('no_free_port'))

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -118,6 +118,9 @@ export function registerGateway(app: Hono, d: Deps): void {
         (u) => {
           try {
             d.manager.recordCompletion({ inputTokens: u.inputTokens, outputTokens: u.outputTokens })
+            // Durable counterpart to the ephemeral session counter above (GitHub #71) — the
+            // session counter resets on engine restart and was never persisted/surfaced.
+            d.db.recordApiUsage({ source: 'anthropic', modelKey: req.model ?? null, promptTokens: u.inputTokens, genTokens: u.outputTokens })
           } catch { /* swallow — stats are best-effort */ }
         },
         // Live per-request progress for the engine card (prefill % + token count),
@@ -144,7 +147,7 @@ export function registerGateway(app: Hono, d: Deps): void {
 
     try {
       const oaiRes = (await res.json()) as Record<string, unknown>
-      recordOpenAiUsage(d, oaiRes) // session stats (B4), fail-safe
+      recordOpenAiUsage(d, oaiRes, 'anthropic', req.model ?? null) // session stats (B4) + durable #71 record, fail-safe
       return c.json(mapFromOpenAI(oaiRes, modelName))
     } finally {
       d.manager.generationEnd()
@@ -252,6 +255,15 @@ export function registerGateway(app: Hono, d: Deps): void {
           const alias = engineModelAlias(d.registry.active()?.kind ?? '')
           if (alias) parsedBody.model = alias
         }
+        // A streaming OpenAI response omits the final `usage` chunk unless the caller
+        // opts in via `stream_options.include_usage` (standard OpenAI API behavior,
+        // which llama.cpp's server mirrors) — without this, recordOpenAiStreamUsage
+        // below silently sees no usage and GitHub #71 undercounts every streaming
+        // OpenAI-protocol client that doesn't already request it. Only fills the gap
+        // when the caller left it unset; never overrides an explicit choice.
+        if (parsedBody?.stream === true && parsedBody.stream_options === undefined) {
+          parsedBody.stream_options = { include_usage: true }
+        }
         headers.delete('content-length') // re-serialised body has a new length
         init.body = parsedBody ? JSON.stringify(parsedBody) : ''
       } else {
@@ -272,7 +284,15 @@ export function registerGateway(app: Hono, d: Deps): void {
         // copy drains, paired so the counter can't leak. (OpenAI clients don't get the
         // prefill % — injecting return_progress would pollute their stream.)
         d.manager.generationStart()
-        void recordOpenAiStreamUsage(d, b).finally(() => d.manager.generationEnd())
+        // The requester's own `stream` flag decides the drain shape: a non-streaming
+        // OpenAI client (common for scripted/extension callers, `stream` false/absent)
+        // gets ONE plain JSON body from the engine, not SSE `data:` lines — the SSE
+        // parser would silently see no matches and record nothing (GitHub #71: this
+        // gap would have made external-client tracking wrong for a common case).
+        const drain = parsedBody?.stream === true
+          ? recordOpenAiStreamUsage(d, b, 'openai', requestedModel || null)
+          : recordOpenAiJsonUsage(d, b, 'openai', requestedModel || null)
+        void drain.finally(() => d.manager.generationEnd())
         return new Response(a, { status: res.status, headers: res.headers })
       } catch {
         return new Response(res.body, { status: res.status, headers: res.headers })
@@ -285,8 +305,10 @@ export function registerGateway(app: Hono, d: Deps): void {
 
 // ── session-stats recording helpers (B4) ────────────────────────────────────
 
-/** Record usage from a non-streaming OpenAI completion. Fail-safe. */
-function recordOpenAiUsage(d: Deps, oai: Record<string, unknown>): void {
+/** Record usage from a non-streaming OpenAI completion. Fail-safe. Also persists a durable
+ *  `api_usage` row (GitHub #71) — `source`/`modelKey` distinguish gateway (external-client)
+ *  traffic from in-app chat, which records into `messages` instead. */
+function recordOpenAiUsage(d: Deps, oai: Record<string, unknown>, source: 'anthropic' | 'openai', modelKey: string | null): void {
   try {
     const usage = oai.usage as { prompt_tokens?: number; completion_tokens?: number } | undefined
     const timings = oai.timings as { prompt_per_second?: number; predicted_per_second?: number } | undefined
@@ -296,12 +318,26 @@ function recordOpenAiUsage(d: Deps, oai: Record<string, unknown>): void {
       promptTps: timings?.prompt_per_second,
       genTps: timings?.predicted_per_second,
     })
+    d.db.recordApiUsage({ source, modelKey, promptTokens: usage?.prompt_tokens ?? 0, genTokens: usage?.completion_tokens ?? 0 })
   } catch { /* swallow — stats are best-effort */ }
 }
 
-/** Drain a teed copy of a streaming OpenAI SSE body to record final usage (B4).
- *  Never touches the client-facing stream; all errors are swallowed. */
-async function recordOpenAiStreamUsage(d: Deps, body: ReadableStream<Uint8Array>): Promise<void> {
+/** Drain a teed copy of a NON-streaming OpenAI JSON body (a single response, not SSE) to
+ *  record usage — the `/v1/*` pass-through's counterpart to `recordOpenAiStreamUsage` for
+ *  requests where the caller didn't set `stream: true`. Never touches the client-facing
+ *  stream; all errors are swallowed. */
+async function recordOpenAiJsonUsage(d: Deps, body: ReadableStream<Uint8Array>, source: 'anthropic' | 'openai', modelKey: string | null): Promise<void> {
+  try {
+    const text = await new Response(body).text()
+    const oai = JSON.parse(text) as Record<string, unknown>
+    recordOpenAiUsage(d, oai, source, modelKey)
+  } catch { /* swallow — stats are best-effort */ }
+}
+
+/** Drain a teed copy of a streaming OpenAI SSE body to record final usage (B4) plus a
+ *  durable `api_usage` row (GitHub #71). Never touches the client-facing stream; all
+ *  errors are swallowed. */
+async function recordOpenAiStreamUsage(d: Deps, body: ReadableStream<Uint8Array>, source: 'anthropic' | 'openai', modelKey: string | null): Promise<void> {
   try {
     const reader = body.getReader()
     const dec = new TextDecoder()
@@ -341,5 +377,6 @@ async function recordOpenAiStreamUsage(d: Deps, body: ReadableStream<Uint8Array>
       }
     }
     d.manager.recordCompletion({ inputTokens: promptTokens, outputTokens: completionTokens, promptTps, genTps })
+    d.db.recordApiUsage({ source, modelKey, promptTokens, genTokens: completionTokens })
   } catch { /* swallow — stats are best-effort */ }
 }

--- a/turbollm/src/models/profile.kv.test.ts
+++ b/turbollm/src/models/profile.kv.test.ts
@@ -191,6 +191,21 @@ test('estimateVram: --no-kv-offload still zeroes the KV term, recurrent state in
   assert.equal(estimateVram(p, qwen36_27b, sys).estMb, Math.round(1000 + 800))
 })
 
+test('estimateVram: asymmetric K/V quant (K=q8_0, V=f16) is weighted independently, not as if both matched K', () => {
+  // Release 1 (2026-07-22): the KV term used to read only kvTypeK and assume V matched it.
+  // kvCacheElems returns the COMBINED K+V count; half is K-only, half is V-only.
+  const p = { ...deriveDefault(dense, sys), ctx: CTX, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'f16' }
+  const weightsMb = dense.sizeBytes / 1e6
+  const halfElems = legacyElems(dense, CTX) / 2 // legacyElems is already the ×2 combined count
+  const kvMb = (halfElems * 1 /* q8_0 */ + halfElems * 2 /* f16 */) / 1e6
+  assert.equal(estimateVram(p, dense, sys).estMb, Math.round(weightsMb + kvMb + 800))
+  // Sanity: strictly between the all-q8_0 and all-f16 readings, not equal to either.
+  const allQ8 = Math.round(weightsMb + (halfElems * 2 * 1) / 1e6 + 800)
+  const allF16 = Math.round(weightsMb + (halfElems * 2 * 2) / 1e6 + 800)
+  const mixed = estimateVram(p, dense, sys).estMb
+  assert.ok(mixed > allQ8 && mixed < allF16, `expected ${allQ8} < ${mixed} < ${allF16}`)
+})
+
 test('kvCacheElems: an interval that no layer can satisfy must NOT zero the KV cache', () => {
   // Regression: `hybrid` used to be gated on `interval > 1` alone. When the stride
   // exceeds the block count, NO layer satisfies (i+1) % interval === 0, so the loop

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -102,6 +102,12 @@ export interface LoadProfile {
    *  {@link nglFit} applies here too. */
   nCpuMoeFit?: boolean
   parallel: number
+  /** Pin this model's engine instance to a specific loopback port instead of the
+   *  default 8081+ first-free walk (allocPort in manager.ts). 0/undefined = auto.
+   *  Distinct from the main daemon port (6996/6997) — this is only the per-model
+   *  llama-server/mlx/vllm/etc. child process's own port. Falls back to auto if the
+   *  requested port is already taken. */
+  port?: number
   kvUnified: boolean
   kvTypeK: string
   kvTypeV: string
@@ -367,9 +373,14 @@ export function estimateVram(p: LoadProfile, m: ModelEntry, sys: SysInfo): VramF
   // KV cache only counts against VRAM when it's offloaded to the GPU. With --no-kv-offload
   // (kvOffload === false) it lives in system RAM, so it adds nothing to the GPU estimate.
   // Absent on pre-feature profiles → treated as the GPU default.
+  // kvCacheElems returns the COMBINED K+V element count (always ×2, identical shape for
+  // both — see its own comment); halving it gives the K-only / V-only count so an
+  // asymmetric quant (e.g. K=q8_0, V=q4_0) is weighted correctly instead of assuming V
+  // matches K's byte width.
+  const kvBytesMb = ((kvElems / 2) * kvBytesPerElem(p.kvTypeK) + (kvElems / 2) * kvBytesPerElem(p.kvTypeV)) / 1e6
   const kvMb = p.kvOffload === false
     ? 0
-    : (((kvElems * kvBytesPerElem(p.kvTypeK)) / 1e6) + ssmMb) * (p.kvUnified ? 1 : Math.max(1, p.parallel))
+    : (kvBytesMb + ssmMb) * (p.kvUnified ? 1 : Math.max(1, p.parallel))
 
   // The mmproj file's on-disk size is a much closer proxy for its real VRAM footprint than
   // a flat guess (already-quantized weights load close to 1:1) — a measured ~15% overhead

--- a/turbollm/src/models/scanner.mmproj.test.ts
+++ b/turbollm/src/models/scanner.mmproj.test.ts
@@ -1,0 +1,118 @@
+// Regression tests for mmproj-to-model pairing in Scanner.build (Discord thread,
+// 2026-07-20). Bug: a modelDir containing more than one vision model's files (a manually
+// curated folder, not one of TurboLLM's own per-repo downloads — see ADR-145) picked
+// "the single largest mmproj in the directory" and attached it to EVERY model there,
+// regardless of which model it actually belongs to. A model paired with the wrong
+// projector fails to start with an incompatible vision tower.
+//
+// resolveMmproj() fixes this per model file: (1) one candidate is unambiguous, (2) a
+// filename-correlated candidate wins when unique, (3) otherwise the closest-mtime
+// candidate wins — the real repro (gemma-4-12B-it-qat-GGUF) ships a GENERICALLY named
+// mmproj ("mmproj-F16.gguf") that carries no model identity to correlate by name at all,
+// so the mtime tiebreak is what actually resolves that case.
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import type { ConfigStore } from '../config/config'
+import { Scanner } from './scanner'
+
+// walk() only records .gguf files >= 1 MiB (real mmproj files are much larger than this
+// in practice, but the floor applies to the fixture too).
+const BYTES = (1 << 20) + 16
+const BUF = Buffer.alloc(BYTES)
+
+function makeTmpRoot(): string {
+  return join(tmpdir(), `turbollm-mmproj-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`)
+}
+
+function stubStore(root: string): ConfigStore {
+  return {
+    dir: () => root,
+    snapshot: () => ({ modelDirs: [root] }),
+  } as unknown as ConfigStore
+}
+
+/** Writes a file with an explicit mtime (seconds since epoch) so pairing-by-proximity
+ *  is deterministic regardless of filesystem mtime resolution or write order. */
+function writeAt(path: string, mtimeSec: number): void {
+  writeFileSync(path, BUF)
+  utimesSync(path, mtimeSec, mtimeSec)
+}
+
+async function scan(root: string) {
+  const scanner = new Scanner(stubStore(root))
+  await scanner.rescan()
+  return scanner.list().models
+}
+
+test('a single mmproj in the directory pairs unambiguously (unchanged common case)', async () => {
+  const root = makeTmpRoot()
+  const dir = join(root, 'repo')
+  mkdirSync(dir, { recursive: true })
+  try {
+    writeAt(join(dir, 'model-Q4_K_M.gguf'), 1000)
+    writeAt(join(dir, 'mmproj-F16.gguf'), 1000)
+    const models = await scan(root)
+    assert.equal(models.length, 1)
+    assert.equal(models[0].vision, true)
+    assert.ok(models[0].mmprojPath?.endsWith('mmproj-F16.gguf'))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('two models with GENERICALLY-named mmprojs (the real repro) pair by closest mtime, not by size', async () => {
+  const root = makeTmpRoot()
+  const dir = join(root, 'flat-folder') // a manually curated dir mixing two repos' files
+  mkdirSync(dir, { recursive: true })
+  try {
+    // Model A's download landed around t=1000; its mmproj is the SMALLER file.
+    writeAt(join(dir, 'model-a-Q4_K_M.gguf'), 1000)
+    writeAt(join(dir, 'mmproj-a-F16.gguf'), 1005)
+    // Model B's download landed much later, around t=5000; its mmproj is the LARGER file
+    // — under the old "always pick the largest" bug, model A would have wrongly received
+    // model B's (bigger) projector.
+    writeAt(join(dir, 'model-b-Q4_K_M.gguf'), 5000)
+    const bigMmprojPath = join(dir, 'mmproj-b-F16.gguf')
+    writeFileSync(bigMmprojPath, Buffer.alloc(BYTES * 3))
+    utimesSync(bigMmprojPath, 5005, 5005)
+
+    const models = await scan(root)
+    assert.equal(models.length, 2)
+    const a = models.find((m) => m.path.includes('model-a'))
+    const b = models.find((m) => m.path.includes('model-b'))
+    assert.ok(a && b)
+    assert.ok(a!.mmprojPath?.includes('mmproj-a'), `model A got ${a!.mmprojPath}`)
+    assert.ok(b!.mmprojPath?.includes('mmproj-b'), `model B got ${b!.mmprojPath}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('filename correlation wins even when mtime proximity would suggest the other candidate', async () => {
+  const root = makeTmpRoot()
+  const dir = join(root, 'flat-folder')
+  mkdirSync(dir, { recursive: true })
+  try {
+    // Two DISTINCT repos' files with no shared prefix between the model names themselves,
+    // so any correlation match is a genuine one, not an artifact of a generic shared prefix.
+    // gemma-4-alpha's own mmproj is named to correlate, but happens to have been touched
+    // much later (e.g. a re-download of just the projector) — correlation must still win
+    // over the closer-in-time but unrelated llava-beta mmproj.
+    writeAt(join(dir, 'gemma-4-alpha-Q4_K_M.gguf'), 1000)
+    writeAt(join(dir, 'llava-beta-Q4_K_M.gguf'), 1000)
+    writeAt(join(dir, 'gemma-4-alpha-mmproj-F16.gguf'), 9000) // far in time, but correlates
+    writeAt(join(dir, 'llava-beta-mmproj-F16.gguf'), 1001) // close in time, correlates to beta
+
+    const models = await scan(root)
+    const alpha = models.find((m) => m.path.includes('gemma-4-alpha'))
+    const beta = models.find((m) => m.path.includes('llava-beta'))
+    assert.ok(alpha && beta)
+    assert.ok(alpha!.mmprojPath?.includes('gemma-4-alpha-mmproj'), `alpha got ${alpha!.mmprojPath}`)
+    assert.ok(beta!.mmprojPath?.includes('llava-beta-mmproj'), `beta got ${beta!.mmprojPath}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -140,6 +140,48 @@ function isEmbeddingModel(arch: string, name: string): boolean {
   return EMBED_ARCHS.has(arch.toLowerCase()) || EMBED_FILE_RE.test(name)
 }
 
+/** How many identical characters two (already-lowercased) strings share from the start —
+ *  a cheap, realistic correlation signal for GGUF filenames: a repo's model and mmproj
+ *  files typically share a "<repo-name>-…" prefix before diverging into their own
+ *  quant/format suffix (e.g. "gemma-4-12b-it-qat" vs "gemma-4-12b-mmproj-F16"). */
+function commonPrefixLen(a: string, b: string): number {
+  let i = 0
+  while (i < a.length && i < b.length && a[i] === b[i]) i++
+  return i
+}
+
+const MIN_MMPROJ_CORRELATION_PREFIX = 6
+
+/** Picks the mmproj that actually belongs to `modelFile` out of every mmproj candidate
+ *  in the same directory. Fixes a real bug (Discord thread, 2026-07-20): a modelDir the
+ *  user points at manually with more than one vision model's files sitting flat in one
+ *  folder used to pick "the single largest mmproj in the directory" and attach it to
+ *  EVERY model there, regardless of which model it actually belongs to — wiring the wrong
+ *  projector onto a model, which then fails to start with an incompatible vision tower.
+ *
+ *  1. One candidate → unambiguous, use it (the common case — and ADR-145's per-repo
+ *     download folders mean TurboLLM's own downloader never produces more than one).
+ *  2. Filename correlation (shared prefix before quant/format suffixes diverge) narrows
+ *     to exactly one candidate → use it.
+ *  3. Still ambiguous (no correlation, or several candidates all correlate) → the mmproj
+ *     with the closest mtime to the model file wins: files pulled down in the same HF
+ *     download land within moments of each other, so this reliably tells two repos' files
+ *     apart even when the mmproj is generically named — e.g. "mmproj-F16.gguf", the ACTUAL
+ *     repro case (gemma-4-12B-it-qat-GGUF), which carries no model identity to correlate
+ *     by name at all. */
+function resolveMmproj(modelFile: FileInfo, candidates: FileInfo[]): FileInfo | undefined {
+  if (candidates.length <= 1) return candidates[0]
+  const modelName = basename(modelFile.path).toLowerCase()
+  const correlated = candidates.filter(
+    (c) => commonPrefixLen(modelName, basename(c.path).toLowerCase()) >= MIN_MMPROJ_CORRELATION_PREFIX,
+  )
+  if (correlated.length === 1) return correlated[0]
+  const pool = correlated.length > 1 ? correlated : candidates
+  return pool.reduce((best, c) =>
+    Math.abs(c.mtime - modelFile.mtime) < Math.abs(best.mtime - modelFile.mtime) ? c : best,
+  )
+}
+
 /** Thrown by Scanner operations that fail in a caller-actionable way (e.g. delete
  *  of an unknown key). Carries a machine-checkable `code` for the API envelope. */
 export class ScannerError extends Error {
@@ -246,9 +288,6 @@ export class Scanner {
     for (const [dir, group] of byDir) {
       const mmprojFiles = group.filter((f) => basename(f.path).toLowerCase().includes('mmproj'))
       const modelFiles = group.filter((f) => !basename(f.path).toLowerCase().includes('mmproj'))
-      const mmproj = mmprojFiles.sort((a, b) => b.size - a.size)[0]
-      const mmprojPath = mmproj?.path ?? null
-      const mmprojSizeBytes = mmproj?.size ?? 0
 
       // Resolve split groups: prefix+total -> shards, keyed by shard INDEX so a split is
       // judged complete by the distinct part numbers present (1..total), not by the raw
@@ -275,7 +314,8 @@ export class Scanner {
       }
 
       for (const f of singles) {
-        entries.push(await this.entryFor(f.path, f.size, f.mtime, dir, mmprojPath, mmprojSizeBytes, false))
+        const mmproj = resolveMmproj(f, mmprojFiles)
+        entries.push(await this.entryFor(f.path, f.size, f.mtime, dir, mmproj?.path ?? null, mmproj?.size ?? 0, false))
         await tick()
       }
       for (const { shards, total } of splits.values()) {
@@ -292,7 +332,8 @@ export class Scanner {
               break
             }
         }
-        entries.push(await this.entryFor(first.path, totalSize, first.mtime, dir, mmprojPath, mmprojSizeBytes, incomplete))
+        const mmproj = resolveMmproj(first, mmprojFiles)
+        entries.push(await this.entryFor(first.path, totalSize, first.mtime, dir, mmproj?.path ?? null, mmproj?.size ?? 0, incomplete))
         await tick()
       }
     }

--- a/turbollm/src/server.ts
+++ b/turbollm/src/server.ts
@@ -25,10 +25,29 @@ const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'webdist')
 export function createApp(d: Deps): Hono {
   const app = new Hono()
 
+  // /v1/* (OpenAI/Anthropic-compatible gateway) stays fully permissive — arbitrary
+  // client software (Claude Code, other CLIs/tools) needs to reach it cross-origin,
+  // and it carries no browser-fingerprinting surface the way /api/* does.
   app.use(
-    '*',
+    '/v1/*',
     cors({
       origin: '*',
+      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'Authorization', 'x-api-key', 'X-TurboLLM-Auth'],
+    }),
+  )
+  // /api/* origin-allowlisted (ADR-216 open question, resolved): wildcard CORS here let
+  // ANY website silently read a loopback user's GPU/CPU/RAM via unauthenticated
+  // /api/v1/sysinfo while the daemon runs — a fingerprinting surface, not just the
+  // turbollm.dev "Suggest for my hardware" integration it was added to support. Compat
+  // swept 2026-07-22: that page (docs/site-build/pages/what-can-i-run.html) is the ONLY
+  // real cross-origin /api/* caller in the codebase, running from the production origin.
+  // A same-origin request (the app's own served UI) is unaffected either way — the
+  // browser never applies CORS to it.
+  app.use(
+    '/api/*',
+    cors({
+      origin: 'https://turbollm.dev',
       allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       allowHeaders: ['Content-Type', 'Authorization', 'x-api-key', 'X-TurboLLM-Auth'],
     }),

--- a/turbollm/src/tools/execute-with-approval.ts
+++ b/turbollm/src/tools/execute-with-approval.ts
@@ -17,6 +17,9 @@ export async function executeToolCallWithApproval(params: {
   args: Record<string, unknown>
   globalPolicies: Record<string, ToolPolicy>
   convOverrides: Record<string, 'allow' | 'deny'>
+  /** Settings → Tool permissions master toggle (default off) — silences a resolved
+   *  'ask' only; an explicit 'deny' is still honored. See resolveToolPolicy. */
+  autoAllowAll?: boolean
   signal: AbortSignal
   /** true for live foreground chat (can prompt a human); false for background agent runs
    *  (must never hang waiting for a human — 'ask'-policy tools are denied unless
@@ -27,9 +30,9 @@ export async function executeToolCallWithApproval(params: {
    *  in for the interactive approval a background run can never get. */
   agentAllowedTools?: string[]
 }): Promise<{ result: string; error?: string }> {
-  const { tools, sink, convId, id, name, args, globalPolicies, convOverrides, signal, interactive, agentAllowedTools } = params
+  const { tools, sink, convId, id, name, args, globalPolicies, convOverrides, signal, interactive, agentAllowedTools, autoAllowAll } = params
 
-  const policy = resolveToolPolicy(name, globalPolicies, convOverrides)
+  const policy = resolveToolPolicy(name, globalPolicies, convOverrides, autoAllowAll)
 
   if (policy === 'deny') {
     const result = 'Blocked: this tool is set to Deny in Tool Permissions settings.'

--- a/turbollm/src/tools/tool-policy.test.ts
+++ b/turbollm/src/tools/tool-policy.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveToolPolicy } from './tool-policy'
+
+test('resolveToolPolicy: default (no policy set) is "ask" when autoAllowAll is off', () => {
+  assert.equal(resolveToolPolicy('web_search', {}, {}), 'ask')
+  assert.equal(resolveToolPolicy('web_search', {}, {}, false), 'ask')
+})
+
+test('resolveToolPolicy: autoAllowAll promotes a default "ask" to "allow"', () => {
+  assert.equal(resolveToolPolicy('web_search', {}, {}, true), 'allow')
+})
+
+test('resolveToolPolicy: autoAllowAll promotes an explicit global "ask" to "allow"', () => {
+  assert.equal(resolveToolPolicy('web_search', { web_search: 'ask' }, {}, true), 'allow')
+})
+
+test('resolveToolPolicy: autoAllowAll never overrides an explicit global "deny"', () => {
+  assert.equal(resolveToolPolicy('run_code', { run_code: 'deny' }, {}, true), 'deny')
+})
+
+test('resolveToolPolicy: autoAllowAll never overrides an explicit per-conversation "deny"', () => {
+  assert.equal(resolveToolPolicy('run_code', {}, { run_code: 'deny' }, true), 'deny')
+})
+
+test('resolveToolPolicy: autoAllowAll is a no-op when the resolved policy is already "allow"', () => {
+  assert.equal(resolveToolPolicy('fetch_url', { fetch_url: 'allow' }, {}, true), 'allow')
+})
+
+test('resolveToolPolicy: per-conversation override still wins over the global policy, autoAllowAll off', () => {
+  assert.equal(resolveToolPolicy('run_code', { run_code: 'deny' }, { run_code: 'allow' }), 'allow')
+})

--- a/turbollm/src/tools/tool-policy.ts
+++ b/turbollm/src/tools/tool-policy.ts
@@ -6,13 +6,18 @@
 export type ToolPolicy = 'ask' | 'allow' | 'deny'
 
 /** Per-conversation override wins over the global default; falling through to 'ask'
- *  when neither is set (safe-by-default: a brand-new/unclassified tool always prompts). */
+ *  when neither is set (safe-by-default: a brand-new/unclassified tool always prompts).
+ *  `autoAllowAll` (Settings → Tool permissions master toggle) only silences a resolved
+ *  'ask' — it never overrides an explicit 'deny' (global or per-conversation), which
+ *  stays a deliberate decision the user already made. */
 export function resolveToolPolicy(
   name: string,
   globalPolicies: Record<string, ToolPolicy>,
   convOverrides: Record<string, 'allow' | 'deny'>,
+  autoAllowAll = false,
 ): ToolPolicy {
   if (convOverrides[name]) return convOverrides[name]
-  if (globalPolicies[name]) return globalPolicies[name]
-  return 'ask'
+  const global = globalPolicies[name]
+  if (global) return global === 'ask' && autoAllowAll ? 'allow' : global
+  return autoAllowAll ? 'allow' : 'ask'
 }

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -586,6 +586,10 @@ export type DaemonSettings = {
   /** Tool-call approval gate (F-025): per-tool default policy. Missing tools default
    *  to 'ask'. Keyed by tool name (e.g. 'run_code', 'mcp__server__tool'). */
   toolPolicies: Record<string, ToolPolicy>
+  /** Master toggle (Settings → Tool permissions), default off: when true, every tool
+   *  call that would show an "awaiting approval" prompt runs immediately instead.
+   *  Only silences a resolved 'ask' — an explicit 'deny' is still honored. */
+  autoAllowAll: boolean
   /** Cloud Launch deploy-link settings (ADR-153). The RunPod Template ID the user
    *  published themselves — not a secret, just an id, echoed back as-is. */
   cloudDeploy: { runpodTemplateId: string }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -83,12 +83,13 @@ const TURBOLLM_KNOWLEDGE =
   '**Usage** (BarChart3 icon in nav, between Customize and Developer): a token-usage dashboard sourced from message-level stats already persisted per turn — no separate opt-in.\n' +
   '- **Overview tab**: 8 stat tiles (sessions, messages, total tokens, active days, current/longest streak, peak hour, favorite model — all range-scoped except streaks/favorite/milestone, which are lifetime), a milestone bar (lifetime tokens vs. the next round-number milestone, plus a rotating "you\'ve generated more tokens than X" comparison), and an adaptive activity heatmap: 1-hour boxes for the 7-day range, 12-hour for 30-day, 1-day (classic GitHub-style) for all-time — always rendered at a constant overall size regardless of range.\n' +
   '- **Models tab**: a stacked daily bar chart plus a ranked legend (input/output split, % of total, "Show N more" past the top 6).\n' +
+  '- **API tab**: tokens hitting the OpenAI/Anthropic-compatible gateway (`/v1/*`) from EXTERNAL tools — Claude Code, other CLIs/extensions — tracked separately from in-app chat above (gateway requests create no conversation, so they never appeared in Overview/Models before this). Requests/tokens split by source (Claude Code / Anthropic-protocol vs. OpenAI-compatible) and by model.\n' +
   '- Range control (7d / 30d / all) at the top switches every stat and the heatmap together.\n\n' +
 
   '**Settings** — a two-pane layout, six categories in the left rail, one sticky Save bar:\n' +
   '- **General**: theme (light/dark/system), enable-thinking-by-default, confirm-before-delete, personalization (assistant name / your name), **Memory** — its toggle now lives in Experimental (see below); when on, the reviewable/deletable fact list still shows here, auto-generate chat titles, open browser on start.\n' +
   '- **Models & loading**: idle timeout (auto-stop after N minutes), default context length, Gateway (auto model-swap + Keep-N pool, 1–4 models), model folders, Hugging Face token, and an **Advanced** collapsible for expert knobs — default GPU layers, VRAM headroom (300 MB–2 GB, default 1 GB, or drag to 0 to opt into MoE auto-tune\'s "VRAM-spill" search — see Auto-Tune below), and image/response token caps.\n' +
-  '- **Tools & safety**: per-tool Ask/Allow/Deny defaults for every tool the model can call (web_search, fetch_url, run_code, MCP tools).\n' +
+  '- **Tools & safety**: per-tool Ask/Allow/Deny defaults for every tool the model can call (web_search, fetch_url, run_code, MCP tools), plus an **Auto-allow all** master toggle (default off) that skips the approval prompt for anything set to Ask — a tool explicitly set to Deny still stays blocked either way.\n' +
   '- **Network & sharing**: LAN exposure (bind to 0.0.0.0 vs loopback-only), port, require-API-key auth, and ComfyUI integration (URL, Reverse GPU gate, update banner).\n' +
   '- **Experimental**: still-in-progress features, off by default — a single on/off row each for **Memory** (silently extracts durable facts from chat using the loaded model; its own settings stay in General, unlocked once this is on), **Code** (the Workspace → Code tab; disabling this removes the tab entirely, not just its content), and **Cloud Launch/RunPod** (earliest-stage of the three — turning it on doesn\'t yet unlock a built UI).\n' +
   '- **System**: hardware panel, telemetry (Off / Anonymous / Full), About (current version, update-available chip, copy install command).\n\n' +
@@ -139,8 +140,8 @@ const TURBOLLM_KNOWLEDGE =
   '**MoE models only**:\n' +
   '- `nCpuMoe` (CPU MoE expert count): number of MoE router experts kept on CPU. Reducing it frees GPU VRAM (moves more routing to GPU). Auto-tune searches this for MoE models. An **Auto-fit MoE CPU offload** toggle (off by default) hands this to llama.cpp\'s own fit logic instead — a finer-grained per-tensor strategy than the fixed count — and Auto-tune skips its own search when it\'s on.\n\n' +
   '**KV Cache**:\n' +
-  '- `kvTypeK` / `kvTypeV`: KV cache quantization. `f16` = best quality, most VRAM. `q8_0` = good quality, ~2× smaller. `q4_0` / `q4_1` = smaller, lower quality. `turbo4` = TurboQuant-specific, high-speed specialized quant. Auto-tune picks automatically.\n' +
-  '- `flashAttn`: Flash Attention 2 — reduces KV memory footprint especially at large ctx. Strongly recommended when ctx > 32k.\n\n' +
+  '- `kvTypeK` / `kvTypeV`: KV cache quantization, set INDEPENDENTLY (two separate selects — e.g. keep K at f16 while quantizing V). `f16` = best quality, most VRAM. `q8_0` = good quality, ~2× smaller. `q4_0` / `q4_1` = smaller, lower quality. `turbo4` = TurboQuant-specific, high-speed specialized quant. Auto-tune does NOT pick the KV type — it tunes offload on whatever type you already have selected (a slow result gets a non-switching advisory naming a faster alternative instead).\n' +
+  '- `flashAttn`: Flash Attention 2 — reduces KV memory footprint especially at large ctx. Strongly recommended when ctx > 32k, and REQUIRED if V is quantized (llama.cpp refuses a quantized V cache with flash attention off).\n\n' +
   '**Parallelism & speculative**:\n' +
   '- `parallel`: concurrent request slots (default 1). Increase for gateway multi-client use.\n' +
   '- Speculative decoding (`speculative`: off / mtp / nextn / draft): `mtp` uses a separate Gemma-style MTP head (`mtpHeadPath`); `nextn` self-speculates off the model\'s own built-in NextN head (Qwen3-family, free — no extra file); `draft` uses a separate small draft GGUF (`draftModelPath`). All three modes honor configurable `draftMax`/`draftMin` (tokens drafted per step, default 16/1) — the draft-window fields apply to whichever speculative mode is active, not just `draft`. A well-matched draft/main pair can 2–4× throughput.\n\n' +
@@ -159,7 +160,10 @@ const TURBOLLM_KNOWLEDGE =
   '**Advanced**:\n' +
   '- `grammar` (GBNF): constrain generation to a format (JSON schema, structured output).\n' +
   '- `ropeScalingType` / `ropeFreqBase` / `ropeFreqScale`: RoPE context extension for models that support it (e.g. YaRN).\n' +
-  '- Multi-GPU (shown only when >1 GPU detected): `splitMode` (row / layer), `tensorSplit` (fraction array), `mainGpu` (output GPU index).\n\n' +
+  '- Multi-GPU (shown only when >1 GPU detected): `splitMode` (row / layer), `tensorSplit` (fraction array), `mainGpu` (output GPU index).\n' +
+  '- `port`: pin this model\'s engine to a specific port instead of auto-assigning the first free one (8081+). Falls back to auto if the pinned port is already taken. Distinct from the main daemon port (6996).\n' +
+  '- `extraArgs`: free-text custom/raw command-line flags, appended to the launch command last so they can override anything above. For llama.cpp/vLLM engines.\n' +
+  '- **Copy launch command**: once a model is loaded, its exact spawned command is copyable from the model config panel — runs the same model+config standalone with llama.cpp/the fork directly, no TurboLLM needed (`--no-webui` is stripped from the copy since TurboLLM\'s own reason for it — running its own frontend instead — doesn\'t apply standalone).\n\n' +
   '**MLX note**: context and KV parameters are hidden for MLX models — MLX sizes the KV cache dynamically. Only temperature, top-p, top-k, and min-p are available (the only flags mlx-lm.server supports).\n\n' +
 
   '## Engines\n\n' +

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -24,6 +24,9 @@ export type EngineRuntime = {
   error?: EngineError
   port?: number
   pid?: number
+  /** The exact command last spawned, formatted for copy-paste into a terminal.
+   *  Present only while this engine is the one actually running/starting. */
+  launchCommand?: string
 }
 
 /** Loaded model from GET /api/v1/status (null when none). */
@@ -555,6 +558,30 @@ export type TokenUsageStats = {
   activity: TokenActivity
   dailyByModel: DailyModelBreakdown[]
   byModel: ModelUsage[]
+  api: ApiUsageStats
+}
+
+/** Gateway (external-client) token usage — Claude Code, other CLIs/extensions hitting
+ *  /v1/messages or /v1/chat/completions — kept separate from the chat-scoped fields above
+ *  (GitHub #71; see db.ts's ApiUsageStats doc comment for why). */
+export type ApiUsageSource = 'anthropic' | 'openai'
+
+export type ApiModelUsage = {
+  modelKey: string
+  displayName: string
+  requests: number
+  promptTokens: number
+  genTokens: number
+  totalTokens: number
+}
+
+export type ApiUsageStats = {
+  range: TokenUsageRange
+  requests: number
+  totalTokens: number
+  lifetimeTotalTokens: number
+  bySource: { source: ApiUsageSource; requests: number; totalTokens: number }[]
+  byModel: ApiModelUsage[]
 }
 
 // ── Load profiles + VRAM fit (A4, spec 05) ───────────────────────────────────
@@ -578,6 +605,8 @@ export type LoadProfile = {
   /** Auto-fit for MoE CPU offload: when true, omit --n-cpu-moe and let -fit decide. */
   nCpuMoeFit?: boolean
   parallel: number
+  /** Pin this model's engine instance to a specific loopback port. 0/undefined = auto. */
+  port?: number
   kvUnified: boolean
   kvTypeK: string
   kvTypeV: string

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -562,8 +562,9 @@ export type TokenUsageStats = {
 }
 
 /** Gateway (external-client) token usage — Claude Code, other CLIs/extensions hitting
- *  /v1/messages or /v1/chat/completions — kept separate from the chat-scoped fields above
- *  (GitHub #71; see db.ts's ApiUsageStats doc comment for why). */
+ *  /v1/messages or /v1/chat/completions (GitHub #71). This isolated breakdown (by source, by
+ *  model) is separate, but TokenUsageStats.totalTokens/lifetimeTotalTokens/milestone already
+ *  INCLUDE it — see db.ts's ApiUsageStats doc comment for why. */
 export type ApiUsageSource = 'anthropic' | 'openai'
 
 export type ApiModelUsage = {

--- a/turbollm/web/src/lib/vram.ts
+++ b/turbollm/web/src/lib/vram.ts
@@ -60,9 +60,12 @@ export function estimateVram(
   const kvElems = 2 * blocks * p.ctx * (m.headCountKv || 8) * HEAD_DIM
   // KV cache only weighs on VRAM when offloaded to the GPU; in RAM mode (--no-kv-offload) it
   // costs no VRAM. Absent on pre-feature profiles → treated as the GPU default.
+  // kvElems is the COMBINED K+V count (×2, identical shape for both) — halved so an
+  // asymmetric quant (K=q8_0, V=q4_0) is weighted correctly instead of assuming V
+  // matches K's byte width (mirrors the same split in src/models/profile.ts).
   const kvMb = p.kvOffload === false
     ? 0
-    : ((kvElems * kvBytesPerElem(p.kvTypeK)) / 1e6) * (p.kvUnified ? 1 : Math.max(1, p.parallel))
+    : ((kvElems / 2) * (kvBytesPerElem(p.kvTypeK) + kvBytesPerElem(p.kvTypeV)) / 1e6) * (p.kvUnified ? 1 : Math.max(1, p.parallel))
   const mmprojMb = p.useMmproj && p.mmprojGpu && m.mmprojPath ? 600 : 0
   const estMb = Math.round(weightsMb + kvMb + 800 + mmprojMb)
   const pct = estMb / totalVramMb

--- a/turbollm/web/src/screens/TokensScreen.tsx
+++ b/turbollm/web/src/screens/TokensScreen.tsx
@@ -6,6 +6,7 @@ import { useTokenUsage } from '../lib/queries'
 import type { TokenUsageRange } from '../lib/types'
 import { ActivityHeatmap } from './tokens/ActivityHeatmap'
 import { ModelsTab } from './tokens/ModelsTab'
+import { ApiUsageTab } from './tokens/ApiUsageTab'
 
 function formatTokenCount(n: number): string {
   if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(n >= 10_000_000_000 ? 0 : 1)}B`
@@ -137,7 +138,7 @@ function Segmented<T extends string>({
  *  sourced entirely from message-level stats already persisted per turn. */
 export function TokensScreen() {
   const [range, setRange] = useState<TokenUsageRange>('all')
-  const [tab, setTab] = useState<'overview' | 'models'>('overview')
+  const [tab, setTab] = useState<'overview' | 'models' | 'api'>('overview')
   const { data, isLoading, isError, refetch } = useTokenUsage(range)
 
   // Lifetime-driven, not range-scoped, and re-rolled only when the underlying lifetime
@@ -147,7 +148,9 @@ export function TokensScreen() {
     () => (lifetimeTotalTokens > 0 ? pickFunFact(lifetimeTotalTokens) : null),
     [lifetimeTotalTokens],
   )
-  const isEmpty = data?.firstMessageAt === null
+  // A user with zero in-app chats but real gateway (Claude Code / extension) traffic
+  // still has something to show — only the true both-empty case gets the empty state.
+  const isEmpty = data?.firstMessageAt === null && (data?.api.requests ?? 0) === 0
 
   return (
     <div className="w-full px-4 py-6 md:px-6">
@@ -176,7 +179,11 @@ export function TokensScreen() {
             <Segmented
               value={tab}
               onChange={setTab}
-              options={[{ value: 'overview', label: 'Overview' }, { value: 'models', label: 'Models' }]}
+              options={[
+                { value: 'overview', label: 'Overview' },
+                { value: 'models', label: 'Models' },
+                { value: 'api', label: 'API' },
+              ]}
             />
             <Segmented
               value={range}
@@ -215,6 +222,8 @@ export function TokensScreen() {
           {tab === 'models' && (
             <ModelsTab models={data.byModel} dailyByModel={data.dailyByModel} totalTokens={data.totalTokens} />
           )}
+
+          {tab === 'api' && <ApiUsageTab api={data.api} />}
         </div>
       )}
     </div>

--- a/turbollm/web/src/screens/TokensScreen.tsx
+++ b/turbollm/web/src/screens/TokensScreen.tsx
@@ -220,7 +220,7 @@ export function TokensScreen() {
           )}
 
           {tab === 'models' && (
-            <ModelsTab models={data.byModel} dailyByModel={data.dailyByModel} totalTokens={data.totalTokens} />
+            <ModelsTab models={data.byModel} dailyByModel={data.dailyByModel} />
           )}
 
           {tab === 'api' && <ApiUsageTab api={data.api} />}

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -6,6 +6,7 @@ import type { CardSampling, LoadProfile, SysGpu } from '../../lib/types'
 import { defaultGpu, defaultVllm } from '../../lib/types'
 import { estimateVram, gpuBudgetMb } from '../../lib/vram'
 import { Button } from '../../components/ui/button'
+import { CopyButton } from '../../components/ui/copy-button'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../../components/ui/sheet'
 import {
   AlertDialog,
@@ -391,12 +392,21 @@ export function ModelDetailDialog({
               <Row label="Parallel slots">
                 <NumberInput value={draft.parallel} min={1} max={16} onChange={(v) => set('parallel', v)} />
               </Row>
-              <Row label="KV cache type" hint="turbo* are TurboQuant-fork exclusive.">
-                <Select value={draft.kvTypeK} options={kvTypes} onChange={(v) => setDraft((d) => (d ? { ...d, kvTypeK: v, kvTypeV: v } : d))} />
+              <Row label="K cache type" hint="turbo* are TurboQuant-fork exclusive.">
+                <Select value={draft.kvTypeK} options={kvTypes} onChange={(v) => set('kvTypeK', v)} />
+              </Row>
+              <Row label="V cache type" hint="A quantized V cache needs Flash attention on (llama.cpp requirement).">
+                <Select value={draft.kvTypeV} options={kvTypes} onChange={(v) => set('kvTypeV', v)} />
               </Row>
               <Row label="Flash attention">
                 <Segmented value={draft.flashAttn} options={['auto', 'on', 'off']} onChange={(v) => set('flashAttn', v as LoadProfile['flashAttn'])} />
               </Row>
+              {draft.kvTypeV !== 'f16' && draft.flashAttn === 'off' && (
+                <p className="text-[11px]" style={{ color: 'var(--warn)' }}>
+                  V cache is quantized but Flash attention is off — llama.cpp requires Flash attention for
+                  a quantized V cache and may refuse to load. Set Flash attention to Auto or On.
+                </p>
+              )}
               <Row label="KV cache" hint="VRAM is fastest; RAM frees VRAM for bigger models.">
                 <Segmented
                   value={draft.kvOffload === false ? 'RAM' : 'GPU'}
@@ -435,9 +445,10 @@ export function ModelDetailDialog({
               <Row label="Stop strings" hint="Halt generation when any of these sequences is produced.">
                 <div className="w-full" />
               </Row>
-              <StopStringInput
+              <ChipListInput
                 value={draft.sampling.stop}
                 onChange={(v) => setDraft((d) => d ? { ...d, sampling: { ...d.sampling, stop: v } } : d)}
+                emptyPlaceholder="Type a stop string, press Enter"
               />
               </>)}
             </Section>
@@ -514,6 +525,14 @@ export function ModelDetailDialog({
                 />
                 {detail.vision && <Toggle label="Vision encoder on GPU" value={draft.mmprojGpu} onChange={(v) => set('mmprojGpu', v)} />}
                 {draft.parallel > 1 && <Toggle label="Unified KV across slots" value={draft.kvUnified} onChange={(v) => set('kvUnified', v)} />}
+                <Row label="Engine port" hint="Pin this model's engine to a specific port instead of auto-assigning the first free one (8081+). Falls back to auto if taken.">
+                  <DefaultableNumberInput value={draft.port || undefined} placeholder="auto" min={1024} max={65535} onChange={(v) => set('port', v)} />
+                </Row>
+                {detail.loaded && statusQ.data?.engine.launchCommand && (
+                  <Row label="Launch command" hint="The exact command TurboLLM spawned this model with.">
+                    <CopyButton text={statusQ.data.engine.launchCommand} label="Copy" size={14} />
+                  </Row>
+                )}
                 <Row label="RoPE scaling" hint="Extend context beyond the model's trained limit. 'none' = model native.">
                   <Segmented
                     value={draft.ropeScalingType}
@@ -534,6 +553,22 @@ export function ModelDetailDialog({
               </Section>
             )}
             </>)}
+
+            {(isLlamaCpp || isVllm) && (
+              <>
+                <SectionTitle>Custom flags</SectionTitle>
+                <Section>
+                  <Row label="Extra command-line flags" hint="Appended to the launch command last, so they can override anything above. e.g. --something value">
+                    <div className="w-full" />
+                  </Row>
+                  <ChipListInput
+                    value={draft.extraArgs}
+                    onChange={(v) => set('extraArgs', v)}
+                    emptyPlaceholder="Type a flag, press Enter"
+                  />
+                </Section>
+              </>
+            )}
 
             {loadError && <p className="text-[12px]" style={{ color: 'var(--err)' }}>{loadError}</p>}
 
@@ -1093,7 +1128,11 @@ function PathField({ label, hint, value, placeholder, onChange }: {
   )
 }
 
-function StopStringInput({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {
+/** Generic chip-list text input: type, press Enter (or blur), get a removable chip.
+ *  Used for stop strings and for custom/raw engine flags (extraArgs) — same shape. */
+function ChipListInput({ value, onChange, placeholder = 'Add another…', emptyPlaceholder }: {
+  value: string[]; onChange: (v: string[]) => void; placeholder?: string; emptyPlaceholder: string
+}) {
   const [input, setInput] = useState('')
   const add = (s: string) => {
     const t = s.trim()
@@ -1115,7 +1154,7 @@ function StopStringInput({ value, onChange }: { value: string[]; onChange: (v: s
       <input
         type="text"
         value={input}
-        placeholder={value.length ? 'Add another…' : 'Type a stop string, press Enter'}
+        placeholder={value.length ? placeholder : emptyPlaceholder}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') { e.preventDefault(); add(input) }

--- a/turbollm/web/src/screens/settings/ToolPermissionsSection.tsx
+++ b/turbollm/web/src/screens/settings/ToolPermissionsSection.tsx
@@ -6,6 +6,7 @@ import { ApiError, type ToolPolicy } from '../../lib/api'
 import { fetchAvailableTools } from '../../lib/chat-api'
 import { friendlyName } from '../../lib/tool-explain'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
+import { Switch } from '../../components/ui/switch'
 import { toast } from '../../components/ui/sonner'
 import { cn } from '../../lib/utils'
 
@@ -23,10 +24,18 @@ export function ToolPermissionsSection() {
   const { query: settingsQ, save } = useSettings()
   const tools = toolsQ.data ?? []
   const policies = settingsQ.data?.toolPolicies ?? {}
+  const autoAllowAll = settingsQ.data?.autoAllowAll ?? false
 
   const setPolicy = (name: string, value: ToolPolicy) => {
     save.mutate(
       { toolPolicies: { ...policies, [name]: value } },
+      { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update tool permission.') },
+    )
+  }
+
+  const setAutoAllowAll = (value: boolean) => {
+    save.mutate(
+      { autoAllowAll: value },
       { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update tool permission.') },
     )
   }
@@ -43,6 +52,16 @@ export function ToolPermissionsSection() {
           Control whether each tool the model can call runs automatically, is always blocked, or asks
           for your approval in chat each time.
         </p>
+
+        <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2.5">
+          <div className="min-w-0">
+            <div className="text-[13px] font-medium text-ink">Auto-allow all</div>
+            <div className="text-[11px] text-faint">
+              Skip the approval prompt for every tool set to Ask below. A tool set to Deny stays blocked.
+            </div>
+          </div>
+          <Switch checked={autoAllowAll} onCheckedChange={setAutoAllowAll} disabled={save.isPending} />
+        </div>
 
         {toolsQ.isLoading && <p className="text-[13px] text-faint">Loading tools…</p>}
         {!toolsQ.isLoading && tools.length === 0 && (

--- a/turbollm/web/src/screens/tokens/ApiUsageTab.tsx
+++ b/turbollm/web/src/screens/tokens/ApiUsageTab.tsx
@@ -1,0 +1,94 @@
+import type { ApiUsageStats } from '../../lib/types'
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(n >= 10_000_000_000 ? 0 : 1)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}K`
+  return n.toLocaleString()
+}
+
+/** Rank-based accent shade — same scheme as the Models tab, kept local since this tab's
+ *  model list is a separate ranking (API traffic only, not combined with chat). */
+function colorForRank(rank: number): string {
+  const intensity = Math.max(20, 85 - rank * 12)
+  return `color-mix(in srgb, var(--accent) ${intensity}%, var(--panel-2))`
+}
+
+const SOURCE_LABEL: Record<ApiUsageStats['bySource'][number]['source'], string> = {
+  anthropic: 'Claude Code / Anthropic-protocol clients',
+  openai: 'OpenAI-compatible clients',
+}
+
+/** Tokens from gateway (external-client) traffic — Claude Code, other CLIs/extensions
+ *  hitting /v1/messages or /v1/chat/completions — as opposed to in-app chat, which the
+ *  Overview/Models tabs already cover (GitHub #71). */
+export function ApiUsageTab({ api }: { api: ApiUsageStats }) {
+  if (api.requests === 0) {
+    return (
+      <p className="py-8 text-center text-[13px] text-faint">
+        No API or extension traffic in this range yet. This counts requests to TurboLLM's
+        OpenAI/Anthropic-compatible gateway from tools like Claude Code — not in-app chat.
+      </p>
+    )
+  }
+
+  const byModelTotal = api.byModel.reduce((sum, m) => sum + m.totalTokens, 0)
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <div className="rounded-lg border border-border bg-panel p-4">
+          <div className="text-[12px] text-muted">Requests</div>
+          <div className="mt-1 truncate text-[20px] font-semibold tracking-[-0.01em] text-ink tabular-nums">
+            {api.requests.toLocaleString()}
+          </div>
+        </div>
+        <div className="rounded-lg border border-border bg-panel p-4">
+          <div className="text-[12px] text-muted">Tokens in range</div>
+          <div className="mt-1 truncate text-[20px] font-semibold tracking-[-0.01em] text-ink tabular-nums">
+            {formatTokenCount(api.totalTokens)}
+          </div>
+        </div>
+        <div className="rounded-lg border border-border bg-panel p-4">
+          <div className="text-[12px] text-muted">Lifetime tokens</div>
+          <div className="mt-1 truncate text-[20px] font-semibold tracking-[-0.01em] text-ink tabular-nums">
+            {formatTokenCount(api.lifetimeTotalTokens)}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-panel p-4">
+        <div className="mb-3 text-[13px] font-medium text-ink">By source</div>
+        <div className="flex flex-col gap-1">
+          {api.bySource.map((s) => (
+            <div key={s.source} className="flex items-center gap-3 rounded-md px-2 py-2 text-[13px]">
+              <span className="min-w-0 flex-1 truncate text-ink">{SOURCE_LABEL[s.source]}</span>
+              <span className="shrink-0 tabular-nums text-muted">{s.requests.toLocaleString()} requests</span>
+              <span className="w-16 shrink-0 text-right tabular-nums text-faint">{formatTokenCount(s.totalTokens)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {api.byModel.length > 0 && (
+        <div className="rounded-lg border border-border bg-panel p-4">
+          <div className="mb-3 text-[13px] font-medium text-ink">By model</div>
+          <div className="flex flex-col gap-1">
+            {api.byModel.map((m, i) => (
+              <div key={m.modelKey} className="flex items-center gap-3 rounded-md px-2 py-2 text-[13px]">
+                <span className="h-2.5 w-2.5 shrink-0 rounded-sm" style={{ background: colorForRank(i) }} />
+                <span className="min-w-0 flex-1 truncate text-ink">{m.displayName}</span>
+                <span className="shrink-0 tabular-nums text-muted">
+                  {formatTokenCount(m.promptTokens)} in · {formatTokenCount(m.genTokens)} out
+                </span>
+                <span className="w-12 shrink-0 text-right tabular-nums text-faint">
+                  {byModelTotal > 0 ? `${((m.totalTokens / byModelTotal) * 100).toFixed(1)}%` : '—'}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/tokens/ModelsTab.tsx
+++ b/turbollm/web/src/screens/tokens/ModelsTab.tsx
@@ -19,16 +19,20 @@ function colorForRank(rank: number): string {
 }
 
 /** Per-model breakdown — stacked usage chart + a ranked legend with in/out split and
- *  share of total (Release 3, Models tab). */
+ *  share of total (Release 3, Models tab). This tab only ever lists CHAT models (API/gateway
+ *  usage has its own tab + models list) — the "% of total" baseline is this list's own sum,
+ *  not the page-level total, since that total is the combined chat+API figure (2026-07-22) and
+ *  would otherwise make percentages under-report by however much of overall usage was API. */
 export function ModelsTab({
-  models, dailyByModel, totalTokens,
-}: { models: ModelUsage[]; dailyByModel: DailyModelBreakdown[]; totalTokens: number }) {
+  models, dailyByModel,
+}: { models: ModelUsage[]; dailyByModel: DailyModelBreakdown[] }) {
   const [expanded, setExpanded] = useState(false)
 
   if (!models.length) {
     return <p className="py-8 text-center text-[13px] text-faint">No model usage in this range yet.</p>
   }
 
+  const totalTokens = models.reduce((sum, m) => sum + m.totalTokens, 0)
   const rankOf = new Map(models.map((m, i) => [m.modelKey, i]))
   const chartDays = dailyByModel.map((d) => ({
     date: d.date,


### PR DESCRIPTION
## Summary
- **API/extension token tracking (#71)** — new Usage → API tab tracking gateway traffic (Claude Code, other CLIs) separately from in-app chat; fixes two real gaps in gateway usage recording found while building it (non-streaming OpenAI requests recorded nothing; streaming requests omitted usage without `stream_options.include_usage`)
- **Auto-allow-all tools toggle** — Settings → Tools & safety switch to skip approval prompts, never overrides an explicit Deny
- **Model config panel batch** — custom/raw engine flags, per-model pinned port, independent K/V cache quant selects (with corrected VRAM math for asymmetric quants), copy exact (standalone-runnable) launch command
- **Security fix** — `/api/*` CORS tightened to an origin allowlist (was wildcard, letting any website read GPU/CPU/RAM via unauthenticated `/api/v1/sysinfo`); `/v1/*` gateway stays fully permissive
- **Bug fix** — mmproj vision-projector pairing no longer picks "the directory's largest file" for every model; now correlates by filename, falling back to closest-mtime

## Test plan
- [x] Backend + frontend `tsc --noEmit` clean
- [x] Full backend suite: 1094/1097 passing (3 pre-existing unrelated skips), including new tests for tool-policy, mmproj pairing, and asymmetric K/V VRAM math
- [x] Live-verified against the real daemon: real gateway calls (stream/non-stream, both protocols), real model loads with custom port/flags/K-V split, a real induced engine crash (error-surfacing), and the CORS allowlist against real cross-origin requests
- [x] Founder tested manually on port 6996 with real models