### PR TITLE
docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+**/node_modules
+**/dist
+**/src/webdist
+assets
+deploy
+*.md
+*.bat
+*.cmd
+lib

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -1,0 +1,46 @@
+# TurboLLM — AMD GPU (ROCm) variant, built from source.
+#
+# On Linux, TurboLLM's own engine provisioning (turbollm/src/engines/download.ts)
+# downloads upstream llama.cpp's `llama-{tag}-bin-ubuntu-rocm-7.2-{arch}.tar.gz` prebuilt
+# for AMD GPUs — i.e. it needs ROCm **7.2** runtime libraries (libamdhip64, rocblas,
+# hipblas, …) present, not just "some ROCm". That's why the runtime stage below pins
+# AMD's own rocm/dev-ubuntu-22.04:7.2 image rather than a generic Ubuntu base.
+#
+# ---------- Stage 1: build (identical to the CUDA/Vulkan Dockerfile) ----------
+FROM node:22-bookworm AS build
+WORKDIR /src
+
+COPY turbollm/package*.json ./
+COPY turbollm/web/package*.json ./web/
+RUN npm install \
+    && cd web && npm ci
+
+COPY turbollm/ ./
+RUN npm run build:web
+RUN npm run build
+RUN npm prune --omit=dev
+
+# ---------- Stage 2: runtime ----------
+# rocm/dev-ubuntu-22.04:7.2-complete ships the full ROCm 7.2 userspace stack (HIP
+# runtime, rocBLAS, etc.) that the llama.cpp ROCm prebuilt links against. It's a large
+# image (~7 GB) — there's no official slim "ROCm runtime-only" image the way NVIDIA
+# ships nvidia/cuda:*-runtime, so this is the safe/known-working choice rather than a
+# guessed-at minimal one.
+FROM rocm/dev-ubuntu-22.04:7.2-complete
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates libgomp1 \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /src/dist ./dist
+COPY --from=build /src/bin ./bin
+COPY --from=build /src/package.json ./package.json
+COPY --from=build /src/node_modules ./node_modules
+
+EXPOSE 6996/tcp
+
+ENTRYPOINT ["node", "bin/turbollm.mjs"]
+CMD ["--addr", "0.0.0.0:6996", "--no-open"]

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -1,38 +1,44 @@
-# TurboLLM — AMD GPU (ROCm) variant, built from source.
-#
-# On Linux, TurboLLM's own engine provisioning (turbollm/src/engines/download.ts)
-# downloads upstream llama.cpp's `llama-{tag}-bin-ubuntu-rocm-7.2-{arch}.tar.gz` prebuilt
-# for AMD GPUs — i.e. it needs ROCm **7.2** runtime libraries (libamdhip64, rocblas,
-# hipblas, …) present, not just "some ROCm". That's why the runtime stage below pins
-# AMD's own rocm/dev-ubuntu-22.04:7.2 image rather than a generic Ubuntu base.
-#
-# ---------- Stage 1: build (identical to the CUDA/Vulkan Dockerfile) ----------
+# =========================
+# Stage 1: Build TurboLLM
+# =========================
 FROM node:22-bookworm AS build
+
 WORKDIR /src
 
-COPY turbollm/package*.json ./
-COPY turbollm/web/package*.json ./web/
-RUN npm install \
-    && cd web && npm ci
+# Copy just the package.json/lock files first so this layer caches across source edits.
+COPY ../turbollm/package*.json ./
+COPY ../turbollm/web/package*.json ./web/
 
-COPY turbollm/ ./
+RUN npm ci 
+RUN cd web && npm ci
+
+# Now bring in the rest of the source and build.
+COPY ../turbollm/ ./
+
+# 1) React UI -> turbollm/src/webdist (web/vite.config.ts outDir)
 RUN npm run build:web
+# 2) Daemon -> turbollm/dist/cli.js (tsup bundle), then copies src/webdist -> dist/webdist
 RUN npm run build
+
+# Prune devDependencies (typescript/tsup/tsx/@types) — tsup externalizes
+# @earendil-works/pi-ai and @earendil-works/pi-coding-agent (dynamic requires it can't
+# bundle), so the *production* node_modules must still ship alongside dist/cli.js.
 RUN npm prune --omit=dev
 
-# ---------- Stage 2: runtime ----------
-# rocm/dev-ubuntu-22.04:7.2-complete ships the full ROCm 7.2 userspace stack (HIP
-# runtime, rocBLAS, etc.) that the llama.cpp ROCm prebuilt links against. It's a large
-# image (~7 GB) — there's no official slim "ROCm runtime-only" image the way NVIDIA
-# ships nvidia/cuda:*-runtime, so this is the safe/known-working choice rather than a
-# guessed-at minimal one.
-FROM rocm/dev-ubuntu-22.04:7.2-complete
+# =========================
+# Stage 2: runtime
+# =========================
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      curl ca-certificates libgomp1 \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+# TurboLLM on ROCm (AMD GPUs)
+FROM rocm/dev-ubuntu-22.04:6.4
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        libgomp1 && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY --from=build /src/dist ./dist
@@ -40,7 +46,17 @@ COPY --from=build /src/bin ./bin
 COPY --from=build /src/package.json ./package.json
 COPY --from=build /src/node_modules ./node_modules
 
+RUN (node bin/turbollm.mjs --no-open --port 6996 &) \
+    && for i in $(seq 1 60); do \
+      node -e "process.exit((()=>{try{return JSON.parse(require('fs').readFileSync(process.env.HOME+'/.turbollm/config.json','utf8')).engines.length>0}catch{return false}})()?0:1)" && break; \
+      sleep 3; \
+    done \
+    && node bin/turbollm.mjs --stop || true
+
+
 EXPOSE 6996/tcp
 
 ENTRYPOINT ["node", "bin/turbollm.mjs"]
+# --addr 0.0.0.0:... required in a container (default bind is loopback-only).
+# --no-open because there's no browser inside the container.
 CMD ["--addr", "0.0.0.0:6996", "--no-open"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -1,0 +1,55 @@
+# TurboLLM — built from source (repo root passed as build context).
+#
+# Verified against the actual repo layout (mohitsoni48/TurboLLM):
+#   turbollm/            <- the actual npm package source (package.json, bin/, src/, web/)
+#   turbollm/web/         <- separate React app, built independently, output copied in
+#
+# ---------- Stage 1: build ----------
+# Needs a full Node toolchain (tsc, tsup, vite) — not the slim runtime image.
+FROM node:22-bookworm AS build
+WORKDIR /src
+
+# Copy just the package.json/lock files first so this layer caches across source edits.
+COPY turbollm/package*.json ./
+COPY turbollm/web/package*.json ./web/
+RUN npm install \
+    && cd web && npm ci
+
+# Now bring in the rest of the source and build.
+COPY turbollm/ ./
+
+# 1) React UI -> turbollm/src/webdist (web/vite.config.ts outDir)
+RUN npm run build:web
+# 2) Daemon -> turbollm/dist/cli.js (tsup bundle), then copies src/webdist -> dist/webdist
+RUN npm run build
+
+# Prune devDependencies (typescript/tsup/tsx/@types) — tsup externalizes
+# @earendil-works/pi-ai and @earendil-works/pi-coding-agent (dynamic requires it can't
+# bundle), so the *production* node_modules must still ship alongside dist/cli.js.
+RUN npm prune --omit=dev
+
+# ---------- Stage 2: runtime ----------
+# Same base as the project's own deploy/runpod/Dockerfile: a CUDA *runtime* image (no
+# compiling happens here) plus the Vulkan loader. On Linux, upstream llama.cpp ships no
+# CUDA prebuilt at all, so TurboLLM's own auto-recommendation picks the Vulkan backend
+# for an NVIDIA GPU on Linux — hence libvulkan1, not a CUDA toolkit. Without GPU
+# passthrough this same image runs fine CPU-only.
+FROM nvidia/cuda:12.6.3-runtime-ubuntu22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates libvulkan1 libgomp1 \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /src/dist ./dist
+COPY --from=build /src/bin ./bin
+COPY --from=build /src/package.json ./package.json
+COPY --from=build /src/node_modules ./node_modules
+
+EXPOSE 6996/tcp
+
+ENTRYPOINT ["node", "bin/turbollm.mjs"]
+# --addr 0.0.0.0:... required in a container (default bind is loopback-only).
+# --no-open because there's no browser inside the container.
+CMD ["--addr", "0.0.0.0:6996", "--no-open"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -1,19 +1,16 @@
-# TurboLLM — built from source (repo root passed as build context).
-#
-# Verified against the actual repo layout (mohitsoni48/TurboLLM):
-#   turbollm/            <- the actual npm package source (package.json, bin/, src/, web/)
-#   turbollm/web/         <- separate React app, built independently, output copied in
-#
-# ---------- Stage 1: build ----------
-# Needs a full Node toolchain (tsc, tsup, vite) — not the slim runtime image.
+# =========================
+# Stage 1: Build TurboLLM
+# =========================
 FROM node:22-bookworm AS build
+
 WORKDIR /src
 
 # Copy just the package.json/lock files first so this layer caches across source edits.
 COPY turbollm/package*.json ./
 COPY turbollm/web/package*.json ./web/
-RUN npm install \
-    && cd web && npm ci
+
+RUN npm ci 
+RUN cd web && npm ci
 
 # Now bring in the rest of the source and build.
 COPY turbollm/ ./
@@ -28,12 +25,10 @@ RUN npm run build
 # bundle), so the *production* node_modules must still ship alongside dist/cli.js.
 RUN npm prune --omit=dev
 
-# ---------- Stage 2: runtime ----------
-# Same base as the project's own deploy/runpod/Dockerfile: a CUDA *runtime* image (no
-# compiling happens here) plus the Vulkan loader. On Linux, upstream llama.cpp ships no
-# CUDA prebuilt at all, so TurboLLM's own auto-recommendation picks the Vulkan backend
-# for an NVIDIA GPU on Linux — hence libvulkan1, not a CUDA toolkit. Without GPU
-# passthrough this same image runs fine CPU-only.
+# =========================
+# Stage 2: runtime
+# =========================
+
 FROM nvidia/cuda:12.6.3-runtime-ubuntu22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates libvulkan1 libgomp1 \
@@ -46,6 +41,14 @@ COPY --from=build /src/dist ./dist
 COPY --from=build /src/bin ./bin
 COPY --from=build /src/package.json ./package.json
 COPY --from=build /src/node_modules ./node_modules
+
+RUN (node bin/turbollm.mjs --no-open --port 6996 &) \
+    && for i in $(seq 1 60); do \
+      node -e "process.exit((()=>{try{return JSON.parse(require('fs').readFileSync(process.env.HOME+'/.turbollm/config.json','utf8')).engines.length>0}catch{return false}})()?0:1)" && break; \
+      sleep 3; \
+    done \
+    && node bin/turbollm.mjs --stop || true
+
 
 EXPOSE 6996/tcp
 

--- a/README.md
+++ b/README.md
@@ -637,6 +637,70 @@ shadcn/ui frontend. One TypeScript codebase, shipped as an npm package.
 
 ---
 
+## 🐳 Docker Deployment (NVIDIA / AMD GPU)
+
+TurboLLM includes Docker support with dedicated configurations for NVIDIA CUDA
+and AMD ROCm GPUs.
+
+The Docker images provide an isolated environment while allowing TurboLLM to
+access your GPU directly for accelerated local LLM inference.
+
+---
+
+## NVIDIA GPU (CUDA)
+
+### Requirements
+
+- NVIDIA GPU with CUDA support
+- Installed NVIDIA drivers
+- NVIDIA Container Toolkit
+
+Install NVIDIA Container Toolkit:
+
+```bash
+# Ubuntu / Debian example
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#' | \
+sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+
+sudo systemctl restart docker
+
+docker compose -f docker-compose-nvidia.yaml up -d
+```
+
+## AMD GPU
+
+### Requirements
+
+- AMD ROCm
+- Installed AMD drivers
+
+```bash
+# Ubuntu / Debian example
+sudo apt update
+sudo apt install wget gnupg
+
+wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+sudo gpg --dearmor -o /usr/share/keyrings/rocm.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/latest ubuntu main" | \
+sudo tee /etc/apt/sources.list.d/rocm.list
+
+sudo apt update
+
+sudo apt install rocm
+sudo usermod -aG render,video $USER
+sudo reboot
+
+docker compose -f docker-compose-amd.yaml up -d
+```
+---
 ## Community
 
 Questions, ideas, and show-and-tell — join the [Discord](https://discord.gg/v6kRbV7nC).

--- a/README.md
+++ b/README.md
@@ -647,9 +647,9 @@ access your GPU directly for accelerated local LLM inference.
 
 ---
 
-## NVIDIA GPU (CUDA)
+### NVIDIA GPU (CUDA)
 
-### Requirements
+#### Requirements
 
 - NVIDIA GPU with CUDA support
 - Installed NVIDIA drivers
@@ -674,9 +674,9 @@ sudo systemctl restart docker
 docker compose -f docker-compose-nvidia.yaml up -d
 ```
 
-## AMD GPU
+### AMD GPU
 
-### Requirements
+#### Requirements
 
 - AMD ROCm
 - Installed AMD drivers

--- a/docker-compose-amd.yaml
+++ b/docker-compose-amd.yaml
@@ -1,0 +1,30 @@
+services:
+  turbollm:
+    build:
+      context: .
+      dockerfile: Dockerfile.amd
+    image: turbollm-amd:latest
+    container_name: turbollm-amd
+    restart: unless-stopped
+    ports:
+      - "6996:6996"
+    volumes:
+      - turbollm-data:/root/.turbollm
+
+    # --- AMD GPU passthrough (ROCm) ---
+    # /dev/kfd is the ROCm kernel driver device; /dev/dri is the DRM/GPU device nodes.
+    # This is the same pair AMD's own docs use for `docker run --device=/dev/kfd
+    # --device=/dev/dri --group-add video`.
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+      - render
+    # If the container can't see the GPU (permission denied on /dev/kfd or /dev/dri),
+    # the usual cause is that the host's `render` group GID doesn't match any group
+    # name inside the container. Find the host GID with `getent group render` and
+    # replace the "render" line above with that numeric GID instead.
+
+volumes:
+  turbollm-data:

--- a/docker-compose-amd.yaml
+++ b/docker-compose-amd.yaml
@@ -1,11 +1,10 @@
 services:
   turbollm:
     build:
-      context: .
+      context: ./deploy/runpod
       dockerfile: Dockerfile.amd
     image: turbollm-amd:latest
     container_name: turbollm-amd
-    restart: unless-stopped
     ports:
       - "6996:6996"
     volumes:
@@ -25,6 +24,13 @@ services:
     # the usual cause is that the host's `render` group GID doesn't match any group
     # name inside the container. Find the host GID with `getent group render` and
     # replace the "render" line above with that numeric GID instead.
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f -s http://turbollm:6996/api/v1/status >/dev/null"]
+      interval: 1s
+      timeout: 3s
+      retries: 3
 
 volumes:
   turbollm-data:
+    name: turbollm-data
+    

--- a/docker-compose-amd.yaml
+++ b/docker-compose-amd.yaml
@@ -1,7 +1,7 @@
 services:
   turbollm:
     build:
-      context: ./deploy/runpod
+      context: .
       dockerfile: Dockerfile.amd
     image: turbollm-amd:latest
     container_name: turbollm-amd

--- a/docker-compose-nvidia.yaml
+++ b/docker-compose-nvidia.yaml
@@ -1,0 +1,35 @@
+services:
+  turbollm:
+    # Build context must be the root of a clone of https://github.com/mohitsoni48/TurboLLM
+    # (this Dockerfile expects to find the `turbollm/` subfolder in it). Put this
+    # docker-compose.yml (and the Dockerfile) at the repo root, or change `context:` below
+    # to point at wherever you cloned it.
+    build:
+      context: .
+      dockerfile: Dockerfile.nvidia
+    image: turbollm-nvidia:latest
+    container_name: turbollm-nvidia
+    restart: unless-stopped
+    ports:
+      - "6996:6996"
+    volumes:
+      # Persists config.json, the chat SQLite DB, downloaded engines/models, and logs
+      # across container restarts/rebuilds (this is ~/.turbollm inside the container).
+      - turbollm-data:/root/.turbollm
+
+    # --- NVIDIA GPU passthrough (requires the NVIDIA Container Toolkit on the host) ---
+    # Delete this whole "environment" + "deploy" block if you're running CPU-only —
+    # TurboLLM falls back to a CPU build automatically.
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+volumes:
+  turbollm-data:

--- a/docker-compose-nvidia.yaml
+++ b/docker-compose-nvidia.yaml
@@ -9,7 +9,6 @@ services:
       dockerfile: Dockerfile.nvidia
     image: turbollm-nvidia:latest
     container_name: turbollm-nvidia
-    restart: unless-stopped
     ports:
       - "6996:6996"
     volumes:
@@ -30,6 +29,12 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f -s http://turbollm:6996/api/v1/status >/dev/null"]
+      interval: 1s
+      timeout: 3s
+      retries: 3
 
 volumes:
   turbollm-data:
+    name: turbollm-data


### PR DESCRIPTION
Fix: 

A few small things worth a look before/after merge — none blocking, your call whether to address:

1. **`npm install` vs `npm ci` inconsistency** (`Dockerfile.nvidia` and `Dockerfile.amd`): the root turbollm install uses `npm install && cd web && npm ci` — the web install is reproducible (`ci`), the root one isn't. Both lockfiles exist (`turbollm/package-lock.json`, `turbollm/web/package-lock.json`), so switching the first to `npm ci` too would make both stages reproducible.
2. **No `HEALTHCHECK`** in either Dockerfile — worth adding since both compose files set `restart: unless-stopped`, so a hung-but-alive process currently won't get restarted.
3. **README heading levels**: `## NVIDIA GPU (CUDA)` and `## AMD GPU` are subsections of `## 🐳 Docker Deployment` but are the same heading level (H2) rather than H3.
4. Minor: none of the 4 new files end with a trailing newline.

Nice work overall — multi-stage build + prune is a real improvement over the existing `deploy/runpod/Dockerfile` pattern.

Dockworker the project 

Created 2 docker compose files one for NVIDIA GPU, and one for AMD GPU


## 🐳 Docker Deployment (NVIDIA / AMD GPU)

TurboLLM includes Docker support with dedicated configurations for NVIDIA CUDA
and AMD ROCm GPUs.

The Docker images provide an isolated environment while allowing TurboLLM to
access your GPU directly for accelerated local LLM inference.

---

### NVIDIA GPU (CUDA)

#### Requirements

- NVIDIA GPU with CUDA support
- Installed NVIDIA drivers
- NVIDIA Container Toolkit

Install NVIDIA Container Toolkit:

```bash
# Ubuntu / Debian example
curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg

curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#' | \
sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list

sudo apt update
sudo apt install -y nvidia-container-toolkit

sudo systemctl restart docker

docker compose -f docker-compose-nvidia.yaml up -d
```

### AMD GPU

#### Requirements

- AMD ROCm
- Installed AMD drivers

```bash
# Ubuntu / Debian example
sudo apt update
sudo apt install wget gnupg

wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
sudo gpg --dearmor -o /usr/share/keyrings/rocm.gpg

echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/latest ubuntu main" | \
sudo tee /etc/apt/sources.list.d/rocm.list

sudo apt update

sudo apt install rocm
sudo usermod -aG render,video $USER
sudo reboot

docker compose -f docker-compose-amd.yaml up -d
```
---