### PR TITLE
v1.8.6 — Solar Open 2 engine (patch-verified build)

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,36 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.6] - 2026-07-24
+
+**New engine: Solar Open 2, via a checksum-verified patch build.**
+
+### Added
+- **Solar Open 2 (250B-A15B) engine catalog entry.** Its architecture isn't in mainline
+  llama.cpp yet — this builds official llama.cpp at a pinned commit with a community patch
+  applied, entirely through the existing "Build from source" 1-click flow. The patch is
+  downloaded and verified against a pinned SHA-256 before it's ever applied; a mismatch hard-fails
+  the build with no fallback.
+- The 1-click build pipeline gained a general `patchUrl`/`patchSha256` capability — reusable by
+  any future engine that needs a pre-compile patch, not specific to this one.
+
+### Fixed
+- **Building official llama.cpp from source could fail on Windows with "Filename too long."**
+  `core.longpaths` was never set, so any repo with deeply-nested paths (llama.cpp's own
+  `tools/ui` and `examples/llama.swiftui` included) broke the checkout. Not specific to any one
+  engine — this affected every Windows "Build from source" flow against the official repo.
+- **The Engines screen could misreport a catalog entry as already built.** The "is this already
+  installed" check matched any registered build of the same repository URL, ignoring which
+  commit/patch it was built from — so an existing plain llama.cpp build could make a
+  differently-pinned entry (like Solar Open 2) falsely show as installed, handing out a binary
+  that didn't actually have the needed support.
+
+### Discord
+- New engine: **Solar Open 2** (Upstage's 250B model) — 1-click build right from the Engines
+  screen, patch verified automatically before it's applied.
+- Fixed a Windows bug where building official llama.cpp from source could fail on repos with long
+  file paths.
+
 ## [1.8.5] - 2026-07-23
 
 **Three gateway bugs fixed, all affecting the Claude Code / Anthropic-protocol integration

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -516,7 +516,7 @@ export function registerApi(app: Hono, d: Deps): void {
       return err(c, 403, 'forbidden', 'Building an engine is only available on the machine running TurboLLM.')
     if (process.platform !== 'win32' && process.platform !== 'linux' && process.platform !== 'darwin')
       return err(c, 409, 'unsupported_platform', 'In-app build is currently Windows, Linux, or macOS only.')
-    const b = await body<{ repoUrl?: string; branch?: string; commit?: string; name?: string }>(c)
+    const b = await body<{ repoUrl?: string; branch?: string; commit?: string; name?: string; patchUrl?: string; patchSha256?: string }>(c)
     const repoUrl = (b.repoUrl ?? '').trim()
     if (!/^https?:\/\//i.test(repoUrl))
       return err(c, 400, 'invalid_config_value', 'A http(s) repo URL is required.')
@@ -528,6 +528,17 @@ export function registerApi(app: Hono, d: Deps): void {
     const commit = (b.commit ?? '').trim() || undefined
     if (commit && !/^[0-9a-f]{7,40}$/i.test(commit))
       return err(c, 400, 'invalid_config_value', 'commit must be a hex SHA (7-40 chars).')
+    // Optional pinned patch (solar_open2-class engines): both-or-neither — a patch is only ever
+    // applied with a checksum to verify it against (build-runner enforces this too; validate here
+    // so a bad request fails fast with a clear 400 instead of failing mid-build).
+    const patchUrl = (b.patchUrl ?? '').trim() || undefined
+    const patchSha256 = (b.patchSha256 ?? '').trim() || undefined
+    if (!!patchUrl !== !!patchSha256)
+      return err(c, 400, 'invalid_config_value', 'patchUrl and patchSha256 must be provided together — a patch may only be applied with a pinned checksum.')
+    if (patchUrl && !/^https?:\/\//i.test(patchUrl))
+      return err(c, 400, 'invalid_config_value', 'patchUrl must be an http(s) URL.')
+    if (patchSha256 && !/^[0-9a-f]{64}$/i.test(patchSha256))
+      return err(c, 400, 'invalid_config_value', 'patchSha256 must be a 64-char hex SHA-256.')
     const busy = engineWorkBusy(d)
     if (busy) return err(c, 409, 'engine_already_running', busy)
     const name = (b.name ?? '').trim() || undefined
@@ -544,7 +555,7 @@ export function registerApi(app: Hono, d: Deps): void {
         let out
         try {
           out = await runBuild(
-            { repoUrl, branch, commit, enginesRoot, toolchainDirs },
+            { repoUrl, branch, commit, patchUrl, patchSha256, enginesRoot, toolchainDirs },
             { phase: (p) => d.build.phase(p), log: (line) => d.build.log(line) },
             ac.signal,
           )
@@ -599,6 +610,7 @@ export function registerApi(app: Hono, d: Deps): void {
           sourceRepo: repoUrl,
           sourceBranch: branch,
           sourceCommit: commit,
+          sourcePatchUrl: patchUrl,
         })).engine
         d.registry.activate(eng.id)
         // A genuinely custom repo (not one of the catalog's own known projects) needs its
@@ -606,7 +618,7 @@ export function registerApi(app: Hono, d: Deps): void {
         // own doc comment. A catalog repo already gets equivalent treatment from the /catalog
         // endpoint's own disk scan, so it's deliberately excluded here.
         if (!isCatalogRepo(repoUrl)) {
-          d.registry.recordCustomSource({ name: eng.name, binPath: eng.binPath, kind: eng.kind, sourceRepo: repoUrl, sourceBranch: branch, sourceCommit: commit })
+          d.registry.recordCustomSource({ name: eng.name, binPath: eng.binPath, kind: eng.kind, sourceRepo: repoUrl, sourceBranch: branch, sourceCommit: commit, sourcePatchUrl: patchUrl })
         }
         d.build.log(`Registered "${eng.name}" — built from ${out.commit.slice(0, 8)}.`)
         d.build.done()
@@ -942,7 +954,7 @@ export function registerApi(app: Hono, d: Deps): void {
       if (recordSource && !purge && eng) {
         d.registry.recordCustomSource({
           name: eng.name, binPath: eng.binPath, kind: eng.kind,
-          sourceRepo: eng.sourceRepo, sourceBranch: eng.sourceBranch, sourceCommit: eng.sourceCommit,
+          sourceRepo: eng.sourceRepo, sourceBranch: eng.sourceBranch, sourceCommit: eng.sourceCommit, sourcePatchUrl: eng.sourcePatchUrl,
         })
       }
       d.registry.remove(id)

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -463,9 +463,20 @@ export function registerApi(app: Hono, d: Deps): void {
       // manage menu (rebuild/disable/delete) instead of a stale "Build from source". Also
       // detect a built-but-disabled engine (registry entry removed, build output still on disk)
       // so Enable can re-register it.
-      const srcEng = regEngines.find((x) => sameRepo(x.sourceRepo, e.homepage))
+      // A repo-only match isn't enough for a catalog entry that pins a commit/patch (e.g.
+      // solar-open2 vs. the plain llama.cpp entry — both build ggml-org/llama.cpp): without also
+      // requiring the SAME commit + patch, a plain unpatched llama.cpp build would falsely read
+      // as "solar-open2 already installed" and hand out a binary with no solar_open2 support at
+      // all. Entries with no commit/patch pin (sourceCommit/patchUrl both '') still match each
+      // other exactly as before.
+      const srcEng = regEngines.find(
+        (x) =>
+          sameRepo(x.sourceRepo, e.homepage) &&
+          (x.sourceCommit ?? '') === (e.sourceCommit ?? '') &&
+          (x.sourcePatchUrl ?? '') === (e.patchUrl ?? ''),
+      )
       let sourceBinPath: string | undefined = srcEng?.binPath
-      if (!srcEng) sourceBinPath = sourceBuildBinary(enginesRoot, e.homepage) ?? undefined
+      if (!srcEng) sourceBinPath = sourceBuildBinary(enginesRoot, e.homepage, undefined, e.sourceCommit) ?? undefined
       const sourceBuilt = !!srcEng || !!sourceBinPath
       if (srcEng) {
         installed = true

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -55,6 +55,10 @@ export interface Engine {
    *  treated as "the same engine, just rebuilt" as a plain branch-tip build of the same
    *  repo (registration would silently replace one with the other). */
   sourceCommit?: string
+  /** Set only when this build applied a pinned third-party patch on top of `sourceCommit`
+   *  (build-runner's `patchUrl`), e.g. an architecture not yet in mainline llama.cpp. Provenance
+   *  only — records that this binary isn't a plain build of `sourceRepo`@`sourceCommit`. */
+  sourcePatchUrl?: string
 }
 
 /** A custom (non-catalog) engine's identity, remembered independent of its live
@@ -77,6 +81,7 @@ export interface CustomEngineSource {
   sourceRepo?: string
   sourceBranch?: string
   sourceCommit?: string
+  sourcePatchUrl?: string
   addedAt: string
 }
 export interface Daemon {

--- a/turbollm/src/engines/build-runner.test.ts
+++ b/turbollm/src/engines/build-runner.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { buildDirName, CMAKE_CONFIGURE_ARGS, isIncompleteMetalBackendError, pickGenerator, vcvarsBatch, stripGenericAsmLanguage, sameRepo, sourceBuildDirOf, notCmakeProjectError } from './build-runner'
+import { buildDirName, CMAKE_CONFIGURE_ARGS, isIncompleteMetalBackendError, pickGenerator, vcvarsBatch, stripGenericAsmLanguage, sameRepo, sourceBuildDirOf, notCmakeProjectError, missingPatchShaError, sha256Hex, patchChecksumMismatchError } from './build-runner'
 import { join } from 'node:path'
 
 test('buildDirName: repo name from a .git URL, branch appended', () => {
@@ -160,4 +160,44 @@ test('notCmakeProjectError: actionable message when CMakeLists.txt is absent', (
   const msg = notCmakeProjectError(false)
   assert.ok(msg && /CMakeLists\.txt/.test(msg))
   assert.ok(msg && /llama\.cpp/.test(msg))
+})
+
+// ── Pinned-patch build (solar_open2-class engines) ───────────────────────────
+// The load-bearing safety property: a build patch is applied ONLY after its downloaded bytes
+// match a SHA-256 pinned in app code. runBuild() drives these three PURE helpers in order
+// (guard → verify), so testing them proves the invariant without a real clone/fetch/compile:
+//   1. missingPatchShaError — refuses a patchUrl with no pin, BEFORE any network call.
+//   2. sha256Hex — the checksum the downloaded bytes are pinned against.
+//   3. patchChecksumMismatchError — hard-fails a byte mismatch BEFORE git apply runs.
+
+test('missingPatchShaError: a patch URL without a pinned checksum is refused', () => {
+  const msg = missingPatchShaError('https://example.com/x.patch', undefined)
+  assert.ok(msg && /pinned SHA-256/.test(msg))
+  // whitespace-only checksum counts as absent
+  assert.ok(missingPatchShaError('https://example.com/x.patch', '   '))
+})
+
+test('missingPatchShaError: null when no patch, or a patch WITH a checksum', () => {
+  assert.equal(missingPatchShaError(undefined, undefined), null)
+  assert.equal(missingPatchShaError('', 'deadbeef'), null) // no URL → nothing to apply
+  assert.equal(missingPatchShaError('https://example.com/x.patch', 'deadbeef'), null)
+})
+
+test('sha256Hex: known vector (sha256 of "abc")', () => {
+  assert.equal(sha256Hex(Buffer.from('abc')), 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+})
+
+test('patchChecksumMismatchError: null when actual matches pinned (case-insensitive)', () => {
+  const sha = sha256Hex(Buffer.from('abc'))
+  assert.equal(patchChecksumMismatchError(sha, sha), null)
+  assert.equal(patchChecksumMismatchError(sha.toUpperCase(), sha), null)
+})
+
+test('patchChecksumMismatchError: actionable hard-fail when bytes do not match the pin', () => {
+  const pinned = sha256Hex(Buffer.from('the patch we vetted'))
+  const actual = sha256Hex(Buffer.from('a mutated/compromised patch'))
+  const msg = patchChecksumMismatchError(pinned, actual)
+  assert.ok(msg && /did not match/.test(msg))
+  assert.ok(msg && msg.includes(pinned.toLowerCase()) && msg.includes(actual.toLowerCase()))
+  assert.ok(msg && /before any patch was applied/.test(msg))
 })

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -597,8 +597,9 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
     } catch (e) {
       if ((e as Error)?.name === 'AbortError') throw e
       throw new Error(
-        'The verified patch does not apply cleanly against the checked-out commit — it may have drifted from the ' +
-          'commit it was authored against. ' + (e instanceof Error ? e.message : String(e)),
+        'The verified patch failed to apply against the checked-out commit (most likely it has drifted from the ' +
+          'commit it was authored against, but see the underlying error below for the exact cause). ' +
+          (e instanceof Error ? e.message : String(e)),
       )
     }
     await runStep('git', ['-C', srcDir, 'apply', patchFile], { env, signal, onLine: hooks.log })

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -15,6 +15,7 @@
 // The toolchain PATH override (build-prereqs.ts `buildEnv`) is applied so a conda-env /
 // custom-path CUDA Toolkit (and a user-provided ninja) are found. Windows or Linux + CUDA only.
 import { execFile, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { delimiter, dirname, join } from 'node:path'
 import { promisify } from 'node:util'
@@ -31,6 +32,15 @@ export interface BuildRequest {
    *  historical commit (e.g. bisecting a reported regression). Takes priority over `branch`
    *  when both are set. Requires the remote to allow fetching arbitrary SHAs (GitHub does). */
   commit?: string
+  /** Optional URL of a unified-diff patch to apply on top of the checked-out commit before
+   *  configuring — for an engine whose architecture isn't in the repo's mainline yet and needs
+   *  a third-party patch to compile (e.g. solar_open2). Opt-in: unset = the build is unchanged.
+   *  MUST be paired with {@link patchSha256} — a patch is never applied without a pinned hash. */
+  patchUrl?: string
+  /** Pinned lowercase 64-char hex SHA-256 the downloaded {@link patchUrl} bytes are verified
+   *  against before the patch is applied. A mismatch hard-fails the build (never apply an
+   *  unverified/mutated patch). Required whenever `patchUrl` is set. */
+  patchSha256?: string
   /** `<dataDir>/engines` — builds live under `<enginesRoot>/build/<slug>/`. */
   enginesRoot: string
   /** Dirs prepended to PATH for the build (ADR-100). */
@@ -134,6 +144,40 @@ export function notCmakeProjectError(hasCMakeLists: boolean): string | null {
     'found at its root. 1-click build currently only supports llama.cpp-family engines built with ' +
     'CMake. If this project exposes a llama-server-compatible binary some other way, add it as a ' +
     'custom engine by pointing TurboLLM directly at that binary instead of building from source.'
+  )
+}
+
+/** PURE: the security guard for the optional patch step. A patch may be applied ONLY when a
+ *  pinned SHA-256 is supplied to verify its downloaded bytes against — so a `patchUrl` with no
+ *  `patchSha256` must refuse *before any network call*. Returns the actionable error string in
+ *  that case, else null (no patch, or a patch with a pin — both fine to proceed). */
+export function missingPatchShaError(patchUrl?: string, patchSha256?: string): string | null {
+  if (!(patchUrl ?? '').trim()) return null
+  if ((patchSha256 ?? '').trim()) return null
+  return (
+    'Refusing to apply a build patch with no pinned SHA-256 checksum — a patch may only be applied when its exact ' +
+    'downloaded bytes can be verified against a known hash.'
+  )
+}
+
+/** PURE: lowercase hex SHA-256 of a buffer — the checksum a downloaded patch's bytes are pinned
+ *  against before it is ever applied. */
+export function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/** PURE: null when a downloaded patch's actual SHA-256 matches the pinned one (case-insensitive),
+ *  else the actionable hard-fail error. This is the load-bearing safety property of the patched
+ *  build: a mutated/compromised remote patch whose bytes don't match the pin must NEVER be
+ *  applied — the build stops here instead. */
+export function patchChecksumMismatchError(expectedSha256: string, actualSha256: string): string | null {
+  const want = expectedSha256.trim().toLowerCase()
+  const got = actualSha256.trim().toLowerCase()
+  if (want === got) return null
+  return (
+    `The downloaded patch did not match its pinned SHA-256 checksum (expected ${want}, got ${got}). TurboLLM refused ` +
+    'to apply an unverified patch — the remote file may have changed or been tampered with. The build was stopped ' +
+    'before any patch was applied.'
   )
 }
 
@@ -500,17 +544,22 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
   // 1) Shallow clone — a branch tip, or (when `req.commit` is set) an exact historical SHA.
   hooks.phase('cloning')
   const pinnedCommit = (req.commit ?? '').trim()
+  // Windows' default ~260-char MAX_PATH breaks a checkout of any repo with deeply-nested paths
+  // (llama.cpp itself ships some, e.g. tools/ui's Svelte components and examples/llama.swiftui's
+  // Xcode project) with "Filename too long" / "cannot create directory" — not an edge case, this
+  // is the official repo. `core.longpaths` lifts that limit; harmless no-op on Linux/macOS.
   if (pinnedCommit) {
     // A plain `clone --branch` can't check out an arbitrary SHA (shallow history only has the
     // tip). Init + fetch that one commit by SHA instead — GitHub allows fetching any reachable
     // SHA, not just refs.
     mkdirSync(srcDir, { recursive: true })
     await runStep('git', ['init'], { cwd: srcDir, env, signal, onLine: hooks.log })
+    if (isWindows) await runStep('git', ['config', 'core.longpaths', 'true'], { cwd: srcDir, env, signal, onLine: hooks.log })
     await runStep('git', ['remote', 'add', 'origin', req.repoUrl], { cwd: srcDir, env, signal, onLine: hooks.log })
     await runStep('git', ['fetch', '--depth', '1', 'origin', pinnedCommit], { cwd: srcDir, env, signal, onLine: hooks.log })
     await runStep('git', ['checkout', 'FETCH_HEAD'], { cwd: srcDir, env, signal, onLine: hooks.log })
   } else {
-    const cloneArgs = ['clone', '--depth', '1']
+    const cloneArgs = isWindows ? ['-c', 'core.longpaths=true', 'clone', '--depth', '1'] : ['clone', '--depth', '1']
     if ((req.branch ?? '').trim()) cloneArgs.push('--branch', req.branch!.trim())
     cloneArgs.push(req.repoUrl, srcDir)
     await runStep('git', cloneArgs, { env, signal, onLine: hooks.log })
@@ -518,6 +567,43 @@ export async function runBuild(req: BuildRequest, hooks: BuildHooks, signal: Abo
 
   // Record the built commit (ADR-088 provenance / rebuild comparison).
   const commit = (await runStep('git', ['-C', srcDir, 'rev-parse', 'HEAD'], { env, signal, onLine: () => {} })).trim()
+
+  // 1b) Apply a pinned, checksum-verified third-party patch on top of the checked-out commit,
+  // when the catalog entry ships one — for an architecture not yet in the repo's mainline that
+  // needs a patch to compile (e.g. solar_open2). OPT-IN: with no `patchUrl` the build below is
+  // byte-for-byte unchanged. The load-bearing safety property is verification: a patch is applied
+  // ONLY after its downloaded bytes match a SHA-256 pinned in app code — no pin refuses (before
+  // any network call), a byte mismatch hard-fails, so a mutated/compromised remote diff is never
+  // silently applied.
+  const patchUrl = (req.patchUrl ?? '').trim()
+  if (patchUrl) {
+    const expectedSha = (req.patchSha256 ?? '').trim()
+    const guard = missingPatchShaError(patchUrl, expectedSha)
+    if (guard) throw new Error(guard)
+    hooks.log(`Downloading build patch from ${patchUrl} …`)
+    const res = await fetch(patchUrl, { signal })
+    if (!res.ok) throw new Error(`Failed to download the build patch (HTTP ${res.status} ${res.statusText}) from ${patchUrl}.`)
+    const patchBytes = Buffer.from(await res.arrayBuffer())
+    const actualSha = sha256Hex(patchBytes)
+    const mismatch = patchChecksumMismatchError(expectedSha, actualSha)
+    if (mismatch) throw new Error(mismatch)
+    const patchFile = join(buildRoot, '_tllm_patch.diff')
+    writeFileSync(patchFile, patchBytes)
+    hooks.log(`Patch verified against its pinned checksum (sha256 ${actualSha.slice(0, 12)}…).`)
+    // --check first so a patch that has drifted from the pinned commit fails with a clear reason
+    // BEFORE we mutate the working tree, rather than leaving a half-applied source dir behind.
+    try {
+      await runStep('git', ['-C', srcDir, 'apply', '--check', patchFile], { env, signal, onLine: hooks.log })
+    } catch (e) {
+      if ((e as Error)?.name === 'AbortError') throw e
+      throw new Error(
+        'The verified patch does not apply cleanly against the checked-out commit — it may have drifted from the ' +
+          'commit it was authored against. ' + (e instanceof Error ? e.message : String(e)),
+      )
+    }
+    await runStep('git', ['-C', srcDir, 'apply', patchFile], { env, signal, onLine: hooks.log })
+    hooks.log(`Applied verified patch (sha256 ${actualSha.slice(0, 12)}…) on top of ${commit.slice(0, 8)}.`)
+  }
 
   // Fail fast with an actionable reason when this isn't a llama.cpp-family CMake project at all
   // (GitHub #61) — before sinking minutes into a configure/compile that can only die cryptically.

--- a/turbollm/src/engines/build-runner.ts
+++ b/turbollm/src/engines/build-runner.ts
@@ -102,8 +102,8 @@ export function normRepoUrl(s?: string): string {
 /** The built `llama-server` for a repo (+optional branch) under `enginesRoot`, or null. Used
  *  to detect a source-built engine whose registry entry was removed (disabled) but whose build
  *  output still sits on disk under `engines/build/<slug>/`. */
-export function sourceBuildBinary(enginesRoot: string, repoUrl: string, branch?: string): string | null {
-  const root = join(enginesRoot, 'build', buildDirName(repoUrl, branch))
+export function sourceBuildBinary(enginesRoot: string, repoUrl: string, branch?: string, commit?: string): string | null {
+  const root = join(enginesRoot, 'build', buildDirName(repoUrl, branch, commit))
   return resolveServerBinary(join(root, 'build')) ?? resolveServerBinary(root)
 }
 

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -77,6 +77,15 @@ export interface CatalogEngine {
   comingSoon?: boolean
   /** Extra context shown under the card (support caveats, etc.). */
   note?: string
+  /** Pin the build-from-source to an exact commit SHA (7-40 hex). Set when the entry needs a
+   *  specific historical commit — e.g. one that a `patchUrl` was authored against. */
+  sourceCommit?: string
+  /** URL of a unified-diff patch applied on top of `sourceCommit` before compiling — for an
+   *  architecture not yet in the repo's mainline (e.g. solar_open2). Requires `patchSha256`. */
+  patchUrl?: string
+  /** Pinned lowercase 64-char hex SHA-256 the downloaded `patchUrl` is verified against before
+   *  it's applied (build-runner hard-fails on a mismatch). Set iff `patchUrl` is set. */
+  patchSha256?: string
   /** Installable variants (one per hardware path). Optional: llama.cpp derives
    *  its variants at call time via llamaCppVariants(); other engines list them
    *  inline or leave undefined (handled in later phases). */
@@ -471,6 +480,40 @@ const ALL: CatalogEngine[] = [
         requires: {},
         stability: 'experimental',
         speed: 'fast',
+        hasPrebuilt: false,
+      },
+    ],
+  },
+  {
+    id: 'solar-open2',
+    name: 'Solar Open 2 (patched llama.cpp)',
+    kind: 'llama-server',
+    description:
+      "Upstage's Solar Open 2 (250B-A15B MoE) isn't in mainline llama.cpp yet — this builds official llama.cpp at a pinned commit with a community patch that adds the solar_open2 architecture, then runs it on the standard llama-server path.",
+    provision: 'github-release',
+    // Builds the OFFICIAL llama.cpp repo (like the prism/beellama build-from-source cards, no
+    // real github-release asset is resolved) — pinned to the exact commit the patch was authored
+    // against, then the checksum-verified patch is applied before compiling. The patch is an
+    // INDEPENDENT community diff, NOT reviewed or endorsed by Upstage or upstream llama.cpp — same
+    // fork-provenance honesty as the prism/beellama entries above (Honesty rule at the top).
+    homepage: 'https://github.com/ggml-org/llama.cpp',
+    repo: 'ggml-org/llama.cpp',
+    sourceCommit: '846e991ec3c7ccec49112ff2c5b00b710e5f551d',
+    patchUrl: 'https://huggingface.co/prometheusAIR/Solar-Open2-250B-GGUF/resolve/main/solar_open2-llama.cpp.patch',
+    patchSha256: '998a9cef479d3b01f25e473793890b05b887a8ce85563431b3b053b14bb21fa8',
+    platforms: ['win32', 'darwin', 'linux'],
+    support: 'experimental',
+    installEndpoint: '',
+    note:
+      'Unofficial: applies an independent community patch (not affiliated with or reviewed by Upstage or upstream llama.cpp) on top of a pinned llama.cpp commit, verified against a pinned SHA-256 before it is applied. This is a 250B-total / ~15B-active MoE — the upstream port was tested on workstation-class hardware (128GB DDR5 + a 96GB RTX PRO 6000), not a typical consumer box; GGUF quants run ~89 GiB (Q2_K) to 191 GiB (Q6_K), with IQ4_XS (~127 GiB) recommended. Two known quirks on this arch: pass -ub 512 or -ub 4096 (a batch size of -ub 2048 crashes with a CUDA illegal-memory-access), and add --no-mmap for any CPU-offloaded setup (mmap page-faulting collapses throughput ~10x on this port).',
+    variants: [
+      {
+        id: 'solar-open2-source',
+        label: 'Build from source (patched)',
+        repo: 'ggml-org/llama.cpp',
+        requires: {},
+        stability: 'experimental',
+        speed: 'baseline',
         hasPrebuilt: false,
       },
     ],

--- a/turbollm/src/engines/registry.ts
+++ b/turbollm/src/engines/registry.ts
@@ -54,7 +54,7 @@ export class Registry {
   async add(
     name: string,
     binPath: string,
-    source?: { sourceRepo?: string; sourceBranch?: string; sourceCommit?: string },
+    source?: { sourceRepo?: string; sourceBranch?: string; sourceCommit?: string; sourcePatchUrl?: string },
   ): Promise<AddResult> {
     const finalName = name.trim() || 'llama-server'
     this.assertNameFree(finalName)
@@ -62,6 +62,7 @@ export class Registry {
     const sourceRepo = source?.sourceRepo?.trim() || undefined
     const sourceBranch = source?.sourceBranch?.trim() || undefined
     const sourceCommit = source?.sourceCommit?.trim() || undefined
+    const sourcePatchUrl = source?.sourcePatchUrl?.trim() || undefined
     const eng: Engine = {
       id: randomUUID(),
       name: finalName,
@@ -73,6 +74,7 @@ export class Registry {
       ...(sourceRepo ? { sourceRepo } : {}),
       ...(sourceBranch ? { sourceBranch } : {}),
       ...(sourceCommit ? { sourceCommit } : {}),
+      ...(sourcePatchUrl ? { sourcePatchUrl } : {}),
     }
     this.store.update((c) => {
       // Re-check under the store lock — the name could have been taken between the

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -193,7 +193,7 @@ export function getBuildPrereqs(): Promise<BuildPrereqs> {
 
 /** Start a 1-click in-app build (ADR-100). 202 immediately; progress streams via
  *  GET /api/v1/status `engineBuild`. Windows/Linux + CUDA only; local-host only. */
-export function runBuild(args: { repoUrl: string; branch?: string; name?: string }): Promise<{ accepted: boolean }> {
+export function runBuild(args: { repoUrl: string; branch?: string; commit?: string; name?: string; patchUrl?: string; patchSha256?: string }): Promise<{ accepted: boolean }> {
   return request('/api/v1/build/run', { method: 'POST', json: args })
 }
 

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -290,7 +290,7 @@ export function useBuild() {
   }
   return {
     start: useMutation({
-      mutationFn: (v: { repoUrl: string; branch?: string; name?: string }) => apiRunBuild(v),
+      mutationFn: (v: { repoUrl: string; branch?: string; commit?: string; name?: string; patchUrl?: string; patchSha256?: string }) => apiRunBuild(v),
       onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.status }),
     }),
     cancel: useMutation({ mutationFn: () => cancelBuild(), onSuccess: refresh }),

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -336,6 +336,15 @@ export type CatalogEngine = {
   installEndpoint: string
   comingSoon?: boolean
   note?: string
+  /** Pin the build-from-source to an exact commit (7-40 hex) — e.g. the commit a `patchUrl`
+   *  was authored against. */
+  sourceCommit?: string
+  /** URL of a unified-diff patch applied on top of `sourceCommit` before compiling (an arch not
+   *  yet in mainline, e.g. solar_open2). Sent to /build/run with `patchSha256`. */
+  patchUrl?: string
+  /** Pinned SHA-256 the downloaded `patchUrl` is verified against (backend hard-fails on a
+   *  mismatch). Set iff `patchUrl` is set. */
+  patchSha256?: string
   /** Whether this engine can run on the current OS. */
   supportedHere: boolean
   /** Whether the engine's files exist on disk (disk-based check). */

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -1178,6 +1178,9 @@ function EngineCard({
                   onOpenChange={setRebuildOpen}
                   repoUrl={catalog.homepage}
                   branch={catalog.sourceBranch || undefined}
+                  commit={catalog.sourceCommit}
+                  patchUrl={catalog.patchUrl}
+                  patchSha256={catalog.patchSha256}
                   engineName={e.name}
                   mode="rebuild"
                 />
@@ -1197,6 +1200,9 @@ function EngineCard({
                 open={guideOpen}
                 onOpenChange={setGuideOpen}
                 repoUrl={catalog.homepage}
+                commit={catalog.sourceCommit}
+                patchUrl={catalog.patchUrl}
+                patchSha256={catalog.patchSha256}
                 engineName={e.name}
               />
             </>

--- a/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
+++ b/turbollm/web/src/screens/engines/BuildGuideDialog.tsx
@@ -103,6 +103,9 @@ export function BuildGuideDialog({
   repoUrl,
   engineName,
   branch,
+  commit,
+  patchUrl,
+  patchSha256,
   mode = 'build',
 }: {
   open: boolean
@@ -110,6 +113,14 @@ export function BuildGuideDialog({
   repoUrl: string
   engineName: string
   branch?: string
+  /** Pin the build to an exact commit (a catalog entry's `sourceCommit`) — undefined for the
+   *  usual branch-tip build. Required when a `patchUrl` must apply against a known commit. */
+  commit?: string
+  /** A pinned, checksum-verified patch to apply on top of `commit` before compiling (a catalog
+   *  entry's `patchUrl`/`patchSha256`). Both undefined for every non-patched entry, so their
+   *  request shape is unchanged. */
+  patchUrl?: string
+  patchSha256?: string
   /** 'rebuild' relabels the action for the ADR-088 "newer source" chip. */
   mode?: 'build' | 'rebuild'
 }) {
@@ -185,7 +196,9 @@ export function BuildGuideDialog({
 
   const startBuild = () => {
     setIntent('build')
-    build.start.mutate({ repoUrl, branch, name: engineName })
+    // commit/patchUrl/patchSha256 are only defined for a catalog entry that pins them (e.g.
+    // solar-open2); undefined for every other entry, so their request shape is unchanged.
+    build.start.mutate({ repoUrl, branch, commit, patchUrl, patchSha256, name: engineName })
   }
 
   const downloadCuda = () => {


### PR DESCRIPTION
## Summary
- New engine catalog entry: **Solar Open 2** (250B-A15B, Upstage) — builds official `ggml-org/llama.cpp` at a pinned commit with a checksum-verified third-party patch applied, since `solar_open2` isn't in mainline llama.cpp yet.
- New generalizable capability in the 1-click build pipeline: `runBuild()` now accepts `patchUrl`/`patchSha256` — downloads a patch, verifies it against a pinned SHA-256, and hard-fails before `git apply` on any mismatch. Reusable for any future engine needing a pre-compile patch.
- Fixed a real, general Windows bug found while validating this live: `runBuild()` never set `core.longpaths`, so cloning any repo with deeply-nested paths (llama.cpp's own `tools/ui` and `examples/llama.swiftui` included) failed with "Filename too long" — not Solar-Open2-specific.
- Fixed a real catalog-identity bug: the engine listing matched *any* registered build of the same repo URL, ignoring commit/patch — a plain unpatched llama.cpp build made Solar Open 2 falsely report as "already installed," handing out a binary with no `solar_open2` support.

## Verification
- Real end-to-end validation on `turbollm-dev`: real clone, real patch download + checksum verification, real CUDA/Ninja compile, real UI "Build from source" flow, real model load (IQ1_M quant, 32K ctx, Q4 KV cache), real chat generation with coherent output.
- Full backend suite passing, both typechecks clean, new unit tests for the checksum-guard logic (missing-checksum refusal, known SHA-256 vector, mismatch handling).

See `docs/decisions/decision-log.md` ADR-244/245 for the full security review and root-cause writeups.

## Test plan
- [x] Backend typecheck clean
- [x] Frontend typecheck clean
- [x] Full backend test suite passing
- [x] Real build verified live (clone → patch → compile → load → chat)