### PR TITLE
Release v1.8.5 — gateway fetch guard fix

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,32 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.5] - 2026-07-23
+
+**Three gateway bugs fixed, all affecting the Claude Code / Anthropic-protocol integration
+(`turbollm launch claude`).**
+
+### Fixed
+- **The OpenAI-compatible `/v1/*` pass-through could return a bodyless 500.** A client
+  disconnecting at just the wrong moment (before its engine request was sent) left `fetch()` an
+  already-aborted signal, which throws immediately with no guard around it. Now caught and
+  returned as a structured error distinguishing a client disconnect from a real engine-unreachable
+  failure.
+- **Claude Code's extended-thinking budget was never forwarded to the local model.** With no
+  budget set, the model could spend its entire response budget on reasoning and never reach a
+  visible answer — the request succeeded, it just looked like silence. Now forwarded to the
+  engine (defaulting to a conservative share of the response budget when the client leaves it
+  unset), and bounded so an explicit budget can't do the same thing when a server-side response
+  cap is configured.
+- **A hook-injected context message could get silently misread as something the assistant had
+  already said**, which made the local model treat its turn as already finished and produce no
+  visible response at all — the real root cause of `turbollm launch claude` intermittently
+  producing nothing. Now mapped correctly.
+
+### Discord
+- Fixed a bug where `turbollm launch claude` could silently produce no response at all — no error, just silence.
+- Local models used with Claude Code now budget their reasoning properly instead of occasionally spending the whole response on thinking.
+
 ## [1.8.4] - 2026-07-22
 
 **Two new engine catalog entries, and downloads can now actually be resumed.**

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -92,6 +92,37 @@ test('mapToOpenAI leaves thinking_budget_tokens unset when thinking is enabled b
   assert.equal('thinking_budget_tokens' in oai, false)
 })
 
+// ── mapToOpenAI maps a `role:'system'` entry inside `messages` correctly ────
+// Regression coverage for a real bug (found + fully root-caused live 2026-07-23, via a
+// captured real Claude Code request): Claude Code injects hook context (e.g. a
+// SessionStart-hook block) as a `role:'system'` message directly inside `messages` —
+// not just via the top-level `system` field. The per-message loop below only branched
+// on `msg.role === 'user'`; anything else (including this system entry) fell into the
+// assistant branch and got hardcoded to `role: 'assistant'`. That made the model see a
+// conversation where the ASSISTANT had apparently already spoken (the hook-context
+// text), so it treated its turn as already finished and emitted an immediate
+// end-of-turn with zero content blocks — a real "no response" bug, not a timeout or
+// crash. Replaying the exact captured request (2 messages: a user turn, then this
+// system-role turn) against the fixed code produced a real thinking block + real text;
+// against the pre-fix code it produced output_tokens:1 and no content blocks at all.
+test('mapToOpenAI maps a mid-conversation role:"system" message to an OpenAI system message, not assistant', () => {
+  const oai = mapToOpenAI({
+    messages: [
+      { role: 'user', content: 'hi' },
+      { role: 'system', content: [{ type: 'text', text: 'SessionStart hook additional context: ...' }] },
+    ],
+    max_tokens: 100,
+  })
+  const msgs = oai.messages as Array<{ role: string; content?: unknown }>
+  const injected = msgs.find((m) => m.content === 'SessionStart hook additional context: ...')
+  assert.ok(injected, 'the system-role message must appear in the mapped messages')
+  assert.equal(injected!.role, 'system')
+  assert.ok(
+    !msgs.some((m) => m.role === 'assistant' && m.content === 'SessionStart hook additional context: ...'),
+    'must NOT be relabeled as an assistant message',
+  )
+})
+
 // ── streamToAnthropic live progress ─────────────────────────────────────────
 
 /** Build a ReadableStream of OpenAI-style SSE bytes from raw line strings. */

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -53,13 +53,35 @@ test('mapToOpenAI sets return_progress only for streaming requests', () => {
 // (the exact request above, replayed against the real daemon, produced visible text
 // after this fix; it produced nothing, twice in a row, before it).
 
-test('mapToOpenAI forwards an explicit thinking.budget_tokens exactly, unchanged', () => {
+test('mapToOpenAI forwards an explicit thinking.budget_tokens exactly, unchanged, when it fits within half of max_tokens', () => {
   const oai = mapToOpenAI({
     messages: [{ role: 'user', content: 'hi' }],
     max_tokens: 32000,
     thinking: { type: 'enabled', budget_tokens: 4096 },
   })
   assert.equal(oai.thinking_budget_tokens, 4096)
+})
+
+// Regression coverage for a real gap flagged by pre-release review (2026-07-23): a server-side
+// maxTokens cap clamps req.max_tokens in gateway.ts BEFORE mapToOpenAI runs, but a client's
+// explicit budget_tokens doesn't know about that cap. An explicit budget >= the (possibly
+// clamped) max_tokens could reintroduce the exact "no response" bug this file's other tests
+// guard against, just via the explicit-budget path instead of the no-budget default path.
+test('mapToOpenAI clamps an explicit thinking.budget_tokens that exceeds half of max_tokens', () => {
+  const oai = mapToOpenAI({
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 4096,
+    thinking: { type: 'enabled', budget_tokens: 24000 },
+  })
+  assert.equal(oai.thinking_budget_tokens, 2048)
+})
+
+test('mapToOpenAI forwards an explicit thinking.budget_tokens unclamped when max_tokens is absent', () => {
+  const oai = mapToOpenAI({
+    messages: [{ role: 'user', content: 'hi' }],
+    thinking: { type: 'enabled', budget_tokens: 24000 },
+  })
+  assert.equal(oai.thinking_budget_tokens, 24000)
 })
 
 test('mapToOpenAI leaves thinking_budget_tokens unset when the caller sends no thinking field at all', () => {

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -35,6 +35,63 @@ test('mapToOpenAI sets return_progress only for streaming requests', () => {
   assert.equal(nonStreamed.return_progress, undefined)
 })
 
+// ── mapToOpenAI forwards the extended-thinking budget ───────────────────────
+// Regression coverage for a real bug (found + fully root-caused live 2026-07-23):
+// mapToOpenAI never forwarded any thinking budget to thinking_budget_tokens (the
+// field the engine's sampler actually reads — see chat-routes.ts's runGeneration for
+// the same mechanism on the in-app chat path). With no budget forwarded, the local
+// model reasoned unconstrained and could exhaust the entire max_tokens response on
+// "thinking," leaving zero tokens for the actual answer — the request succeeds (200,
+// valid stream) but the user sees no response at all.
+//
+// Captured from a REAL Claude Code request via temporary daemon-side logging:
+// {"max_tokens":32000,"thinking":{"type":"adaptive","display":"omitted"},"stream":true}
+// — note there is no `budget_tokens` at all, and `type` is `"adaptive"`, not the
+// `"enabled"` this code originally (and wrongly) assumed was the only real shape.
+// An adaptive/budget-less thinking request gets a conservative default (half of
+// max_tokens) rather than being left unbounded — confirmed to fix the live repro
+// (the exact request above, replayed against the real daemon, produced visible text
+// after this fix; it produced nothing, twice in a row, before it).
+
+test('mapToOpenAI forwards an explicit thinking.budget_tokens exactly, unchanged', () => {
+  const oai = mapToOpenAI({
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 32000,
+    thinking: { type: 'enabled', budget_tokens: 4096 },
+  })
+  assert.equal(oai.thinking_budget_tokens, 4096)
+})
+
+test('mapToOpenAI leaves thinking_budget_tokens unset when the caller sends no thinking field at all', () => {
+  const oai = mapToOpenAI({ messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
+  assert.equal('thinking_budget_tokens' in oai, false)
+})
+
+test('mapToOpenAI defaults to half of max_tokens for adaptive thinking with no budget_tokens (the real Claude Code shape)', () => {
+  const oai = mapToOpenAI({
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 32000,
+    thinking: { type: 'adaptive', display: 'omitted' },
+  })
+  assert.equal(oai.thinking_budget_tokens, 16000)
+})
+
+test('mapToOpenAI defaults to half of max_tokens when thinking is enabled but budget_tokens is missing, zero, or negative', () => {
+  const missing = mapToOpenAI({ messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024, thinking: { type: 'enabled' } })
+  assert.equal(missing.thinking_budget_tokens, 512)
+
+  const zero = mapToOpenAI({ messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024, thinking: { type: 'enabled', budget_tokens: 0 } })
+  assert.equal(zero.thinking_budget_tokens, 512)
+
+  const negative = mapToOpenAI({ messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024, thinking: { type: 'enabled', budget_tokens: -5 } })
+  assert.equal(negative.thinking_budget_tokens, 512)
+})
+
+test('mapToOpenAI leaves thinking_budget_tokens unset when thinking is enabled but max_tokens is absent (nothing sane to default off of)', () => {
+  const oai = mapToOpenAI({ messages: [{ role: 'user', content: 'hi' }], thinking: { type: 'enabled' } })
+  assert.equal('thinking_budget_tokens' in oai, false)
+})
+
 // ── streamToAnthropic live progress ─────────────────────────────────────────
 
 /** Build a ReadableStream of OpenAI-style SSE bytes from raw line strings. */

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -9,7 +9,10 @@ type ABlock =
   | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }
   | { type: 'tool_use'; id: string; name: string; input: unknown }
   | { type: 'tool_result'; tool_use_id: string; content: string | Array<{ type: string; text?: string }> }
-type AMessage = { role: 'user' | 'assistant'; content: string | ABlock[] }
+// 'system' is undocumented but real: Claude Code injects hook context (e.g. SessionStart)
+// as a `role:'system'` entry directly into `messages`, not just via the top-level `system`
+// field — see mapToOpenAI's per-message role handling below.
+type AMessage = { role: 'user' | 'assistant' | 'system'; content: string | ABlock[] }
 
 export interface AnthropicRequest {
   model?: string
@@ -85,6 +88,20 @@ export function mapToOpenAI(req: AnthropicRequest): Record<string, unknown> {
             : parts
         messages.push({ role: 'user', content })
       }
+    } else if ((msg.role as string) === 'system') {
+      // Claude Code sometimes injects a `role: 'system'` entry directly into `messages`
+      // (e.g. a SessionStart-hook context block), separate from the top-level `system`
+      // field. Falling through to the assistant branch below relabeled this as something
+      // the ASSISTANT had already said — which made the model see a conversation that
+      // looked already finished, so it emitted an immediate end-of-turn with zero output
+      // (a real "no response" bug, confirmed via a live capture of an actual Claude Code
+      // request: a `role:'system'` message as messages[1], mis-mapped to `role:'assistant'`,
+      // reproduced a stream with output_tokens:1 and no content blocks at all).
+      const text = raw
+        .filter((b) => b.type === 'text')
+        .map((b) => (b as { text?: string }).text ?? '')
+        .join('\n')
+      if (text) messages.push({ role: 'system', content: text })
     } else {
       let text = ''
       const toolCalls: unknown[] = []

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -23,7 +23,11 @@ export interface AnthropicRequest {
   stream?: boolean
   tools?: Array<{ name: string; description?: string; input_schema: Record<string, unknown> }>
   tool_choice?: { type: 'auto' | 'any' | 'tool'; name?: string }
-  thinking?: { type: 'enabled'; budget_tokens?: number }
+  // 'enabled' with an explicit budget_tokens is the documented shape; 'adaptive' (no
+  // budget_tokens, plus a display field) is a real shape confirmed live from Claude
+  // Code (2026-07-23) — the type value isn't branched on below, only budget_tokens'
+  // presence/validity, so any thinking-enabled type string is accepted.
+  thinking?: { type: string; budget_tokens?: number; display?: string }
   metadata?: unknown
 }
 
@@ -134,6 +138,33 @@ export function mapToOpenAI(req: AnthropicRequest): Record<string, unknown> {
           : tc.type === 'any'
             ? 'required'
             : { type: 'function', function: { name: tc.name } }
+  }
+  // Forward the caller's extended-thinking budget to the field the engine's sampler
+  // actually reads (thinking_budget_tokens — mirrors chat-routes.ts's runGeneration).
+  // Without this, a client with thinking enabled got no budget at all — the local
+  // model reasoned unconstrained and could exhaust the entire max_tokens on thinking,
+  // leaving zero tokens for the actual answer (a real "no response" bug, not a timeout
+  // or crash — the request succeeds, it just never reaches visible text).
+  //
+  // Two real shapes seen in the wild, both must be handled:
+  //  - {type:'enabled', budget_tokens:N} — an explicit budget; honor it exactly.
+  //  - {type:'adaptive', ...} (Claude Code's actual request, confirmed live 2026-07-23:
+  //    max_tokens 32000, thinking:{type:'adaptive',display:'omitted'}, no budget_tokens
+  //    at all) — the client deliberately left the budget to the server/model. Real
+  //    Anthropic models cap their own adaptive reasoning sensibly; a local model has no
+  //    such built-in restraint, so leaving thinking_budget_tokens unset here reproduced
+  //    the exact bug (thinking consumed the entire 32000-token budget, twice in a row,
+  //    with zero tokens ever reaching visible text). Any thinking type with no usable
+  //    budget_tokens gets a conservative default: half of max_tokens, guaranteeing the
+  //    other half survives for the actual answer regardless of how verbose the model's
+  //    reasoning is.
+  if (req.thinking) {
+    const requested = req.thinking.budget_tokens
+    if (Number.isFinite(requested) && (requested ?? 0) > 0) {
+      oai.thinking_budget_tokens = requested
+    } else if (Number.isFinite(req.max_tokens) && (req.max_tokens ?? 0) > 0) {
+      oai.thinking_budget_tokens = Math.floor(req.max_tokens! / 2)
+    }
   }
   return oai
 }

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -177,9 +177,18 @@ export function mapToOpenAI(req: AnthropicRequest): Record<string, unknown> {
   //    reasoning is.
   if (req.thinking) {
     const requested = req.thinking.budget_tokens
+    const hasMaxTokens = Number.isFinite(req.max_tokens) && (req.max_tokens ?? 0) > 0
     if (Number.isFinite(requested) && (requested ?? 0) > 0) {
-      oai.thinking_budget_tokens = requested
-    } else if (Number.isFinite(req.max_tokens) && (req.max_tokens ?? 0) > 0) {
+      // `req.max_tokens` here already reflects the server-side maxTokens cap applied in
+      // gateway.ts (clampMaxTokens runs before mapToOpenAI) — but the caller's requested
+      // budget does not know about that cap. An explicit budget >= the (possibly-clamped)
+      // max_tokens can reintroduce this exact bug via the explicit-budget path: thinking
+      // consumes the whole capped response, leaving nothing for the actual answer. Bound
+      // it to the same half-of-max_tokens invariant the no-budget default already relies on.
+      oai.thinking_budget_tokens = hasMaxTokens
+        ? Math.min(requested!, Math.floor(req.max_tokens! / 2))
+        : requested
+    } else if (hasMaxTokens) {
       oai.thinking_budget_tokens = Math.floor(req.max_tokens! / 2)
     }
   }

--- a/turbollm/src/gateway/gateway.errors.test.ts
+++ b/turbollm/src/gateway/gateway.errors.test.ts
@@ -1,0 +1,77 @@
+// Regression coverage for a real bug: the /v1/* OpenAI pass-through's engine fetch
+// (gateway.ts) was unguarded — any throw (an unreachable engine, or fetch() rejecting
+// immediately because the client's abort signal was already fired) escaped straight to
+// Hono's default error handler: a bodyless 500 with no client-facing error envelope at
+// all. Found live (2026-07-23) via a real /v1/chat/completions failure from an external
+// tool while the Anthropic-protocol path and the engine itself both worked fine for the
+// same model. Fixed by wrapping the fetch, mirroring the /v1/messages handler's guard.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerGateway } from './gateway'
+import type { Deps } from '../deps'
+
+const LIBRARY = [{ key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' }]
+
+/** Minimal Deps double routing every request to `target` — a genuinely unreachable host
+ *  by default, so the real fetch() call throws for real (no network mocking needed). */
+function fakeDeps(target = 'http://engine.invalid.local:1'): Deps {
+  return {
+    scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
+    modelRouter: { route: async () => ({ target }) },
+    store: { snapshot: () => ({ modelDefaults: { maxTokens: 0 }, gateway: { autoSwap: false } }) },
+    manager: {
+      status: () => ({ state: 'stopped', model: null }),
+      target: () => target,
+      generationStart: () => {},
+      generationEnd: () => {},
+    },
+    registry: { active: () => ({ kind: 'llama.cpp' }) },
+  } as unknown as Deps
+}
+
+test('POST /v1/chat/completions returns a structured error, not a bodyless 500, when the engine fetch throws', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+
+  const res = await app.request('/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], stream: false }),
+  })
+
+  assert.equal(res.status, 500)
+  const body = (await res.json()) as { error?: { message: string; type: string; code: string } }
+  assert.ok(body.error, 'response must carry a structured error envelope, not an empty body')
+  assert.equal(body.error!.type, 'api_error')
+  assert.equal(body.error!.code, 'engine_unreachable')
+  assert.ok(body.error!.message.length > 0, 'message must not be empty')
+})
+
+test('POST /v1/chat/completions with an already-aborted client signal reports client_disconnected, not a crash', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+
+  const ac = new AbortController()
+  ac.abort() // simulate the client having already disconnected before the fetch fires
+
+  const res = await app.request('/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], stream: false }),
+    signal: ac.signal,
+  })
+
+  assert.equal(res.status, 500)
+  const body = (await res.json()) as { error?: { message: string; type: string; code: string } }
+  assert.ok(body.error, 'response must carry a structured error envelope, not an empty body')
+  assert.equal(body.error!.code, 'client_disconnected')
+})
+
+test('GET /v1/models is unaffected by the fetch guard (no engine call on this path)', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+
+  const res = await app.request('/v1/models', { method: 'GET' })
+  assert.equal(res.status, 200)
+})

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -272,7 +272,32 @@ export function registerGateway(app: Hono, d: Deps): void {
       }
     }
 
-    const res = await fetch(upstream, init)
+    // Unguarded before this fix: a throw here (e.g. the client disconnecting while the
+    // body was being parsed/routed above hands fetch an ALREADY-aborted signal, which
+    // throws immediately with no network I/O — clientAbort() fires ac.abort() synchronously
+    // when c.req.raw.signal.aborted is already true) escaped straight to Hono's default
+    // error handler: a bodyless 500 with no diagnostic, and no client-facing error envelope
+    // at all. Mirrors the /v1/messages handler's guard above.
+    let res: Response
+    try {
+      res = await fetch(upstream, init)
+    } catch (e) {
+      const err = e as Error & { cause?: unknown }
+      const isAbort = err.name === 'AbortError' || ac.signal.aborted
+      const cause = err.cause instanceof Error ? `: ${err.cause.message}` : ''
+      return c.json(
+        {
+          error: {
+            message: isAbort
+              ? 'Client disconnected before the engine responded.'
+              : `${err.message || 'Engine unreachable.'}${cause}`,
+            type: 'api_error',
+            code: isAbort ? 'client_disconnected' : 'engine_unreachable',
+          },
+        },
+        500,
+      )
+    }
 
     // Best-effort session-stats recording (B4) for OpenAI chat completions, fully
     // fail-safe and non-intrusive: tee the body so the client still gets the exact


### PR DESCRIPTION
## Summary

Three gateway bugs fixed for the local-model Claude Code integration (`turbollm launch claude`):

1. **OpenAI pass-through unguarded fetch** (ADR-241) — a client-abort race could throw an
   unguarded `fetch()` all the way to Hono's default handler, producing a bodyless 500.
2. **Extended-thinking budget never forwarded** (ADR-242) — `thinking_budget_tokens` wasn't
   forwarded to the engine, so a thinking-enabled request could exhaust the whole `max_tokens`
   budget on reasoning with nothing left for the answer.
3. **`role:'system'` message mis-mapped to `assistant`** (ADR-242) — the real root cause of the
   "no response" report. Claude Code injects hook context as a `role:'system'` entry inside
   `messages`; the gateway relabeled it as `assistant`, making the model think its own turn was
   already finished, so it emitted an immediate end-of-turn with zero content blocks.

Root-caused end-to-end via a live capture of a real Claude Code request (2 messages, 32 tools,
adaptive thinking) and confirmed fixed both via direct replay and through the actual `claude` CLI
binary against the real daemon.

## Test plan
- [x] Full backend suite (1110/1110), both typechecks clean
- [x] New regression tests: `gateway.errors.test.ts` (fetch guard), `anthropic.test.ts`
      (thinking-budget forwarding + system-role mapping)
- [x] Live-verified via `claude --print` against the real daemon: real thinking + text now
      returned for the exact request shape that previously produced nothing