### PR TITLE
Release v1.8.4 — engine catalog additions + download resume fix

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,28 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.4] - 2026-07-22
+
+**Two new engine catalog entries, and downloads can now actually be resumed.**
+
+### Added
+- **Engine catalog: Prism and BeeLlama** — two llama.cpp forks, build-from-source (guided
+  walkthrough). Prism specializes in 1-2 bit ternary/Bonsai models; BeeLlama adds
+  variance-normalized KV-cache quantization (KVarN), a KV precision tail, and adaptive DFlash
+  speculative decoding.
+
+### Fixed
+- **Interrupted downloads can now be resumed.** A download interrupted mid-transfer (e.g. a daemon
+  restart) previously came back showing "Paused" with no way to continue it — Cancel was the only
+  option. A Resume action now picks up exactly where it left off, byte-for-byte.
+
+### Discord
+- Two new engines in the catalog: **Prism** (great for 1-2 bit ternary models) and **BeeLlama**
+  (better KV-cache compression + speculative decoding). Both build from source with a guided
+  walkthrough — no manual setup.
+- Fixed a real annoyance: an interrupted download used to be stuck forever with no way to continue
+  it. Now it just resumes.
+
 ## [1.8.3] - 2026-07-22
 
 **API token tracking, tool/model config batch, and two real bug fixes (mmproj pairing, an

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1997,6 +1997,12 @@ export function registerApi(app: Hono, d: Deps): void {
     return c.json({ ok: true })
   })
 
+  app.post('/api/v1/downloads/:id/resume', (c) => {
+    const ok = d.downloads.resume(c.req.param('id'))
+    if (!ok) return err(c, 404, 'no_such_download', 'No paused or errored download with that id.')
+    return c.json({ ok: true })
+  })
+
   app.delete('/api/v1/downloads/:id', (c) => {
     const ok = d.downloads.remove(c.req.param('id'))
     if (!ok) return err(c, 404, 'no_such_download', 'No download with that id.')

--- a/turbollm/src/downloads/downloads.resume.test.ts
+++ b/turbollm/src/downloads/downloads.resume.test.ts
@@ -1,0 +1,128 @@
+// Tests for DownloadManager.resume (spec 10 §5): a job interrupted by a daemon
+// restart comes back from restore() as 'paused' with the .part file's real byte
+// offset — resume() is the only way to get it moving again (there is no
+// auto-resume; pump() only starts 'queued' jobs). Regression coverage for a real
+// bug: this trigger didn't exist at all before, so a restart-interrupted download
+// had no way back — the UI only offered Cancel.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DownloadManager } from './downloads'
+
+function fakeStore(modelDir: string, stateDir: string) {
+  return {
+    dir: () => stateDir,
+    snapshot: () => ({ primaryModelDir: modelDir, modelDirs: [modelDir] }),
+  } as unknown as ConstructorParameters<typeof DownloadManager>[0]
+}
+
+function newDirs() {
+  const root = mkdtempSync(join(tmpdir(), 'tllm-dl-resume-'))
+  const modelDir = join(root, 'models')
+  const stateDir = join(root, 'state')
+  mkdirSync(modelDir, { recursive: true })
+  mkdirSync(join(stateDir, 'downloads'), { recursive: true })
+  return { modelDir, stateDir }
+}
+
+/** Never-resolving fetch — freezes run() right after it flips status to
+ *  'downloading', so the test can observe the transition without real network I/O
+ *  or an OS handle left open after the process exits. */
+function stubFetch(): () => void {
+  const real = globalThis.fetch
+  globalThis.fetch = (() => new Promise(() => {})) as unknown as typeof fetch
+  return () => {
+    globalThis.fetch = real
+  }
+}
+
+/** Seed a manifest + partial file exactly as a real interrupted download leaves
+ *  them on disk, then construct a DownloadManager over that state dir — exercising
+ *  the real restore() path, not a hand-built record. */
+function seedInterruptedDownload(modelDir: string, stateDir: string) {
+  const dest = join(modelDir, 'model.gguf')
+  writeFileSync(`${dest}.part`, Buffer.alloc(1024, 1))
+  writeFileSync(
+    join(stateDir, 'downloads', 'manifest.json'),
+    JSON.stringify({
+      version: 1,
+      entries: [
+        {
+          id: 'dl-restored-1',
+          name: 'model.gguf',
+          repo: 'owner/repo',
+          url: 'https://huggingface.co/owner/repo/resolve/main/model.gguf',
+          dest,
+          total: 4096,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    }),
+  )
+  return dest
+}
+
+test('resume: a restart-restored (paused) job flips to downloading and picks up from the .part offset', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    seedInterruptedDownload(modelDir, stateDir)
+
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}))
+    const restored = dm.list().find((r) => r.id === 'dl-restored-1')
+    assert.ok(restored, 'the interrupted job should be restored from the manifest')
+    assert.equal(restored!.status, 'paused', 'restore() never auto-resumes — it comes back paused')
+    assert.equal(restored!.received, 1024, 'received bytes reflect the real .part file size on disk')
+
+    const ok = dm.resume('dl-restored-1')
+    assert.equal(ok, true)
+    const after = dm.list().find((r) => r.id === 'dl-restored-1')
+    assert.equal(after!.status, 'downloading', 'resume() re-queues and pump() starts it immediately')
+  } finally {
+    restore()
+  }
+})
+
+test('resume: an errored job can also be resumed (a network hiccup, not just a restart)', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), async () => ({
+      dir: '',
+      files: [{ rfilename: 'model.gguf', size: 10, mmproj: false }],
+    }))
+    const [rec] = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model.gguf' })
+    // Simulate a failed attempt without waiting on the frozen fetch.
+    const asAny = dm as unknown as { records: Map<string, { status: string; error: string | null }> }
+    asAny.records.get(rec.id)!.status = 'error'
+    asAny.records.get(rec.id)!.error = 'network blip'
+
+    const ok = dm.resume(rec.id)
+    assert.equal(ok, true)
+    const after = dm.list().find((r) => r.id === rec.id)
+    assert.equal(after!.status, 'downloading')
+    assert.equal(after!.error, null, 'resume clears the stale error message')
+  } finally {
+    restore()
+  }
+})
+
+test('resume: returns false for an unknown id, or one that is not paused/errored', async () => {
+  const restore = stubFetch()
+  try {
+    const { modelDir, stateDir } = newDirs()
+    const dm = new DownloadManager(fakeStore(modelDir, stateDir), () => {}, () => ({}), async () => ({
+      dir: '',
+      files: [{ rfilename: 'model.gguf', size: 10, mmproj: false }],
+    }))
+    assert.equal(dm.resume('does-not-exist'), false)
+
+    const [rec] = await dm.enqueue({ repo: 'owner/repo', rfilename: 'model.gguf' })
+    // Freshly enqueued -> already 'downloading' (frozen by the stub fetch) -> not resumable.
+    assert.equal(dm.resume(rec.id), false)
+  } finally {
+    restore()
+  }
+})

--- a/turbollm/src/downloads/downloads.ts
+++ b/turbollm/src/downloads/downloads.ts
@@ -296,6 +296,21 @@ export class DownloadManager {
     return true
   }
 
+  /** Resume a paused or errored job (spec 10 §5): re-queue it so pump() picks it back
+   *  up. run() already resumes from the .part file's byte offset via a Range request —
+   *  this just flips the status so the queue actually starts it again. A restart-
+   *  restored job comes back as 'paused' with no automatic way back to 'downloading'
+   *  until this is called. */
+  resume(id: string): boolean {
+    const rec = this.records.get(id)
+    if (!rec || (rec.status !== 'paused' && rec.status !== 'error')) return false
+    rec.status = 'queued'
+    rec.error = null
+    this.persist()
+    this.pump()
+    return true
+  }
+
   /** Remove a record entirely (and any lingering .part). */
   remove(id: string): boolean {
     const rec = this.records.get(id)

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -417,6 +417,85 @@ const ALL: CatalogEngine[] = [
       },
     ],
   },
+  {
+    id: 'prism',
+    name: 'Prism (llama.cpp fork)',
+    kind: 'llama-server',
+    description:
+      'A llama.cpp fork tuned for 1-2 bit ternary/Bonsai models. Ships llama-server but has no install endpoint here yet — build it, then add your own engine.',
+    provision: 'github-release',
+    homepage: 'https://github.com/PrismML-Eng/llama.cpp',
+    repo: 'PrismML-Eng/llama.cpp',
+    // The fork itself publishes extensive per-commit prebuilt archives (CUDA/Vulkan/ROCm ×
+    // win/linux/macOS, same naming convention as official llama.cpp) — but TurboLLM doesn't
+    // resolve them automatically (deliberately deferred, see ADR-238). Build-from-source only.
+    platforms: ['win32', 'darwin', 'linux'],
+    support: 'experimental',
+    installEndpoint: '',
+    note: 'Upstream publishes prebuilt binaries, but TurboLLM builds from source here (guided walkthrough) rather than resolving a specific release asset. Proven on a ternary/Bonsai-class model at 200K context (Q2_0 + q8 KV).',
+    variants: [
+      {
+        id: 'prism-source',
+        label: 'Build from source',
+        repo: 'PrismML-Eng/llama.cpp',
+        requires: {},
+        stability: 'experimental',
+        speed: 'fast',
+        hasPrebuilt: false,
+      },
+    ],
+  },
+  {
+    id: 'beellama',
+    name: 'BeeLlama.cpp',
+    kind: 'llama-server',
+    description:
+      'A llama.cpp fork adding variance-normalized KV-cache quantization (KVarN), a KV precision tail, and adaptive DFlash speculative decoding. Ships llama-server but has no install endpoint here yet — build it, then add your own engine.',
+    provision: 'github-release',
+    homepage: 'https://github.com/Anbeeld/beellama.cpp',
+    repo: 'Anbeeld/beellama.cpp',
+    // Also publishes a full prebuilt matrix (CUDA/ROCm/Vulkan/SYCL/CPU) in one normal
+    // release — but solo-maintainer, fast-churn fork (v0.4.0 dropped its own TurboQuant/TCQ
+    // support), so one-click install is deliberately deferred; build-from-source only.
+    platforms: ['win32', 'darwin', 'linux'],
+    support: 'experimental',
+    installEndpoint: '',
+    note: "Upstream publishes prebuilt binaries, but TurboLLM builds from source here. The KVarN cache types (kvarn2...kvarn8, set via --cache-type-k/-v) aren't in the auto-tune sweep yet — use the custom/raw flags field to set them manually.",
+    variants: [
+      {
+        id: 'beellama-source',
+        label: 'Build from source',
+        repo: 'Anbeeld/beellama.cpp',
+        requires: {},
+        stability: 'experimental',
+        speed: 'fast',
+        hasPrebuilt: false,
+      },
+    ],
+  },
+  {
+    id: 'croco',
+    name: 'Croco.Cpp',
+    kind: 'koboldcpp',
+    description:
+      "A KoboldCpp mod carrying ik_llama.cpp's SOTA IQ quants and extra KV-cache modes, mainly for NVIDIA/CUDA users.",
+    provision: 'github-release',
+    homepage: 'https://github.com/Nexesenex/croco.cpp',
+    repo: 'Nexesenex/croco.cpp',
+    // No macOS release asset published (Windows/Linux only).
+    platforms: ['win32', 'linux'],
+    support: 'experimental',
+    installEndpoint: '',
+    // Genuinely not installable here yet, on EITHER path: it's Python + PyInstaller-packaged
+    // like upstream KoboldCpp (confirmed via repo listing — koboldcpp.py + make_pyinstaller*
+    // scripts), not a plain CMake project, so the guided build-from-source flow
+    // (notCmakeProjectError, build-runner.ts) can't produce a working binary from it either.
+    // One-click install needs new provisioning code (a croco.ts mirroring koboldcpp.ts) plus
+    // empirical verification that its CLI flags match koboldcppProfileToArgs's — not yet done
+    // (ADR-238 deliberately deferred this rather than shipping a broken or unverified path).
+    comingSoon: true,
+    note: "Not yet one-click installable in TurboLLM — it needs new provisioning code (like KoboldCpp's), which hasn't been built. Not buildable from source here either (Python/PyInstaller-packaged, not a plain CMake project).",
+  },
 ]
 
 /** The catalog as seen on this platform: engines runnable here, plus a per-entry

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -12,8 +12,10 @@
 //   - 'builtin':        already provisioned by another path (the auto default).
 //
 // Honesty rule (project HARD RULE / ADR-012 ethos): an engine is only listed as
-// installable when a real provisioning path exists. Use `comingSoon: true` for
-// engines without a real release path yet; remove the flag once they publish one.
+// installable when a real provisioning path exists. If NEITHER build-from-source
+// NOR one-click install works yet, don't list it at all — a "coming soon, not
+// actually installable" entry reads as a red flag, not awareness (ADR-239). Add
+// the entry once a real path (either one) is built.
 
 import { type BackendId, availableBackends } from './download'
 import type { Arch } from './hardware'
@@ -472,29 +474,6 @@ const ALL: CatalogEngine[] = [
         hasPrebuilt: false,
       },
     ],
-  },
-  {
-    id: 'croco',
-    name: 'Croco.Cpp',
-    kind: 'koboldcpp',
-    description:
-      "A KoboldCpp mod carrying ik_llama.cpp's SOTA IQ quants and extra KV-cache modes, mainly for NVIDIA/CUDA users.",
-    provision: 'github-release',
-    homepage: 'https://github.com/Nexesenex/croco.cpp',
-    repo: 'Nexesenex/croco.cpp',
-    // No macOS release asset published (Windows/Linux only).
-    platforms: ['win32', 'linux'],
-    support: 'experimental',
-    installEndpoint: '',
-    // Genuinely not installable here yet, on EITHER path: it's Python + PyInstaller-packaged
-    // like upstream KoboldCpp (confirmed via repo listing — koboldcpp.py + make_pyinstaller*
-    // scripts), not a plain CMake project, so the guided build-from-source flow
-    // (notCmakeProjectError, build-runner.ts) can't produce a working binary from it either.
-    // One-click install needs new provisioning code (a croco.ts mirroring koboldcpp.ts) plus
-    // empirical verification that its CLI flags match koboldcppProfileToArgs's — not yet done
-    // (ADR-238 deliberately deferred this rather than shipping a broken or unverified path).
-    comingSoon: true,
-    note: "Not yet one-click installable in TurboLLM — it needs new provisioning code (like KoboldCpp's), which hasn't been built. Not buildable from source here either (Python/PyInstaller-packaged, not a plain CMake project).",
   },
 ]
 

--- a/turbollm/src/engines/recommend.test.ts
+++ b/turbollm/src/engines/recommend.test.ts
@@ -179,10 +179,6 @@ test('recommendEngines: every catalog engine is classified (none left unclassifi
   // reason about all four engines (compatible OR incompatible-with-reason).
   const rec = recommendEngines(nvidiaWin, fullCatalog())
   for (const fit of rec.fits) {
-    // comingSoon engines (e.g. croco) have no provisioning path yet, so there's no
-    // hardware fit to reason about — the UI special-cases them before ever consulting
-    // fit.compatible/variants (EnginesScreen.tsx's compatFor/EngineCard).
-    if (fit.engine.comingSoon) continue
     assert.ok(fit.variants.length > 0, `${fit.engine.id} should have variants to classify`)
     const classified = fit.compatible.length > 0 || fit.incompatibleReason !== undefined
     assert.ok(classified, `${fit.engine.id} must be either compatible or carry an incompatibleReason`)

--- a/turbollm/src/engines/recommend.test.ts
+++ b/turbollm/src/engines/recommend.test.ts
@@ -179,6 +179,10 @@ test('recommendEngines: every catalog engine is classified (none left unclassifi
   // reason about all four engines (compatible OR incompatible-with-reason).
   const rec = recommendEngines(nvidiaWin, fullCatalog())
   for (const fit of rec.fits) {
+    // comingSoon engines (e.g. croco) have no provisioning path yet, so there's no
+    // hardware fit to reason about — the UI special-cases them before ever consulting
+    // fit.compatible/variants (EnginesScreen.tsx's compatFor/EngineCard).
+    if (fit.engine.comingSoon) continue
     assert.ok(fit.variants.length > 0, `${fit.engine.id} should have variants to classify`)
     const classified = fit.compatible.length > 0 || fit.incompatibleReason !== undefined
     assert.ok(classified, `${fit.engine.id} must be either compatible or carry an incompatibleReason`)

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -815,6 +815,13 @@ export function removeDownload(id: string): Promise<{ ok: true }> {
   return request<{ ok: true }>(`/api/v1/downloads/${encodeURIComponent(id)}`, { method: 'DELETE' })
 }
 
+export function resumeDownload(id: string): Promise<{ ok: true }> {
+  return request<{ ok: true }>(`/api/v1/downloads/${encodeURIComponent(id)}/resume`, {
+    method: 'POST',
+    json: {},
+  })
+}
+
 // ── Chat (non-streaming gateway passthrough) ─────────────────────────────────
 export function chatCompletion(input: {
   model: string

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -49,6 +49,7 @@ const TURBOLLM_KNOWLEDGE =
   '- **Discover** tab: a live, sortable split-pane (list on the left, detail pane on the right, no dialog) browsing Hugging Face directly — filtered by active engine kind (GGUF for llama.cpp/TurboQuant, MLX tag for MLX, unrestricted for vLLM), sortable by trending / downloads / likes / recently updated / newest; the detail pane renders the actual model card (headings, images, links) and shows a per-quant VRAM-fit dot. Both panes are resizable.\n' +
   '- **Downloading a GGUF** places it in its own `<owner>/<repo>` folder (mirroring Hugging Face\'s layout) and automatically pulls its vision projector (mmproj) and every shard of a split/multipart quant into that same folder, so it always loads as one working model — no manual mmproj hunting or missing shards.\n' +
   '- **Import from URL** (link icon next to Discover\'s search box) accepts a direct `.gguf`/resolve link (any HTTPS host) for a one-off download, or a Hugging Face **model page** link, which opens that repo\'s quant picker instead of downloading directly (a repo has many quants — picking one there gets the same folder/mmproj/shard handling as browsing Discover).\n' +
+  '- **An interrupted download (e.g. a daemon restart) can be resumed** — it comes back showing "Paused" with a Resume button that continues from the exact byte it left off at, not a full restart. Cancel deletes the partial file instead.\n' +
   '- Click a model → **Model Detail** side panel: load profile config, VRAM estimate bar, auto-tune button, per-(model, engine) saved profile — switching the active engine saves/loads that engine\'s own tuning for the model, instead of sharing one profile across every installed engine. An untuned engine falls back to whichever engine\'s profile you saved most recently.\n' +
   '- **Load** button starts the model; progress indicator shows load time.\n' +
   '- **Multi-quant models** fold into one row with a quant dropdown (Size/Ctx/Speed/Load follow the selected quant), instead of one row per quant.\n' +
@@ -184,6 +185,10 @@ const TURBOLLM_KNOWLEDGE =
   'GGUF model bundled into a single self-contained executable. Very easy distribution. Launch flag is `--no-webui` (not `--nobrowser`). Full gateway passthrough verified.\n\n' +
   '**ik_llama.cpp** (Linux / macOS — GGUF):\n' +
   'Drop-in fork with additional quantization optimizations. No universal prebuilt — build from source, then register via "Add your own engine."\n\n' +
+  '**Prism** (Windows / Linux / macOS — GGUF):\n' +
+  'llama.cpp fork tuned for 1-2 bit ternary/Bonsai models. Build-from-source only (guided walkthrough) — no one-click install, even though upstream publishes prebuilts.\n\n' +
+  '**BeeLlama.cpp** (Windows / Linux / macOS — GGUF):\n' +
+  'llama.cpp fork adding variance-normalized KV-cache quantization (KVarN: `kvarn2`…`kvarn8`, set via `--cache-type-k`/`-v`), a KV precision tail, and adaptive DFlash speculative decoding. Build-from-source only. The KVarN types aren\'t in the auto-tune sweep yet — set them via the custom/raw flags field.\n\n' +
 
   '## Gateway\n\n' +
   'TurboLLM at `http://localhost:6996` exposes:\n' +

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -69,6 +69,7 @@ import {
   listEngines,
   loadModel,
   removeDownload,
+  resumeDownload,
   removeEngine,
   disableCustomEngine,
   removeModelDir,
@@ -737,6 +738,7 @@ export function useDownloadMutations() {
     }),
     cancel: useMutation({ mutationFn: (id: string) => cancelDownload(id), onSuccess: invalidate }),
     remove: useMutation({ mutationFn: (id: string) => removeDownload(id), onSuccess: invalidate }),
+    resume: useMutation({ mutationFn: (id: string) => resumeDownload(id), onSuccess: invalidate }),
   }
 }
 

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -10,12 +10,14 @@ import {
   Feather,
   Flame,
   Gauge,
+  Gem,
   Layers,
   Loader2,
   Minus,
   MoreHorizontal,
   Network,
   Package,
+  Puzzle,
   RefreshCw,
   Rocket,
   Server,
@@ -310,6 +312,39 @@ const ENGINE_META: Record<string, EngineMeta> = {
     ],
     cons: ['NVIDIA + Linux only (Docker)', 'TensorRT backend needs per-model builds', 'Heavyweight setup'],
   },
+  prism: {
+    icon: Gem,
+    tagline: '1-2 bit ternary specialist',
+    format: 'GGUF',
+    pros: [
+      'Purpose-built for 1-2 bit ternary/Bonsai models',
+      'Tracks upstream llama.cpp closely (per-commit builds)',
+      'Same llama-server API + GGUF flow',
+    ],
+    cons: ['Niche — most value only for ternary/BitNet-class models', 'No install endpoint yet — build from source', 'Small community'],
+  },
+  beellama: {
+    icon: Layers,
+    tagline: 'KV-cache precision at lower bits',
+    format: 'GGUF',
+    pros: [
+      'KVarN: independent K/V bit-widths, better quality-per-bit',
+      'KV precision tail keeps recent tokens exact, cheaply',
+      'Adaptive DFlash speculative decoding',
+    ],
+    cons: ['Solo maintainer, fast churn (v0.4.0 dropped TurboQuant/TCQ)', 'No install endpoint yet — build from source', 'KVarN types need the raw flags field, not auto-tune yet'],
+  },
+  croco: {
+    icon: Puzzle,
+    tagline: 'KoboldCpp + ik_llama quants',
+    format: 'GGUF',
+    pros: [
+      "Carries ik_llama.cpp's SOTA IQ quants into KoboldCpp",
+      'Wide KV-cache quant mode selection',
+      'Active fork, frequent point releases',
+    ],
+    cons: ['Not yet one-click installable in TurboLLM', 'Mainly NVIDIA/CUDA-tuned', 'No macOS build published'],
+  },
 }
 
 const FALLBACK_META: EngineMeta = { icon: Boxes, tagline: 'Inference engine', format: '', pros: [], cons: [] }
@@ -323,6 +358,9 @@ const COMPAT_COLOR: Record<CompatLevel, string> = { ok: 'var(--ok)', caution: 'v
 /** Green / amber / red hardware fit for a card: incompatible (red) · compatible but with
  *  no prebuilt so it must be built (amber) · ready to install/installed (green). */
 function compatFor(fit: EngineFit): { level: CompatLevel; label: string } {
+  if (fit.engine.comingSoon) {
+    return { level: 'caution', label: 'Not yet installable' }
+  }
   if (fit.compatible.length === 0) {
     return { level: 'none', label: fit.incompatibleReason ?? 'Not supported on your hardware' }
   }
@@ -1004,6 +1042,7 @@ function EngineCard({
   const sourceBuilt = !!catalog?.sourceBuilt
   const incompatible = fit.compatible.length === 0
   const buildYourself = !incompatible && fit.compatible.every((v) => !v.hasPrebuilt)
+  const comingSoon = !!catalog?.comingSoon
   const isInstalled = !!catalog?.installed
   const isEnabled = !!catalog?.enabled
   const isDisabled = isInstalled && !isEnabled
@@ -1160,6 +1199,10 @@ function EngineCard({
                 />
               )}
             </>
+          ) : comingSoon ? (
+            <span className="max-w-[240px] text-right text-[11px] text-muted" title={catalog?.note}>
+              {catalog?.note ?? 'Not yet installable in TurboLLM.'}
+            </span>
           ) : buildYourself ? (
             <>
               <Button

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -1110,6 +1110,13 @@ function EngineCard({
         </div>
       )}
 
+      {/* Extra context (Windows build caveats, "no prebuilts published", flag guidance, etc.)
+       *  — comingSoon engines show their note in the footer instead (it IS the primary
+       *  explanation there), so skip it here to avoid showing it twice. */}
+      {catalog?.note && !catalog.comingSoon && (
+        <p className="mt-3 text-[12px] leading-snug text-muted">{catalog.note}</p>
+      )}
+
       {/* Footer: docs link + primary action / manage */}
       <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3">
         {catalog ? (

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -1110,13 +1110,6 @@ function EngineCard({
         </div>
       )}
 
-      {/* Extra context (Windows build caveats, "no prebuilts published", flag guidance, etc.)
-       *  — comingSoon engines show their note in the footer instead (it IS the primary
-       *  explanation there), so skip it here to avoid showing it twice. */}
-      {catalog?.note && !catalog.comingSoon && (
-        <p className="mt-3 text-[12px] leading-snug text-muted">{catalog.note}</p>
-      )}
-
       {/* Footer: docs link + primary action / manage */}
       <div className="mt-3 flex items-center justify-between gap-2 border-t border-border pt-3">
         {catalog ? (

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -17,7 +17,6 @@ import {
   MoreHorizontal,
   Network,
   Package,
-  Puzzle,
   RefreshCw,
   Rocket,
   Server,
@@ -334,17 +333,6 @@ const ENGINE_META: Record<string, EngineMeta> = {
     ],
     cons: ['Solo maintainer, fast churn (v0.4.0 dropped TurboQuant/TCQ)', 'No install endpoint yet — build from source', 'KVarN types need the raw flags field, not auto-tune yet'],
   },
-  croco: {
-    icon: Puzzle,
-    tagline: 'KoboldCpp + ik_llama quants',
-    format: 'GGUF',
-    pros: [
-      "Carries ik_llama.cpp's SOTA IQ quants into KoboldCpp",
-      'Wide KV-cache quant mode selection',
-      'Active fork, frequent point releases',
-    ],
-    cons: ['Not yet one-click installable in TurboLLM', 'Mainly NVIDIA/CUDA-tuned', 'No macOS build published'],
-  },
 }
 
 const FALLBACK_META: EngineMeta = { icon: Boxes, tagline: 'Inference engine', format: '', pros: [], cons: [] }
@@ -358,9 +346,6 @@ const COMPAT_COLOR: Record<CompatLevel, string> = { ok: 'var(--ok)', caution: 'v
 /** Green / amber / red hardware fit for a card: incompatible (red) · compatible but with
  *  no prebuilt so it must be built (amber) · ready to install/installed (green). */
 function compatFor(fit: EngineFit): { level: CompatLevel; label: string } {
-  if (fit.engine.comingSoon) {
-    return { level: 'caution', label: 'Not yet installable' }
-  }
   if (fit.compatible.length === 0) {
     return { level: 'none', label: fit.incompatibleReason ?? 'Not supported on your hardware' }
   }
@@ -1042,7 +1027,6 @@ function EngineCard({
   const sourceBuilt = !!catalog?.sourceBuilt
   const incompatible = fit.compatible.length === 0
   const buildYourself = !incompatible && fit.compatible.every((v) => !v.hasPrebuilt)
-  const comingSoon = !!catalog?.comingSoon
   const isInstalled = !!catalog?.installed
   const isEnabled = !!catalog?.enabled
   const isDisabled = isInstalled && !isEnabled
@@ -1199,10 +1183,6 @@ function EngineCard({
                 />
               )}
             </>
-          ) : comingSoon ? (
-            <span className="max-w-[240px] text-right text-[11px] text-muted" title={catalog?.note}>
-              {catalog?.note ?? 'Not yet installable in TurboLLM.'}
-            </span>
           ) : buildYourself ? (
             <>
               <Button

--- a/turbollm/web/src/screens/models/DownloadsPanel.tsx
+++ b/turbollm/web/src/screens/models/DownloadsPanel.tsx
@@ -3,7 +3,7 @@
 // percent, speed, and a Cancel action. Completed rows show a "✓ added to library"
 // confirmation and can be removed. Renders nothing-but-empty-state when idle.
 
-import { CheckCircle2, Download, X } from 'lucide-react'
+import { CheckCircle2, Download, RotateCw, X } from 'lucide-react'
 import { useDownloads, useDownloadMutations } from '../../lib/queries'
 import type { DownloadRecord } from '../../lib/types'
 import { Button } from '../../components/ui/button'
@@ -35,7 +35,9 @@ export function DownloadsPanel() {
             d={d}
             onCancel={() => mut.cancel.mutate(d.id)}
             onRemove={() => mut.remove.mutate(d.id)}
+            onResume={() => mut.resume.mutate(d.id)}
             cancelling={mut.cancel.isPending}
+            resuming={mut.resume.isPending}
           />
         ))}
       </div>
@@ -47,18 +49,25 @@ function DownloadRow({
   d,
   onCancel,
   onRemove,
+  onResume,
   cancelling,
+  resuming,
 }: {
   d: DownloadRecord
   onCancel: () => void
   onRemove: () => void
+  onResume: () => void
   cancelling: boolean
+  resuming: boolean
 }) {
   const pct = d.total > 0 ? Math.min(100, Math.round((d.received / d.total) * 100)) : 0
   const inFlight = d.status === 'downloading' || d.status === 'queued' || d.status === 'paused'
   const isDone = d.status === 'done'
   const isError = d.status === 'error'
   const isCancelled = d.status === 'cancelled'
+  // paused (a restart-restored job) or errored (a network hiccup) both have a .part
+  // file on disk and can continue from that byte offset via Range — see resume().
+  const canResume = d.status === 'paused' || isError
 
   const barColor = isError ? 'var(--err)' : isDone ? 'var(--ok)' : 'var(--accent)'
 
@@ -74,6 +83,18 @@ function DownloadRow({
             <StatusLine d={d} pct={pct} />
           </div>
         </div>
+        {canResume && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onResume}
+            disabled={resuming}
+            title="Resume from where it left off"
+          >
+            <RotateCw size={13} />
+            Resume
+          </Button>
+        )}
         {inFlight && (
           <Button
             size="sm"


### PR DESCRIPTION
## Summary
- Engine catalog additions (Release 2a, ADR-235/238/239): **prism** and **beellama** added as build-from-source llama.cpp fork entries. Croco was investigated, added, then removed — no working install path either way, so it doesn't ship.
- Fixed a real bug (ADR-240): interrupted downloads had no way to resume — `restore()` correctly brought them back as `'paused'` with the right byte offset, but nothing ever flipped them back to `'queued'`. Added `DownloadManager.resume()`, the `/resume` API route, and a Resume button.

## Test plan
- [x] Backend typecheck clean
- [x] Frontend typecheck clean
- [x] Full backend suite: 1074/1074 passing (3 pre-existing skips)
- [x] Live-verified against the real daemon (port 6996): new catalog cards render correctly, croco's absence confirmed, download resume verified end-to-end on a real ~40GB interrupted download