### PR TITLE
chore(release): v1.8.7 — Code UI/UX redesign, loop hard-stop, prefill progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ Thumbs.db
 /turbollm/.playwright-mcp/
 /.playwright-mcp/
 
+# Playwright test-runner output (turbollm/web) — traces/screenshots from `npm run test:e2e`
+/turbollm/web/test-results/
+/turbollm/web/playwright-report/
+
 # Downloaded engine binaries (multi-GB; not product source, build-time content)
 /turbollm/engines/
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,39 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.8.7] - 2026-07-24
+
+**Code feature: a denser, more familiar terminal-style redesign, a real prefill progress bar, and a fix for a rare stuck-loop bug.**
+
+### Added
+- **Real prefill progress bar in Code.** While the model is processing a large prompt, Code now
+  shows live progress (processed/total tokens) by polling the local engine's `/slots` endpoint —
+  independent of the underlying agent SDK, which doesn't expose this natively.
+- **Consecutive similar terminal commands are now grouped** into a single expandable unit (e.g. a
+  run of `git` commands) instead of each appearing as its own separate line.
+- **A hard stop for tool-call loops.** If the model keeps repeating the exact same tool call after
+  already being told to stop, the run is now aborted outright and reported as a stopped run,
+  instead of silently repeating the same unhelpful nudge forever.
+
+### Changed
+- **Code's UI redesigned toward a denser, more familiar terminal feel** — closer to what users of
+  tools like opencode/Claude Code CLI already expect: flat tool-call lines instead of cards, a
+  persistent stats footer, a loaded-resources header (AGENTS.md/skills), and updated icons.
+
+### Fixed
+- User message cards in Code had an odd, hard-to-notice copy/revert button layout and low-contrast
+  background in dark theme — buttons moved outside the card and background contrast increased.
+- Terminal commands run by the agent now default to **collapsed** instead of expanded.
+- Removed a duplicate stat ("Auto · 16% ctx") that was shown twice in the Code composer footer.
+- A visual clipping bug on the "running" status banner's rounded corners.
+
+### Discord
+- Code now shows a live prefill progress bar while the model processes large prompts.
+- Code's UI got a denser, more familiar terminal-style redesign — flat tool lines, a persistent
+  stats footer, and grouped terminal commands.
+- Fixed a rare bug where a stuck AI tool-call loop in Code could repeat forever instead of
+  stopping.
+
 ## [1.8.6] - 2026-07-24
 
 **New engine: Solar Open 2, via a checksum-verified patch build.**

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -40,7 +40,7 @@
     "dev": "tsx watch src/cli.ts",
     "start": "tsx src/cli.ts",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test",
+    "test": "tsx --test \"src/**/*.test.ts\" \"web/src/lib/engine-groups.test.ts\" \"web/src/lib/personas.test.ts\" \"web/src/lib/tool-explain.test.ts\" \"web/src/lib/vram.test.ts\"",
     "build:web": "cd web && npm ci && npm run build",
     "build": "npm run typecheck && tsup && node -e \"const fs=require('fs'),p='dist/cli.js',c=fs.readFileSync(p,'utf8');fs.writeFileSync(p,c.replaceAll('from \\\"sqlite\\\"','from \\\"node:sqlite\\\"'))\" && node -e \"require('fs').cpSync('src/webdist','dist/webdist',{recursive:true,force:true})\"",
     "prepublishOnly": "npm run build:web && npm run build"

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -1655,6 +1655,34 @@ export class ConversationStore {
       .run({ $cid: convId, $seq: from.seq } as P) as unknown) as Changes).changes
   }
 
+  /** /clear (v34): deactivates `uptoMessageId` and every message BEFORE it (by `seq`) — a real,
+   *  resumable PREFIX deactivation (is_active=0), the mirror of {@link deactivateMessagesFrom}'s
+   *  suffix and the same mechanism /revert and Chat branching use. Replaces /clear's old
+   *  clearedUpToMessageId DISPLAY cursor, which left the "cleared" rows is_active=1 — so
+   *  getMessages()/getConversation() (hence session export AND the model's own history replay via
+   *  resolveEffectiveHistory) still saw them, applying the cut only client-side. /clear hides
+   *  everything up to AND INCLUDING the cut (showing only turns added AFTER it), so this is a
+   *  prefix. Returns the number of rows deactivated (0 if `uptoMessageId` doesn't exist). Only ever
+   *  called on Code conversations, which have no regenerate/branch siblings, so every prefix row is
+   *  active at clear time — same coarse assumption reactivateMessagesFrom already relies on. */
+  deactivateMessagesUpTo(convId: string, uptoMessageId: string): number {
+    const upto = this.db.prepare(`SELECT seq FROM messages WHERE id = $id AND conv_id = $cid`).get({ $id: uptoMessageId, $cid: convId } as P) as unknown as { seq: number } | undefined
+    if (!upto) return 0
+    return ((this.db.prepare(`UPDATE messages SET is_active = 0 WHERE conv_id = $cid AND seq <= $seq`)
+      .run({ $cid: convId, $seq: upto.seq } as P) as unknown) as Changes).changes
+  }
+
+  /** Undoes {@link deactivateMessagesUpTo} — reactivates `uptoMessageId` and every message before
+   *  it (by `seq`). A NEW turn appended after a /clear has a HIGHER seq than the cut, so /resume
+   *  never touches it — only the originally-cleared prefix comes back. Safe if `uptoMessageId` no
+   *  longer exists (0 rows). */
+  reactivateMessagesUpTo(convId: string, uptoMessageId: string): number {
+    const upto = this.db.prepare(`SELECT seq FROM messages WHERE id = $id AND conv_id = $cid`).get({ $id: uptoMessageId, $cid: convId } as P) as unknown as { seq: number } | undefined
+    if (!upto) return 0
+    return ((this.db.prepare(`UPDATE messages SET is_active = 1 WHERE conv_id = $cid AND seq <= $seq`)
+      .run({ $cid: convId, $seq: upto.seq } as P) as unknown) as Changes).changes
+  }
+
   /** Permanently delete a Code session: its messages, working doc, and the agent_run +
    *  conversation rows. There is no FK cascade on these tables (each is deleted explicitly,
    *  same as chat's own conversation delete never cascaded to messages) — miss one and it's

--- a/turbollm/src/code/code-routes.export.test.ts
+++ b/turbollm/src/code/code-routes.export.test.ts
@@ -1,0 +1,183 @@
+// Route-level tests for GET /api/v1/code/sessions/:id/export (Phase 3 test gap, spec 16 §5) —
+// session-export.test.ts already covers the pure serializer/filename functions in isolation
+// (19 tests); these exercise the actual HTTP route on a real Hono app + real ConversationStore
+// (temp-dir SQLite, same discipline as db.timeline.test.ts / gateway.errors.test.ts's real-app
+// testing), which the serializer-only tests can't reach: headers, status codes, and how the route
+// composes with real DB state (a /clear'd session, an "active" run).
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Hono } from 'hono'
+import { ConversationStore } from '../chat/db'
+import { registerCodeRoutes } from './code-routes'
+import type { Deps } from '../deps'
+
+function tmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+/** registerCodeRoutes's export handler only ever touches `d.db` (confirmed by reading the route:
+ *  `const md = serializeCodeSessionMarkdown(run, conv); ...`, no reference to `d.manager`/
+ *  `d.registry`/etc.), and CodeRunManager's constructor + reconcileOnStartup() (run once, eagerly,
+ *  at registerCodeRoutes() time) likewise only touch `d.db` — so a real ConversationStore plus an
+ *  unsound cast for the rest of Deps is sufficient, same minimal-double approach
+ *  gateway.errors.test.ts already uses for a different route module. */
+function makeApp(db: ConversationStore): { app: Hono } {
+  const app = new Hono()
+  const d = { db, version: 'test' } as unknown as Deps
+  registerCodeRoutes(app, d)
+  return { app }
+}
+
+function seedSession(db: ConversationStore, opts: { title?: string; repoRoot?: string } = {}) {
+  const conv = db.createConversation({ kind: 'code', modelKey: 'model-a' })
+  const run = db.createAgentRun({ convId: conv.id, title: opts.title ?? 'Fix the login bug', allowedTools: [], repoRoot: opts.repoRoot })
+  return { conv, run }
+}
+
+test('GET .../export: 200 with real Content-Disposition/Content-Type headers and a Markdown body', async () => {
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db)
+  db.addMessage(conv.id, 'user', 'Add a health check endpoint.')
+
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/export`)
+  assert.equal(res.status, 200)
+  assert.equal(res.headers.get('Content-Type'), 'text/markdown; charset=utf-8')
+  const disposition = res.headers.get('Content-Disposition') ?? ''
+  assert.match(disposition, /^attachment; filename="Fix-the-login-bug-\d{4}-\d{2}-\d{2}\.md"$/)
+  const body = await res.text()
+  assert.match(body, /^# Fix the login bug/)
+  assert.match(body, /Add a health check endpoint\./)
+})
+
+test('GET .../export: 404 for a session that does not exist', async () => {
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+
+  const res = await app.request('/api/v1/code/sessions/does-not-exist/export')
+  assert.equal(res.status, 404)
+  const body = (await res.json()) as { error?: { code?: string } }
+  assert.equal(body.error?.code, 'not_found')
+})
+
+test('GET .../export?format=html: 400 unsupported_format (HTML export is not built yet)', async () => {
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+  const { run } = seedSession(db)
+
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/export?format=html`)
+  assert.equal(res.status, 400)
+  const body = (await res.json()) as { error?: { code?: string } }
+  assert.equal(body.error?.code, 'unsupported_format')
+})
+
+test('GET .../export: succeeds even while the run\'s persisted status is "running" — the route has no active-run guard', async () => {
+  // NOTE on scope: this drives the DB-persisted `status` column, not CodeRunManager's own
+  // in-memory isActive() tracking (that state lives in a Map private to the CodeRunManager
+  // instance registerCodeRoutes constructs internally — not independently injectable from a
+  // route-level test without changing registerCodeRoutes's signature, out of scope here). What
+  // this DOES prove: the export handler's source has zero reference to `runs`/`isActive` at all
+  // (confirmed by reading code-routes.ts — unlike /compact, /clear, /revert, which all check
+  // `runs.isActive(id)` before proceeding) — a persisted 'running' status is the closest
+  // reachable proxy for "this session looks like it's mid-turn" without that deeper seam.
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db)
+  db.addMessage(conv.id, 'user', 'Do the thing.')
+  db.updateAgentRun(run.id, { status: 'running' })
+
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/export`)
+  assert.equal(res.status, 200)
+})
+
+test('GET .../export on a /clear\'d session EXCLUDES the cleared history — matches what the user sees (v34/ADR-261, the export-leak fix)', async () => {
+  // Answered product question (spec 16 §5 flagged it as undecided; the founder decided /clear should
+  // truly clear). Task #31 made /clear DEACTIVATE (is_active=0) its prefix — the same mechanism
+  // /revert uses — instead of only setting a display cursor. getMessages() (what getConversation(id,
+  // true) and this export route read) filters is_active=1, so cleared history is now omitted at the
+  // source: export matches the transcript, no longer leaking what the user hid. Drives the REAL
+  // /clear route end-to-end (not just the DB helper), so the whole path is covered.
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db)
+  db.addMessage(conv.id, 'user', 'An early attempt the user later cleared away.')
+
+  const clearRes = await app.request(`/api/v1/code/sessions/${run.id}/clear`, { method: 'POST' })
+  assert.equal(clearRes.status, 200)
+  // A NEW turn after the clear — the visible tail export SHOULD include (and proof the clear only
+  // deactivated the earlier prefix, not everything).
+  db.addMessage(conv.id, 'user', 'The visible follow-up after /clear.')
+
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/export`)
+  assert.equal(res.status, 200)
+  const body = await res.text()
+  assert.match(body, /The visible follow-up after \/clear\./, 'the visible post-clear tail is present')
+  assert.doesNotMatch(body, /An early attempt the user later cleared away\./, 'the cleared pre-clear history is NO LONGER exported — the leak is fixed')
+})
+
+test('POST .../resume after a /clear brings the cleared history back into the export', async () => {
+  const db = new ConversationStore(tmp('tllm-export-route-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db)
+  db.addMessage(conv.id, 'user', 'A message that gets cleared then resumed.')
+
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/clear`, { method: 'POST' })).status, 200)
+  assert.doesNotMatch(await (await app.request(`/api/v1/code/sessions/${run.id}/export`)).text(), /A message that gets cleared then resumed\./)
+
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/resume`, { method: 'POST' })).status, 200)
+  assert.match(await (await app.request(`/api/v1/code/sessions/${run.id}/export`)).text(), /A message that gets cleared then resumed\./, 'resume reactivated the cleared message — it is exportable again')
+})
+
+// ── /clear <-> /revert mutual exclusion (final-gate coherence check, task #30) ───────────────────
+// Both now deactivate messages (is_active=0): /clear a PREFIX (v34), /revert a SUFFIX (v33). They
+// are two independent resumable hidden-states that must never overlap — each route refuses to start
+// while the OTHER is pending, so /resume is never ambiguous about which one it's undoing. These
+// route-level tests pin that invariant end-to-end (the guards existed but weren't route-tested).
+
+test('POST .../revert is refused (409 session_cleared) while the session is /clear\'d', async () => {
+  const db = new ConversationStore(tmp('tllm-clear-revert-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db, { repoRoot: '/repo' })
+  db.addMessage(conv.id, 'user', 'first')
+  db.addMessage(conv.id, 'assistant', 'reply')
+  const target = db.addMessage(conv.id, 'user', 'second')
+
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/clear`, { method: 'POST' })).status, 200)
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: target.id }), headers: { 'Content-Type': 'application/json' } })
+  assert.equal(res.status, 409)
+  assert.equal(((await res.json()) as { error?: { code?: string } }).error?.code, 'session_cleared')
+})
+
+test('POST .../clear is refused (409 session_reverted) while the session has a pending /revert', async () => {
+  const db = new ConversationStore(tmp('tllm-clear-revert-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db, { repoRoot: '/repo' })
+  db.addMessage(conv.id, 'user', 'first')
+  db.addMessage(conv.id, 'assistant', 'reply')
+  const target = db.addMessage(conv.id, 'user', 'second')
+  db.addMessage(conv.id, 'assistant', 'second reply')
+
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: target.id }), headers: { 'Content-Type': 'application/json' } })).status, 200)
+  const res = await app.request(`/api/v1/code/sessions/${run.id}/clear`, { method: 'POST' })
+  assert.equal(res.status, 409)
+  assert.equal(((await res.json()) as { error?: { code?: string } }).error?.code, 'session_reverted')
+})
+
+test('the mutual-exclusion lock releases: /clear → /resume → /revert all succeed in sequence', async () => {
+  const db = new ConversationStore(tmp('tllm-clear-revert-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db, { repoRoot: '/repo' })
+  db.addMessage(conv.id, 'user', 'first')
+  db.addMessage(conv.id, 'assistant', 'reply')
+  const target = db.addMessage(conv.id, 'user', 'second')
+
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/clear`, { method: 'POST' })).status, 200)
+  assert.equal((await app.request(`/api/v1/code/sessions/${run.id}/resume`, { method: 'POST' })).status, 200)
+  // With the clear resolved, a revert is allowed again (proving the guard is a live state, not a
+  // permanent lock) — reverting to the now-reactivated 'second' user message.
+  const revert = await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: target.id }), headers: { 'Content-Type': 'application/json' } })
+  assert.equal(revert.status, 200)
+})

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -27,6 +27,7 @@ import { revertFileEdits } from './revert'
 import { codeSessionExportFilename, serializeCodeSessionMarkdown } from './session-export'
 import { commitGitChanges, getGithubCompareUrl, getGitStatus, pushGitBranch } from './git-actions'
 import { runShellCommand, shellContextText } from './code-shell'
+import { agentsMdPresence } from './persona'
 import type { CodeMode } from './persona'
 
 type S = 200 | 201 | 202 | 400 | 404 | 409 | 500
@@ -207,6 +208,13 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       // The active turn's current step checklist (ADR-255), so a reopened session shows live
       // progress immediately without waiting for the next update_todos frame. [] when none.
       todos: runs.todos(run.id),
+      // Whether an AGENTS.md is actually loaded for this session (ADR-262's loaded-resources
+      // header) — project (<repoRoot>/AGENTS.md) and/or global (~/.turbollm/agents.md). Computed
+      // with the SAME lookup persona.ts injects into the prompt, so "shown as loaded" == "actually
+      // fed to the model". Both false when the session has no repoRoot.
+      hasAgentsMd: run.repoRoot
+        ? agentsMdPresence(run.repoRoot, d.store.dir())
+        : { project: false, global: false },
     })
   })
 

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -21,9 +21,12 @@ import type { Context, Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { Deps } from '../deps'
 import type { AgentRun, Message } from '../chat/db'
-import { CodeRunManager } from './code-run-manager'
+import { CodeRunManager, type SteerKind } from './code-run-manager'
 import { compactCodeSession, disposeLspClientsForConv } from './code-session'
 import { revertFileEdits } from './revert'
+import { codeSessionExportFilename, serializeCodeSessionMarkdown } from './session-export'
+import { commitGitChanges, getGithubCompareUrl, getGitStatus, pushGitBranch } from './git-actions'
+import { runShellCommand, shellContextText } from './code-shell'
 import type { CodeMode } from './persona'
 
 type S = 200 | 201 | 202 | 400 | 404 | 409 | 500
@@ -100,6 +103,7 @@ function toSidebarRow(run: AgentRun) {
     add: run.linesAdded ?? 0,
     del: run.linesRemoved ?? 0,
     mode: undefined as string | undefined, // filled from conv below when available
+    running: undefined as boolean | undefined, // filled from CodeRunManager below when available
     createdAt: run.createdAt,
     repoRoot: run.repoRoot ?? '',
     error: run.error,
@@ -165,16 +169,19 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
   app.get('/api/v1/code/sessions', (c) => {
     const filter = (c.req.query('filter') ?? 'active') as 'active' | 'archived' | 'all'
     // Only code-kind runs — a run maps to a code conversation. Filter by the conv kind.
-    const runs = db.listAgentRuns().filter((r) => {
+    const agentRuns = db.listAgentRuns().filter((r) => {
       const conv = db.getConversation(r.convId)
       if (conv?.kind !== 'code') return false
       if (filter === 'active') return !r.archivedAt
       if (filter === 'archived') return !!r.archivedAt
       return true
     })
-    const rows = runs.map((r) => {
+    const rows = agentRuns.map((r) => {
       const row = toSidebarRow(r)
       row.mode = db.getConversation(r.convId)?.agentMode
+      // Sidebar's own liveness signal (ADR-256) — same authoritative check the detail route
+      // uses below, so a background session (tab not open) still shows as running.
+      row.running = runs.isActive(r.id)
       return row
     })
     return c.json({ sessions: rows })
@@ -197,7 +204,34 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       // Tasks waiting behind the active turn — the server-side message queue, so its chips
       // survive a page reload / reconnect.
       queued: runs.queued(run.id),
+      // The active turn's current step checklist (ADR-255), so a reopened session shows live
+      // progress immediately without waiting for the next update_todos frame. [] when none.
+      todos: runs.todos(run.id),
     })
+  })
+
+  // ── export (Phase 3, ADR-251) ─────────────────────────────────────────────────
+  // GET /api/v1/code/sessions/:id/export?format=markdown — Markdown-only for this pass (HTML is
+  // a spec-15-§5 fast-follow; session-export.ts's serializer is written so that fast-follow can
+  // reuse this same Markdown through the app's existing renderer instead of a second serializer).
+  // Deliberately NOT blocked on an active run (unlike /compact, /archive, /delete above) —
+  // exporting mid-generation is safe: this only reads what's already persisted in
+  // `conv.messages`, so an in-flight turn's not-yet-saved content is naturally just absent from
+  // the export rather than an error case to guard against.
+  app.get('/api/v1/code/sessions/:id/export', (c) => {
+    const id = c.req.param('id')
+    const run = db.getAgentRun(id)
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    const conv = db.getConversation(run.convId, true)
+    if (!conv) return err(c, 404, 'not_found', 'Session conversation not found.')
+    const format = c.req.query('format') === 'html' ? 'html' : 'markdown'
+    if (format === 'html') return err(c, 400, 'unsupported_format', 'HTML export is not available yet — use format=markdown.')
+
+    const md = serializeCodeSessionMarkdown(run, conv)
+    const filename = codeSessionExportFilename(run.title, run.createdAt, 'md')
+    c.header('Content-Disposition', `attachment; filename="${filename}"`)
+    c.header('Content-Type', 'text/markdown; charset=utf-8')
+    return c.body(md)
   })
 
   // ── change mode (auto/plan/ask) — live for the ask-approval gate ──────────────
@@ -315,12 +349,14 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
 
   // ── /clear + /resume ───────────────────────────────────────────────────────
   // /clear hides the conversation so far (a blank slate for the model AND the transcript UI)
-  // WITHOUT touching the session's repo/worktree/branch or deleting anything — it just sets
-  // cleared_upto_message_id to the current last message, which resolveEffectiveHistory
-  // (code-session.ts) and the frontend transcript both cut at. /resume un-hides it by setting
-  // that marker back to null — the messages were never deleted, so resuming restores the
-  // conversation exactly as it was. Both blocked while a run is active, same rationale as
-  // /compact: clearing/resuming out from under a turn mid-flight against the OLD history frame
+  // WITHOUT touching the session's repo/worktree/branch or deleting anything — it DEACTIVATES
+  // (is_active=0) every message up to and including the current last one (v34/ADR-261, the SAME
+  // mechanism /revert uses), so getMessages()/getConversation() drop them from every consumer at
+  // the source (the model's replay via resolveEffectiveHistory, session export, and the transcript
+  // alike); clearedUpToMessageId records the cut so /resume knows the range. /resume REACTIVATES
+  // (is_active=1) that same prefix and nulls the marker — the messages were never deleted, so it
+  // restores the conversation exactly as it was. Both blocked while a run is active, same rationale
+  // as /compact: clearing/resuming out from under a turn mid-flight against the OLD history frame
   // is confusing regardless of whether it would technically corrupt anything. ALSO blocked while
   // reverted (v33) — /clear and revert are two independent resumable hidden-states; stacking them
   // on one session would leave /resume ambiguous about which one it's undoing.
@@ -334,6 +370,13 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     const lastMsg = (conv?.messages ?? []).at(-1)
     if (!lastMsg) return err(c, 400, 'nothing_to_clear', 'Nothing to clear yet.')
     if (run.clearedUpToMessageId === lastMsg.id) return err(c, 400, 'nothing_to_clear', 'Already cleared up to the latest message.')
+    // Real deactivation (v34, ADR-261): is_active=0 on the whole prefix up to AND including the
+    // current last message — the SAME mechanism /revert uses — so cleared history disappears from
+    // getMessages()/getConversation() at the source (session export, the model's own replay via
+    // resolveEffectiveHistory, and the transcript), not just a client-side display slice that left
+    // the rows is_active=1 (the export-leak bug this fixes). clearedUpToMessageId still records the
+    // cut so /resume knows the exact range to reactivate.
+    db.deactivateMessagesUpTo(run.convId, lastMsg.id)
     db.setClearedUpToMessageId(id, lastMsg.id)
     return c.json({ ok: true, clearedUpToMessageId: lastMsg.id })
   })
@@ -351,6 +394,10 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       return c.json({ ok: true })
     }
     if (!run.clearedUpToMessageId) return err(c, 400, 'not_cleared', 'This session has not been cleared.')
+    // Real reactivation (v34) — is_active=1 on the same prefix /clear deactivated, the mirror of the
+    // /revert branch above. A turn added AFTER the clear has a higher seq than the cut, so it's
+    // untouched; only the originally-cleared history comes back.
+    db.reactivateMessagesUpTo(run.convId, run.clearedUpToMessageId)
     db.setClearedUpToMessageId(id, null)
     return c.json({ ok: true })
   })
@@ -415,6 +462,129 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     return c.json({ ok: true, revertedFromMessageId: messageId, revertText: cut.revertText, revertedFiles, failedFiles })
   })
 
+  // ── git status / commit / push / PR-link (Phase 3, ADR-259) ───────────────────────────────
+  // Real `git` subprocess calls in the session's own repoRoot — see git-actions.ts's own header
+  // for the full scope note (commit+push only, no gh/GitHub-API call, push never forces).
+  //
+  // /git/status is read-only against the filesystem, so — unlike commit/push below — it does NOT
+  // gate on runs.isActive(id): a live agent turn's own bash/edit tool calls are already reading
+  // and writing that same working tree concurrently, and a `git status` racing with them is no
+  // different from a human running one in a second terminal (same as a plain read, not a
+  // conflicting mutation). Deliberately NOT gated on clearedUpToMessageId/revertedFromMessageId
+  // either — those are conversation-history hidden-states, an orthogonal concern from the actual
+  // git working tree.
+  app.get('/api/v1/code/sessions/:id/git/status', async (c) => {
+    const run = db.getAgentRun(c.req.param('id'))
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
+    const status = await getGitStatus(run.repoRoot)
+    return c.json({ ok: true, status })
+  })
+
+  // Commit and push DO gate on runs.isActive(id) — same discipline as /compact, /clear, /revert
+  // above: a live turn's own edit/write tool calls mutate this exact working tree, so staging or
+  // committing concurrently risks capturing a file mid-write. (The pi tool-call approval gate,
+  // waitForToolApproval/resolveToolApproval, is a different mechanism for a different shape of
+  // action — it exists to gate the MODEL interrupting a live turn to ask permission for a tool
+  // call; these are plain user-triggered REST actions with no live turn or toolCallId involved at
+  // all, so the run_active 409 below — the same guard every other repo-mutating Code route already
+  // uses — is the correct fit, not a bypass of the approval gate.)
+  app.post('/api/v1/code/sessions/:id/git/commit', async (c) => {
+    const id = c.req.param('id')
+    const run = db.getAgentRun(id)
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
+    if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before committing.')
+    const b = await body<{ message?: string; files?: string[] }>(c)
+    try {
+      const result = await commitGitChanges(run.repoRoot, b.message ?? '', b.files)
+      return c.json({ ok: true, ...result })
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Commit failed.'
+      if (/commit message is required/i.test(message)) return err(c, 400, 'invalid_input', message)
+      if (/not a git repository/i.test(message)) return err(c, 400, 'not_a_git_repo', message)
+      if (/nothing to commit|nothing staged/i.test(message)) return err(c, 400, 'nothing_to_commit', message)
+      if (/outside the repo/i.test(message)) return err(c, 400, 'invalid_input', message)
+      return err(c, 500, 'git_commit_failed', message)
+    }
+  })
+
+  app.post('/api/v1/code/sessions/:id/git/push', async (c) => {
+    const id = c.req.param('id')
+    const run = db.getAgentRun(id)
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
+    if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before pushing.')
+    const result = await pushGitBranch(run.repoRoot)
+    if (!result.ok) {
+      const status = result.reason === 'diverged' ? 409 : 400
+      return err(c, status, result.reason, result.message)
+    }
+    const compareUrl = await getGithubCompareUrl(run.repoRoot, result.branch)
+    return c.json({ ok: true, remote: result.remote, branch: result.branch, compareUrl })
+  })
+
+  // Standalone lookup (independent of push) — lets the UI offer "Create PR" for a branch that
+  // was already pushed by a previous session/turn, without pushing again.
+  app.get('/api/v1/code/sessions/:id/git/compare-url', async (c) => {
+    const run = db.getAgentRun(c.req.param('id'))
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
+    const status = await getGitStatus(run.repoRoot)
+    if (!status.isRepo || status.detached || !status.branch) return c.json({ ok: true, compareUrl: null })
+    const compareUrl = await getGithubCompareUrl(run.repoRoot, status.branch)
+    return c.json({ ok: true, compareUrl })
+  })
+
+  // `!command` / `!!command` shell escape (ADR-258) — the USER runs a shell command in the session
+  // repoRoot (via the same robust-bash wrapper the agent's own bash tool uses). Gated on
+  // runs.isActive, same discipline as commit/push/compact/revert: a user command can mutate the
+  // working tree, and `feedToModel` additionally writes a conversation message that a live turn's
+  // history is mid-use of. `feedToModel` (the `!` variant) persists the command + its output as a
+  // user message so the model sees it as context on the next turn (seedPriorHistory replays a user
+  // message's content verbatim); `!!` passes false — the output is returned for a transcript-only
+  // peek and nothing is persisted.
+  app.post('/api/v1/code/sessions/:id/exec', async (c) => {
+    const id = c.req.param('id')
+    const run = db.getAgentRun(id)
+    if (!run) return err(c, 404, 'not_found', 'Session not found.')
+    if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
+    if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before running a command.')
+    const b = await body<{ command?: string; feedToModel?: boolean }>(c)
+    const command = (b.command ?? '').trim()
+    if (!command) return err(c, 400, 'invalid_input', 'A command is required.')
+    const feedToModel = b.feedToModel !== false // default true (the `!` variant); `!!` sends false
+
+    let result
+    try {
+      result = await runShellCommand(command, run.repoRoot, id)
+    } catch (e) {
+      return err(c, 500, 'exec_failed', e instanceof Error ? e.message : 'Command failed to run.')
+    }
+
+    let messageId: string | undefined
+    if (feedToModel) {
+      const msg = db.addMessage(run.convId, 'user', shellContextText(result), {
+        toolCalls: [{
+          id: `shell-${Date.now()}`,
+          name: 'shell',
+          args: { command, exitCode: result.exitCode, timedOut: result.timedOut },
+          result: result.output,
+        }],
+      })
+      messageId = msg.id
+    }
+    return c.json({
+      ok: true,
+      command,
+      output: result.output,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      truncated: result.truncated,
+      messageId,
+    }, 200)
+  })
+
   // ── stop the in-flight run (+ drop the queue) ─────────────────────────────────
   app.post('/api/v1/code/sessions/:id/stop', (c) => {
     const id = c.req.param('id')
@@ -441,7 +611,12 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
   // that is how a follow-up submitted mid-run survives a disconnect and still fires in order.
   app.post('/api/v1/code/sessions/:id/messages', async (c) => {
     const id = c.req.param('id')
-    const b = await body<{ content?: string; promptOverride?: string; contextFiles?: string[]; thinkingBudget?: number }>(c)
+    const b = await body<{ content?: string; promptOverride?: string; contextFiles?: string[]; thinkingBudget?: number; kind?: string }>(c)
+    // How to deliver this message when a run is already active (Phase 1, ADR-246): 'steer'
+    // redirects the CURRENTLY ACTIVE turn, 'followUp' queues a fresh turn behind it. Anything
+    // else — including the field being omitted by the not-yet-updated frontend — defaults to
+    // 'followUp', which is byte-for-byte today's behavior (zero change for existing callers).
+    const kind: SteerKind = b.kind === 'steer' ? 'steer' : 'followUp'
 
     const run = db.getAgentRun(id)
     if (!run) return err(c, 404, 'not_found', 'Session not found.')
@@ -456,20 +631,20 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     if (ms.state !== 'running' || !ms.model) return err(c, 409, 'model_not_loaded', 'Load a model first.')
     if (!d.manager.target()) return err(c, 409, 'model_not_loaded', 'Engine not running.')
 
-    // The task for this turn: an explicit follow-up body wins; otherwise the last user message
+    // The task for this turn: an explicit message body wins; otherwise the last user message
     // (the seeded task on the first run).
-    const followUp = (b.content ?? '').trim()
+    const newContent = (b.content ?? '').trim()
     let userMsgId: string
     let task: string
-    if (followUp) {
-      userMsgId = db.addMessage(run.convId, 'user', followUp, { textAttachments: b.contextFiles }).id
+    if (newContent) {
+      userMsgId = db.addMessage(run.convId, 'user', newContent, { textAttachments: b.contextFiles }).id
       // promptOverride lets the CALLER separate "what's stored/shown" from "what's actually
       // prompted this turn" — the founder's own literal message must never be silently rewritten
       // (see CodeSessionScreen.tsx's skill-invocation picker, the one caller of this today), but
       // the model still needs an explicit nudge to invoke a picked skill. Future turns' history
-      // replay always uses the STORED message (followUp), never the override, so past turns read
+      // replay always uses the STORED message (newContent), never the override, so past turns read
       // back as what the user actually said, not the synthetic nudge that steered that one turn.
-      task = contextFilesBlock(b.contextFiles) + ((b.promptOverride ?? '').trim() || followUp)
+      task = contextFilesBlock(b.contextFiles) + ((b.promptOverride ?? '').trim() || newContent)
     } else {
       const lastUser = (conv.messages ?? []).filter((m) => m.role === 'user').at(-1)
       if (!lastUser) return err(c, 400, 'no_task', 'No task to run.')
@@ -477,8 +652,17 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       task = contextFilesBlock(lastUser.textAttachments) + lastUser.content
     }
 
-    const { queued } = runs.enqueue(id, { convId: run.convId, repoRoot: run.repoRoot, task, userMsgId, thinkingBudget: b.thinkingBudget })
-    return c.json({ ok: true, queued, userMessageId: userMsgId }, 202)
+    // 'steer' tries to inject into the live turn (falling back to the queue if there's nothing to
+    // steer); 'followUp' (the default) queues a fresh turn exactly as before. `steered` tells the
+    // caller which happened — the frontend renders an injected message inline instead of as a
+    // pending "Queued" chip.
+    const enqueueParams = { convId: run.convId, repoRoot: run.repoRoot, task, userMsgId, thinkingBudget: b.thinkingBudget }
+    if (kind === 'steer') {
+      const { steered, queued } = await runs.steer(id, enqueueParams)
+      return c.json({ ok: true, queued, steered, userMessageId: userMsgId }, 202)
+    }
+    const { queued } = runs.enqueue(id, enqueueParams)
+    return c.json({ ok: true, queued, steered: false, userMessageId: userMsgId }, 202)
   })
 
   // ── (re)connect to a session's run stream (SSE) ───────────────────────────────
@@ -506,6 +690,10 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       if (meta) await stream.writeSSE({ event: 'meta', data: JSON.stringify(meta) })
       // Current server-side queue snapshot, so the client's "Queued" chips are correct on connect.
       await stream.writeSSE({ event: 'queue', data: JSON.stringify({ queued: runs.queued(id) }) })
+      // Current step checklist snapshot (ADR-255), so a mid-turn (re)connect shows live progress up
+      // front. Only when non-empty — no point emitting an empty checklist on every connect.
+      const currentTodos = runs.todos(id)
+      if (currentTodos.length > 0) await stream.writeSSE({ event: 'todos', data: JSON.stringify({ todos: currentTodos }) })
 
       for await (const ev of sub) {
         // The `id:` field carries the seq so the client can reconnect with ?fromSeq=<last id>.

--- a/turbollm/src/code/code-run-manager.reconnect.test.ts
+++ b/turbollm/src/code/code-run-manager.reconnect.test.ts
@@ -180,11 +180,11 @@ test('a queued follow-up survives a mid-run disconnect and runs in order server-
   const u2 = store.addMessage(convId, 'user', 'second')
   const r2 = mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
   assert.equal(r2.queued, true, 'the follow-up queued behind the active turn')
-  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second' }], 'server-side queue holds the follow-up')
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second', kind: 'followUp' }], 'server-side queue holds the follow-up (tagged followUp by default)')
 
   // DISCONNECT mid-run. The queue is server-side, so it must survive.
   sub1.close()
-  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second' }], 'queue survived the client disconnect')
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second', kind: 'followUp' }], 'queue survived the client disconnect')
 
   // Reconnect and watch everything to the end.
   const sub2 = mgr.subscribe(sessionId, 0)
@@ -269,7 +269,7 @@ test('stop() aborts the active run and drops everything queued behind it', async
   mgr.enqueue(sessionId, { convId, repoRoot, task: 'do gamma', userMsgId })
   const u2 = store.addMessage(convId, 'user', 'queued one')
   mgr.enqueue(sessionId, { convId, repoRoot, task: 'queued one', userMsgId: u2.id })
-  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'queued one' }])
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'queued one', kind: 'followUp' }])
 
   const sub1 = mgr.subscribe(sessionId, 0)
   await collect(sub1, (ev) => ev.event === 'tool_call') // early return closes sub1 (a disconnect)
@@ -392,4 +392,149 @@ test('a runner that THROWS AbortError also floors ctxUsed at the last confirmed 
   assert.equal(last?.stats.aborted, true)
   assert.equal(last?.stats.ctxUsed, 3000, 'a thrown AbortError still carries forward the last known context, not 0')
   assert.equal(store.getAgentRun(sessionId)?.status, 'interrupted')
+})
+
+// ── steer/followUp dispatch (Phase 1, ADR-246) ─────────────────────────────────────────
+//
+// These drive the manager's steer() vs enqueue() dispatch with an injected runner that exposes
+// (or refuses) a live steer handle, exactly the way the real runCodeSession publishes pi's
+// session.steer via onSteerable — no loaded model needed.
+
+/** A runner that publishes a steer handle via onSteerable (like runCodeSession does once its pi
+ *  session is streaming), records every steered text into `steerLog`, and stays "active" long
+ *  enough (holdMs) for a test to steer into it before it settles. `streaming: false` makes the
+ *  handle refuse (return false) to simulate the turn having just finished (the race the fallback
+ *  guards). Honors the abort signal like the real runner. */
+function steerableRunner(opts: { steerLog: string[]; streaming?: boolean; holdMs?: number }): CodeSessionRunner {
+  return (async (params) => {
+    const { signal } = params
+    params.onSteerable?.(async (text: string) => {
+      if (opts.streaming === false) return false
+      opts.steerLog.push(text)
+      return true
+    })
+    const hold = opts.holdMs ?? 120
+    const start = Date.now()
+    while (Date.now() - start < hold) {
+      if (signal.aborted) break
+      await delay(10)
+    }
+    params.onSteerable?.(null)
+    return { finalText: 'ok', contextUsed: 100, contextMax: 8192, aborted: signal.aborted }
+  }) as CodeSessionRunner
+}
+
+test('enqueue tags a queued follow-up with kind:followUp by default', async () => {
+  const { d, store } = makeDeps()
+  const mgr = new CodeRunManager(d, { runner: pacedRunner('fu') })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  const sub1 = mgr.subscribe(sessionId, 0)
+  await collect(sub1, (ev) => ev.event === 'tool_call')
+  const u2 = store.addMessage(convId, 'user', 'second')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'second', kind: 'followUp' }])
+  sub1.close()
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+})
+
+test('steer() injects into the ACTIVE turn via the live handle, and does NOT queue', async () => {
+  const { d, store } = makeDeps()
+  const steerLog: string[] = []
+  const mgr = new CodeRunManager(d, { runner: steerableRunner({ steerLog, holdMs: 250 }) })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  await delay(40) // let the turn start and register its steer handle
+  assert.equal(mgr.isActive(sessionId), true)
+
+  const u2 = store.addMessage(convId, 'user', 'go left instead')
+  const res = await mgr.steer(sessionId, { convId, repoRoot, task: 'go left instead', userMsgId: u2.id })
+  assert.equal(res.steered, true, 'delivered into the live turn')
+  assert.equal(res.queued, false)
+  assert.deepEqual(steerLog, ['go left instead'], 'pi steer handle received the message')
+  assert.deepEqual(mgr.queued(sessionId), [], 'a steered message is never queued')
+
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+})
+
+test('steer() with no active turn falls back to starting the turn (never errors)', async () => {
+  const { d, store } = makeDeps()
+  const steerLog: string[] = []
+  const mgr = new CodeRunManager(d, { runner: steerableRunner({ steerLog, holdMs: 20 }) })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+
+  // Idle session: nothing live to steer, so it falls back to enqueue, which STARTS the turn.
+  const res = await mgr.steer(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  assert.equal(res.steered, false, 'nothing live to steer')
+  assert.equal(res.queued, false, 'idle session: fell back to starting the turn, not queuing behind one')
+  assert.deepEqual(steerLog, [], 'the handle was never called (no active turn existed)')
+  assert.equal(mgr.isActive(sessionId), true, 'the fallback started the turn')
+
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+})
+
+test('steer() falls back to the queue (tagged kind:steer) when the live turn is no longer streaming', async () => {
+  const { d, store } = makeDeps()
+  const steerLog: string[] = []
+  // streaming:false → the handle returns false, simulating the turn having just settled (race).
+  const mgr = new CodeRunManager(d, { runner: steerableRunner({ steerLog, streaming: false, holdMs: 250 }) })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  await delay(40)
+
+  const u2 = store.addMessage(convId, 'user', 'redirect')
+  const res = await mgr.steer(sessionId, { convId, repoRoot, task: 'redirect', userMsgId: u2.id })
+  assert.equal(res.steered, false, 'the handle refused (not streaming)')
+  assert.equal(res.queued, true, 'fell back to queuing behind the still-active turn')
+  assert.deepEqual(steerLog, [], 'no message delivered live')
+  assert.deepEqual(mgr.queued(sessionId), [{ userMsgId: u2.id, task: 'redirect', kind: 'steer' }], 'the fallback queue entry preserves the requested kind')
+
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+})
+
+// ── todo/step checklist live state (ADR-255) ───────────────────────────────────────────
+
+/** A runner that emits one `todos` frame (the update_todos tool's SSE shape) then completes. */
+function todoRunner(todos: Array<{ content: string; status: string }>): CodeSessionRunner {
+  return (async (params) => {
+    params.sink({ event: 'todos', data: { todos } })
+    return { finalText: 'ok', contextUsed: 100, contextMax: 8192, aborted: false }
+  }) as CodeSessionRunner
+}
+
+test('a todos frame is captured into the run\'s live state and exposed via todos() for reconnect', async () => {
+  const { d, store } = makeDeps()
+  const list = [{ content: 'step 1', status: 'in_progress' }, { content: 'step 2', status: 'pending' }]
+  const mgr = new CodeRunManager(d, { runner: todoRunner(list) })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'multi-step')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'multi-step', userMsgId })
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.deepEqual(mgr.todos(sessionId), list, 'the latest checklist is held in live state (snapshot on connect)')
+})
+
+test('a new turn resets the checklist so a prior turn\'s todos never leak forward', async () => {
+  const { d, store } = makeDeps()
+  const runner: CodeSessionRunner = (params) => {
+    if (params.task === 'first') return todoRunner([{ content: 'a', status: 'pending' }])(params)
+    // Turn 2 emits NO todos frame — the pump-time reset must clear turn 1's list on its own.
+    return (async () => ({ finalText: 'ok', contextUsed: 1, contextMax: 2, aborted: false }))()
+  }
+  const mgr = new CodeRunManager(d, { runner })
+  const repoRoot = tmp('tllm-code-repo-')
+  const { sessionId, convId, userMsgId } = makeSession(store, repoRoot, 'first')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'first', userMsgId })
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.deepEqual(mgr.todos(sessionId), [{ content: 'a', status: 'pending' }], 'turn 1 left a checklist')
+
+  const u2 = store.addMessage(convId, 'user', 'second')
+  mgr.enqueue(sessionId, { convId, repoRoot, task: 'second', userMsgId: u2.id })
+  await collect(mgr.subscribe(sessionId, 0), () => false)
+  assert.deepEqual(mgr.todos(sessionId), [], 'turn 2 emitted no checklist, so the reset left it empty — no leak from turn 1')
 })

--- a/turbollm/src/code/code-run-manager.ts
+++ b/turbollm/src/code/code-run-manager.ts
@@ -27,8 +27,14 @@ import { EventEmitter } from 'node:events'
 import type { Deps } from '../deps'
 import type { ToolCallRecord, MessageTimelineBlock } from '../chat/db'
 import { autoTitleFromConversation } from '../chat/chat-routes'
-import { runCodeSession } from './code-session'
+import { runCodeSession, type SteerHandle, type TodoItem } from './code-session'
 import type { CodeMode } from './persona'
+
+/** How a new message submitted while a run is active should be delivered (Phase 1, ADR-246):
+ *  `'steer'` interrupts and redirects the CURRENTLY ACTIVE turn (pi's session.steer), `'followUp'`
+ *  waits its turn in the server-side queue and runs as a fresh turn after (today's behavior, and
+ *  the default when a caller omits it — the not-yet-updated frontend). */
+export type SteerKind = 'steer' | 'followUp'
 
 /** The one function the manager drives per turn. Defaults to the real pi-SDK `runCodeSession`;
  *  injectable so the daemon-ownership + reconnect mechanism can be exercised deterministically
@@ -87,12 +93,19 @@ interface PendingTurn {
   userMsgId: string
   /** -1 = unlimited (default), 0 = off, N>0 = a real token cap — see RunCodeParams.thinkingBudget. */
   thinkingBudget: number
+  /** What the caller requested for this message — recorded even for a queued entry so the UI can
+   *  distinguish a steer that fell back to the queue from a plain follow-up (see SteerKind). */
+  kind: SteerKind
 }
 
 interface ActiveTurn {
   ac: AbortController
   assistantMsgId: string
   userMsgId: string
+  /** The live turn's steer handle, set by runCodeSession's onSteerable once its pi session is
+   *  streaming and cleared (null) when it settles. Lets steer() inject into THIS turn instead of
+   *  queueing a fresh one. null while the session is still starting up or already finishing. */
+  steer: SteerHandle | null
 }
 
 interface SessionState {
@@ -107,6 +120,11 @@ interface SessionState {
    *  already-persisted earlier turn); bumped to buffer.head() when the session goes idle (so
    *  a fresh reconnect replays nothing and hands straight off to the DB transcript). */
   replayFloor: number
+  /** The latest todo/step checklist the active turn emitted via update_todos (ADR-255), held so a
+   *  (re)connecting client gets the current list up front (like the queue), not only if it happened
+   *  to be watching when the frame streamed. Reset to [] at the start of each turn — a checklist is
+   *  the CURRENT turn's plan, never carried over from a prior one. */
+  todos: TodoItem[]
   cleanupTimer?: ReturnType<typeof setTimeout>
 }
 
@@ -141,8 +159,14 @@ export class CodeRunManager {
    *  message queue, surfaced to the UI so its "Queued" chips survive a disconnect. `userMsgId`
    *  (not just index) identifies each entry so a per-chip action (sendNow) can target one
    *  specific queued turn even if two queued tasks have identical text. */
-  queued(sessionId: string): { userMsgId: string; task: string }[] {
-    return this.sessions.get(sessionId)?.queue.map((t) => ({ userMsgId: t.userMsgId, task: t.task })) ?? []
+  queued(sessionId: string): { userMsgId: string; task: string; kind: SteerKind }[] {
+    return this.sessions.get(sessionId)?.queue.map((t) => ({ userMsgId: t.userMsgId, task: t.task, kind: t.kind })) ?? []
+  }
+
+  /** The active turn's current todo/step checklist (ADR-255), for a (re)connecting client to show
+   *  up front. Empty when no turn has emitted one this turn (or the session is unknown). */
+  todos(sessionId: string): TodoItem[] {
+    return this.sessions.get(sessionId)?.todos ?? []
   }
 
   /** The in-flight turn's message ids, so a reconnecting stream can synthesize a `meta` frame
@@ -157,7 +181,7 @@ export class CodeRunManager {
     if (!s) {
       const emitter = new EventEmitter()
       emitter.setMaxListeners(0) // unbounded: many tabs may watch one session
-      s = { convId, repoRoot, buffer: new RingBuffer(), emitter, queue: [], active: null, replayFloor: 0 }
+      s = { convId, repoRoot, buffer: new RingBuffer(), emitter, queue: [], active: null, replayFloor: 0, todos: [] }
       this.sessions.set(sessionId, s)
     }
     if (s.cleanupTimer) { clearTimeout(s.cleanupTimer); s.cleanupTimer = undefined }
@@ -171,13 +195,43 @@ export class CodeRunManager {
    *
    * `queued` is true when the turn had to wait (a run was already active), false when it started.
    */
-  enqueue(sessionId: string, params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number }): { queued: boolean } {
+  enqueue(sessionId: string, params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number; kind?: SteerKind }): { queued: boolean } {
     const s = this.ensure(sessionId, params.convId, params.repoRoot)
     const willQueue = s.active !== null
-    s.queue.push({ task: params.task, userMsgId: params.userMsgId, thinkingBudget: params.thinkingBudget ?? -1 })
+    s.queue.push({ task: params.task, userMsgId: params.userMsgId, thinkingBudget: params.thinkingBudget ?? -1, kind: params.kind ?? 'followUp' })
     this.emitQueue(sessionId)
     void this.pump(sessionId)
     return { queued: willQueue }
+  }
+
+  /**
+   * Steer a message into the CURRENTLY ACTIVE turn (pi's session.steer, reached via the handle
+   * runCodeSession registers) so it redirects the running turn instead of queueing a fresh one
+   * behind it.
+   *
+   * Falls back to enqueue() (follow-up/queue) rather than erroring when there is nothing live to
+   * steer — either no active turn at all, or the active turn stopped streaming in the moment
+   * before we reached it (a race: the turn just finished). In the fallback the message is never
+   * dropped; it simply runs as the next turn instead, and its queue entry keeps kind:'steer' so
+   * the UI can still tell it apart from a plain follow-up.
+   *
+   * Returns `steered` (delivered into the live turn) and, when it wasn't, `queued` (whether the
+   * fallback had to wait behind an active turn, mirroring enqueue's own return).
+   */
+  async steer(
+    sessionId: string,
+    params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number },
+  ): Promise<{ steered: boolean; queued: boolean }> {
+    const active = this.sessions.get(sessionId)?.active
+    if (active?.steer) {
+      try {
+        if (await active.steer(params.task)) return { steered: true, queued: false }
+      } catch {
+        // A steer that can't be delivered live still runs — fall through to the queue below.
+      }
+    }
+    const { queued } = this.enqueue(sessionId, { ...params, kind: 'steer' })
+    return { steered: false, queued }
   }
 
   /** The most recent real ctxUsed/ctxMax on record for this conversation (the last assistant
@@ -231,11 +285,14 @@ export class CodeRunManager {
     // empty placeholder whose id the live block dedups against (CodeTranscript liveAssistantId).
     const assistantMsg = this.d.db.addMessage(s.convId, 'assistant', '', { stats: { aborted: false } })
     const ac = new AbortController()
-    s.active = { ac, assistantMsgId: assistantMsg.id, userMsgId: turn.userMsgId }
+    s.active = { ac, assistantMsgId: assistantMsg.id, userMsgId: turn.userMsgId, steer: null }
 
     // Only this turn (from its meta onward) is replayable to a fresh reconnect — earlier turns
     // are already DB-persisted messages.
     s.replayFloor = s.buffer.head()
+    // A checklist belongs to the CURRENT turn — clear any list a prior turn left behind so a
+    // reconnect to this fresh turn (before the model emits its own todos) shows nothing stale.
+    s.todos = []
 
     const push = (event: string, data: unknown) => {
       const ss = this.sessions.get(sessionId)
@@ -268,6 +325,13 @@ export class CodeRunManager {
         else timeline.push({ type: 'text', text: delta })
       }
       else if (ev.event === 'reasoning') reasoning += String(data.delta ?? '')
+      else if (ev.event === 'todos') {
+        // Hold the latest checklist in live state so a (re)connecting client gets it up front (the
+        // stream handler snapshots runs.todos on connect) — the frame is already normalized by the
+        // update_todos tool. Ephemeral: never DB-persisted, just carried for reconnect like queue.
+        const ss = this.sessions.get(sessionId)
+        if (ss) ss.todos = Array.isArray(data.todos) ? (data.todos as TodoItem[]) : []
+      }
       else if (ev.event === 'tool_call' && (data.status === 'done' || data.status === 'error')) {
         const id = String(data.id ?? '')
         toolCalls.push({
@@ -305,6 +369,13 @@ export class CodeRunManager {
         task: turn.task,
         signal: ac.signal,
         sink,
+        // Publish/withdraw the live turn's steer handle so steer() can inject into THIS turn.
+        // Reads s.active fresh each call (rather than closing over the ActiveTurn captured above)
+        // so a null clear can't accidentally resurrect a handle onto a since-replaced turn.
+        onSteerable: (steer) => {
+          const cur = this.sessions.get(sessionId)?.active
+          if (cur && cur.ac === ac) cur.steer = steer
+        },
       })
 
       const finalContent = content.trim() || result.finalText

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
 import { toSessionStatus, resolveRevertCut } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, type TodoItem } from './code-session'
+import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, LOOP_ABORT_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, pickPrefillProgress, PREFILL_POLL_MS, type TodoItem } from './code-session'
 import { ConversationStore, type Message } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
@@ -699,6 +699,20 @@ test('ToolLoopTracker: counts consecutive identical calls; the (LOOP_BREAK_AFTER
   assert.equal(call(), LOOP_BREAK_AFTER + 2)
 })
 
+test('ToolLoopTracker: the count keeps climbing past LOOP_BREAK_AFTER, crossing LOOP_ABORT_AFTER for the hard-stop escalation', () => {
+  // Founder-reported live (2026-07-24): the soft nudge alone had "no effect" — a stuck model just
+  // re-emitted the exact same call anyway, and since record() never caps, the hook's own
+  // LOOP_ABORT_AFTER check (code-session.ts, tool_call hook) needs count to keep growing past the
+  // soft threshold so it can actually cross the hard one and abort the run for real.
+  assert.ok(LOOP_ABORT_AFTER > LOOP_BREAK_AFTER, 'the hard-stop threshold must be strictly past the soft-nudge one')
+  const t = new ToolLoopTracker()
+  const call = () => t.record('bash', { command: 'npm test' })
+  let last = 0
+  for (let n = 1; n <= LOOP_ABORT_AFTER; n++) last = call()
+  assert.equal(last, LOOP_ABORT_AFTER, 'still at the threshold, not yet past it')
+  assert.equal(call(), LOOP_ABORT_AFTER + 1, 'the next identical call is the one that crosses it')
+})
+
 test('ToolLoopTracker: any different call resets the run to 1', () => {
   const t = new ToolLoopTracker()
   t.record('read', { path: 'a.ts' })
@@ -928,4 +942,58 @@ test('summarizeTodos: omits the in-progress clause when nothing is in progress',
 
 test('summarizeTodos: an empty list reads as an explicit clear', () => {
   assert.equal(summarizeTodos([]), 'Todo list cleared.')
+})
+
+// ── pickPrefillProgress (code-session.ts) — the llama.cpp /slots → prefill-percentage extractor,
+// pure/isolable so the slot-matching + math is tested without a live engine (mirrors codeEventToFrame).
+
+const procSlot = (processed: number, total: number, extra: Record<string, unknown> = {}) =>
+  ({ is_processing: true, n_prompt_tokens: total, n_prompt_tokens_processed: processed, ...extra })
+
+test('pickPrefillProgress: a single processing slot yields processed/total/pct (rounded)', () => {
+  assert.deepEqual(pickPrefillProgress([procSlot(27140, 93760)]), { processed: 27140, total: 93760, pct: 29 })
+})
+
+test('pickPrefillProgress: pct is clamped to 100 when processed reaches or exceeds total', () => {
+  assert.equal(pickPrefillProgress([procSlot(93760, 93760)])?.pct, 100)
+  assert.equal(pickPrefillProgress([procSlot(99999, 93760)])?.pct, 100)
+})
+
+test('pickPrefillProgress: 0 processed against a real total is a valid 0%', () => {
+  assert.deepEqual(pickPrefillProgress([procSlot(0, 1000)]), { processed: 0, total: 1000, pct: 0 })
+})
+
+test('pickPrefillProgress: null for a non-array body (an error object, null, undefined)', () => {
+  assert.equal(pickPrefillProgress({ error: 'not found' }), null)
+  assert.equal(pickPrefillProgress(null), null)
+  assert.equal(pickPrefillProgress(undefined), null)
+})
+
+test('pickPrefillProgress: null when no slot is processing (idle engine / empty array)', () => {
+  assert.equal(pickPrefillProgress([{ is_processing: false, n_prompt_tokens: 100, n_prompt_tokens_processed: 0 }]), null)
+  assert.equal(pickPrefillProgress([]), null)
+})
+
+test('pickPrefillProgress: null when the processing slot has a zero/absent prompt-token total (avoid /0)', () => {
+  assert.equal(pickPrefillProgress([procSlot(0, 0)]), null)
+  assert.equal(pickPrefillProgress([{ is_processing: true, n_prompt_tokens_processed: 5 }]), null)
+})
+
+test('pickPrefillProgress: bails (null) when MORE THAN ONE slot is processing — ambiguous, would risk a wrong bar', () => {
+  // Only reachable under --parallel>1 with a concurrent generation the gate doesn't serialize; pi
+  // exposes no id_task to correlate, so showing nothing beats attributing another request's progress.
+  assert.equal(pickPrefillProgress([procSlot(10, 100), procSlot(50, 200)]), null)
+})
+
+test('pickPrefillProgress: ignores idle/malformed slots and uses the single valid processing one', () => {
+  const slots = [
+    { is_processing: false, n_prompt_tokens: 100, n_prompt_tokens_processed: 100 }, // idle → ignored
+    { is_processing: true },                                                         // malformed → ignored
+    procSlot(400, 800),                                                              // the real one
+  ]
+  assert.deepEqual(pickPrefillProgress(slots), { processed: 400, total: 800, pct: 50 })
+})
+
+test('PREFILL_POLL_MS: a sane sub-second poll interval', () => {
+  assert.ok(PREFILL_POLL_MS >= 100 && PREFILL_POLL_MS <= 1000)
 })

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -13,10 +13,11 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
 import { toSessionStatus, resolveRevertCut } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER } from './code-session'
+import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, type TodoItem } from './code-session'
 import { ConversationStore, type Message } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
+import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent'
 
 // ── toolsForMode ──────────────────────────────────────────────────────────────────
 
@@ -168,6 +169,57 @@ test('reactivateMessagesFrom: a NEW message sent after a revert is unaffected by
   // Resuming (undoing) the revert brings attempt 1 back WITHOUT disturbing attempt 2.
   store.reactivateMessagesFrom(convId, m1.id)
   assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['first task', 'second task (attempt 1)', 'second task (attempt 2)'])
+})
+
+// ── deactivateMessagesUpTo / reactivateMessagesUpTo (db.ts) — the /clear PREFIX deactivation (v34,
+// ADR-261). The mirror of deactivateMessagesFrom's suffix: /clear hides everything up to AND
+// INCLUDING the cut, so getMessages()/getConversation()/export/model-replay all exclude it at the
+// source (is_active=0), replacing the old client-only clearedUpToMessageId display cursor. --------
+
+test('deactivateMessagesUpTo: deactivates the cut message AND everything before it, leaving later turns active', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'old task')
+  const oldReply = store.addMessage(convId, 'assistant', 'old reply')
+  store.addMessage(convId, 'user', 'newer, kept turn')
+
+  const affected = store.deactivateMessagesUpTo(convId, oldReply.id)
+  assert.equal(affected, 2, 'the two messages at/before the cut')
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['newer, kept turn'], 'everything at/before the cut is hidden; the later turn stays')
+})
+
+test('deactivateMessagesUpTo: an unknown message id is a no-op (0 rows), never throws', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'task')
+  assert.equal(store.deactivateMessagesUpTo(convId, 'does-not-exist'), 0)
+  assert.equal(store.getMessages(convId).length, 1, 'untouched')
+})
+
+test('reactivateMessagesUpTo: undoes a /clear exactly, restoring the cleared prefix (the /resume contract)', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'first')
+  const cut = store.addMessage(convId, 'assistant', 'first reply')
+  store.deactivateMessagesUpTo(convId, cut.id)
+  assert.equal(store.getMessages(convId).length, 0, 'the whole history is cleared')
+
+  const restored = store.reactivateMessagesUpTo(convId, cut.id)
+  assert.equal(restored, 2)
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['first', 'first reply'])
+})
+
+test('reactivateMessagesUpTo: a NEW turn appended AFTER a /clear is unaffected by a later /resume (step-6 case)', () => {
+  const { store, convId } = makeRevertConv()
+  store.addMessage(convId, 'user', 'A')
+  const cut = store.addMessage(convId, 'assistant', 'B') // clear cut here
+  store.deactivateMessagesUpTo(convId, cut.id)
+  // A brand-new turn after the clear — higher seq than the cut, so it must never be touched by the
+  // clear's own resume, and it must remain visible throughout.
+  store.addMessage(convId, 'user', 'C (new turn after clear)')
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['C (new turn after clear)'])
+
+  // /resume reactivates ONLY the originally-cleared prefix (seq <= cut); the new turn is already
+  // active and stays exactly once, not duplicated or disturbed.
+  store.reactivateMessagesUpTo(convId, cut.id)
+  assert.deepEqual(store.getMessages(convId).map((m) => m.content), ['A', 'B', 'C (new turn after clear)'])
 })
 
 // ── tool-set contracts ──────────────────────────────────────────────────────────────
@@ -326,10 +378,11 @@ test('buildAppendPrompt: plan omits edit guidance; auto/ask include it', () => {
   const plan = buildAppendPrompt('plan')
   const auto = buildAppendPrompt('auto')
   const ask = buildAppendPrompt('ask')
-  // Plan mode has no edit tool, so the edit-reliability and LSP blocks are both dropped.
+  // Plan mode has no edit tool, so the edit-reliability, LSP, and todo-tracker blocks are all
+  // dropped there (auto/ask get basePersona + mode + edit + lsp + todo = 5).
   assert.equal(plan.length, 2)
-  assert.equal(auto.length, 4)
-  assert.equal(ask.length, 4)
+  assert.equal(auto.length, 5)
+  assert.equal(ask.length, 5)
   assert.ok(plan.every((b) => typeof b === 'string' && b.length > 0))
   // Every mode's guidance mentions its own name.
   assert.match(plan[1], /PLAN/)
@@ -369,11 +422,11 @@ test('skillsBlock: caps a pathological instructions body at 20,000 chars', () =>
 })
 
 test('buildAppendPrompt: with no skills argument, output is unchanged from before Task 4', () => {
-  // basePersona + modeGuidance always; +editReliabilityGuidance +lspGuidance outside plan mode
-  // (plan has no edit tool, see buildAppendPrompt's own comment); hasWebTools defaults false so
-  // the item 1/2 blocks are omitted here (covered separately in persona.test.ts).
+  // basePersona + modeGuidance always; +editReliabilityGuidance +lspGuidance +todoTrackerGuidance
+  // outside plan mode (plan has no edit tool, see buildAppendPrompt's own comment); hasWebTools
+  // defaults false so the item 1/2 blocks are omitted here (covered separately in persona.test.ts).
   for (const m of ['auto', 'plan', 'ask'] as CodeMode[]) {
-    assert.equal(buildAppendPrompt(m).length, m === 'plan' ? 2 : 4)
+    assert.equal(buildAppendPrompt(m).length, m === 'plan' ? 2 : 5)
   }
 })
 
@@ -491,12 +544,15 @@ test('resolveEffectiveHistory: a compaction marker pointing at a deleted/missing
 
 // ── resolveEffectiveHistory + /clear + /resume ───────────────────────────────────────
 
-test('resolveEffectiveHistory: after a /clear marker — no summary, only messages after the cut', () => {
+test('resolveEffectiveHistory: after a /clear (v34 — real deactivation) — no summary, only the still-active post-clear messages', () => {
   const { d, store, convId, sessionId } = makeCodeConv()
   store.addMessage(convId, 'user', 'old task')
   const oldReply = store.addMessage(convId, 'assistant', 'old reply')
   store.addMessage(convId, 'user', 'new task')
 
+  // A real /clear now DEACTIVATES the prefix (is_active=0) AND records the marker — mirror both, so
+  // getConversation/getMessages already excludes the cleared messages (no cursor slice here anymore).
+  store.deactivateMessagesUpTo(convId, oldReply.id)
   store.setClearedUpToMessageId(sessionId, oldReply.id)
 
   const { summaryText, messages } = resolveEffectiveHistory(d, convId, sessionId)
@@ -514,10 +570,11 @@ test('resolveEffectiveHistory: a /clear after an earlier /compact wins — blank
   store.addMessage(convId, 'user', 'newest task 3')
 
   store.updateAgentRun(sessionId, { compactionSummary: 'summary of task 1', compactionUpToMessageId: oldReply.id })
-  store.setClearedUpToMessageId(sessionId, newReply.id) // clears everything up through the compacted turn too
+  store.deactivateMessagesUpTo(convId, newReply.id) // /clear deactivates everything through the compacted turn too
+  store.setClearedUpToMessageId(sessionId, newReply.id)
 
   const { summaryText, messages } = resolveEffectiveHistory(d, convId, sessionId)
-  assert.equal(summaryText, null)
+  assert.equal(summaryText, null) // the earlier compaction summary is behind the clear — dropped
   assert.equal(messages.length, 1)
   assert.equal(messages[0].content, 'newest task 3')
 })
@@ -530,7 +587,11 @@ test('resolveEffectiveHistory: /resume (clearing the marker back to null) restor
   const newReply = store.addMessage(convId, 'assistant', 'new reply 2')
 
   store.updateAgentRun(sessionId, { compactionSummary: 'summary of task 1', compactionUpToMessageId: oldReply.id })
+  // /clear (deactivate + marker), then /resume (reactivate + null the marker) — the round trip must
+  // restore full history AND the earlier compaction summary, exactly as if the clear never happened.
+  store.deactivateMessagesUpTo(convId, newReply.id)
   store.setClearedUpToMessageId(sessionId, newReply.id)
+  store.reactivateMessagesUpTo(convId, newReply.id)
   store.setClearedUpToMessageId(sessionId, null) // /resume
 
   const { summaryText, messages } = resolveEffectiveHistory(d, convId, sessionId)
@@ -540,10 +601,13 @@ test('resolveEffectiveHistory: /resume (clearing the marker back to null) restor
   assert.equal(messages[1].content, 'new reply 2')
 })
 
-test('resolveEffectiveHistory: an unresolvable /clear marker (deleted/missing message id) falls through to compaction-only behavior', () => {
+test('resolveEffectiveHistory: a set /clear marker drops any summary and returns only active messages (blank-slate path)', () => {
   const { d, store, convId, sessionId } = makeCodeConv()
   store.addMessage(convId, 'user', 'task')
   store.addMessage(convId, 'assistant', 'reply')
+  // A set clear marker takes the blank-slate branch regardless of the marker resolving to a specific
+  // row — the cleared messages are is_active=0 at the source, so `all` is whatever stays active. Here
+  // nothing was deactivated (a defensive stale-marker case), so both raw messages remain, no summary.
   store.setClearedUpToMessageId(sessionId, 'does-not-exist')
 
   const { summaryText, messages } = resolveEffectiveHistory(d, convId, sessionId)
@@ -651,4 +715,217 @@ test('ToolLoopTracker: reset() clears the count (new top-level turn)', () => {
   t.record('bash', { command: 'npm test' })
   t.reset()
   assert.equal(t.record('bash', { command: 'npm test' }), 1)
+})
+
+// ── codeEventToFrame (code-session.ts) — pi AgentSessionEvent → SSE frame map (Phase 2, ADR-250).
+// The live agentic loop that PRODUCES these events is out of scope here (needs a loaded model),
+// same as the rest of this file — but the pure event→frame contract the relay depends on is fully
+// testable without one. This is exactly what the relay closure now delegates to. ------------------
+
+// codeEventToFrame only reads a handful of fields per event; a minimal literal cast to the union
+// is enough to exercise it without constructing full AgentMessage/ToolResultMessage shapes.
+const evt = (e: Record<string, unknown>): AgentSessionEvent => e as unknown as AgentSessionEvent
+const freshCounter = () => ({ index: 0 })
+
+test('codeEventToFrame: message_update text_delta → a delta frame (existing behavior preserved)', () => {
+  const frame = codeEventToFrame(evt({ type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'hi' } }), freshCounter())
+  assert.deepEqual(frame, { event: 'delta', data: { delta: 'hi' } })
+})
+
+test('codeEventToFrame: message_update thinking_delta → a reasoning frame (existing behavior preserved)', () => {
+  const frame = codeEventToFrame(evt({ type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', delta: 'hmm' } }), freshCounter())
+  assert.deepEqual(frame, { event: 'reasoning', data: { delta: 'hmm' } })
+})
+
+test('codeEventToFrame: a message_update sub-event we do not surface → null (no stray frame)', () => {
+  assert.equal(codeEventToFrame(evt({ type: 'message_update', assistantMessageEvent: { type: 'tool_call_delta', delta: 'x' } }), freshCounter()), null)
+})
+
+test('codeEventToFrame: compaction_start / compaction_end → compaction frames (existing behavior preserved)', () => {
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'compaction_start', reason: 'threshold' }), freshCounter()),
+    { event: 'compaction', data: { phase: 'start', reason: 'threshold' } },
+  )
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'compaction_end', reason: 'threshold', aborted: false, result: { tokensBefore: 5000 } }), freshCounter()),
+    { event: 'compaction', data: { phase: 'end', reason: 'threshold', aborted: false, tokensBefore: 5000 } },
+  )
+})
+
+test('codeEventToFrame: turn_start / turn_end → turn frames sharing one index; the counter advances on end', () => {
+  const counter = freshCounter()
+  assert.deepEqual(codeEventToFrame(evt({ type: 'turn_start' }), counter), { event: 'turn', data: { phase: 'start', index: 0 } })
+  assert.equal(counter.index, 0, 'turn_start does not advance the counter')
+  assert.deepEqual(codeEventToFrame(evt({ type: 'turn_end', message: {}, toolResults: [{}, {}] }), counter), { event: 'turn', data: { phase: 'end', index: 0, toolResults: 2 } })
+  assert.equal(counter.index, 1, 'turn_end advances the counter so the next turn gets a fresh index')
+  // The next turn's start/end share index 1 (a start/end pair is always one number).
+  assert.deepEqual(codeEventToFrame(evt({ type: 'turn_start' }), counter), { event: 'turn', data: { phase: 'start', index: 1 } })
+})
+
+test('codeEventToFrame: auto_retry_start → a retry frame with attempt/max/delay + the error message', () => {
+  const frame = codeEventToFrame(evt({ type: 'auto_retry_start', attempt: 2, maxAttempts: 5, delayMs: 1500, errorMessage: 'rate limited' }), freshCounter())
+  assert.deepEqual(frame, { event: 'retry', data: { phase: 'start', attempt: 2, maxAttempts: 5, delayMs: 1500, message: 'rate limited' } })
+})
+
+test('codeEventToFrame: auto_retry_end → a retry frame carrying success and the final error (if any)', () => {
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'auto_retry_end', success: true, attempt: 3 }), freshCounter()),
+    { event: 'retry', data: { phase: 'end', attempt: 3, success: true, message: undefined } },
+  )
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'auto_retry_end', success: false, attempt: 5, finalError: 'gave up' }), freshCounter()),
+    { event: 'retry', data: { phase: 'end', attempt: 5, success: false, message: 'gave up' } },
+  )
+})
+
+test('codeEventToFrame: tool_execution_update → a tool_progress frame with the flattened partial text', () => {
+  const frame = codeEventToFrame(evt({
+    type: 'tool_execution_update', toolCallId: 'tc1', toolName: 'bash',
+    args: { command: 'ls' }, partialResult: { content: [{ type: 'text', text: 'line1\n' }, { type: 'text', text: 'line2\n' }], details: undefined },
+  }), freshCounter())
+  assert.deepEqual(frame, { event: 'tool_progress', data: { id: 'tc1', name: 'bash', partial: 'line1\nline2\n' } })
+})
+
+test('codeEventToFrame: tool_execution_update with an empty/odd partialResult yields partial "" (never throws)', () => {
+  // The bash tool emits an initial empty snapshot ({ content: [] }); non-text/absent content is
+  // defended against since partialResult is typed `any`.
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'tool_execution_update', toolCallId: 't', toolName: 'bash', args: {}, partialResult: { content: [] } }), freshCounter()),
+    { event: 'tool_progress', data: { id: 't', name: 'bash', partial: '' } },
+  )
+  assert.deepEqual(
+    codeEventToFrame(evt({ type: 'tool_execution_update', toolCallId: 't', toolName: 'bash', args: {}, partialResult: null }), freshCounter()),
+    { event: 'tool_progress', data: { id: 't', name: 'bash', partial: '' } },
+  )
+})
+
+test('codeEventToFrame: lifecycle events that would DUPLICATE the tool_call pending/done frames are not surfaced', () => {
+  // tool_execution_start/_end mirror the pending/done tool_call frames the extension hooks already
+  // emit — relaying them too would double-render every call, so they must map to null. Likewise for
+  // the message/agent boundary events the relay doesn't use.
+  const counter = freshCounter()
+  for (const type of ['tool_execution_start', 'tool_execution_end', 'message_start', 'message_end', 'agent_start', 'agent_settled', 'entry_appended']) {
+    assert.equal(codeEventToFrame(evt({ type }), counter), null, `${type} must not produce a frame`)
+  }
+  assert.equal(counter.index, 0, 'unsurfaced events never touch the turn counter')
+})
+
+// ── delegate_task pure helpers (code-session.ts) — the subagent/task-delegation tool (ADR-259).
+// The live nested sub-session (runDelegatedSubSession, needs a loaded model) is out of scope here,
+// same as runSkillSubSession and the rest of this file; its resource-contention correctness rests
+// on GenerationGate, which gate.test.ts already proves (single-holder serialization, fg-preempt,
+// abort/timeout self-heal). These cover the tool's own pure input/result decision logic. -----------
+
+test('validateDelegateTask: a real task string is accepted and trimmed', () => {
+  assert.deepEqual(validateDelegateTask('  investigate the auth flow  '), { ok: true, task: 'investigate the auth flow' })
+})
+
+test('validateDelegateTask: empty, whitespace-only, or non-string input is rejected with a usable message', () => {
+  for (const bad of ['', '   ', '\n\t', undefined, null, 42, {}]) {
+    const r = validateDelegateTask(bad as unknown)
+    assert.equal(r.ok, false, `expected rejection for ${JSON.stringify(bad)}`)
+    if (!r.ok) assert.match(r.message, /non-empty description/)
+  }
+})
+
+test('normalizeDelegateResult: a completed sub-agent returns its final text, trimmed', () => {
+  assert.equal(normalizeDelegateResult('  the summary of what I did  '), 'the summary of what I did')
+})
+
+test('normalizeDelegateResult: an empty completed result becomes an explicit no-output placeholder (never "")', () => {
+  assert.equal(normalizeDelegateResult('   '), '(the delegated sub-agent produced no output.)')
+})
+
+test('normalizeDelegateResult: a timed-out run is reported as INCOMPLETE and carries any partial text', () => {
+  const out = normalizeDelegateResult('got halfway through the refactor', { timedOut: true, timeoutMs: 5 * 60_000 })
+  assert.match(out, /did not finish within ~5 minute/)
+  assert.match(out, /INCOMPLETE/)
+  assert.match(out, /Partial progress before it was stopped:\ngot halfway through the refactor/)
+})
+
+test('normalizeDelegateResult: a timed-out run with NO partial output omits the partial section', () => {
+  const out = normalizeDelegateResult('', { timedOut: true })
+  assert.match(out, /did not finish/)
+  assert.doesNotMatch(out, /Partial progress/)
+  // Falls back to the module default timeout when timeoutMs is omitted.
+  assert.match(out, new RegExp(`~${Math.round(DELEGATE_SUBAGENT_TIMEOUT_MS / 60_000)} minute`))
+})
+
+test('DELEGATE_SUBAGENT_TIMEOUT_MS: is a sane positive bound (minutes, not ms typo)', () => {
+  assert.ok(DELEGATE_SUBAGENT_TIMEOUT_MS >= 60_000 && DELEGATE_SUBAGENT_TIMEOUT_MS <= 30 * 60_000)
+})
+
+// ── update_todos pure helpers (code-session.ts) — the todo/step progress tracker (ADR-255). The
+// live tool (registered on a running pi session) is out of scope here, same as the rest of this
+// file; these cover the model-facing input coercion + the confirmation summary. --------------------
+
+test('normalizeTodos: passes through a clean list, trimming content and keeping order', () => {
+  const raw = [
+    { content: '  Add the route  ', status: 'completed' },
+    { content: 'Wire the UI', status: 'in_progress' },
+    { content: 'Write tests', status: 'pending' },
+  ]
+  assert.deepEqual(normalizeTodos(raw), [
+    { content: 'Add the route', status: 'completed' },
+    { content: 'Wire the UI', status: 'in_progress' },
+    { content: 'Write tests', status: 'pending' },
+  ])
+})
+
+test('normalizeTodos: a non-array (or missing) argument is an empty list, never a throw', () => {
+  for (const bad of [undefined, null, 'nope', 42, {}]) {
+    assert.deepEqual(normalizeTodos(bad as unknown), [])
+  }
+})
+
+test('normalizeTodos: drops entries with empty/whitespace/non-string content', () => {
+  const raw = [
+    { content: 'keep me', status: 'pending' },
+    { content: '   ', status: 'pending' },
+    { content: '', status: 'pending' },
+    { content: 123, status: 'pending' },
+    { status: 'pending' }, // no content at all
+    'not an object',
+    null,
+  ]
+  assert.deepEqual(normalizeTodos(raw), [{ content: 'keep me', status: 'pending' }])
+})
+
+test('normalizeTodos: an unknown/missing status defaults to pending (never a bogus status)', () => {
+  const raw = [
+    { content: 'a', status: 'done' },      // 'done' is not a valid status (it's 'completed')
+    { content: 'b' },                       // missing status
+    { content: 'c', status: 'in_progress' }, // valid, preserved
+  ]
+  assert.deepEqual(normalizeTodos(raw), [
+    { content: 'a', status: 'pending' },
+    { content: 'b', status: 'pending' },
+    { content: 'c', status: 'in_progress' },
+  ])
+})
+
+test('normalizeTodos: caps the list at MAX_TODOS', () => {
+  const raw = Array.from({ length: MAX_TODOS + 25 }, (_, i) => ({ content: `step ${i}`, status: 'pending' }))
+  const out = normalizeTodos(raw)
+  assert.equal(out.length, MAX_TODOS)
+  assert.equal(out[0].content, 'step 0')
+})
+
+test('summarizeTodos: reports counts of done and in-progress steps', () => {
+  const todos: TodoItem[] = [
+    { content: 'a', status: 'completed' },
+    { content: 'b', status: 'completed' },
+    { content: 'c', status: 'in_progress' },
+    { content: 'd', status: 'pending' },
+  ]
+  assert.equal(summarizeTodos(todos), 'Tracking 4 step(s): 2/4 done, 1 in progress.')
+})
+
+test('summarizeTodos: omits the in-progress clause when nothing is in progress', () => {
+  const todos: TodoItem[] = [{ content: 'a', status: 'completed' }, { content: 'b', status: 'pending' }]
+  assert.equal(summarizeTodos(todos), 'Tracking 2 step(s): 1/2 done.')
+})
+
+test('summarizeTodos: an empty list reads as an explicit clear', () => {
+  assert.equal(summarizeTodos([]), 'Todo list cleared.')
 })

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -150,19 +150,18 @@ const COMPACTION_SUFFIX = '\n\n(End of summary — the actual conversation conti
 export function resolveEffectiveHistory(d: Deps, convId: string, sessionId: string): { summaryText: string | null; messages: DbMessage[] } {
   const all = d.db.getConversation(convId, true)?.messages ?? []
   const run = d.db.getAgentRun(sessionId)
-  const compactionIdx = run?.compactionUpToMessageId ? all.findIndex((m) => m.id === run.compactionUpToMessageId) : -1
-  const clearedIdx = run?.clearedUpToMessageId ? all.findIndex((m) => m.id === run.clearedUpToMessageId) : -1
-  // A RESOLVABLE clear that's at/after any compaction cut wins outright — a blank slate, no
-  // summary carried forward. An unresolvable (stale/corrupt) clear marker falls through to the
-  // compaction-only path below, same "degrade to replaying raw rather than silently dropping
-  // everything" philosophy as an unresolvable compaction marker.
-  if (clearedIdx !== -1 && clearedIdx >= compactionIdx) {
-    return { summaryText: null, messages: all.slice(clearedIdx + 1) }
-  }
+  // /clear (v34, ADR-261) now DEACTIVATES its messages (is_active=0), so getConversation →
+  // getMessages has already dropped them from `all` — no cursor slice needed here anymore. A
+  // cleared session is a blank slate: also drop any earlier compaction summary (it summarized
+  // history that now sits behind the clear), returning just the still-active post-clear messages.
+  // /resume reactivates that history and nulls this marker, falling straight through to the
+  // compaction/full path below again (exactly as if the clear never happened).
+  if (run?.clearedUpToMessageId) return { summaryText: null, messages: all }
   if (!run?.compactionUpToMessageId) return { summaryText: null, messages: all }
   // An unresolvable compaction marker (cut message deleted/corrupt) still surfaces its summary —
   // replaying every raw message alongside a redundant summary loses nothing, whereas resolving
   // it as "no compaction at all" would silently discard a real (if now unanchored) summary.
+  const compactionIdx = all.findIndex((m) => m.id === run.compactionUpToMessageId)
   const rest = compactionIdx === -1 ? all : all.slice(compactionIdx + 1)
   return { summaryText: `${COMPACTION_PREFIX}${run.compactionSummary}${COMPACTION_SUFFIX}`, messages: rest }
 }
@@ -231,6 +230,12 @@ export function keepRecentTokensFor(messages: DbMessage[], baseKeepRecentTokens:
 /** A minimal SSE sink — matches the chat wire shape so the existing frontend parser works. */
 export type CodeSseSink = (ev: { event: string; data: unknown }) => void | Promise<void>
 
+/** Injects a message into the CURRENTLY ACTIVE turn via pi's real `session.steer()` (Phase 1,
+ *  ADR-246). Resolves `true` when the message was actually handed to the live agent loop, `false`
+ *  when the turn is no longer streaming (a race — it just finished), so the caller can fall back
+ *  to follow-up/queue behavior instead of dropping the message into a dead session. */
+export type SteerHandle = (text: string) => Promise<boolean>
+
 export interface RunCodeParams {
   d: Deps
   convId: string
@@ -250,6 +255,12 @@ export interface RunCodeParams {
   /** Fires when the HTTP request is aborted / the run is stopped. */
   signal: AbortSignal
   sink: CodeSseSink
+  /** Registers (and later clears) a {@link SteerHandle} the daemon-side run manager can call to
+   *  STEER a message into THIS live turn instead of queueing a fresh one behind it (Phase 1,
+   *  ADR-246). Called with the handle once the pi session exists, and again with `null` in the
+   *  finally when the turn settles, so the manager never routes a steer into a disposed session.
+   *  Optional: the reconnect tests' injected runners don't steer and simply omit it. */
+  onSteerable?: (steer: SteerHandle | null) => void
 }
 
 export interface RunCodeResult {
@@ -352,6 +363,161 @@ export function disposeLspClientsForConv(convId: string): void {
   if (!clients) return
   for (const c of clients.values()) c.dispose()
   lspClientsByConv.delete(convId)
+}
+
+/** Extract the plain text out of a pi tool `partialResult` (tool_execution_update) — pi's bash
+ *  tool streams `{ content: [{ type: 'text', text }], details }` snapshots through it (verified in
+ *  the bundled bash tool's `onUpdate`). Mirrors the tool_result hook's own content-flattening;
+ *  tool-agnostic and defensive since `partialResult` is typed `any` and other tools could differ. */
+function extractPartialText(partialResult: unknown): string {
+  const pr = partialResult as { content?: Array<{ type?: string; text?: string }> } | null | undefined
+  if (!pr || !Array.isArray(pr.content)) return ''
+  return pr.content.map((c) => (c?.type === 'text' ? c.text ?? '' : '')).join('')
+}
+
+/** One SSE frame the relay emits, or null for an event we deliberately don't surface. */
+export type CodeRelayFrame = { event: string; data: Record<string, unknown> } | null
+
+/** Pure map from a pi `AgentSessionEvent` to the SSE frame the Code relay emits for it (Phase 2,
+ *  ADR-250). Extracted from runCodeSession's session.subscribe closure so the whole event→frame
+ *  contract is unit-testable without a live pi session or a loaded model (the live loop itself
+ *  stays out of scope, same as the rest of code-session.test.ts).
+ *
+ *  Surfaces, beyond the original text/thinking deltas and compaction:
+ *   • turn_start / turn_end        → a `turn` frame (phase + a monotonic index the caller threads
+ *     via `turnCounter`, incremented on turn_end so a start/end pair share one index) so the UI can
+ *     group a turn's deltas + tool calls into one visual unit.
+ *   • auto_retry_start / _end      → a `retry` frame (attempt / maxAttempts / delayMs / message) so
+ *     the UI can show a real "Retrying…" banner when pi auto-retries a transient provider failure,
+ *     instead of a silent stall.
+ *   • tool_execution_update        → a `tool_progress` frame carrying the tool call's incremental
+ *     output snapshot. pi's built-in bash tool streams stdout/stderr through this (verified); the
+ *     edit tool is atomic and never emits it. DISTINCT from the `tool_call` frames the tool_call/
+ *     tool_result extension hooks already emit (pending → done): this fills the live gap between
+ *     them. tool_execution_start/_end are intentionally NOT surfaced — they'd duplicate those
+ *     pending/done `tool_call` frames and double-render every call.
+ *
+ *  All the new frames are ephemeral live signals: code-run-manager's sink persists nothing for
+ *  them (it keys DB accumulation off delta/reasoning/tool_call), so they only ever cost a
+ *  live-tail + reconnect-replay frame, never DB writes. */
+export function codeEventToFrame(ev: AgentSessionEvent, turnCounter: { index: number }): CodeRelayFrame {
+  switch (ev.type) {
+    case 'message_update': {
+      const ame = ev.assistantMessageEvent
+      if (ame.type === 'text_delta') return { event: 'delta', data: { delta: ame.delta } }
+      if (ame.type === 'thinking_delta') return { event: 'reasoning', data: { delta: ame.delta } }
+      return null
+    }
+    case 'compaction_start':
+      return { event: 'compaction', data: { phase: 'start', reason: ev.reason } }
+    case 'compaction_end':
+      return { event: 'compaction', data: { phase: 'end', reason: ev.reason, aborted: ev.aborted, tokensBefore: ev.result?.tokensBefore } }
+    case 'turn_start':
+      return { event: 'turn', data: { phase: 'start', index: turnCounter.index } }
+    case 'turn_end': {
+      const frame: CodeRelayFrame = { event: 'turn', data: { phase: 'end', index: turnCounter.index, toolResults: ev.toolResults.length } }
+      turnCounter.index++
+      return frame
+    }
+    case 'auto_retry_start':
+      return { event: 'retry', data: { phase: 'start', attempt: ev.attempt, maxAttempts: ev.maxAttempts, delayMs: ev.delayMs, message: ev.errorMessage } }
+    case 'auto_retry_end':
+      return { event: 'retry', data: { phase: 'end', attempt: ev.attempt, success: ev.success, message: ev.finalError } }
+    case 'tool_execution_update':
+      return { event: 'tool_progress', data: { id: ev.toolCallId, name: ev.toolName, partial: extractPartialText(ev.partialResult) } }
+    default:
+      return null
+  }
+}
+
+// ── Delegated sub-tasks (delegate_task tool, ADR-259) ──────────────────────────────
+// Hard ceiling on ONE delegated sub-task's wall-clock time. A delegated sub-agent runs a full
+// nested agentic loop; without a bound a stuck/looping sub-task could hold a background engine slot
+// (via d.gate) far longer than the parent — or any waiting foreground Chat — should tolerate. On
+// expiry the sub-session is aborted and whatever it produced so far is returned as an explicit
+// "did not finish" result, never a silent hang. A parent Stop aborts it immediately too (sooner).
+export const DELEGATE_SUBAGENT_TIMEOUT_MS = 5 * 60_000
+
+/** Validate the `task` argument the model passes to delegate_task. Pure/exported so the tool's
+ *  input contract is unit-testable without a live pi session or a loaded model. */
+export function validateDelegateTask(raw: unknown): { ok: true; task: string } | { ok: false; message: string } {
+  const task = typeof raw === 'string' ? raw.trim() : ''
+  if (!task) return { ok: false, message: 'delegate_task: `task` must be a non-empty description of the sub-task to delegate.' }
+  return { ok: true, task }
+}
+
+/** Fold a delegated sub-agent's final text into the single string returned to the PARENT as the
+ *  tool result — the ONLY thing that crosses back (the sub-agent's step-by-step transcript never
+ *  enters the parent's context). Pure/exported for unit testing. A timed-out / stopped run is
+ *  reported as explicitly INCOMPLETE (with any partial text) rather than passed off as a finished
+ *  answer, so the parent doesn't build on a half-done result believing it succeeded. */
+export function normalizeDelegateResult(finalText: string, opts?: { timedOut?: boolean; timeoutMs?: number }): string {
+  const text = finalText.trim()
+  if (opts?.timedOut) {
+    const mins = Math.max(1, Math.round((opts.timeoutMs ?? DELEGATE_SUBAGENT_TIMEOUT_MS) / 60_000))
+    const partial = text ? `\n\nPartial progress before it was stopped:\n${text}` : ''
+    return `(the delegated sub-task did not finish within ~${mins} minute(s) and was stopped — treat it as INCOMPLETE; consider doing it yourself or delegating a smaller piece.${partial})`
+  }
+  return text || '(the delegated sub-agent produced no output.)'
+}
+
+// System-prompt preamble appended AFTER the normal mode persona for a delegated sub-agent, so it
+// behaves as a focused, self-contained worker: it never sees the parent conversation, cannot
+// delegate further or invoke skills (enforced structurally — those tools are simply not registered
+// on the sub-session, giving a hard nesting depth of 1), and must end with a self-contained summary
+// since that summary is all the parent receives.
+const DELEGATED_SUBAGENT_PREAMBLE = 'You are an isolated sub-agent handling ONE delegated sub-task on behalf of a parent coding agent. ' +
+  'You do NOT see the parent conversation or its history — everything you need is in the task message below. ' +
+  'Do exactly that task and nothing more, using your tools against the same repository. You cannot delegate ' +
+  'further or invoke skills. When finished, end your reply with a concise, self-contained summary of what you ' +
+  'did, what you found, and anything the parent needs in order to continue — that summary is the ONLY thing ' +
+  'returned to the parent.'
+
+// ── Todo / step progress tracker (update_todos tool, ADR-255) ──────────────────────
+// A structured checklist the model maintains for a multi-step task so the UI can show live
+// progress ("3/7 done") instead of an opaque stream of tool calls. The model re-sends the WHOLE
+// list each call (replace, not diff — the simplest model to call correctly); it's emitted as an
+// ephemeral `todos` SSE frame and held in the run's live state for reconnect (code-run-manager.ts),
+// never a DB column. Registered ONLY on the top-level session — a delegated/skill sub-session never
+// gets update_todos, so a sub-agent's internal steps stay out of the parent's list (one list per
+// top-level turn; see the delegate_task interaction note in this task's write-up).
+export interface TodoItem { content: string; status: 'pending' | 'in_progress' | 'completed' }
+const TODO_STATUSES = new Set<TodoItem['status']>(['pending', 'in_progress', 'completed'])
+// A real multi-step task is a handful of steps, not hundreds — this caps a confused/looping model
+// from emitting an unbounded list (and bounds the frame size).
+export const MAX_TODOS = 50
+
+/** Coerce the model's raw update_todos argument into a clean TodoItem[] (pure/exported for
+ *  testing). Local models send messy input, so this is defensive: a non-array → []; each entry
+ *  must be an object with non-empty `content` (trimmed) or it's dropped; an unknown/missing status
+ *  defaults to 'pending'; the list is capped at MAX_TODOS. The result REPLACES the prior list —
+ *  the tool's contract is "re-send the full current list each call", not incremental diffs. */
+export function normalizeTodos(raw: unknown): TodoItem[] {
+  if (!Array.isArray(raw)) return []
+  const out: TodoItem[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const rec = item as Record<string, unknown>
+    const content = typeof rec.content === 'string' ? rec.content.trim() : ''
+    if (!content) continue
+    const status = typeof rec.status === 'string' && TODO_STATUSES.has(rec.status as TodoItem['status'])
+      ? (rec.status as TodoItem['status']) : 'pending'
+    out.push({ content, status })
+    if (out.length >= MAX_TODOS) break
+  }
+  return out
+}
+
+/** One-line confirmation returned to the model after an update_todos call (pure/exported), so it
+ *  gets concrete feedback that the list registered and where it stands — e.g. "Tracking 7 step(s):
+ *  3 done, 1 in progress." An empty list reads as an explicit clear. */
+export function summarizeTodos(todos: TodoItem[]): string {
+  if (todos.length === 0) return 'Todo list cleared.'
+  const completed = todos.filter((t) => t.status === 'completed').length
+  const inProgress = todos.filter((t) => t.status === 'in_progress').length
+  const parts = [`${completed}/${todos.length} done`]
+  if (inProgress > 0) parts.push(`${inProgress} in progress`)
+  return `Tracking ${todos.length} step(s): ${parts.join(', ')}.`
 }
 
 /**
@@ -652,6 +818,181 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     return finalText.trim() || '(the skill produced no output)'
   }
 
+  /** Runs one free-form DELEGATED sub-task as a REAL, contained agentic sub-session (delegate_task
+   *  tool, ADR-259) — a sibling of runSkillSubSession with the same isolation, containment, mode-
+   *  based tool access, and ask-mode approval boundary, but driven by a caller-supplied task string
+   *  instead of a pre-authored skill's fixed instructions. Its own history is NOT seeded with the
+   *  parent conversation (the whole point: keep the sub-task's step-by-step work out of the parent's
+   *  token budget); only its final summary is returned.
+   *
+   *  Nesting depth is hard-capped at 1: the sub-session registers NO invoke_skill and NO
+   *  delegate_task tool (they're only registered on the outer session below), so a delegated
+   *  sub-agent structurally cannot spawn its own sub-agents — no runaway recursion.
+   *
+   *  Resource contention (the real correctness concern): a delegated sub-task runs INSIDE the
+   *  parent's tool_call execution, which pi runs BETWEEN provider requests — the parent's own
+   *  provider request already completed when the model emitted this tool call, and the parent's
+   *  before/after_provider_request hooks release d.gate around each request, so the parent holds NO
+   *  gate while this sub-session runs. The sub-session acquires d.gate('bg') around its OWN provider
+   *  requests exactly as runSkillSubSession does, so it serializes cleanly against foreground Chat
+   *  (which preempts at 'fg') and any other background work, WITHOUT self-deadlocking against its
+   *  own parent. It is therefore not true concurrent engine load — it runs while the parent turn is
+   *  parked awaiting this result. Bounded by DELEGATE_SUBAGENT_TIMEOUT_MS and the parent's Stop
+   *  signal (whichever fires first), so a stuck sub-task can never hold a slot indefinitely. */
+  async function runDelegatedSubSession(subMode: CodeMode, task: string): Promise<string> {
+    const subAuth = AuthStorage.inMemory()
+    const subRegistry = ModelRegistry.inMemory(subAuth)
+    subRegistry.registerProvider('local', {
+      baseUrl: `${target}/v1`,
+      apiKey: 'agent-key',
+      authHeader: true,
+      api: 'openai-completions',
+      models: [{
+        id: modelId,
+        name: modelDisplayName,
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow,
+        maxTokens: 8192,
+        compat: { supportsDeveloperRole: false, thinkingFormat: 'qwen-chat-template' },
+      }],
+    })
+    const subModel = subRegistry.find('local', modelId)
+    if (!subModel) throw new Error('Failed to register local model with pi.')
+
+    // Bounded lifetime: the parent's Stop (signal) OR a hard timeout aborts the sub-agent. subAc
+    // is what the sub-session's gate acquires and its own session.abort() key off, so both causes
+    // unstick a queued gate wait and stop the loop the same way.
+    const subAc = new AbortController()
+    let timedOut = false
+    const onParentAbort = () => subAc.abort()
+    if (signal.aborted) subAc.abort()
+    else signal.addEventListener('abort', onParentAbort, { once: true })
+    const timer = setTimeout(() => { timedOut = true; subAc.abort() }, DELEGATE_SUBAGENT_TIMEOUT_MS)
+
+    let subHeldGate: (() => void) | undefined
+    const releaseSubGate = () => { const r = subHeldGate; subHeldGate = undefined; r?.() }
+
+    const subExtension = (pi: ExtensionAPI): void => {
+      pi.on('before_provider_request', async (event) => {
+        releaseSubGate()
+        // 'bg' priority + subAc.signal: foreground Chat preempts, and a parent Stop / timeout gives
+        // up a queued wait instead of hanging (see gate.ts). The parent isn't holding the gate here
+        // (it released before executing this tool), so this acquire can't deadlock against it.
+        if (d.gate) subHeldGate = await d.gate.acquire('bg', { signal: subAc.signal })
+        const payload = { ...(event.payload as Record<string, unknown>) }
+        delete payload.max_tokens
+        delete payload.max_completion_tokens
+        return payload
+      })
+      pi.on('after_provider_response', () => { releaseSubGate() })
+
+      // Same containment + approval boundary as the outer/skill sessions (deliberately duplicated,
+      // per the note on runSkillSubSession's own hooks — a different pi session object, and the hook
+      // is small enough that sharing would cost more in indirection than it saves). Approval waits
+      // key off subAc.signal so a parent Stop / timeout also cancels a pending approval prompt.
+      pi.on('tool_call', async (event: ToolCallEvent): Promise<ToolCallEventResult | void> => {
+        const toolName = event.toolName
+        const toolCallId = event.toolCallId
+        const input = event.input as Record<string, unknown>
+        await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'pending' } })
+
+        if (PATH_TOOLS.has(toolName)) {
+          const p = input.path
+          const pathRequired = toolName === 'read' || toolName === 'edit' || toolName === 'write'
+          if (p !== undefined && typeof p === 'string') {
+            if (!isContainedFromRoot(p, repoRoot)) {
+              const reason = 'path is outside the allowed repo root'
+              await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
+              return { block: true, reason }
+            }
+          } else if (pathRequired) {
+            const reason = `${toolName}: a valid path is required`
+            await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
+            return { block: true, reason }
+          }
+        }
+
+        if (subMode === 'ask' && MUTATING_TOOLS.has(toolName)) {
+          await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'awaiting_approval' } })
+          const decision = await waitForToolApproval(`${convId}:${toolCallId}`, subAc.signal)
+          if (decision === 'deny') {
+            const reason = 'denied by user'
+            await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
+            return { block: true, reason }
+          }
+        }
+        return
+      })
+
+      pi.on('tool_result', async (event: ToolResultEvent): Promise<void> => {
+        const text = event.content.map((c) => (c.type === 'text' ? c.text : '')).join('')
+        const data: Record<string, unknown> = {
+          id: event.toolCallId, name: event.toolName, args: event.input,
+          status: event.isError ? 'error' : 'done', result: text,
+        }
+        if (isEditToolResult(event) && event.details) {
+          data.diff = event.details.diff
+          data.patch = event.details.patch
+          data.firstChangedLine = event.details.firstChangedLine
+        }
+        await sink({ event: 'tool_call', data })
+      })
+    }
+
+    const subAgentDir = join(d.store.dir(), 'pi-agent')
+    const subResourceLoader = new DefaultResourceLoader({
+      cwd: repoRoot,
+      agentDir: subAgentDir,
+      settingsManager: SettingsManager.inMemory(),
+      extensionFactories: [{ name: 'turbollm-delegate', factory: subExtension }],
+      // The normal mode persona (no skill catalog — a delegated sub-agent can't invoke skills),
+      // plus the delegation preamble that frames it as a focused, summary-returning worker.
+      appendSystemPrompt: [...buildAppendPrompt(subMode, [], { repoRoot, globalDir: d.store.dir() }, !!d.tools), DELEGATED_SUBAGENT_PREAMBLE],
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+    })
+    await subResourceLoader.reload()
+
+    const subTools = toolsForMode(subMode)
+    const subBash = createBashTool(repoRoot, { operations: createRobustBashOperations({ sessionLabel: `${sessionId}:delegate` }) })
+    const { session: subSession } = await createAgentSession({
+      cwd: repoRoot,
+      agentDir: subAgentDir,
+      model: subModel,
+      authStorage: subAuth,
+      modelRegistry: subRegistry,
+      resourceLoader: subResourceLoader,
+      sessionManager: SessionManager.inMemory(repoRoot),
+      settingsManager: SettingsManager.inMemory({ compaction: compactionSettingsFor(contextWindow) }),
+      customTools: [subBash],
+      ...(subTools ? { tools: subTools } : {}),
+      // No invoke_skill / delegate_task / web / mcp / lsp tools registered → depth-1, bounded set.
+    })
+
+    const onSubAbort = () => { void subSession.abort() }
+    if (subAc.signal.aborted) onSubAbort()
+    else subAc.signal.addEventListener('abort', onSubAbort, { once: true })
+
+    try {
+      await subSession.prompt(task)
+    } catch (e) {
+      // A Stop / timeout aborts mid-prompt (AbortError, or a gate give-up) — return whatever the
+      // sub-agent produced so far as an explicit "incomplete" result rather than throwing. Any
+      // OTHER error is a real failure and propagates to delegate_task's execute catch.
+      if (!timedOut && !subAc.signal.aborted) throw e
+    } finally {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', onParentAbort)
+      releaseSubGate()
+    }
+    const finalText = subSession.getLastAssistantText() ?? ''
+    subSession.dispose()
+    return normalizeDelegateResult(finalText, timedOut ? { timedOut: true, timeoutMs: DELEGATE_SUBAGENT_TIMEOUT_MS } : undefined)
+  }
+
   // MCP tools (Customize → MCP Servers) — the same tools Chat gets from any user-connected MCP
   // server, extended to Code (founder decision, 2026-07-13: "all the tools built from customize
   // that are added in chat should be available in code as well"). Fetched HERE, once, before the
@@ -928,6 +1269,77 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       },
     })
 
+    // Delegate a focused, self-contained sub-task to an isolated sub-agent (delegate_task, ADR-259):
+    // a real nested agentic sub-session (runDelegatedSubSession, above) that shares this session's
+    // repo + tools + mode/approval boundary, runs the sub-task to completion, and returns ONLY its
+    // final summary — the sub-agent's step-by-step work never enters this conversation, keeping the
+    // parent's context focused. Depth-capped at 1 (the sub-agent gets no delegate_task/invoke_skill),
+    // gate-serialized so it never starves foreground Chat, and time-bounded. See its own doc comment.
+    pi.registerTool({
+      name: 'delegate_task',
+      label: 'Delegate task',
+      description: 'Delegate a focused, self-contained sub-task to an isolated sub-agent that has ' +
+        'your same repository access and tools (subject to the current mode), runs it to completion, ' +
+        'and returns ONLY its final summary — the sub-agent\'s step-by-step work never enters this ' +
+        'conversation, so your own context stays focused. Use it for a well-scoped chunk you can ' +
+        'describe completely up front (e.g. "investigate how X works and report back", or "apply ' +
+        'this specific refactor across these files"). The sub-agent does NOT see this conversation, ' +
+        'so put everything it needs in the task; it cannot delegate further or invoke skills.',
+      promptSnippet: 'delegate_task(task) - hand a focused, fully-described sub-task to an isolated sub-agent and get back its summary',
+      parameters: Type.Object({
+        task: Type.String({ description: 'The complete, self-contained sub-task, including every bit of context the sub-agent needs (it does not see this conversation or its history).' }),
+      }),
+      async execute(_toolCallId, params) {
+        const valid = validateDelegateTask(params.task)
+        if (!valid.ok) return { content: [{ type: 'text', text: valid.message }], details: {} }
+        // Live mode — same fresh-from-DB resolution and plan-mode exception as invoke_skill above.
+        const dbMode = (d.db.getConversation(convId)?.agentMode ?? mode) as CodeMode
+        const liveMode: CodeMode = dbMode === 'plan' ? mode : dbMode
+        try {
+          const text = await runDelegatedSubSession(liveMode, valid.task)
+          return { content: [{ type: 'text', text }], details: {} }
+        } catch (e) {
+          return { content: [{ type: 'text', text: `delegate_task: failed (${e instanceof Error ? e.message : String(e)}) — try again, or do the task yourself.` }], details: {} }
+        }
+      },
+    })
+
+    // Todo / step progress tracker (update_todos, ADR-255): the model maintains a visible checklist
+    // of a multi-step task's steps so the UI shows live progress instead of an opaque tool-call
+    // stream. Whole-list-replace each call (simplest for a model to get right). Emits an ephemeral
+    // `todos` SSE frame via the same sink every other event uses; code-run-manager holds the latest
+    // list in the run's live state so it survives a reconnect (like the queue), no DB column needed.
+    // Registered on the top-level session ONLY (never on delegate_task/skill sub-sessions), so the
+    // list is strictly the parent turn's plan — a delegated sub-agent's internal steps stay hidden.
+    pi.registerTool({
+      name: 'update_todos',
+      label: 'Update todos',
+      description: 'Maintain a visible checklist of the steps for a multi-step task so the user can ' +
+        'see your plan and live progress. Call it when you START a task that has several distinct ' +
+        'steps (send the full list, each step pending), and again whenever a step\'s state changes: ' +
+        'mark a step in_progress when you begin it and completed as soon as it is done. ALWAYS send ' +
+        'the ENTIRE current list each call — it REPLACES the previous one, it is not a diff. Skip it ' +
+        'for trivial single-step requests; a one-item checklist is just noise.',
+      promptSnippet: 'update_todos(todos) - show/refresh a checklist of steps for a multi-step task (send the whole list each call)',
+      parameters: Type.Object({
+        todos: Type.Array(
+          Type.Object({
+            content: Type.String({ description: 'The step as a short imperative phrase, e.g. "Add the /export route".' }),
+            status: Type.Union(
+              [Type.Literal('pending'), Type.Literal('in_progress'), Type.Literal('completed')],
+              { description: 'pending, in_progress, or completed.' },
+            ),
+          }),
+          { description: 'The COMPLETE current step list, in order — replaces the previous list entirely.' },
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        const todos = normalizeTodos(params.todos)
+        await sink({ event: 'todos', data: { todos } })
+        return { content: [{ type: 'text', text: summarizeTodos(todos) }], details: {} }
+      },
+    })
+
     // Real web access (founder-reported gap, 2026-07-13): Code previously had NO way to look
     // anything up — only Chat had web_search/fetch_url. A local model that fails at something
     // (a real repro: Camera2 API) tends to silently substitute an easier, DIFFERENT feature
@@ -1112,32 +1524,39 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // ── relay streaming deltas/reasoning from the session event stream ────────────
   // Tool-call SSE is driven entirely by the extension hooks above; here we only relay the
   // model's text/thinking deltas so the two never double-emit.
+  // Relay pi's event stream to SSE via the pure codeEventToFrame map (see its doc comment for the
+  // full event→frame contract and rationale). Text/thinking deltas and compaction were surfaced
+  // before; turn boundaries, auto-retries, and live tool-output streaming are the Phase 2 additions
+  // (ADR-250). `turnCounter` is this run's own monotonic turn index, mutated across events.
+  const turnCounter = { index: 0 }
   const unsubscribe = session.subscribe((ev: AgentSessionEvent) => {
-    if (ev.type === 'message_update') {
-      const ame = ev.assistantMessageEvent
-      if (ame.type === 'text_delta') {
-        void sink({ event: 'delta', data: { delta: ame.delta } })
-      } else if (ame.type === 'thinking_delta') {
-        void sink({ event: 'reasoning', data: { delta: ame.delta } })
-      }
-    } else if (ev.type === 'compaction_start') {
-      // pi's own AUTO-compaction (distinct from the manual /compact route below, which only
-      // ever calls session.compact() on demand) — a real first-class pi feature this session
-      // registered no listener for until now, so it fired with zero UI feedback: the transcript
-      // just went quiet while pi silently summarized history mid-turn. Forwarded so the
-      // frontend can show a real "Compacting conversation…" state instead of a generic/blank gap.
-      void sink({ event: 'compaction', data: { phase: 'start', reason: ev.reason } })
-    } else if (ev.type === 'compaction_end') {
-      void sink({ event: 'compaction', data: { phase: 'end', reason: ev.reason, aborted: ev.aborted, tokensBefore: ev.result?.tokensBefore } })
-    }
+    const frame = codeEventToFrame(ev, turnCounter)
+    if (frame) void sink(frame)
   })
 
+  // Steering (Phase 1, ADR-246): hand the run manager a handle it can call to inject a message
+  // into THIS live turn via pi's real session.steer(), delivered after the current assistant
+  // turn's tool calls finish and before the next LLM call — redirecting the SAME turn rather than
+  // queueing a fresh one. pi keeps the agentic loop alive until the steered message is drained
+  // (agent-session.js's _runAgentPrompt loops while agent.hasQueuedMessages()), so the
+  // `await session.prompt(task)` below still resolves only after the steered continuation settles
+  // and the one accumulating assistant message captures it all. Guarded on isStreaming: if the
+  // turn has already settled by the time a steer lands (a race — it just finished), return false
+  // so the manager falls back to follow-up/queue instead of dropping it into a dead session.
+  const steerHandle: SteerHandle = async (text) => {
+    if (!session.isStreaming) return false
+    await session.steer(text)
+    return true
+  }
+
   d.manager.generationStart()
+  params.onSteerable?.(steerHandle)
   try {
     // Not-streaming prompt: resolves after the whole agentic loop settles (mirrors pi's own
-    // print mode). Steering/follow-up messages are a fast-follow.
+    // print mode), including any steered continuation folded in via steerHandle above.
     await session.prompt(task)
   } finally {
+    params.onSteerable?.(null)
     unsubscribe()
     releaseGate()
     d.manager.generationEnd()

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -291,6 +291,17 @@ export const PATH_TOOLS = new Set(['read', 'edit', 'write', 'grep', 'find', 'ls'
 // model that legitimately repeats a call a few times is unaffected — only a genuine loop is cut.
 export const LOOP_BREAK_AFTER = 3
 
+// The soft nudge above assumes the model actually reads and acts on the blocked-call result — a
+// genuinely stuck weak/local model can just re-emit the exact same call again anyway, and
+// ToolLoopTracker.record() has no ceiling (a re-tripped signature keeps incrementing forever, see
+// its own test), so nothing was stopping this from repeating indefinitely — reproduced live
+// (founder-reported, 2026-07-24: the nudge fired and had "no effect", the run stayed stuck).
+// LOOP_ABORT_AFTER is the hard ceiling: after this many consecutive identical calls (i.e. the
+// model ignored LOOP_ABORT_AFTER - LOOP_BREAK_AFTER separate nudges), stop assuming it'll
+// self-heal and abort the run outright via session.abort() — the same real-stop path a user's own
+// Stop button uses, so it surfaces as a genuinely stopped run (stats.aborted), not a silent hang.
+export const LOOP_ABORT_AFTER = LOOP_BREAK_AFTER + 3
+
 /** Order-stable signature of a tool call: the name plus its arguments with object keys sorted at
  *  every depth, so a model re-emitting the same call with its keys in a different order still
  *  compares equal. Pure. */
@@ -518,6 +529,47 @@ export function summarizeTodos(todos: TodoItem[]): string {
   const parts = [`${completed}/${todos.length} done`]
   if (inProgress > 0) parts.push(`${inProgress} in progress`)
   return `Tracking ${todos.length} step(s): ${parts.join(', ')}.`
+}
+
+// ── Real prefill (prompt-processing) progress via llama.cpp /slots ─────────────────
+// Founder-reported: Code shows the prompt-processing phase as a generic "thinking" spinner while
+// Chat shows a real progress bar. Chat gets it by hand-parsing llama.cpp's own `prompt_progress`
+// SSE field from its own raw HTTP call; Code goes through pi's `openai` client, which never
+// surfaces that field. So we read progress OUT OF BAND from the engine's own `/slots` endpoint
+// (enabled by default, no --slots flag) while a provider request is in flight — independent of pi's
+// request entirely. `pct = n_prompt_tokens_processed / n_prompt_tokens`.
+export const PREFILL_POLL_MS = 300
+
+export interface PrefillProgress { processed: number; total: number; pct: number }
+
+function isProcessingSlot(s: unknown): s is { n_prompt_tokens: number; n_prompt_tokens_processed: number } {
+  if (!s || typeof s !== 'object') return false
+  const r = s as Record<string, unknown>
+  return r.is_processing === true && typeof r.n_prompt_tokens === 'number' && typeof r.n_prompt_tokens_processed === 'number'
+}
+
+/** Pick THIS request's prefill progress out of a llama.cpp `/slots` response — pure/exported so the
+ *  slot-matching + percentage logic is testable without a live engine (mirrors codeEventToFrame's
+ *  extract-pure-decision-logic pattern). Returns null ("emit nothing this poll") for anything
+ *  unusable: a non-array body, no slot actively processing, a zero/absent prompt-token total, or
+ *  processed<0.
+ *
+ *  Slot matching: returns null when MORE THAN ONE slot is processing at once. The in-app gate
+ *  (gate.ts) serializes Code+Chat generations and llama.cpp defaults to --parallel 1 (a single
+ *  slot), so the normal case has exactly one processing slot that is unambiguously ours. Only a
+ *  user-set --parallel>1 running a genuinely concurrent generation the gate does NOT cover (gateway
+ *  / Claude-Code traffic never takes the gate) can light up two slots simultaneously — and pi's
+ *  openai client never exposes the llama.cpp `id_task` needed to correlate precisely, so we refuse
+ *  to guess and show nothing rather than risk attributing another request's progress to this turn. */
+export function pickPrefillProgress(slots: unknown): PrefillProgress | null {
+  if (!Array.isArray(slots)) return null
+  const processing = slots.filter(isProcessingSlot)
+  if (processing.length !== 1) return null
+  const total = processing[0].n_prompt_tokens
+  const processed = processing[0].n_prompt_tokens_processed
+  if (!(total > 0) || processed < 0) return null
+  const pct = Math.min(100, Math.max(0, Math.round((processed / total) * 100)))
+  return { processed, total, pct }
 }
 
 /**
@@ -1006,6 +1058,40 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   const mcpToolNames = new Set(mcpToolDefs.map((t) => t.function.name))
 
   // ── the inline extension: containment + approval + diff plumbing ──────────────
+  // Prefill progress poller (see pickPrefillProgress above) — reads the engine's /slots endpoint
+  // while a provider request is in flight and relays a `prefill` SSE frame. Lifecycle is per
+  // agentic ROUND: started in before_provider_request, stopped the instant prefill completes
+  // (processed>=total), the first real token streams (message_update, a cross-check against stale
+  // slot numbers), the response ends, or the turn aborts. A self-rearming setTimeout — NOT
+  // setInterval — so a slow /slots fetch never stacks overlapping polls; every /slots failure or
+  // odd shape is swallowed, because prefill telemetry must never break the actual generation.
+  let prefillTimer: ReturnType<typeof setTimeout> | undefined
+  let prefillActive = false
+  const stopPrefillPoll = (): void => {
+    prefillActive = false
+    if (prefillTimer) { clearTimeout(prefillTimer); prefillTimer = undefined }
+  }
+  const startPrefillPoll = (): void => {
+    stopPrefillPoll()
+    prefillActive = true
+    let lastPct = -1
+    const tick = async (): Promise<void> => {
+      if (!prefillActive) return
+      try {
+        const res = await fetch(`${target}/slots`, { signal })
+        if (res.ok) {
+          const progress = pickPrefillProgress(await res.json())
+          if (progress && prefillActive) {
+            if (progress.pct !== lastPct) { lastPct = progress.pct; void sink({ event: 'prefill', data: { ...progress } }) }
+            if (progress.processed >= progress.total) { stopPrefillPoll(); return }
+          }
+        }
+      } catch { /* /slots must never break generation — skip this turn's prefill silently */ }
+      if (prefillActive) prefillTimer = setTimeout(() => void tick(), PREFILL_POLL_MS)
+    }
+    prefillTimer = setTimeout(() => void tick(), PREFILL_POLL_MS)
+  }
+
   const extension = (pi: ExtensionAPI): void => {
     // Background-priority engine slot, acquired/released around each provider request. Also
     // where the thinking budget is injected: pi makes its own provider HTTP call (registered
@@ -1019,6 +1105,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       // (see gate.ts's own comment for the incident this fixed) rather than hanging the whole
       // turn forever with no way to cancel it.
       if (d.gate) heldGate = await d.gate.acquire('bg', { signal })
+      // Gate acquired, request is about to go out — begin polling /slots for prefill progress for
+      // THIS round (stopped on first token / completion / response end / abort). Best-effort.
+      startPrefillPoll()
       const payload = { ...(event.payload as Record<string, unknown>) }
       // Strip the completion-length cap pi derives from this model's declared `maxTokens` (a
       // fixed ceiling set once in the model metadata above, at model-load time). Sent verbatim as
@@ -1043,7 +1132,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       }
       return payload // unlimited (default) — still stripped of the stale max_tokens ceiling
     })
-    pi.on('after_provider_response', () => { releaseGate() })
+    pi.on('after_provider_response', () => { stopPrefillPoll(); releaseGate() })
 
     // No turn_start reset — deliberately. pi fires `turn_start` once per agentic ROUND (it carries
     // an incrementing turnIndex; `agent_start` is the per-task boundary), so resetting here cleared
@@ -1065,8 +1154,22 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       // 0. Loop breaker — BEFORE containment/mode, so it catches a stuck model regardless of tool
       //    or mode. A weak local model can fire the SAME call with the SAME args indefinitely; once
       //    it has done so more than LOOP_BREAK_AFTER times in a row, stop executing it and hand the
-      //    model a break-the-loop instruction as the (blocked) result instead. Silent to the user.
-      if (toolLoop.record(toolName, input) > LOOP_BREAK_AFTER) {
+      //    model a break-the-loop instruction as the (blocked) result instead.
+      const loopCount = toolLoop.record(toolName, input)
+      if (loopCount > LOOP_ABORT_AFTER) {
+        // The nudge below didn't work — LOOP_ABORT_AFTER - LOOP_BREAK_AFTER separate nudges were
+        // sent and the model kept re-emitting the exact same call anyway. Stop assuming it'll
+        // self-heal: abort the run for real (same path the user's own Stop button uses, so this
+        // surfaces as a genuinely stopped run — stats.aborted — not a silent hang) rather than
+        // trip the same soft block forever (founder-reported live, 2026-07-24: "no effect").
+        const reason = `[SYSTEM: \`${toolName}\` was called with identical arguments ${loopCount} times ` +
+          'in a row, including after being told to stop — this run has been stopped automatically ' +
+          'rather than continue looping. Start a new turn with different instructions to try again.]'
+        await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
+        void session.abort()
+        return { block: true, reason }
+      }
+      if (loopCount > LOOP_BREAK_AFTER) {
         const reason = `[SYSTEM: you have called \`${toolName}\` with identical arguments too many ` +
           'times in a row and it is not making progress — this call was NOT executed. Stop repeating ' +
           'it: take a different action, call it with different arguments, or, if you already have what ' +
@@ -1530,6 +1633,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // (ADR-250). `turnCounter` is this run's own monotonic turn index, mutated across events.
   const turnCounter = { index: 0 }
   const unsubscribe = session.subscribe((ev: AgentSessionEvent) => {
+    // First real model output means prefill is over — stop the /slots poller now, a cross-check in
+    // case a slot's numbers never quite reach n_prompt_tokens (stale/rounding) before decode begins.
+    if (ev.type === 'message_update') stopPrefillPoll()
     const frame = codeEventToFrame(ev, turnCounter)
     if (frame) void sink(frame)
   })
@@ -1557,6 +1663,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     await session.prompt(task)
   } finally {
     params.onSteerable?.(null)
+    stopPrefillPoll() // belt-and-suspenders: never leak the /slots timer past the turn (incl. abort)
     unsubscribe()
     releaseGate()
     d.manager.generationEnd()

--- a/turbollm/src/code/code-shell.test.ts
+++ b/turbollm/src/code/code-shell.test.ts
@@ -1,0 +1,58 @@
+// Real spawned shell processes (no mocks) — same discipline as robust-bash.test.ts, since the
+// whole point is that a user's `!command` runs a genuine shell in the repo root.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { tmpdir } from 'node:os'
+import { runShellCommand, shellContextText } from './code-shell'
+
+test('runShellCommand captures stdout and a zero exit code', async () => {
+  const r = await runShellCommand('echo hello-shell', tmpdir(), 'test')
+  assert.match(r.output, /hello-shell/)
+  assert.equal(r.exitCode, 0)
+  assert.equal(r.timedOut, false)
+  assert.equal(r.truncated, false)
+})
+
+test('runShellCommand reports a non-zero exit code without throwing', async () => {
+  const r = await runShellCommand('exit 3', tmpdir(), 'test')
+  assert.equal(r.exitCode, 3)
+  assert.equal(r.timedOut, false)
+})
+
+test('runShellCommand runs in the given cwd (repoRoot containment)', async () => {
+  const r = await runShellCommand('pwd', tmpdir(), 'test')
+  // pwd should echo the cwd we handed it (allowing for symlink canonicalization of tmpdir).
+  assert.ok(r.output.trim().length > 0)
+  assert.equal(r.exitCode, 0)
+})
+
+test('runShellCommand caps output at maxOutput and flags truncated', async () => {
+  const r = await runShellCommand("printf 'x%.0s' $(seq 1 5000)", tmpdir(), 'test', { maxOutput: 100 })
+  assert.equal(r.truncated, true)
+  assert.ok(r.output.length <= 100, `expected <=100 chars, got ${r.output.length}`)
+})
+
+test('runShellCommand times out a hung command and reports timedOut (no throw)', async () => {
+  const r = await runShellCommand('sleep 5', tmpdir(), 'test', { timeoutSec: 1 })
+  assert.equal(r.timedOut, true)
+  assert.equal(r.exitCode, null)
+})
+
+test('shellContextText frames the command + output for the model to read', () => {
+  const text = shellContextText({ command: 'ls', output: 'file.txt\n', exitCode: 0, timedOut: false, truncated: false })
+  assert.match(text, /I ran a shell command/)
+  assert.match(text, /\$ ls/)
+  assert.match(text, /file\.txt/)
+})
+
+test('shellContextText notes a non-zero exit, empty output, and truncation', () => {
+  const text = shellContextText({ command: 'false', output: '', exitCode: 1, timedOut: false, truncated: true })
+  assert.match(text, /exit code 1/)
+  assert.match(text, /\(no output\)/)
+  assert.match(text, /truncated/)
+})
+
+test('shellContextText notes a timeout', () => {
+  const text = shellContextText({ command: 'sleep 99', output: '', exitCode: null, timedOut: true, truncated: false })
+  assert.match(text, /timed out/)
+})

--- a/turbollm/src/code/code-shell.ts
+++ b/turbollm/src/code/code-shell.ts
@@ -1,0 +1,83 @@
+// `!command` / `!!command` shell escape hatch (ADR-258) — the USER (not the model) runs a real
+// shell command straight from the Code composer, in the session's own repo root. `!` feeds the
+// output back to the model as context (persisted as a user message by the route); `!!` is a
+// transcript-only peek that never enters model context.
+//
+// Runs through createRobustBashOperations — the SAME verified-kill bash wrapper the agent's own
+// bash tool uses (robust-bash.ts) — so the command executes with the identical shell resolution,
+// spawn shape, and abort/timeout kill discipline, in the session `repoRoot` as cwd. No shell-string
+// injection surface: the user's command is handed to the shell verbatim as the command to run (the
+// intended behavior of a shell escape — the user IS the author), never concatenated into a larger
+// script we build. A hard output cap and wall-clock timeout bound a runaway command.
+import { createRobustBashOperations } from './robust-bash'
+
+/** Default ceilings — a `!command` is an interactive peek, not a build: keep output bounded so a
+ *  chatty command can't blow up the transcript or the next turn's context window, and time-box it
+ *  so a hung command can't wedge the composer. */
+export const SHELL_MAX_OUTPUT = 100_000 // characters
+export const SHELL_TIMEOUT_SEC = 60
+
+export interface ShellRunResult {
+  command: string
+  /** Combined stdout+stderr, capped at `maxOutput` characters. */
+  output: string
+  /** Process exit code, or null when it was killed/terminated without one. */
+  exitCode: number | null
+  /** True when the process was killed for exceeding `timeoutSec`. */
+  timedOut: boolean
+  /** True when `output` was cut off at the cap. */
+  truncated: boolean
+}
+
+/** Run one user-typed shell command in `repoRoot`. Never throws for a non-zero exit or a timeout —
+ *  those are normal outcomes reported in the result; it only rejects if the shell itself can't be
+ *  spawned (e.g. the cwd vanished). `sessionLabel` is threaded to robust-bash purely for its
+ *  kill-escalation warning logs. */
+export async function runShellCommand(
+  command: string,
+  repoRoot: string,
+  sessionLabel: string,
+  opts?: { maxOutput?: number; timeoutSec?: number; signal?: AbortSignal },
+): Promise<ShellRunResult> {
+  const maxOutput = opts?.maxOutput ?? SHELL_MAX_OUTPUT
+  const timeoutSec = opts?.timeoutSec ?? SHELL_TIMEOUT_SEC
+  const ops = createRobustBashOperations({ sessionLabel })
+
+  let output = ''
+  let truncated = false
+  const onData = (chunk: Buffer | string) => {
+    if (truncated) return
+    output += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    if (output.length > maxOutput) {
+      output = output.slice(0, maxOutput)
+      truncated = true
+    }
+  }
+
+  const signal = opts?.signal ?? new AbortController().signal
+  try {
+    const { exitCode } = await ops.exec(command, repoRoot, { onData, signal, timeout: timeoutSec, env: process.env })
+    return { command, output, exitCode, timedOut: false, truncated }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    // robust-bash throws `timeout:<sec>` when it kills a command for exceeding the wall clock —
+    // report that as a normal (timed-out) result with whatever output was captured before the kill,
+    // rather than a 500. An abort (the caller cancelled) rethrows.
+    if (msg.startsWith('timeout:')) return { command, output, exitCode: null, timedOut: true, truncated }
+    throw e
+  }
+}
+
+/** The user-message body a `!command` (feed-to-model) persists — what the model reads back as
+ *  context on the next turn (seedPriorHistory replays a user message's `content` verbatim). Framed
+ *  as the user reporting a command THEY ran, so the model never mistakes it for a tool IT called. */
+export function shellContextText(result: ShellRunResult): string {
+  const body = result.output.trim() || '(no output)'
+  const status = result.timedOut
+    ? ` (timed out after ${SHELL_TIMEOUT_SEC}s)`
+    : result.exitCode !== null && result.exitCode !== 0
+      ? ` (exit code ${result.exitCode})`
+      : ''
+  const trunc = result.truncated ? '\n…(output truncated)' : ''
+  return `I ran a shell command in the repo${status}:\n\n$ ${result.command}\n\n${body}${trunc}`
+}

--- a/turbollm/src/code/git-actions.test.ts
+++ b/turbollm/src/code/git-actions.test.ts
@@ -1,0 +1,252 @@
+// Unit tests for git-actions.ts — real git subprocesses against real throwaway repos (no mocking
+// of child_process or the filesystem), matching this codebase's own testing discipline for
+// process-lifecycle/exec code (see robust-bash.test.ts, revert.test.ts). Pushes are tested against
+// a real local bare repo used as the "remote" — a plain filesystem path is a completely valid git
+// remote, so this exercises the real push/rejection code paths without touching the network.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, appendFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  buildGithubCompareUrl,
+  commitGitChanges,
+  getGithubCompareUrl,
+  getGitStatus,
+  GitError,
+  pushGitBranch,
+} from './git-actions'
+
+function tmp(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function gitSync(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', windowsHide: true }).trim()
+}
+
+/** A real repo, one commit in, on a fixed branch name (explicit -b so tests never depend on the
+ *  ambient init.defaultBranch config) with local test-only identity so commits work in any CI
+ *  environment regardless of global git config. */
+function initRepo(branch = 'main'): string {
+  const dir = tmp('tllm-git-actions-')
+  gitSync(['init', '-b', branch, '-q'], dir)
+  gitSync(['config', 'user.email', 'test@example.com'], dir)
+  gitSync(['config', 'user.name', 'Test'], dir)
+  writeFileSync(join(dir, 'README.md'), 'hello\n')
+  gitSync(['add', 'README.md'], dir)
+  gitSync(['commit', '-q', '-m', 'init'], dir)
+  return dir
+}
+
+/** A real bare repo (a valid git remote — just a filesystem path) to push/pull against, so the
+ *  push/diverged-push tests exercise the real network-shaped code path locally. HEAD is pointed
+ *  at 'main' explicitly — a fresh bare repo's HEAD otherwise defaults to whatever
+ *  init.defaultBranch resolves to locally (often 'master'), which doesn't exist once a push only
+ *  ever creates 'main', so a later `git clone` of it fails to check anything out. */
+function initBareRemote(): string {
+  const dir = tmp('tllm-git-actions-remote-')
+  gitSync(['init', '--bare', '-q'], dir)
+  gitSync(['symbolic-ref', 'HEAD', 'refs/heads/main'], dir)
+  return dir
+}
+
+test('getGitStatus: a plain non-repo folder reports isRepo:false', async () => {
+  const dir = tmp('tllm-git-actions-notrepo-')
+  const status = await getGitStatus(dir)
+  assert.equal(status.isRepo, false)
+  assert.deepEqual(status.files, [])
+})
+
+test('getGitStatus: a brand-new repo with no commits (unborn HEAD) is still isRepo:true, with an empty branch', async () => {
+  const dir = tmp('tllm-git-actions-unborn-')
+  gitSync(['init', '-b', 'main', '-q'], dir)
+  const status = await getGitStatus(dir)
+  assert.equal(status.isRepo, true)
+  assert.equal(status.branch, '')
+  assert.equal(status.detached, false)
+})
+
+test('getGitStatus: a clean tree after a commit reports no files, and the real branch name', async () => {
+  const dir = initRepo('main')
+  const status = await getGitStatus(dir)
+  assert.equal(status.isRepo, true)
+  assert.equal(status.branch, 'main')
+  assert.deepEqual(status.files, [])
+  assert.equal(status.hasRemote, false)
+})
+
+test('getGitStatus: an untracked new file shows up with the real porcelain code', async () => {
+  const dir = initRepo()
+  writeFileSync(join(dir, 'new.txt'), 'new\n')
+  const status = await getGitStatus(dir)
+  assert.deepEqual(status.files, [{ code: '??', path: 'new.txt' }])
+})
+
+test('getGitStatus: a configured remote is reflected in hasRemote', async () => {
+  const dir = initRepo()
+  const remote = initBareRemote()
+  gitSync(['remote', 'add', 'origin', remote], dir)
+  const status = await getGitStatus(dir)
+  assert.equal(status.hasRemote, true)
+})
+
+test('getGitStatus: after pushing with tracking, ahead/behind reflects an un-pushed local commit', async () => {
+  const dir = initRepo()
+  const remote = initBareRemote()
+  gitSync(['remote', 'add', 'origin', remote], dir)
+  gitSync(['push', '-u', 'origin', 'main'], dir)
+  let status = await getGitStatus(dir)
+  assert.equal(status.hasUpstream, true)
+  assert.equal(status.ahead, 0)
+  assert.equal(status.behind, 0)
+
+  appendFileSync(join(dir, 'README.md'), 'more\n')
+  gitSync(['commit', '-aq', '-m', 'second'], dir)
+  status = await getGitStatus(dir)
+  assert.equal(status.ahead, 1)
+  assert.equal(status.behind, 0)
+})
+
+test('commitGitChanges: rejects an empty/whitespace-only message without touching git', async () => {
+  const dir = initRepo()
+  writeFileSync(join(dir, 'new.txt'), 'x\n')
+  await assert.rejects(() => commitGitChanges(dir, '   '), GitError)
+  // Nothing was staged/committed by the rejected call.
+  const status = await getGitStatus(dir)
+  assert.deepEqual(status.files, [{ code: '??', path: 'new.txt' }])
+})
+
+test('commitGitChanges: rejects when the working tree is clean (nothing to commit)', async () => {
+  const dir = initRepo()
+  await assert.rejects(() => commitGitChanges(dir, 'a message'), /Nothing to commit/)
+})
+
+test('commitGitChanges: default (no files given) stages and commits everything', async () => {
+  const dir = initRepo()
+  writeFileSync(join(dir, 'a.txt'), 'a\n')
+  writeFileSync(join(dir, 'b.txt'), 'b\n')
+  const result = await commitGitChanges(dir, 'add a and b')
+  assert.equal(result.filesCommitted, 2)
+  assert.match(result.hash, /^[0-9a-f]{40}$/)
+  const status = await getGitStatus(dir)
+  assert.deepEqual(status.files, [])
+})
+
+test('commitGitChanges: an explicit file list stages ONLY those paths, leaving the rest untouched', async () => {
+  const dir = initRepo()
+  writeFileSync(join(dir, 'a.txt'), 'a\n')
+  writeFileSync(join(dir, 'b.txt'), 'b\n')
+  const result = await commitGitChanges(dir, 'add only a', ['a.txt'])
+  assert.equal(result.filesCommitted, 1)
+  const status = await getGitStatus(dir)
+  assert.deepEqual(status.files, [{ code: '??', path: 'b.txt' }])
+})
+
+test('commitGitChanges: refuses a path outside the repo root (containment), without staging anything', async () => {
+  const dir = initRepo()
+  writeFileSync(join(dir, 'a.txt'), 'a\n')
+  const outside = join(tmpdir(), 'not-in-repo.txt')
+  await assert.rejects(
+    () => commitGitChanges(dir, 'escape attempt', [outside]),
+    /outside the repo/,
+  )
+  const status = await getGitStatus(dir)
+  // a.txt is still untracked — the rejected call never ran `git add`.
+  assert.deepEqual(status.files, [{ code: '??', path: 'a.txt' }])
+})
+
+test('pushGitBranch: no remote configured reports the no_remote reason, not a thrown error', async () => {
+  const dir = initRepo()
+  const result = await pushGitBranch(dir)
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.equal(result.reason, 'no_remote')
+})
+
+test('pushGitBranch: a detached HEAD is refused before ever attempting a push', async () => {
+  const dir = initRepo()
+  const remote = initBareRemote()
+  gitSync(['remote', 'add', 'origin', remote], dir)
+  const headSha = gitSync(['rev-parse', 'HEAD'], dir)
+  gitSync(['checkout', '-q', headSha], dir) // detach
+  const result = await pushGitBranch(dir)
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.equal(result.reason, 'detached_head')
+})
+
+test('pushGitBranch: a real push to a local bare remote succeeds and sets upstream on first push', async () => {
+  const dir = initRepo()
+  const remote = initBareRemote()
+  gitSync(['remote', 'add', 'origin', remote], dir)
+  const result = await pushGitBranch(dir)
+  assert.equal(result.ok, true)
+  if (result.ok) {
+    assert.equal(result.remote, 'origin')
+    assert.equal(result.branch, 'main')
+  }
+  const status = await getGitStatus(dir)
+  assert.equal(status.hasUpstream, true)
+})
+
+test('pushGitBranch: a diverged remote is rejected as "diverged", never force-pushed', async () => {
+  const remote = initBareRemote()
+  const a = initRepo()
+  gitSync(['remote', 'add', 'origin', remote], a)
+  const first = await pushGitBranch(a)
+  assert.equal(first.ok, true)
+
+  // A second, independent clone of the SAME remote — diverges by committing without ever
+  // fetching a's later commit.
+  const b = tmp('tllm-git-actions-clone-')
+  gitSync(['clone', '-q', remote, '.'], b)
+  gitSync(['config', 'user.email', 'test@example.com'], b)
+  gitSync(['config', 'user.name', 'Test'], b)
+  writeFileSync(join(b, 'from-b.txt'), 'b\n')
+  gitSync(['add', 'from-b.txt'], b)
+  gitSync(['commit', '-q', '-m', 'from b'], b)
+  const pushedB = await pushGitBranch(b)
+  assert.equal(pushedB.ok, true) // b pushes first, moving the remote ahead of a's local view
+
+  // a is now behind the remote — its push must be rejected, not force-pushed.
+  appendFileSync(join(a, 'README.md'), 'from a, unaware of b\n')
+  gitSync(['commit', '-aq', '-m', 'from a'], a)
+  const result = await pushGitBranch(a)
+  assert.equal(result.ok, false)
+  if (!result.ok) assert.equal(result.reason, 'diverged')
+
+  // Confirm nothing was force-pushed: the remote's tip is still b's commit, not a rewritten
+  // history discarding it.
+  const remoteTip = gitSync(['log', '-1', '--format=%s', 'HEAD'], b)
+  assert.equal(remoteTip, 'from b')
+})
+
+test('buildGithubCompareUrl: parses an https GitHub remote', () => {
+  assert.equal(
+    buildGithubCompareUrl('https://github.com/acme/widgets.git', 'feature/x'),
+    'https://github.com/acme/widgets/compare/feature%2Fx?expand=1',
+  )
+})
+
+test('buildGithubCompareUrl: parses an ssh GitHub remote', () => {
+  assert.equal(
+    buildGithubCompareUrl('git@github.com:acme/widgets.git', 'main'),
+    'https://github.com/acme/widgets/compare/main?expand=1',
+  )
+})
+
+test('buildGithubCompareUrl: a non-GitHub remote resolves to null, not an error', () => {
+  assert.equal(buildGithubCompareUrl('https://gitlab.com/acme/widgets.git', 'main'), null)
+  assert.equal(buildGithubCompareUrl('/local/bare/repo', 'main'), null)
+})
+
+test('getGithubCompareUrl: no origin remote resolves to null', async () => {
+  const dir = initRepo()
+  assert.equal(await getGithubCompareUrl(dir, 'main'), null)
+})
+
+test('getGithubCompareUrl: a GitHub-style origin resolves the real compare URL', async () => {
+  const dir = initRepo()
+  gitSync(['remote', 'add', 'origin', 'https://github.com/acme/widgets.git'], dir)
+  assert.equal(await getGithubCompareUrl(dir, 'main'), 'https://github.com/acme/widgets/compare/main?expand=1')
+})

--- a/turbollm/src/code/git-actions.ts
+++ b/turbollm/src/code/git-actions.ts
@@ -1,0 +1,236 @@
+// Git commit/push + PR-link actions for Code sessions (Phase 3, ADR-259) — thin, safe wrappers
+// around real `git` subprocess calls in a session's repoRoot. Every call uses execFile with an
+// argv array (never a shell string), matching routes.ts's `/api/v1/fs/git-branch` route (the one
+// existing precedent for shelling out to git in this codebase) — a command never passes through a
+// shell, so there's no injection surface even from a user-supplied commit message or file path.
+//
+// Scope, deliberately narrow for this pass (see docs/decisions/decision-log.md ADR-259):
+//  - Commit + push only; NO GitHub API call anywhere. "Open a PR" resolves to a GitHub compare URL
+//    the UI opens in the user's own browser (parsed from the remote's own URL) — there is no
+//    existing `gh` CLI / GitHub token precedent anywhere in this codebase to build real PR
+//    creation on (grepped: zero matches outside docs/RELEASE.md's own release runbook, a
+//    human-run script, not app code), and inventing auth handling for it from scratch is
+//    explicitly out of scope for this task. Non-GitHub remotes (GitLab, Bitbucket, a bare local
+//    path) just get `compareUrl: null` — a graceful miss, not an error.
+//  - Push NEVER forces, ever. A rejected (non-fast-forward) push is surfaced as a typed result the
+//    caller must react to, not silently retried with --force — this repo's own CLAUDE.md treats
+//    force-push as something that requires explicit human authorization every time, and a Code
+//    session pushing on a user's behalf gets no special exemption from that.
+//  - A detached HEAD can commit (git allows it) but is refused for push — `git push` from a
+//    detached HEAD needs an explicit `<remote> HEAD:<branch>` refspec, extra complexity/risk this
+//    pass doesn't add; surfaced as a distinct, actionable error instead of a confusing generic one.
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { isContainedFromRoot } from './containment'
+
+const execFileAsync = promisify(execFile)
+
+// Local, read-only/local-mutation ops (status, add, commit) — bounded short since nothing here
+// touches the network.
+const GIT_TIMEOUT_MS = 15_000
+// Push touches the network — more headroom, but still bounded so a hung credential prompt can't
+// wedge a daemon request forever. GIT_TERMINAL_PROMPT=0 (set on every call below) is the real fix
+// for that case; this timeout is only the backstop if it doesn't work for the remote's exact auth
+// setup (e.g. a credential helper that itself hangs instead of erroring).
+const GIT_NETWORK_TIMEOUT_MS = 30_000
+
+export class GitError extends Error {
+  readonly stderr: string
+  readonly exitCode: number | null
+  constructor(message: string, stderr: string, exitCode: number | null) {
+    super(message)
+    this.name = 'GitError'
+    this.stderr = stderr
+    this.exitCode = exitCode
+  }
+}
+
+async function git(args: string[], cwd: string, timeoutMs = GIT_TIMEOUT_MS): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      cwd,
+      timeout: timeoutMs,
+      windowsHide: true,
+      // Never block on an interactive username/password/passphrase prompt — surface the auth
+      // failure as a normal command error instead of hanging the request.
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    })
+    return stdout.trim()
+  } catch (e) {
+    const failure = e as { stderr?: string; code?: number; killed?: boolean; message: string }
+    if (failure.killed) throw new GitError(`git ${args[0]} timed out after ${timeoutMs}ms`, failure.stderr ?? '', null)
+    throw new GitError((failure.stderr ?? '').trim() || failure.message, failure.stderr ?? '', failure.code ?? null)
+  }
+}
+
+export interface GitFileStatus {
+  path: string
+  /** Raw two-character porcelain status code (e.g. 'M ', '??', ' D', 'AM') — the UI maps this to
+   *  an icon/label; not re-interpreted here so no meaning is lost or guessed at. */
+  code: string
+}
+
+export interface GitStatusResult {
+  isRepo: boolean
+  /** '' for an unborn HEAD (brand-new repo, no commits yet) or a detached HEAD. */
+  branch: string
+  detached: boolean
+  files: GitFileStatus[]
+  hasRemote: boolean
+  /** Whether the current branch has an upstream tracking branch configured. */
+  hasUpstream: boolean
+  ahead: number
+  behind: number
+}
+
+const EMPTY_STATUS: GitStatusResult = {
+  isRepo: false, branch: '', detached: false, files: [], hasRemote: false, hasUpstream: false, ahead: 0, behind: 0,
+}
+
+/** Best-effort, read-only — a folder that isn't a git repo (or has no commits yet) just reports
+ *  `isRepo: false` / empty fields rather than throwing, so callers can render "not tracked" state
+ *  instead of an error screen. Mirrors `/api/v1/fs/git-branch`'s own best-effort convention. */
+export async function getGitStatus(repoRoot: string): Promise<GitStatusResult> {
+  try {
+    if ((await git(['rev-parse', '--is-inside-work-tree'], repoRoot)) !== 'true') return EMPTY_STATUS
+  } catch {
+    return EMPTY_STATUS
+  }
+
+  let branch = ''
+  let detached = false
+  try {
+    branch = await git(['rev-parse', '--abbrev-ref', 'HEAD'], repoRoot)
+    if (branch === 'HEAD') { detached = true; branch = '' }
+  } catch { /* unborn HEAD — no commits yet, still a valid (empty) repo */ }
+
+  let hasRemote = false
+  try { hasRemote = (await git(['remote'], repoRoot)).length > 0 } catch { /* no remotes configured */ }
+
+  let hasUpstream = false
+  let ahead = 0
+  let behind = 0
+  if (!detached && branch) {
+    try {
+      await git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], repoRoot)
+      hasUpstream = true
+      const counts = await git(['rev-list', '--left-right', '--count', 'HEAD...@{u}'], repoRoot)
+      const [a, b] = counts.split(/\s+/).map((n) => parseInt(n, 10) || 0)
+      ahead = a ?? 0
+      behind = b ?? 0
+    } catch { /* branch has no upstream tracking configured yet */ }
+  }
+
+  const raw = await git(['status', '--porcelain=v1'], repoRoot)
+  const files: GitFileStatus[] = raw
+    ? raw.split('\n').filter(Boolean).map((line) => ({ code: line.slice(0, 2), path: line.slice(3) }))
+    : []
+
+  return { isRepo: true, branch, detached, files, hasRemote, hasUpstream, ahead, behind }
+}
+
+export interface CommitResult {
+  hash: string
+  filesCommitted: number
+}
+
+/** Stages then commits. `files`, when given, stages ONLY those paths (each containment-checked
+ *  against `repoRoot` — the same boundary every other Code filesystem operation enforces, since a
+ *  caller-supplied path list is exactly the input that boundary exists for); omitted stages
+ *  everything (`git add -A`), matching a plain "commit all my changes" affordance. Throws
+ *  `GitError` for every failure case (no message, not a repo, nothing to commit/stage, containment
+ *  violation, or the underlying `git commit` itself failing) — callers map `.message` to a route
+ *  error, no silent partial-success. */
+export async function commitGitChanges(repoRoot: string, message: string, files?: string[]): Promise<CommitResult> {
+  const trimmedMessage = message.trim()
+  if (!trimmedMessage) throw new GitError('A commit message is required.', '', null)
+
+  const status = await getGitStatus(repoRoot)
+  if (!status.isRepo) throw new GitError('Not a git repository.', '', null)
+  if (status.files.length === 0) throw new GitError('Nothing to commit — the working tree is clean.', '', null)
+
+  if (files && files.length > 0) {
+    for (const f of files) {
+      if (!isContainedFromRoot(f, repoRoot)) throw new GitError(`Refusing to stage a path outside the repo: ${f}`, '', null)
+    }
+    await git(['add', '--', ...files], repoRoot)
+  } else {
+    await git(['add', '-A'], repoRoot)
+  }
+
+  // Re-check what's actually staged rather than trusting `status.files` was non-empty for the
+  // repo as a whole — a caller-supplied `files` list can point at paths with no real changes,
+  // which `git add` silently no-ops on, leaving nothing staged.
+  const staged = await git(['diff', '--cached', '--name-only'], repoRoot).catch(() => '')
+  const stagedList = staged.split('\n').filter(Boolean)
+  if (stagedList.length === 0) throw new GitError('Nothing staged — the selected file(s) have no changes.', '', null)
+
+  await git(['commit', '-m', trimmedMessage], repoRoot)
+  const hash = await git(['rev-parse', 'HEAD'], repoRoot)
+  return { hash, filesCommitted: stagedList.length }
+}
+
+export type PushResult =
+  | { ok: true; remote: string; branch: string }
+  | { ok: false; reason: 'not_a_repo' | 'no_remote' | 'detached_head'; message: string }
+  | { ok: false; reason: 'diverged' | 'push_failed'; message: string }
+
+/** Pushes the current branch to `origin`, setting the upstream on first push if none is
+ *  configured yet. NEVER passes `--force`/`-f` under any circumstance — a rejected
+ *  (non-fast-forward) push comes back as `{ reason: 'diverged' }` for the caller to surface, not
+ *  retried automatically. */
+export async function pushGitBranch(repoRoot: string): Promise<PushResult> {
+  const status = await getGitStatus(repoRoot)
+  if (!status.isRepo) return { ok: false, reason: 'not_a_repo', message: 'Not a git repository.' }
+  if (status.detached) {
+    return { ok: false, reason: 'detached_head', message: 'Cannot push from a detached HEAD — check out a branch first.' }
+  }
+  if (!status.hasRemote) return { ok: false, reason: 'no_remote', message: 'This repo has no configured remote.' }
+
+  const args = status.hasUpstream ? ['push'] : ['push', '--set-upstream', 'origin', status.branch]
+  try {
+    await git(args, repoRoot, GIT_NETWORK_TIMEOUT_MS)
+    return { ok: true, remote: 'origin', branch: status.branch }
+  } catch (e) {
+    const ge = e as GitError
+    // Real git wording for a rejected non-fast-forward push, across the common remote hosts —
+    // matched, never silently retried with --force.
+    if (/\[rejected\]|non-fast-forward|fetch first|tip of your current branch is behind/i.test(ge.stderr)) {
+      return {
+        ok: false,
+        reason: 'diverged',
+        message: 'The remote has commits this branch doesn\'t have. Pull/rebase first — never force-pushed automatically.',
+      }
+    }
+    return { ok: false, reason: 'push_failed', message: ge.message }
+  }
+}
+
+/** Parses a GitHub remote URL (https://github.com/owner/repo[.git] or
+ *  git@github.com:owner/repo[.git]) into a compare/PR-creation URL for `branch` against the
+ *  repo's default base branch selection (GitHub's own compare UI lets the user change the base;
+ *  omitting it here rather than guessing keeps this a pure, no-extra-request parse). Returns null
+ *  for any non-GitHub remote — a graceful miss for GitLab/Bitbucket/local remotes, not an error,
+ *  since PR-link support beyond GitHub is out of scope for this pass. */
+export function buildGithubCompareUrl(remoteUrl: string, branch: string): string | null {
+  const trimmed = remoteUrl.trim()
+  const httpsMatch = trimmed.match(/^https?:\/\/(?:[^@/]+@)?github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/)
+  const sshMatch = trimmed.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/)
+  const m = httpsMatch ?? sshMatch
+  if (!m) return null
+  const [, owner, repo] = m
+  return `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(branch)}?expand=1`
+}
+
+/** Best-effort: reads the `origin` remote URL and resolves a compare link for `branch`. Returns
+ *  null (never throws) when there's no `origin` remote or the remote isn't GitHub — same
+ *  graceful-miss contract as {@link buildGithubCompareUrl}. */
+export async function getGithubCompareUrl(repoRoot: string, branch: string): Promise<string | null> {
+  let remoteUrl: string
+  try {
+    remoteUrl = await git(['remote', 'get-url', 'origin'], repoRoot)
+  } catch {
+    return null
+  }
+  return buildGithubCompareUrl(remoteUrl, branch)
+}

--- a/turbollm/src/code/persona.test.ts
+++ b/turbollm/src/code/persona.test.ts
@@ -6,7 +6,7 @@ import { test } from 'node:test'
 import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { agentsMdBlock, buildAppendPrompt } from './persona'
+import { agentsMdBlock, agentsMdPresence, buildAppendPrompt } from './persona'
 
 function tmp(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
@@ -63,6 +63,42 @@ test('agentsMdBlock: a path that is a directory, not a file, is silently skipped
   mkdirSync(join(repoRoot, 'AGENTS.md')) // a directory named AGENTS.md, not a file
   assert.doesNotThrow(() => agentsMdBlock(repoRoot, globalDir))
   assert.equal(agentsMdBlock(repoRoot, globalDir), '')
+})
+
+// ── agentsMdPresence (ADR-262 loaded-resources header) — the boolean-per-file existence check,
+// same lookup + whitespace-counts-as-absent rule as agentsMdBlock so "shown loaded" == "injected".
+
+test('agentsMdPresence: both false when neither file exists', () => {
+  assert.deepEqual(agentsMdPresence(tmp('tllm-amp-repo-'), tmp('tllm-amp-global-')), { project: false, global: false })
+})
+
+test('agentsMdPresence: detects a project AGENTS.md only', () => {
+  const repoRoot = tmp('tllm-amp-repo-')
+  const globalDir = tmp('tllm-amp-global-')
+  writeFileSync(join(repoRoot, 'AGENTS.md'), 'Use pnpm here.')
+  assert.deepEqual(agentsMdPresence(repoRoot, globalDir), { project: true, global: false })
+})
+
+test('agentsMdPresence: detects a global agents.md only', () => {
+  const repoRoot = tmp('tllm-amp-repo-')
+  const globalDir = tmp('tllm-amp-global-')
+  writeFileSync(join(globalDir, 'agents.md'), 'Always present tense.')
+  assert.deepEqual(agentsMdPresence(repoRoot, globalDir), { project: false, global: true })
+})
+
+test('agentsMdPresence: detects both when both exist', () => {
+  const repoRoot = tmp('tllm-amp-repo-')
+  const globalDir = tmp('tllm-amp-global-')
+  writeFileSync(join(repoRoot, 'AGENTS.md'), 'project')
+  writeFileSync(join(globalDir, 'agents.md'), 'global')
+  assert.deepEqual(agentsMdPresence(repoRoot, globalDir), { project: true, global: true })
+})
+
+test('agentsMdPresence: a whitespace-only file counts as absent (matches agentsMdBlock)', () => {
+  const repoRoot = tmp('tllm-amp-repo-')
+  const globalDir = tmp('tllm-amp-global-')
+  writeFileSync(join(repoRoot, 'AGENTS.md'), '   \n\n  ')
+  assert.deepEqual(agentsMdPresence(repoRoot, globalDir), { project: false, global: false })
 })
 
 test('buildAppendPrompt: omitting agentsMd (existing call sites) keeps output unchanged — no AGENTS.md block', () => {

--- a/turbollm/src/code/persona.test.ts
+++ b/turbollm/src/code/persona.test.ts
@@ -111,3 +111,10 @@ test('buildAppendPrompt: LSP guidance appears in auto/ask but not plan mode (no 
   assert.ok(auto.some((b) => b.includes('LSP diagnostics for')))
   assert.ok(!plan.some((b) => b.includes('LSP diagnostics for')))
 })
+
+test('buildAppendPrompt: todo-tracker guidance (update_todos) appears in auto/ask but not plan mode', () => {
+  assert.ok(buildAppendPrompt('auto').some((b) => b.includes('call update_todos')))
+  assert.ok(buildAppendPrompt('ask').some((b) => b.includes('call update_todos')))
+  // Plan mode's deliverable is already a written step list, so no live checklist guidance there.
+  assert.ok(!buildAppendPrompt('plan').some((b) => b.includes('call update_todos')))
+})

--- a/turbollm/src/code/persona.ts
+++ b/turbollm/src/code/persona.ts
@@ -152,6 +152,23 @@ export function dependencyDisciplineGuidance(): string {
   ].join(' ')
 }
 
+/** Todo/step tracker guidance (ADR-255) — nudges the model to surface a live checklist for a
+ *  genuinely multi-step task via the update_todos tool (registered in code-session.ts), the same
+ *  way lspGuidance explains install_lsp. Deliberately NOT mandatory: for a trivial single-action
+ *  request a checklist is noise, so the guidance scopes it to multi-step work. Non-plan only (like
+ *  edit/LSP guidance): plan mode's whole deliverable is already a written step-by-step plan, so a
+ *  parallel live checklist there would just duplicate it. */
+export function todoTrackerGuidance(): string {
+  return [
+    'For a task with several distinct steps, call update_todos to give the user a live checklist:',
+    'send the full list of steps (each { content, status }) when you start, mark a step in_progress',
+    'when you begin it and completed as soon as it is done, and re-send the WHOLE list on every',
+    'update (it replaces the previous one). This shows the user the plan and real progress instead',
+    'of an opaque run of tool calls. Do NOT use it for trivial single-step requests — a one-item',
+    'checklist is just noise.',
+  ].join(' ')
+}
+
 /** The pi tool set for a Code mode. plan is READ-ONLY (its real safety mechanism): mutating
  *  tools simply aren't in the toolset, so nothing reaches the containment/approval hook to gate.
  *  auto/ask use pi's DEFAULT tool set (read/bash/edit/write) — returned as `undefined` so the
@@ -239,6 +256,7 @@ export function buildAppendPrompt(mode: CodeMode, skills: Skill[] = [], agentsMd
   if (mode !== 'plan') {
     blocks.push(editReliabilityGuidance())
     blocks.push(lspGuidance())
+    blocks.push(todoTrackerGuidance())
   }
   // Only when web_search/fetch_url are actually registered — see antiFallbackGuidance's comment.
   if (hasWebTools) {

--- a/turbollm/src/code/persona.ts
+++ b/turbollm/src/code/persona.ts
@@ -228,6 +228,19 @@ function readAgentsFile(path: string): string | null {
   }
 }
 
+/** Whether a project (`<repoRoot>/AGENTS.md`) and/or global (`<globalDir>/agents.md`) AGENTS.md
+ *  file is actually present — for the loaded-resources header (ADR-262), which needs a boolean per
+ *  file, not the injected prompt text `agentsMdBlock` returns. Uses the exact same lookup +
+ *  whitespace-only-counts-as-absent rule as `agentsMdBlock`, so "present here" always matches
+ *  "actually injected into the prompt." Cheap (two small reads); safe to call per session-detail
+ *  request. */
+export function agentsMdPresence(repoRoot: string, globalDir: string): { project: boolean; global: boolean } {
+  return {
+    project: readAgentsFile(join(repoRoot, 'AGENTS.md')) !== null,
+    global: readAgentsFile(join(globalDir, 'agents.md')) !== null,
+  }
+}
+
 /** `<repoRoot>/AGENTS.md` (project-level, the user's own repo) and `<globalDir>/agents.md`
  *  (global — TurboLLM's own data dir, e.g. `~/.turbollm/agents.md`), like OpenCode's AGENTS.md
  *  convention: standing project/user instructions picked up automatically, no per-session setup.

--- a/turbollm/src/code/session-export.test.ts
+++ b/turbollm/src/code/session-export.test.ts
@@ -1,0 +1,268 @@
+// Unit tests for session-export.ts's Markdown serializer + filename sanitizer — both pure
+// functions, tested directly without a DB/route (per this codebase's real-process-over-mocks
+// discipline, these two are genuinely pure so there's nothing to fake).
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { AgentRun, Conversation, Message } from '../chat/db'
+import {
+  EXPORT_TRUNCATE_LIMIT,
+  codeSessionExportFilename,
+  serializeCodeSessionMarkdown,
+} from './session-export'
+
+function makeRun(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: 'run-1',
+    convId: 'conv-1',
+    title: 'Fix the login bug',
+    status: 'done',
+    allowedTools: [],
+    createdAt: '2026-07-20T10:00:00.000Z',
+    updatedAt: '2026-07-20T10:05:00.000Z',
+    repoRoot: 'C:\\repo',
+    repoBranch: 'main',
+    ...overrides,
+  }
+}
+
+function makeConv(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: 'conv-1',
+    title: 'Fix the login bug',
+    systemPrompt: '',
+    modelKey: 'm|q4|1',
+    sampling: {},
+    expertMode: false,
+    kind: 'code',
+    preserveThinking: true,
+    agentMode: 'auto',
+    createdAt: '2026-07-20T10:00:00.000Z',
+    updatedAt: '2026-07-20T10:05:00.000Z',
+    messages: [],
+    ...overrides,
+  }
+}
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-1',
+    convId: 'conv-1',
+    seq: 1,
+    role: 'user',
+    content: '',
+    reasoning: '',
+    attachments: [],
+    textAttachments: [],
+    toolCalls: [],
+    stats: {},
+    createdAt: '2026-07-20T10:00:00.000Z',
+    variantGroup: null,
+    isActive: true,
+    branchOf: null,
+    edited: false,
+    ...overrides,
+  }
+}
+
+// ── serializeCodeSessionMarkdown ──────────────────────────────────────────────
+
+test('serializeCodeSessionMarkdown: empty session still produces a valid header-only document', () => {
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages: [] }), { exportedAt: '2026-07-24T00:00:00.000Z' })
+  assert.match(md, /^# Fix the login bug/)
+  assert.match(md, /\*\*Session ID:\*\* run-1/)
+  assert.match(md, /\*\*Repo:\*\* C:\\repo \(branch: main\)/)
+  assert.match(md, /\*\*Exported:\*\* 2026-07-24T00:00:00\.000Z/)
+  assert.match(md, /no messages in this session yet/)
+})
+
+test('serializeCodeSessionMarkdown: falls back to a placeholder title when run.title is blank', () => {
+  const md = serializeCodeSessionMarkdown(makeRun({ title: '   ' }), makeConv())
+  assert.match(md, /^# Untitled Code session/)
+})
+
+test('serializeCodeSessionMarkdown: omits the Repo line entirely when repoRoot is unset', () => {
+  const md = serializeCodeSessionMarkdown(makeRun({ repoRoot: undefined, repoBranch: undefined }), makeConv())
+  assert.ok(!md.includes('**Repo:**'))
+})
+
+test('serializeCodeSessionMarkdown: renders a normal multi-message session in seq order with a separator', () => {
+  const messages = [
+    makeMessage({ id: 'u1', seq: 1, role: 'user', content: 'Add a health check endpoint.' }),
+    makeMessage({
+      id: 'a1', seq: 2, role: 'assistant', content: 'Done — added /healthz.',
+      timeline: [{ type: 'text', text: 'Done — added /healthz.' }],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  const userIdx = md.indexOf('## You')
+  const asstIdx = md.indexOf('## Assistant')
+  assert.ok(userIdx !== -1 && asstIdx !== -1 && userIdx < asstIdx, 'user message renders before the assistant reply')
+  assert.match(md, /Add a health check endpoint\./)
+  assert.match(md, /Done — added \/healthz\./)
+  assert.match(md, /\n---\n/, 'messages are separated by a horizontal rule')
+})
+
+test('serializeCodeSessionMarkdown: sorts messages by seq even if the array arrives out of order', () => {
+  const messages = [
+    makeMessage({ id: 'a1', seq: 2, role: 'assistant', content: 'second', timeline: [{ type: 'text', text: 'second' }] }),
+    makeMessage({ id: 'u1', seq: 1, role: 'user', content: 'first' }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.ok(md.indexOf('first') < md.indexOf('second'))
+})
+
+test('serializeCodeSessionMarkdown: renders reasoning in a collapsible <details> block', () => {
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant', content: 'Fixed it.', reasoning: 'The bug was an off-by-one.',
+      timeline: [{ type: 'text', text: 'Fixed it.' }],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.match(md, /<details>\n<summary>Reasoning<\/summary>/)
+  assert.match(md, /The bug was an off-by-one\./)
+})
+
+test('serializeCodeSessionMarkdown: interleaves text and tool-call blocks in true timeline order, not grouped', () => {
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant', content: 'Reading the file, then editing it.',
+      toolCalls: [
+        { id: 't1', name: 'read', args: { path: 'src/a.ts' }, result: 'file contents' },
+        { id: 't2', name: 'edit', args: { path: 'src/a.ts' }, diff: '-old\n+new' },
+      ],
+      timeline: [
+        { type: 'text', text: 'Reading the file' },
+        { type: 'tool', id: 't1' },
+        { type: 'text', text: 'now editing' },
+        { type: 'tool', id: 't2' },
+      ],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  const iRead = md.indexOf('Reading the file')
+  const iT1 = md.indexOf('### Tool call: `read`')
+  const iEdit = md.indexOf('now editing')
+  const iT2 = md.indexOf('### Tool call: `edit`')
+  assert.ok(iRead < iT1 && iT1 < iEdit && iEdit < iT2, 'blocks render in exact timeline order')
+})
+
+test('serializeCodeSessionMarkdown: a tool call with a diff renders a fenced diff block, not raw JSON', () => {
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant',
+      toolCalls: [{ id: 't1', name: 'edit', args: { path: 'a.ts' }, diff: '-const x = 1\n+const x = 2' }],
+      timeline: [{ type: 'tool', id: 't1' }],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.match(md, /```diff\n-const x = 1\n\+const x = 2\n```/)
+})
+
+test('serializeCodeSessionMarkdown: a failed tool call renders the error, not the (absent) result', () => {
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant',
+      toolCalls: [{ id: 't1', name: 'bash', args: { cmd: 'exit 1' }, error: 'command failed with exit code 1' }],
+      timeline: [{ type: 'tool', id: 't1' }],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.match(md, /\*\*Error:\*\*/)
+  assert.match(md, /command failed with exit code 1/)
+})
+
+test('serializeCodeSessionMarkdown: falls back to content + toolCalls (no true interleave) when timeline is absent', () => {
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant', content: 'Legacy message, pre-timeline.',
+      toolCalls: [{ id: 't1', name: 'read', args: {}, result: 'ok' }],
+      // timeline intentionally omitted — simulates a pre-existing-field message.
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.match(md, /Legacy message, pre-timeline\./)
+  assert.match(md, /### Tool call: `read`/)
+})
+
+test('serializeCodeSessionMarkdown: a huge tool result is truncated with an inline note, not included in full', () => {
+  const huge = 'x'.repeat(EXPORT_TRUNCATE_LIMIT + 5000)
+  const messages = [
+    makeMessage({
+      id: 'a1', seq: 1, role: 'assistant',
+      toolCalls: [{ id: 't1', name: 'read', args: {}, result: huge }],
+      timeline: [{ type: 'tool', id: 't1' }],
+    }),
+  ]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.ok(md.length < huge.length + 2000, 'output is bounded, not the full 25k-char result')
+  assert.match(md, /truncated — 5,000 more characters/)
+})
+
+test('serializeCodeSessionMarkdown: text attachments render as a chip-like attached-files line', () => {
+  const messages = [makeMessage({ role: 'user', content: 'See these files.', textAttachments: ['src/a.ts', 'src/b.ts'] })]
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  assert.match(md, /\*\*Attached:\*\* `src\/a\.ts`, `src\/b\.ts`/)
+})
+
+test('serializeCodeSessionMarkdown: a genuinely large session (thousands of messages/tool calls) serializes quickly, not hanging', () => {
+  const messages: Message[] = []
+  const MESSAGE_COUNT = 4000
+  for (let i = 0; i < MESSAGE_COUNT; i++) {
+    if (i % 2 === 0) {
+      messages.push(makeMessage({ id: `u${i}`, seq: i, role: 'user', content: `Task step ${i}: do the next thing.` }))
+    } else {
+      messages.push(makeMessage({
+        id: `a${i}`, seq: i, role: 'assistant', content: `Done with step ${i}.`,
+        toolCalls: [{ id: `t${i}`, name: 'edit', args: { path: `src/file-${i}.ts` }, diff: `-old line ${i}\n+new line ${i}` }],
+        timeline: [{ type: 'text', text: `Done with step ${i}.` }, { type: 'tool', id: `t${i}` }],
+      }))
+    }
+  }
+  const start = performance.now()
+  const md = serializeCodeSessionMarkdown(makeRun(), makeConv({ messages }))
+  const elapsedMs = performance.now() - start
+  assert.ok(elapsedMs < 5000, `serializing ${MESSAGE_COUNT} messages took ${elapsedMs.toFixed(0)}ms, expected well under 5000ms`)
+  assert.ok(md.includes(`Task step 0:`), 'the first message survived')
+  assert.ok(md.includes(`Done with step ${MESSAGE_COUNT - 1}.`), 'the last message survived')
+  const headingCount = (md.match(/^## (You|Assistant)$/gm) ?? []).length
+  assert.equal(headingCount, MESSAGE_COUNT, 'every message rendered as its own heading, none dropped')
+})
+
+// ── codeSessionExportFilename ─────────────────────────────────────────────────
+
+test('codeSessionExportFilename: a normal title becomes a dashed, dated .md filename', () => {
+  const name = codeSessionExportFilename('Fix the login bug', '2026-07-20T10:00:00.000Z', 'md')
+  assert.equal(name, 'Fix-the-login-bug-2026-07-20.md')
+})
+
+test('codeSessionExportFilename: empty title falls back to a safe default name', () => {
+  assert.equal(codeSessionExportFilename('', '2026-07-20T10:00:00.000Z', 'md'), 'code-session-2026-07-20.md')
+  assert.equal(codeSessionExportFilename('   ', '2026-07-20T10:00:00.000Z', 'md'), 'code-session-2026-07-20.md')
+})
+
+test('codeSessionExportFilename: strips path separators and other illegal filesystem characters', () => {
+  const name = codeSessionExportFilename('fix: src/auth.ts <bug>?', '2026-07-20T10:00:00.000Z', 'md')
+  assert.ok(!/[\\/:*?"<>|]/.test(name), `filename still contains an illegal character: ${name}`)
+})
+
+test('codeSessionExportFilename: a title that is ONLY illegal characters falls back to the default', () => {
+  const name = codeSessionExportFilename(':/\\*?"<>|', '2026-07-20T10:00:00.000Z', 'md')
+  assert.equal(name, 'code-session-2026-07-20.md')
+})
+
+test('codeSessionExportFilename: unicode-only title falls back to the default rather than producing an empty slug', () => {
+  const name = codeSessionExportFilename('修复登录错误 🐛', '2026-07-20T10:00:00.000Z', 'md')
+  assert.equal(name, 'code-session-2026-07-20.md')
+})
+
+test('codeSessionExportFilename: a very long title is capped to a reasonable length', () => {
+  const name = codeSessionExportFilename('a'.repeat(500), '2026-07-20T10:00:00.000Z', 'md')
+  const slug = name.replace(/-2026-07-20\.md$/, '')
+  assert.ok(slug.length <= 80, `slug is ${slug.length} chars, expected <= 80`)
+})
+
+test('codeSessionExportFilename: uses only the date portion of createdAt, ignoring time-of-day', () => {
+  const name = codeSessionExportFilename('Task', '2026-07-20T23:59:59.999Z', 'md')
+  assert.equal(name, 'Task-2026-07-20.md')
+})

--- a/turbollm/src/code/session-export.ts
+++ b/turbollm/src/code/session-export.ts
@@ -1,0 +1,145 @@
+// Session export (Phase 3, ADR-251) — a pure serializer from a Code session's already-persisted
+// AgentRun + Conversation (the same data CodeTranscript.tsx renders) to a Markdown document.
+// Markdown-only for this pass (spec 15 §5 defers HTML as a fast-follow) — deliberately built so
+// that fast-follow can reuse this exact output through the app's existing Markdown/rehypeHighlight
+// renderer instead of a second serializer.
+import type { AgentRun, Conversation, Message, MessageTimelineBlock, ToolCallRecord } from '../chat/db'
+
+/** Cap on any single rendered chunk (tool result/error/diff) so one runaway tool output (e.g. a
+ *  `cat` of a huge file) can't blow up the export into an unopenable multi-hundred-MB document.
+ *  20k chars is generous for a human-readable transcript (a full screen of terminal output is a
+ *  few hundred to a couple thousand chars) while still bounding worst case. Truncation is always
+ *  flagged inline rather than silent. */
+export const EXPORT_TRUNCATE_LIMIT = 20_000
+
+function truncateForExport(text: string, limit = EXPORT_TRUNCATE_LIMIT): string {
+  if (text.length <= limit) return text
+  const cut = text.length - limit
+  return `${text.slice(0, limit)}\n\n… [truncated — ${cut.toLocaleString()} more character${cut === 1 ? '' : 's'}] …`
+}
+
+function fence(lang: string, body: string): string {
+  return `\`\`\`${lang}\n${body}\n\`\`\``
+}
+
+function renderReasoning(reasoning: string): string {
+  if (!reasoning.trim()) return ''
+  // <details> is valid GFM (renders collapsed) and degrades to plain readable text in any
+  // markdown viewer that doesn't support it — safer than inventing a bespoke convention.
+  return `<details>\n<summary>Reasoning</summary>\n\n${reasoning.trim()}\n\n</details>\n\n`
+}
+
+function renderToolCall(call: ToolCallRecord): string {
+  const parts = [`### Tool call: \`${call.name}\``]
+  const argsJson = (() => {
+    try { return JSON.stringify(call.args, null, 2) } catch { return String(call.args) }
+  })()
+  if (argsJson && argsJson !== '{}') parts.push(fence('json', truncateForExport(argsJson)))
+  if (call.diff) {
+    parts.push(fence('diff', truncateForExport(call.diff)))
+  } else if (call.error) {
+    parts.push(`**Error:**\n\n${fence('text', truncateForExport(call.error))}`)
+  } else if (call.result) {
+    parts.push(fence('text', truncateForExport(call.result)))
+  }
+  return parts.join('\n\n')
+}
+
+/** True chronological interleave when `timeline` is present (Code messages always populate it —
+ *  see db.ts's MessageTimelineBlock doc comment). Falls back to content-then-tool-calls for
+ *  messages persisted before that field existed (older sessions) — still renders every field,
+ *  just without the original interleave order, since that information no longer exists. */
+function legacyTimeline(message: Message): MessageTimelineBlock[] {
+  const blocks: MessageTimelineBlock[] = []
+  if (message.content) blocks.push({ type: 'text', text: message.content })
+  for (const call of message.toolCalls) blocks.push({ type: 'tool', id: call.id })
+  return blocks
+}
+
+function renderAssistantMessage(message: Message): string {
+  const toolsById = new Map(message.toolCalls.map((t) => [t.id, t]))
+  const timeline = message.timeline?.length ? message.timeline : legacyTimeline(message)
+  const parts: string[] = ['## Assistant']
+  const reasoning = renderReasoning(message.reasoning)
+  if (reasoning) parts.push(reasoning.trimEnd())
+  for (const block of timeline) {
+    if (block.type === 'text') {
+      if (block.text.trim()) parts.push(block.text.trim())
+    } else {
+      const call = toolsById.get(block.id)
+      if (call) parts.push(renderToolCall(call))
+    }
+  }
+  if (parts.length === 1) parts.push('*(no content)*')
+  return parts.join('\n\n')
+}
+
+function renderUserMessage(message: Message): string {
+  const parts = ['## You', message.content.trim() || '*(empty message)*']
+  if (message.textAttachments.length) {
+    parts.push(`**Attached:** ${message.textAttachments.map((p) => `\`${p}\``).join(', ')}`)
+  }
+  return parts.join('\n\n')
+}
+
+function renderMessage(message: Message): string {
+  return message.role === 'user' ? renderUserMessage(message) : renderAssistantMessage(message)
+}
+
+export interface SerializeOptions {
+  /** ISO timestamp to stamp as "Exported". Defaults to now — overridable so callers (tests) get
+   *  deterministic output without mocking the clock globally. */
+  exportedAt?: string
+}
+
+/** The whole export: a metadata header (title, repo/branch, mode, status, created/exported) then
+ *  every message in order. Zero-message sessions still produce a valid document (header only, plus
+ *  a note) rather than an empty/error file — exporting a session that's still actively generating
+ *  is likewise never an error here: this only ever reads what `conv.messages` already has
+ *  persisted, so an in-flight turn's not-yet-saved content is naturally just absent, not a failure
+ *  case the caller needs to guard against. */
+export function serializeCodeSessionMarkdown(
+  run: AgentRun,
+  conv: Conversation,
+  opts: SerializeOptions = {},
+): string {
+  const exportedAt = opts.exportedAt ?? new Date().toISOString()
+  const title = run.title.trim() || 'Untitled Code session'
+  const meta = [
+    `- **Session ID:** ${run.id}`,
+    run.repoRoot ? `- **Repo:** ${run.repoRoot}${run.repoBranch ? ` (branch: ${run.repoBranch})` : ''}` : undefined,
+    `- **Mode:** ${conv.agentMode ?? 'auto'}`,
+    `- **Status:** ${run.status}`,
+    `- **Created:** ${run.createdAt}`,
+    `- **Exported:** ${exportedAt}`,
+  ].filter((line): line is string => !!line)
+
+  const messages = (conv.messages ?? []).slice().sort((a, b) => a.seq - b.seq)
+  const body = messages.length
+    ? messages.map(renderMessage).join('\n\n---\n\n')
+    : '*(no messages in this session yet)*'
+
+  return `# ${title}\n\n${meta.join('\n')}\n\n---\n\n${body}\n`
+}
+
+/** Illegal-on-Windows characters (the strictest of the three target filesystems — see
+ *  turbollm/CLAUDE.md's cross-platform rule) plus control chars. Whitelist approach (strip
+ *  anything not alnum/space/underscore/dash) rather than a blacklist — mirrors the existing
+ *  chat-export filename sanitizer (chat-routes.ts's GET .../export route) for consistency, and by
+ *  construction can never let a `/`, `:`, or similar through regardless of what's added to the
+ *  illegal-char list later. Non-ASCII/unicode titles are NOT preserved (stripped, same as the
+ *  existing chat-export precedent) — an intentional simplification: a Windows-safe filename
+ *  guarantee is worth more here than preserving unicode in a filename, and the title is never lost
+ *  (it's still the export's own `# <title>` heading inside the document). */
+const MAX_FILENAME_SLUG = 80
+
+export function codeSessionExportFilename(title: string, createdAt: string, ext: string): string {
+  const slug = title
+    .replace(/[^a-zA-Z0-9 _-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .slice(0, MAX_FILENAME_SLUG)
+    .replace(/-+$/, '') || 'code-session'
+  const dateStr = createdAt.slice(0, 10) || new Date().toISOString().slice(0, 10)
+  return `${slug}-${dateStr}.${ext}`
+}

--- a/turbollm/web/e2e/code-final-gate-a11y.spec.ts
+++ b/turbollm/web/e2e/code-final-gate-a11y.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { mockCodeApp, type CodeMessageFixture } from './fixtures/code-mocks'
+
+// Final gate (task #30, spec 16 §9 item 4): "Real aria-labels on every new interactive element,
+// not just icons." A manual grep can miss things and can't verify the browser's ACTUAL
+// accessibility tree — page.getByRole(..., { name }) queries the real computed accessible name
+// (aria-label, or native label association, or visible text), the same way a screen reader
+// would resolve it, so a false pass here isn't possible the way it is with a source-code regex.
+// No axe-core dependency exists in this project (checked package.json) and wasn't added for this
+// alone, per the task brief — getByRole/name is the built-in equivalent for "does this control
+// have a real accessible name," which is the specific, narrow claim this spec makes.
+//
+// Deliberately scoped to states reachable through the existing idle-session mock
+// (mockCodeApp/code-mocks.ts has no live-SSE support — code-phase0-tokens.spec.ts hit the same
+// wall for --toolcard-approval-bg/--status-banner-bg and worked around it with a direct
+// CSS-variable probe rather than building live-stream mock infrastructure). The composer's
+// Steer/Queue/Stop buttons (only rendered while `live`) are covered instead by
+// CodeComposer.test.tsx's existing Vitest+RTL suite, which already asserts on their exact
+// aria-label text via component props — a more precise and much cheaper way to pin an
+// accessible name to a controlled prop state than faking a live run end-to-end in a real browser.
+
+const SESSION = { id: 's1', title: 'Fix the login bug', repoRoot: '/repo', branch: 'main' }
+const MESSAGES: CodeMessageFixture[] = [
+  { id: 'u1', seq: 1, role: 'user', content: 'Please fix the pagination bug.' },
+  { id: 'a1', seq: 2, role: 'assistant', content: 'Done — fixed the off-by-one.' },
+]
+
+test.describe('Final gate — real accessible names on session-screen controls', () => {
+  test('session header: rename and session-actions menu both have real accessible names', async ({ page }) => {
+    await mockCodeApp(page, { session: SESSION, messages: MESSAGES })
+    await page.goto(`/workspace/code/${SESSION.id}`)
+    // getByText(title) is ambiguous — the same title also appears in the persistent sidebar's
+    // session list (same trick code-phase0-overflow.spec.ts uses: only the HEADER instance
+    // carries a `title=""` attribute).
+    await expect(page.getByTitle(SESSION.title, { exact: true })).toBeVisible()
+
+    // Fixed by this gate: was icon-only with only a `title` tooltip, no aria-label at all.
+    await expect(page.getByRole('button', { name: 'Rename session' })).toBeVisible()
+    // The header's own trigger — specifically NOT the sidebar row's per-session one (also fixed
+    // by this gate, see ConversationSidebar.tsx: it used to share this exact generic name, which
+    // this test caught as a real duplicate-accessible-name collision before that fix landed).
+    await expect(page.getByRole('button', { name: 'Session actions', exact: true })).toBeVisible()
+  })
+
+  test('the "Export"/"Git…" session-actions menu items expose their real (already-visible) names', async ({ page }) => {
+    await mockCodeApp(page, { session: SESSION, messages: MESSAGES })
+    await page.goto(`/workspace/code/${SESSION.id}`)
+    await page.getByRole('button', { name: 'Session actions', exact: true }).click()
+    await expect(page.getByRole('menuitem', { name: /Export/ })).toBeVisible()
+    await expect(page.getByRole('menuitem', { name: /Git/ })).toBeVisible()
+  })
+
+  test('a persisted message\'s CopyButton has a real accessible name, not just a title tooltip', async ({ page }) => {
+    // Fixed by this gate: the shared CopyButton (components/ui/copy-button.tsx) had no
+    // aria-label in its icon-only mode (no `label` prop passed) — used exactly that way here,
+    // by CodeCommentary for every assistant/user message in the transcript.
+    await mockCodeApp(page, { session: SESSION, messages: MESSAGES })
+    await page.goto(`/workspace/code/${SESSION.id}`)
+    await expect(page.getByText('Done — fixed the off-by-one.')).toBeVisible()
+    // Hover-only in CSS (`.hover-actions`) but still present/queryable in the accessibility
+    // tree regardless of visual hover state — getByRole doesn't require visibility to match.
+    await expect(page.getByRole('button', { name: 'Copy' }).first()).toBeAttached()
+  })
+})
+
+test.describe('Final gate — real accessible names on the Code launchpad composer', () => {
+  test('idle Send and Add-context both have real accessible names', async ({ page }) => {
+    await mockCodeApp(page)
+    await page.goto('/workspace/code')
+    await expect(page.getByPlaceholder(/describe a task/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Send' })).toBeAttached()
+    await expect(page.getByRole('button', { name: 'Add context' })).toBeVisible()
+  })
+})

--- a/turbollm/web/e2e/code-final-gate-combined.spec.ts
+++ b/turbollm/web/e2e/code-final-gate-combined.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+import { mockCodeApp, type CodeMessageFixture } from './fixtures/code-mocks'
+
+// FINAL GATE (task #30): individual Code features were each tested in isolation across ~15
+// separate tasks this session. Nobody has checked whether they compose visually in ONE view
+// without clashing — spacing/overlap/inconsistent weight/confusing ordering are exactly the class
+// of bug per-feature automated tests structurally can't catch (spec 16 §9). This renders a single
+// session with every PERSISTED/mockable feature family visible at once: a plain instruction, a
+// shell `!command` entry, an edit with a real diff, and a queued follow-up card at the tail.
+//
+// SCOPE NOTE, stated up front rather than discovered by a reader: turn dividers, the todo
+// checklist, and the retry banner are confirmed live-SSE-only — no persisted DB representation at
+// all (TurnDivider/TodoChecklist's own doc comments in CodeTranscript.tsx say so explicitly, and
+// code-run-manager.ts's sink only ever stores a tool call's FINAL status, never a live one). A real
+// attempt was made to mock a genuinely-open `/stream` connection for this spec (see
+// fixtures/code-mocks.ts's comment on the stream route) and abandoned after confirming empirically
+// — not assumed — that Playwright's `route.fulfill()` doesn't surface a mocked SSE body to the
+// app's fetch reader in a way that ever renders, even with an accurate Content-Length. Verifying
+// those three live-only states in combination with everything else here needs a real daemon
+// connection, matching spec 16 §8's own documented limitation for this exact class of state — not
+// a gap unique to this spec.
+
+const SESSION = { id: 's-combined', title: 'Add rate limiting to the API', repoRoot: '/repo/backend-api', branch: 'main', add: 42, del: 8 }
+
+const MESSAGES: CodeMessageFixture[] = [
+  { id: 'u1', seq: 1, role: 'user', content: 'Add rate limiting to the public API and check it works.' },
+  {
+    id: 'a1', seq: 2, role: 'assistant', content: 'Added a token-bucket limiter.',
+    toolCalls: [{
+      id: 't1', name: 'edit', args: { path: 'src/middleware/rate-limit.ts' },
+      diff: '@@ -1,3 +1,4 @@\n import { Hono } from \'hono\'\n+import { rateLimiter } from \'./token-bucket\'\n context\n context',
+      patch: '@@ -1,3 +1,4 @@\n import { Hono } from \'hono\'\n+import { rateLimiter } from \'./token-bucket\'\n context\n context',
+    }],
+    // A leading text block is required for `content` to actually render anywhere — CodeTranscript
+    // prefers `timeline` over `content` whenever a timeline is present (true chronological
+    // interleave), so a tool-only timeline genuinely shows no commentary text at all, matching
+    // real interleaved-turn rendering (confirmed empirically while building this fixture).
+    timeline: [{ type: 'text', text: 'Added a token-bucket limiter.' }, { type: 'tool', id: 't1' }],
+  },
+  // A persisted `!command` — a user message carrying a `shell` tool call (ADR-258), rendered via
+  // CodeShellEntry with the same --log-* console tokens tool output uses.
+  {
+    id: 'u2', seq: 3, role: 'user', content: '!npm test -- rate-limit',
+    toolCalls: [{ id: 'sh1', name: 'shell', args: { command: 'npm test -- rate-limit' }, result: '3 passing (42ms)' }],
+    timeline: [{ type: 'tool', id: 'sh1' }],
+  },
+]
+
+const QUEUED = [{ userMsgId: 'q1', task: 'Also add a Retry-After header on 429 responses.', kind: 'followUp' as const }]
+
+async function gotoCombined(page: import('@playwright/test').Page, theme: 'light' | 'dark') {
+  await page.addInitScript((t) => window.localStorage.setItem('tllm.theme', t), theme)
+  await mockCodeApp(page, { session: SESSION, messages: MESSAGES, queued: QUEUED })
+  await page.goto(`/workspace/code/${SESSION.id}`)
+}
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`${theme}: combined view — instruction, shell entry, diff, and a queued follow-up card all render together without clashing`, async ({ page }) => {
+    await gotoCombined(page, theme)
+
+    await expect(page.getByText('Added a token-bucket limiter.')).toBeVisible()
+    await expect(page.getByText('$ npm test -- rate-limit')).toBeVisible() // CodeShellEntry
+    await expect(page.locator('table').first()).toBeVisible() // the diff panel
+    await expect(page.getByText('Also add a Retry-After header on 429 responses.')).toBeVisible() // queued card
+    await expect(page.getByText('Runs next')).toBeVisible() // queued card's followUp badge
+
+    // No page-level horizontal scroll with this much content stacked in one transcript.
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth)
+
+    // Real DOM order: history in seq order, the queued card strictly AFTER all persisted
+    // messages, never interleaved — the ADR-199 ordering invariant CodeTranscript's own `queued`
+    // prop doc comment states explicitly.
+    const order = await page.evaluate(() => {
+      const text = document.body.innerText
+      return {
+        instructionIdx: text.indexOf('Add rate limiting to the public API'),
+        shellIdx: text.indexOf('npm test -- rate-limit'),
+        queuedIdx: text.indexOf('Also add a Retry-After header'),
+      }
+    })
+    expect(order.instructionIdx).toBeGreaterThan(-1)
+    expect(order.shellIdx).toBeGreaterThan(order.instructionIdx)
+    expect(order.queuedIdx).toBeGreaterThan(order.shellIdx)
+  })
+}

--- a/turbollm/web/e2e/code-phase0-overflow.spec.ts
+++ b/turbollm/web/e2e/code-phase0-overflow.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test'
+import { mockCodeApp, type CodeMessageFixture } from './fixtures/code-mocks'
+
+// Phase 0 test suite (task #12, spec 16 §2 "Edge cases" + §9's "no horizontal scroll / no
+// clipped content" acceptance criterion): the ORIGINAL bug that triggered this whole redesign.
+// This is exactly the class jsdom-based Vitest tests cannot catch at all (no real layout engine)
+// — Playwright exists in this test plan specifically for this.
+//
+// The concrete narrow width used throughout: 375px. Not an arbitrary choice — it's the exact
+// width the original bug was caught at (CodeSessionScreen.tsx's own header comment: "measured
+// 0px with a real long repo/branch pair at 375px"). 320px is also checked (spec 16 §9's own
+// "320px through a wide monitor" convention) as an even harder stress case.
+
+// Long enough that, pre-fix, it would have claimed the header row's full width and squeezed the
+// session title to 0px (the exact live-caught bug) — same shape of input as the original report.
+const LONG_SESSION = {
+  id: 's-long',
+  title: 'Fix the login bug',
+  repoRoot: '/Users/founder/dev/some-really-long-nested-project-directory-name/packages/backend-api',
+  branch: 'feature/a-genuinely-long-branch-name-that-does-not-fit',
+  add: 128,
+  del: 47,
+}
+
+const NARROW_WIDTHS = [375, 320]
+
+async function noHorizontalOverflow(page: import('@playwright/test').Page): Promise<void> {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }))
+  expect(scrollWidth, 'page must not scroll horizontally').toBeLessThanOrEqual(clientWidth)
+}
+
+test.describe('Phase 0 overflow — session header chips at narrow widths', () => {
+  for (const width of NARROW_WIDTHS) {
+    test(`${width}px: long repo/branch/diff-stat chips truncate, session title stays visible (non-zero width)`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 })
+      await mockCodeApp(page, { session: LONG_SESSION, messages: [] })
+      await page.goto(`/workspace/code/${LONG_SESSION.id}`)
+
+      // getByText(exact title) is ambiguous — the same title also appears in the persistent
+      // sidebar's session list. The header instance carries a `title=""` HTML attribute
+      // (CodeSessionScreen.tsx's rename/title span), which the sidebar row does not.
+      const title = page.getByTitle(LONG_SESSION.title, { exact: true })
+      await expect(title).toBeVisible()
+      const titleBox = await title.boundingBox()
+      expect(titleBox?.width ?? 0).toBeGreaterThan(0) // the exact regression: title squeezed to 0px
+
+      await noHorizontalOverflow(page)
+    })
+  }
+})
+
+test.describe('Phase 0 overflow — composer toolbar at narrow widths', () => {
+  for (const width of NARROW_WIDTHS) {
+    test(`${width}px: full toolbar (mode, add-context, context ring, model, send) stays reachable, no page-level scroll`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 })
+      await mockCodeApp(page, { session: LONG_SESSION, messages: [] })
+      await page.goto(`/workspace/code/${LONG_SESSION.id}`)
+
+      // The toolbar's own `overflow-x-auto` (CodeComposer.tsx:730) is the DELIBERATE fix —
+      // containing any overflow to the toolbar row itself. What must NOT happen is that
+      // overflow escaping the toolbar and blowing out the whole page's scroll width.
+      await expect(page.getByPlaceholder(/follow-up/i)).toBeVisible()
+      await noHorizontalOverflow(page)
+
+      // The send button (last toolbar slot) must still be reachable — this is the actual
+      // functional claim the toolbar's own comment makes ("scrolling the row itself keeps
+      // Send reachable"), not just "nothing looks broken."
+      const sendButton = page.getByRole('button', { name: /send/i })
+      await sendButton.scrollIntoViewIfNeeded()
+      await expect(sendButton).toBeVisible()
+    })
+  }
+})
+
+test.describe('Phase 0 overflow — extremely long unbroken monospace content', () => {
+  test('a 500+ char unbroken diff line wraps or scrolls within its own container, never the page', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 })
+    // An edit-tool diff, not a bash result — CodeToolCard only starts expanded for a diff-bearing
+    // call (`useState(hasDiff)`, CodeTranscript.tsx:252); a bash/output call starts collapsed and
+    // would need an extra click before its <pre> content is even in the DOM.
+    const longLine = '+const url = "https://example.com/' + 'x'.repeat(480) + '/end.ts"'
+    const diff = `@@ -1,1 +1,1 @@\n-old\n${longLine}`
+    const messages: CodeMessageFixture[] = [
+      { id: 'u1', seq: 1, role: 'user', content: 'update the constant' },
+      {
+        id: 'a1', seq: 2, role: 'assistant', content: '',
+        toolCalls: [{ id: 't1', name: 'edit', args: { path: 'src/const.ts' }, diff, patch: diff }],
+        timeline: [{ type: 'tool', id: 't1' }],
+      },
+    ]
+    await mockCodeApp(page, { session: LONG_SESSION, messages })
+    await page.goto(`/workspace/code/${LONG_SESSION.id}`)
+    await expect(page.locator('td', { hasText: 'x'.repeat(50) })).toBeVisible()
+    await noHorizontalOverflow(page)
+  })
+})
+
+test.describe('Phase 0 overflow — very large diff', () => {
+  test('a 1000+ line diff stays internally scrollable (max-h-[420px]), does not inflate page height', async ({ page }) => {
+    const hugeDiff = ['@@ -1,1000 +1,1000 @@', ...Array.from({ length: 1000 }, (_, i) => `-old line ${i}\n+new line ${i}`)].join('\n')
+    const messages: CodeMessageFixture[] = [
+      { id: 'u1', seq: 1, role: 'user', content: 'big refactor' },
+      {
+        id: 'a1', seq: 2, role: 'assistant', content: '',
+        toolCalls: [{ id: 't1', name: 'edit', args: { path: 'src/big.ts' }, diff: hugeDiff, patch: hugeDiff }],
+        timeline: [{ type: 'tool', id: 't1' }],
+      },
+    ]
+    await mockCodeApp(page, { session: LONG_SESSION, messages })
+    await page.goto(`/workspace/code/${LONG_SESSION.id}`)
+
+    const panel = page.locator('table').first().locator('..')
+    const box = await panel.boundingBox()
+    // max-h-[420px] on CodeDiffPanel's own scroll container (CodeTranscript.tsx:179) — allow a
+    // little slack for the border/header row, but this must stay bounded, not render all 2000+
+    // diff rows into the page's natural height.
+    expect(box?.height ?? 0).toBeLessThanOrEqual(440)
+  })
+})
+
+test.describe('Phase 0 overflow — ultrawide viewport', () => {
+  test('3440px: content does not stretch into unreadably long line lengths', async ({ page }) => {
+    await page.setViewportSize({ width: 3440, height: 1000 })
+    await mockCodeApp(page, { session: LONG_SESSION, messages: [{ id: 'u1', seq: 1, role: 'user', content: 'hello' }] })
+    await page.goto(`/workspace/code/${LONG_SESSION.id}`)
+    await expect(page.getByText('hello', { exact: true })).toBeVisible()
+
+    const contentWidth = await page.evaluate(() => {
+      const scroller = document.querySelector('main') ?? document.body
+      return scroller.getBoundingClientRect().width
+    })
+    // No hard max-width decision is recorded anywhere in specs 11/14/15 as of this test being
+    // written — this locks in a generous sanity ceiling (not full 3440px edge-to-edge text) so a
+    // real regression (content genuinely spanning the full ultrawide width with no cap at all)
+    // fails loudly; tighten this once Phase 0 actually records a specific max-width decision
+    // (flagged in the report — this is the one edge case spec 16 itself says still needs that
+    // decision made during implementation).
+    expect(contentWidth).toBeLessThan(3440)
+  })
+})

--- a/turbollm/web/e2e/code-phase0-reduced-motion.spec.ts
+++ b/turbollm/web/e2e/code-phase0-reduced-motion.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { mockCodeApp } from './fixtures/code-mocks'
+
+// Final-gate item 5 (docs/specs/16-code-ui-redesign-test-plan.md §9): "Reduced-motion respected
+// for every new animation." Follows the same page.emulateMedia() convention
+// code-phase0-tokens.spec.ts already uses for prefers-color-scheme — real browser media-query
+// emulation, not a matchMedia mock — driving `.tllm-pulse` (the sidebar's live running-indicator
+// dot, ADR-256/task #17) through both states and asserting the real computed animation, not just
+// that the class name is present.
+
+const SESSION = { id: 's1', title: 'Live session', repoRoot: '/repo', running: true }
+
+test.describe('Phase 0 — reduced motion (spec 16 §9 item 5)', () => {
+  test('the sidebar\'s live running-indicator dot (.tllm-pulse) actually animates with no preference, and stops under prefers-reduced-motion: reduce', async ({ page }) => {
+    await mockCodeApp(page, { session: SESSION, messages: [] })
+
+    // Baseline: no reduced-motion preference — the dot's infinite pulse must be real, not just
+    // present in markup (otherwise the "and stops" half of this test would be vacuous).
+    await page.emulateMedia({ reducedMotion: 'no-preference' })
+    await page.goto(`/workspace/code/${SESSION.id}`)
+    const dot = page.locator('span.tllm-pulse').first()
+    await expect(dot).toBeVisible()
+    await expect(dot).toHaveCSS('animation-name', 'tllm-pulse')
+    await expect(dot).not.toHaveCSS('animation-duration', '0s')
+
+    // Same session, same markup — only the OS-level preference changes. index.css's
+    // `@media (prefers-reduced-motion: reduce) { .tllm-pulse { animation: none } }` must kill it.
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.reload()
+    const dotAfter = page.locator('span.tllm-pulse').first()
+    await expect(dotAfter).toBeVisible()
+    await expect(dotAfter).toHaveCSS('animation-name', 'none')
+  })
+})

--- a/turbollm/web/e2e/code-phase0-tokens.spec.ts
+++ b/turbollm/web/e2e/code-phase0-tokens.spec.ts
@@ -1,0 +1,182 @@
+import { test, expect, type Page } from '@playwright/test'
+import { mockCodeApp, type CodeMessageFixture } from './fixtures/code-mocks'
+
+// Phase 0 test suite (task #12, spec 16 §2 "Basic requirements"): the 8 Code-scoped tokens
+// (index.css:49-58) are color-mix() over base tokens that already flip between :root/.dark
+// (--accent/--warn/--ok/--err/--border) — jsdom (Vitest) cannot compute real color-mix() output
+// at all, which is exactly why this needs a real browser. Playwright is the only layer that can
+// actually verify "does this resolve to a genuinely different, sensible value in each theme."
+
+const SESSION = { id: 's1', title: 'Fix the login bug', repoRoot: '/repo', branch: 'main' }
+
+// Exercises 6 of the 8 tokens through real rendered components: a user message
+// (CodeInstructionEntry → --instruction-border/-bg/-chip-border, via its text attachment chip),
+// and an assistant message with an edit tool call carrying a real unified diff
+// (CodeDiffPanel → --diff-hunk-bg/-add-bg/-del-bg).
+const MESSAGES: CodeMessageFixture[] = [
+  { id: 'u1', seq: 1, role: 'user', content: 'Fix the off-by-one in the paginator.', toolCalls: [] },
+  {
+    id: 'a1', seq: 2, role: 'assistant', content: 'Fixed.',
+    toolCalls: [{
+      id: 't1', name: 'edit', args: { path: 'src/paginate.ts' },
+      diff: '@@ -1,3 +1,3 @@\n context line\n-const page = i;\n+const page = i + 1;\n context line',
+      patch: '@@ -1,3 +1,3 @@\n context line\n-const page = i;\n+const page = i + 1;\n context line',
+    }],
+    timeline: [{ type: 'tool', id: 't1' }],
+  },
+]
+
+async function gotoSession(page: Page, theme: 'light' | 'dark'): Promise<void> {
+  await page.addInitScript((t) => window.localStorage.setItem('tllm.theme', t), theme)
+  await mockCodeApp(page, { session: SESSION, messages: MESSAGES })
+  await page.goto(`/workspace/code/${SESSION.id}`)
+  // The diff panel starts expanded for a lone edit call (CodeToolCard's own default), so no
+  // click is needed — but wait for it to actually be in the DOM before asserting on it.
+  await expect(page.locator('table').first()).toBeVisible()
+}
+
+test.describe('Phase 0 tokens — light/dark resolution', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${theme}: instruction/diff tokens resolve to non-empty, distinct computed colors`, async ({ page }) => {
+      await gotoSession(page, theme)
+      const html = page.locator('html')
+      await expect(html).toHaveClass(theme === 'dark' ? /dark/ : /^(?!.*dark).*$/)
+
+      // --instruction-border/-bg: the user message's own bordered card.
+      const instructionCard = page.getByText('Fix the off-by-one in the paginator.').locator('..')
+      const cardBg = await instructionCard.evaluate((el) => getComputedStyle(el).backgroundColor)
+      const cardBorder = await instructionCard.evaluate((el) => getComputedStyle(el).borderColor)
+      expect(cardBg).not.toBe('') // resolves to SOME real rgba(), not an unset/transparent no-op
+      expect(cardBorder).not.toBe('')
+
+      // --diff-add-bg / --diff-del-bg: the two colored rows in the rendered diff table.
+      const addRow = page.locator('tr', { hasText: 'const page = i + 1;' })
+      const delRow = page.locator('tr', { hasText: 'const page = i;' }).filter({ hasNotText: '+' })
+      const addBg = await addRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+      const delBg = await delRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+      expect(addBg).not.toBe(delBg) // add (--ok-tinted) and del (--err-tinted) must differ
+
+      // --diff-hunk-bg: the "@@ ... @@" header row.
+      const hunkRow = page.locator('tr', { hasText: '@@ -1,3 +1,3 @@' })
+      const hunkBg = await hunkRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+      expect(hunkBg).not.toBe(addBg)
+      expect(hunkBg).not.toBe(delBg)
+    })
+  }
+
+  test('the SAME token resolves to a genuinely different color between light and dark', async ({ page, context }) => {
+    // Two independent page loads (theme is read once at module-init, per stores/ui.ts — no
+    // supported live-flip API to test within one page load here) rather than one page with a
+    // runtime toggle, so this is a second, more direct cross-theme diff on top of the
+    // per-theme checks above — the actual regression this guards against is index.css losing
+    // its color-mix() self-adjustment (e.g. someone hardcoding one of these 8 tokens to a flat
+    // hex, which would make it IDENTICAL across themes instead of flipping with --accent/etc).
+    await gotoSession(page, 'light')
+    const addRowLight = page.locator('tr', { hasText: 'const page = i + 1;' })
+    const lightAddBg = await addRowLight.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+    const darkPage = await context.newPage()
+    await gotoSession(darkPage, 'dark')
+    const addRowDark = darkPage.locator('tr', { hasText: 'const page = i + 1;' })
+    const darkAddBg = await addRowDark.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+    expect(lightAddBg).not.toBe(darkAddBg)
+    await darkPage.close()
+  })
+
+  test('toggling the theme class WHILE the Code screen is mounted updates tokens immediately, no reload, no stale leftover', async ({ page }) => {
+    // Drives the same DOM primitive stores/ui.ts's applyTheme() uses
+    // (document.documentElement.classList.toggle('dark', ...), index.css:61) directly, rather
+    // than hunting Settings' theme-toggle UI for this specific claim — what's under test here
+    // (does color-mix() recompute immediately when .dark flips, with no leftover stale value
+    // from the previous theme) is a pure CSS-cascade behavior, identical regardless of which UI
+    // control flips the class. This is exactly spec 16 §2's "no flash-of-wrong-theme, no stale
+    // --accent-derived colors left over from the previous theme" requirement.
+    await gotoSession(page, 'light')
+    const addRow = page.locator('tr', { hasText: 'const page = i + 1;' })
+    const lightBg = await addRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+
+    await page.evaluate(() => document.documentElement.classList.add('dark'))
+    const darkBg = await addRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(darkBg).not.toBe(lightBg) // updated, not stuck on the old theme's value
+
+    await page.evaluate(() => document.documentElement.classList.remove('dark'))
+    const backToLightBg = await addRow.evaluate((el) => getComputedStyle(el).backgroundColor)
+    expect(backToLightBg).toBe(lightBg) // and flips back cleanly, no residue
+  })
+
+  test('theme="system" follows a live OS-level color-scheme change without a page reload', async ({ page }) => {
+    // stores/ui.ts supports 'system' as a real Theme value; main.tsx wires
+    // matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ...) specifically to
+    // re-apply the theme live when the OS preference flips while theme === 'system' — spec 16 §2's
+    // edge case. page.emulateMedia can drive a real prefers-color-scheme change in Chromium; no
+    // reload is triggered by this call, matching what a real OS-level flip looks like to the page.
+    await page.emulateMedia({ colorScheme: 'light' })
+    await page.addInitScript(() => window.localStorage.setItem('tllm.theme', 'system'))
+    await mockCodeApp(page, { session: SESSION, messages: MESSAGES })
+    await page.goto(`/workspace/code/${SESSION.id}`)
+    await expect(page.locator('table').first()).toBeVisible()
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+
+    await page.emulateMedia({ colorScheme: 'dark' })
+    await expect(page.locator('html')).toHaveClass(/dark/)
+
+    await page.emulateMedia({ colorScheme: 'light' })
+    await expect(page.locator('html')).not.toHaveClass(/dark/)
+  })
+})
+
+// --toolcard-approval-bg (CodeTranscript.tsx:276) and --status-banner-bg (CodeComposer.tsx:678)
+// both ONLY ever apply through a live, SSE-driven state (an in-flight `awaiting_approval` tool
+// call; an active run) — never from persisted DB data (confirmed: code-run-manager.ts's sink only
+// ever persists a tool call's FINAL 'done'/'error' status, never a live 'pending'/
+// 'awaiting_approval' one). Reproducing that through a real live SSE mock is real extra
+// infrastructure for two tokens that use the exact same color-mix() mechanism already verified
+// above — checked directly against the loaded stylesheet instead. This does NOT verify the
+// component wires the token correctly (that's confirmed by source inspection, not this test —
+// see the report), only that the token itself resolves correctly per theme, same as the six above.
+test.describe('Phase 0 tokens — live-only tokens (toolcard-approval-bg, status-banner-bg)', () => {
+  for (const theme of ['light', 'dark'] as const) {
+    test(`${theme}: resolve to a real, non-transparent color`, async ({ page }) => {
+      await page.addInitScript((t) => window.localStorage.setItem('tllm.theme', t), theme)
+      await mockCodeApp(page)
+      await page.goto('/workspace/code')
+      await expect(page.getByPlaceholder(/describe a task/i)).toBeVisible()
+
+      const colors = await page.evaluate(() => {
+        const probe = document.createElement('div')
+        probe.style.background = 'var(--toolcard-approval-bg)'
+        document.body.appendChild(probe)
+        const approval = getComputedStyle(probe).backgroundColor
+        probe.style.background = 'var(--status-banner-bg)'
+        const banner = getComputedStyle(probe).backgroundColor
+        probe.remove()
+        return { approval, banner }
+      })
+      expect(colors.approval).not.toBe('rgba(0, 0, 0, 0)')
+      expect(colors.banner).not.toBe('rgba(0, 0, 0, 0)')
+      expect(colors.approval).not.toBe(colors.banner) // warn-tinted vs accent-tinted, must differ
+    })
+  }
+})
+
+test.describe('Phase 0 — monospace scope (spec 14 §1.2 audit: already correct, regression guard)', () => {
+  test('diff/tool-args content is monospace; prose and nav chrome are not', async ({ page }) => {
+    await gotoSession(page, 'light')
+
+    const diffLine = page.locator('td', { hasText: 'const page = i + 1;' })
+    const diffFont = await diffLine.evaluate((el) => getComputedStyle(el).fontFamily)
+    expect(diffFont.toLowerCase()).toMatch(/mono/)
+
+    // The user message's own prose text must stay sans-serif — monospace only "where it earns
+    // it" (ADR-252), never forced onto ordinary prose.
+    const prose = page.getByText('Fix the off-by-one in the paginator.')
+    const proseFont = await prose.evaluate((el) => getComputedStyle(el).fontFamily)
+    expect(proseFont.toLowerCase()).not.toMatch(/mono/)
+
+    // Nav chrome (unrelated to Code at all) must never pick up the Code surface's monospace.
+    const navLink = page.getByRole('link', { name: 'Workspace' })
+    const navFont = await navLink.evaluate((el) => getComputedStyle(el).fontFamily)
+    expect(navFont.toLowerCase()).not.toMatch(/mono/)
+  })
+})

--- a/turbollm/web/e2e/fixtures/code-mocks.ts
+++ b/turbollm/web/e2e/fixtures/code-mocks.ts
@@ -1,0 +1,168 @@
+import type { Page } from '@playwright/test'
+
+// Shared Playwright network-mock fixtures for Code-screen E2E tests (Phase 0 test suite,
+// task #12). Deliberately fully mocked rather than driven against a real daemon: these tests
+// assert layout/token/font behavior, which needs to be deterministic and CI-safe, not dependent
+// on a loaded model or real session content. `page.route` intercepts every `/api/v1/**` call
+// BEFORE the app's own dev-proxy would forward it to a real daemon on :6996 — no real daemon
+// needs to be running for these specs at all.
+
+/** Bare-minimum settings payload: only `experimental.code` is read by `RequireCodeEnabled`
+ *  (App.tsx) — everything else is left absent since nothing else in these specs reads it. */
+const SETTINGS = { experimental: { code: true } }
+
+/** Bare-minimum status payload — enough for Shell/EngineProvisionBanner to render without
+ *  crashing on an unexpected shape; values chosen to read as "idle, nothing to report" so no
+ *  extra banners compete for space with the elements under test. */
+const STATUS = {
+  version: '0.0.0-test',
+  state: 'stopped',
+  engine: { state: 'stopped' },
+  model: null,
+  downloads: { active: 0 },
+  // queries.ts:154 reads `data?.bench.running` — only `.data` is optional-chained, not
+  // `.bench` — so an incomplete status mock throws instead of just rendering an idle state.
+  // Every real daemon response includes this field, so the gap never surfaces in production.
+  bench: { running: false },
+}
+
+const MODELS = { models: [], scanning: false, lastScanAt: null }
+const CODE_STATS = { totalSessions: 0, totalMinutes: 0, days: [] }
+
+export interface CodeToolCallFixture {
+  id: string
+  name: string
+  args?: Record<string, unknown>
+  result?: string
+  error?: string
+  diff?: string
+  patch?: string
+  firstChangedLine?: number
+}
+
+export interface CodeMessageFixture {
+  id: string
+  seq: number
+  role: 'user' | 'assistant'
+  content: string
+  reasoning?: string
+  toolCalls?: CodeToolCallFixture[]
+  /** Interleaved text/tool timeline — omit to fall back to content-then-toolCalls order,
+   *  same fallback CodeTranscript.tsx itself uses for pre-timeline-field messages. */
+  timeline?: ({ type: 'text'; text: string } | { type: 'tool'; id: string })[]
+}
+
+function toMessage(m: CodeMessageFixture) {
+  return {
+    id: m.id,
+    convId: 'conv-1',
+    seq: m.seq,
+    role: m.role,
+    content: m.content,
+    reasoning: m.reasoning ?? '',
+    attachments: [],
+    textAttachments: [],
+    toolCalls: (m.toolCalls ?? []).map((t) => ({ args: {}, ...t })),
+    timeline: m.timeline,
+    stats: {},
+    createdAt: '2026-07-24T10:00:00.000Z',
+    variantGroup: null,
+    isActive: true,
+    branchOf: null,
+    edited: false,
+  }
+}
+
+/** Registers route mocks for every API call `CodeHomeScreen`/`CodeSessionScreen` make, plus
+ *  fulfills the given session (if any) for both the sidebar list and the detail route. Call
+ *  before `page.goto(...)`. */
+export interface CodeQueuedFixture {
+  userMsgId: string
+  task: string
+  kind: 'steer' | 'followUp'
+}
+
+export async function mockCodeApp(
+  page: Page,
+  opts: {
+    session?: { id: string; title: string; repoRoot: string; branch?: string; add?: number; del?: number; running?: boolean }
+    messages?: CodeMessageFixture[]
+    /** The server-side message queue (DB-persisted via the session-detail GET response, not
+     *  SSE-driven) — safe to render deterministically, unlike live-only state (see the `/stream`
+     *  route below). */
+    queued?: CodeQueuedFixture[]
+  } = {},
+): Promise<void> {
+  await page.route('**/api/v1/settings', (route) => route.fulfill({ json: SETTINGS }))
+  await page.route('**/api/v1/status', (route) => route.fulfill({ json: STATUS }))
+  await page.route('**/api/v1/models', (route) => route.fulfill({ json: MODELS }))
+  await page.route('**/api/v1/code/stats**', (route) => route.fulfill({ json: CODE_STATS }))
+
+  const { session, messages = [], queued = [] } = opts
+  const sidebarRow = session
+    ? {
+        id: session.id,
+        convId: 'conv-1',
+        title: session.title,
+        status: 'review',
+        branch: session.branch ?? '',
+        when: 'just now',
+        add: session.add ?? 0,
+        del: session.del ?? 0,
+        mode: 'auto',
+        running: session.running ?? false,
+        createdAt: '2026-07-24T10:00:00.000Z',
+        repoRoot: session.repoRoot,
+        archivedAt: undefined,
+        clearedUpToMessageId: undefined,
+        revertedFromMessageId: undefined,
+      }
+    : null
+
+  await page.route('**/api/v1/code/sessions?**', (route) => {
+    if (route.request().method() !== 'GET') return route.continue()
+    return route.fulfill({ json: { sessions: sidebarRow ? [sidebarRow] : [] } })
+  })
+
+  if (session) {
+    await page.route(`**/api/v1/code/sessions/${session.id}`, (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      return route.fulfill({
+        json: {
+          session: sidebarRow,
+          conversation: {
+            id: 'conv-1',
+            title: session.title,
+            systemPrompt: '',
+            modelKey: '',
+            sampling: {},
+            expertMode: false,
+            kind: 'code',
+            preserveThinking: true,
+            agentMode: 'auto',
+            createdAt: '2026-07-24T10:00:00.000Z',
+            updatedAt: '2026-07-24T10:00:00.000Z',
+            messages: messages.map(toMessage),
+          },
+          doc: null,
+          running: session.running ?? false,
+          queued,
+        },
+      })
+    })
+
+    // Live SSE state (turn dividers, the todo checklist, the retry banner — see
+    // CodeStreamingEntry/TurnDivider/TodoChecklist's own doc comments) has no persisted DB
+    // representation, so it can't be rendered through a mocked GET response the way messages/
+    // queued turns can. Mocking a genuinely still-open `/stream` connection was attempted (see
+    // this fixture's git history / the FINAL GATE report) and abandoned after confirming
+    // empirically that a Playwright `route.fulfill()` response — even a completely well-formed,
+    // accurately-length one — never gets its bytes surfaced to the app's fetch reader in a way
+    // that renders. Routed to an always-empty, never-live stream here so an unexpected reconnect
+    // attempt fails fast/visibly instead of falling through to a real daemon on :6996 — verifying
+    // those three live-only states in combination with everything else needs a real daemon
+    // connection (spec 16 §8's own documented limitation for this class of state).
+    await page.route(`**/api/v1/code/sessions/${session.id}/stream**`, (route) =>
+      route.fulfill({ status: 200, contentType: 'text/event-stream', body: '' }))
+  }
+}

--- a/turbollm/web/e2e/smoke.spec.ts
+++ b/turbollm/web/e2e/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test'
+
+test('app shell renders at the root', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveTitle('TurboLLM')
+  await expect(page.getByRole('link', { name: 'Workspace' })).toBeVisible()
+})

--- a/turbollm/web/package-lock.json
+++ b/turbollm/web/package-lock.json
@@ -41,14 +41,27 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.0",
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/jest-dom": "^6.6.0",
+        "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.5.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "jsdom": "^25.0.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -62,6 +75,27 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -298,6 +332,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -357,6 +401,123 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -1162,6 +1323,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2375,6 +2552,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2673,6 +2857,103 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2716,6 +2997,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -2980,6 +3272,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3096,6 +3395,152 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -3107,6 +3552,33 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -3175,6 +3647,20 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -3204,6 +3690,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3267,6 +3763,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3323,6 +3832,34 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3831,6 +4368,20 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -3854,6 +4405,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -3874,6 +4432,16 @@
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -3914,6 +4482,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
       "version": "3.4.11",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
@@ -3921,6 +4496,21 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3954,6 +4544,62 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-toolkit": {
@@ -4040,6 +4686,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4064,6 +4730,23 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4079,6 +4762,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4087,6 +4780,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-nonce": {
@@ -4098,11 +4816,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/gifenc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
       "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
       "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -4116,6 +4861,48 @@
       "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
@@ -4304,6 +5091,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4337,6 +5137,34 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4357,6 +5185,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -4430,6 +5268,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4446,6 +5291,48 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -4820,6 +5707,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4850,6 +5747,16 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -5714,6 +6621,39 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5747,6 +6687,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/package-manager-detector": {
@@ -5798,6 +6759,13 @@
       "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pdfjs-dist": {
       "version": "6.1.200",
       "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
@@ -5829,6 +6797,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -5876,6 +6891,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -5884,6 +6914,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -5908,6 +6948,13 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6051,6 +7098,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rehype-highlight": {
@@ -6228,6 +7289,13 @@
         "points-on-path": "^0.2.1"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
@@ -6239,6 +7307,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -6261,6 +7342,13 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/simple-icons": {
       "version": "16.24.0",
@@ -6311,6 +7399,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -6323,6 +7425,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -6347,6 +7462,13 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -6389,6 +7511,13 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -6413,6 +7542,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -6779,6 +7964,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6788,6 +8076,110 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/turbollm/web/package.json
+++ b/turbollm/web/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.16",
@@ -42,12 +45,18 @@
     "zustand": "^5.0.14"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/turbollm/web/playwright.config.ts
+++ b/turbollm/web/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Real-browser E2E for the Code UI redesign (ADR-253) — jsdom (Vitest) can't catch
+// overflow/clipping layout bugs, which is part of why this suite exists.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    // 'localhost' (not '127.0.0.1') — on this machine Node/Vite binds the dev server's
+    // loopback listener to IPv6 (::1) only, so an IPv4-literal health check/navigation
+    // times out even though the server is up.
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  // Spins up its own `vite` dev server scoped to the test run on the standard web-dev
+  // port (5173, per .claude/launch.json) rather than a one-off port. This is just the
+  // Vite frontend server — it does not touch ~/.turbollm; API calls proxy to whatever
+  // daemon (if any) is already running on :6996, and the smoke test only asserts on
+  // static chrome that renders regardless of daemon/auth state.
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+})

--- a/turbollm/web/src/components/ui/badge.test.tsx
+++ b/turbollm/web/src/components/ui/badge.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Badge } from './badge'
+
+describe('Badge', () => {
+  it('renders its children', () => {
+    render(<Badge>Active</Badge>)
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/components/ui/copy-button.tsx
+++ b/turbollm/web/src/components/ui/copy-button.tsx
@@ -28,6 +28,9 @@ export function CopyButton({
       type="button"
       onClick={handle}
       title={copied ? 'Copied!' : 'Copy'}
+      // Real accessible name always, not just a title tooltip — matters most for the icon-only
+      // case (no `label` passed), where the button otherwise has no accessible name at all.
+      aria-label={copied ? 'Copied' : (label ?? 'Copy')}
       className={`inline-flex items-center gap-1.5 rounded transition-colors ${
         copied ? '' : 'text-faint hover:text-ink'
       } ${padding} ${className ?? ''}`}

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -47,7 +47,7 @@
      row highlight, is NOT Code-specific — candidate for a spec-11 app-wide
      token instead; left out of this Code-scoped layer pending that decision. */
   --instruction-border: color-mix(in srgb, var(--accent) 35%, var(--border));
-  --instruction-bg: color-mix(in srgb, var(--accent) 6%, transparent);
+  --instruction-bg: color-mix(in srgb, var(--accent) 14%, transparent);
   --instruction-chip-border: color-mix(in srgb, var(--accent) 25%, var(--border));
   /* Status banner border reuses --instruction-border (identical 35%-accent-
      over-border math at both call sites); only the background differs. */

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -34,6 +34,28 @@
   --log-ink: #d6d3cd;
   --log-faint: #7a7872;
   --log-err-ink: #e0b3ad;
+
+  /* ── Code feature surface tokens (spec 14 Phase 0 / ADR-252) ────────────
+     Named after the surface they style (instruction/diff/toolcard/status),
+     never `--code-*`/`--codeui-*` — that prefix is already taken above by
+     the markdown code-block surface. Each is a color-mix() over tokens that
+     already flip between :root/.dark (--accent/--warn/--ok/--err/--border),
+     so a single declaration self-adjusts per theme — no .dark override
+     needed here, same reasoning as why --log-* above only sets one value.
+     TODO: --chip-active-bg (color-mix(in srgb, var(--accent) 10%, transparent)),
+     used by both CodeComposer's worktree chip and ConversationSidebar's active-
+     row highlight, is NOT Code-specific — candidate for a spec-11 app-wide
+     token instead; left out of this Code-scoped layer pending that decision. */
+  --instruction-border: color-mix(in srgb, var(--accent) 35%, var(--border));
+  --instruction-bg: color-mix(in srgb, var(--accent) 6%, transparent);
+  --instruction-chip-border: color-mix(in srgb, var(--accent) 25%, var(--border));
+  /* Status banner border reuses --instruction-border (identical 35%-accent-
+     over-border math at both call sites); only the background differs. */
+  --status-banner-bg: color-mix(in srgb, var(--accent) 12%, transparent);
+  --toolcard-approval-bg: color-mix(in srgb, var(--warn) 6%, transparent);
+  --diff-hunk-bg: color-mix(in srgb, var(--accent) 8%, transparent);
+  --diff-add-bg: color-mix(in srgb, var(--ok) 10%, transparent);
+  --diff-del-bg: color-mix(in srgb, var(--err) 10%, transparent);
 }
 
 .dark {
@@ -314,6 +336,11 @@ body {
 .tllm-pulse {
   animation: tllm-pulse 1.2s ease-in-out infinite;
 }
+@media (prefers-reduced-motion: reduce) {
+  .tllm-pulse {
+    animation: none;
+  }
+}
 
 /* Hover-reveal row actions (message copy/edit/regenerate/delete, conversation rename/delete,
    Code transcript step actions): hidden until `.group:hover` on a device that actually HAS hover
@@ -387,11 +414,26 @@ body {
 .tllm-sheet[data-state='closed'] {
   animation: tllm-sheet-out-right 0.24s ease-in;
 }
+@media (prefers-reduced-motion: reduce) {
+  .tllm-sheet[data-state='open'],
+  .tllm-sheet[data-state='closed'] {
+    animation: none;
+  }
+}
 
 /* Desktop (≥768px, matches the app's nav breakpoint): right-docked panel and a
    matching right-pad on the shell so the rest of the UI resizes (no overlap). */
 .app-shell {
   transition: padding-right 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  /* Paired with .tllm-sheet's own reduced-motion override above — without this, a
+     reduced-motion user would still see the shell's padding slide over 280ms even
+     though the panel itself now appears/disappears instantly, a jarring half-fixed
+     mismatch between the two halves of the same open/close interaction. */
+  .app-shell {
+    transition: none;
+  }
 }
 @media (min-width: 768px) {
   .tllm-sheet {

--- a/turbollm/web/src/lib/chat-types.ts
+++ b/turbollm/web/src/lib/chat-types.ts
@@ -40,6 +40,10 @@ export interface LiveToolCall {
   diff?: string
   patch?: string
   firstChangedLine?: number
+  /** Code mode only (Phase 2, ADR-250) — the latest CUMULATIVE live-output snapshot from a
+   *  `tool_progress` SSE frame while the tool is still running (bash streams its stdout; edit
+   *  doesn't). Shown streaming in the tool card until the terminal `result` supersedes it. */
+  partial?: string
 }
 
 /** Tool-call approval gate policy (mirrors turbollm/src/tools/tool-policy.ts). */

--- a/turbollm/web/src/lib/code-api.test.ts
+++ b/turbollm/web/src/lib/code-api.test.ts
@@ -1,0 +1,71 @@
+// Unit tests for code-api.ts's session-export download (Phase 3, ADR-251) — the one function in
+// this module that isn't a plain JSON req() call, so it gets its own focused coverage: real
+// fetch/Blob/anchor-download plumbing, mocked at the browser API boundary (fetch, URL.createObjectURL,
+// anchor.click), not the function's own logic.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { downloadCodeSessionExport } from './code-api'
+import { ApiError } from './api'
+
+// jsdom doesn't implement localStorage's methods by default (authHeaders() reads it on every
+// call) — same gap CodeComposer.test.tsx already works around; stubbed locally, not in the
+// shared src/test/setup.ts.
+beforeEach(() => {
+  vi.restoreAllMocks()
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => store.clear(),
+  })
+  // jsdom doesn't implement the Blob-URL APIs, and clicking a real <a href="blob:..."> would log
+  // a jsdom "not implemented: navigation" warning — both stubbed so the test exercises the real
+  // download-trigger code path without either noise.
+  vi.stubGlobal('URL', { ...URL, createObjectURL: vi.fn(() => 'blob:mock-url'), revokeObjectURL: vi.fn() })
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+})
+
+describe('downloadCodeSessionExport', () => {
+  it('fetches the export URL, reads the real filename off Content-Disposition, and triggers a download', async () => {
+    const blob = new Blob(['# hello'], { type: 'text/markdown' })
+    const fetchMock = vi.fn(async () => new Response(blob, {
+      status: 200,
+      headers: { 'Content-Disposition': 'attachment; filename="my-session-2026-07-24.md"' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await downloadCodeSessionExport('sess-1')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/code/sessions/sess-1/export?format=markdown',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('falls back to a default filename when Content-Disposition is missing/unparsable', async () => {
+    const blob = new Blob(['# hello'])
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(blob, { status: 200 })))
+
+    let capturedDownload = ''
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      capturedDownload = this.download
+    })
+
+    await downloadCodeSessionExport('sess-1')
+    expect(capturedDownload).toBe('code-session.md')
+  })
+
+  it('throws ApiError (not a generic Error) on a non-OK response, without attempting a download', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: 'not_found', message: 'Session not found.' } }),
+      { status: 404 },
+    )))
+
+    await expect(downloadCodeSessionExport('missing')).rejects.toThrow(ApiError)
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+    expect(HTMLAnchorElement.prototype.click).not.toHaveBeenCalled()
+  })
+})

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -1,7 +1,11 @@
 // Code launchpad API client — mirrors chat-api.ts's conventions (req() helper, the
 // hand-rolled SSE line parser) against turbollm/src/code/code-routes.ts.
 import type { Conversation } from './chat-types'
-import type { CodeSession, CodeSessionFilter, CodeStats, CodeStatsRange, CodeStreamEvent, CreateCodeSessionParams, QueuedTurn } from './code-types'
+import type {
+  CodeExecResponse, CodeSendMessageBody, CodeSendMessageResponse, CodeSession, CodeSessionFilter, CodeStats,
+  CodeStatsRange, CodeStreamEvent, CommitGitResult, CreateCodeSessionParams, GitStatusResult, PushGitReason,
+  PushGitResult, QueuedTurn, SteerKind, TodoItem,
+} from './code-types'
 import { ApiError, authHeaders } from './api'
 import { markCodeAuthNeeded, clearCodeAuthNeeded } from './auth-signal'
 
@@ -86,6 +90,9 @@ export interface CodeSessionDetail {
   /** Turns waiting behind the active one (server-side queue) — restores the "Queued" chips
    *  after a reload/reconnect. */
   queued: QueuedTurn[]
+  /** The live turn's current checklist, if the run is active — reflects the daemon's in-memory
+   *  state (reset per turn), same reconnect-resilience purpose as `queued`. */
+  todos: TodoItem[]
 }
 export function getCodeSession(id: string): Promise<CodeSessionDetail> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}`)
@@ -130,23 +137,42 @@ export function compactCodeSession(id: string, instructions?: string): Promise<{
  *  typed message (see CodeSessionScreen.tsx's skill picker — it used to rewrite `content` itself,
  *  which the founder explicitly asked to stop). `contextFiles`, when given, are absolute paths
  *  picked via the composer's "Add context" file browser — stored as attachment chips on the
- *  message, folded server-side into a "read this file" nudge for this turn's prompt. */
+ *  message, folded server-side into a "read this file" nudge for this turn's prompt. `kind`
+ *  (Phase 1, ADR-246) chooses how the turn is delivered while a run is already active — 'steer'
+ *  redirects the live turn, 'followUp' (default when omitted) queues behind it; the response's
+ *  `steered` reports whether a 'steer' actually injected live vs. fell back to the queue. */
 export async function startCodeRun(
   sessionId: string,
   content: string,
   thinkingBudget?: number,
   promptOverride?: string,
   contextFiles?: string[],
-): Promise<{ ok: true; queued: boolean; userMessageId: string }> {
-  return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/messages`, {
-    method: 'POST',
-    json: {
-      content: content || undefined,
-      promptOverride: promptOverride || undefined,
-      contextFiles: contextFiles?.length ? contextFiles : undefined,
-      thinkingBudget: thinkingBudget !== undefined && thinkingBudget !== -1 ? thinkingBudget : undefined,
-    },
-  })
+  kind?: SteerKind,
+): Promise<CodeSendMessageResponse> {
+  const body: CodeSendMessageBody = {
+    content: content || undefined,
+    promptOverride: promptOverride || undefined,
+    contextFiles: contextFiles?.length ? contextFiles : undefined,
+    thinkingBudget: thinkingBudget !== undefined && thinkingBudget !== -1 ? thinkingBudget : undefined,
+    kind,
+  }
+  return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/messages`, { method: 'POST', json: body })
+}
+
+/** `!command` / `!!command` shell escape (ADR-258): run `command` in the session's repo root.
+ *  `feedToModel` true (the `!` variant) persists the command+output as a user message the model
+ *  reads next turn (response carries its `messageId`); false (`!!`) is a transcript-only peek. */
+export function execShellCommand(id: string, command: string, feedToModel: boolean): Promise<CodeExecResponse> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/exec`, { method: 'POST', json: { command, feedToModel } })
+}
+
+/** Confirmation copy for a `steer` send — the daemon can silently fall back to queuing the message
+ *  if the live turn already settled between the click and the request (`steered:false`), so the
+ *  toast reports which actually happened rather than assuming the steer landed. */
+export function steerOutcomeMessage(steered: boolean): string {
+  return steered
+    ? 'Steered into the current turn.'
+    : 'Queued to run next — the current turn had already moved on.'
 }
 
 /** (Re)connect to a session's run stream from `fromSeq` (the last ring-buffer seq already seen;
@@ -201,4 +227,87 @@ export async function* streamCodeSession(
   } finally {
     reader.releaseLock()
   }
+}
+
+// ── Session export (Phase 3, ADR-251) ───────────────────────────────────────────────────────
+// GET .../export returns the raw file body (not JSON, so it bypasses req()) with a real
+// Content-Disposition attachment filename — read that back rather than re-deriving a filename
+// client-side, so the export's name always matches exactly what the server actually sent.
+const CONTENT_DISPOSITION_FILENAME_RE = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i
+
+/** Fetches a session's Markdown export and triggers a real browser download (Blob + a
+ *  temporary `<a download>` click, immediately revoked) — no server-side file write, per
+ *  `turbollm/CLAUDE.md`'s cross-platform/no-stray-paths rule. Throws `ApiError` on a non-OK
+ *  response, same shape every other Code API call throws, so callers can toast.error() it
+ *  uniformly. */
+export async function downloadCodeSessionExport(sessionId: string, format: 'markdown' = 'markdown'): Promise<void> {
+  const res = await fetch(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/export?format=${format}`, {
+    method: 'GET',
+    headers: { ...authHeaders() },
+  })
+  if (res.status === 401) markCodeAuthNeeded()
+  else if (res.ok) clearCodeAuthNeeded()
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    const env = (() => { try { return JSON.parse(text) } catch { return undefined } })() as { error?: { code?: string; message?: string } } | undefined
+    throw new ApiError(env?.error?.code ?? 'http_error', env?.error?.message ?? `Export failed with status ${res.status}.`, res.status)
+  }
+  const disposition = res.headers.get('Content-Disposition') ?? ''
+  const filename = CONTENT_DISPOSITION_FILENAME_RE.exec(disposition)?.[1]?.trim() || `code-session.${format === 'markdown' ? 'md' : format}`
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  try {
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+// ── Git actions (Phase 3, ADR-259) ──────────────────────────────────────────────────────────
+// Thin clients over turbollm/src/code/git-actions.ts's routes — see that file's header for the
+// full scope note (commit+push only, no gh/GitHub-API call, push never forces).
+
+export function getCodeSessionGitStatus(sessionId: string): Promise<{ ok: true; status: GitStatusResult }> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/git/status`)
+}
+
+/** `files` omitted stages everything (`git add -A`); given, stages ONLY those paths. Rejects
+ *  (ApiError) for every failure case — no message, not a repo, nothing to commit/stage, or a
+ *  containment violation — with a specific `error.code`/`message` from the route, not a generic
+ *  failure. */
+export function commitCodeSessionGit(sessionId: string, message: string, files?: string[]): Promise<{ ok: true } & CommitGitResult> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/git/commit`, { method: 'POST', json: { message, files } })
+}
+
+const PUSH_GIT_REASONS: ReadonlySet<string> = new Set<PushGitReason>(['not_a_repo', 'no_remote', 'detached_head', 'diverged', 'push_failed'])
+
+/** Pushes the current branch (setting the upstream on first push). NEVER forces. Resolves to a
+ *  typed `PushGitResult` rather than throwing for the EXPECTED rejection cases (diverged, no
+ *  remote, detached HEAD, generic push failure) — the route sends those as a 400/409 whose
+ *  `error.code` is exactly one of {@link PushGitReason}, caught here and turned back into the
+ *  same discriminated union `git-actions.ts` returns server-side. A genuinely unexpected error
+ *  (session not found, no repo root at all) still throws `ApiError`, same as every other call. */
+export async function pushCodeSessionGit(sessionId: string): Promise<PushGitResult> {
+  try {
+    return await req<{ ok: true; remote: string; branch: string; compareUrl: string | null }>(
+      `/api/v1/code/sessions/${encodeURIComponent(sessionId)}/git/push`,
+      { method: 'POST', json: {} },
+    )
+  } catch (e) {
+    if (e instanceof ApiError && PUSH_GIT_REASONS.has(e.code)) {
+      return { ok: false, reason: e.code as PushGitReason, message: e.message }
+    }
+    throw e
+  }
+}
+
+/** Standalone PR-link lookup (independent of push) — for a branch already pushed by an earlier
+ *  session/turn. Never throws for "no link available"; `compareUrl` is simply null. */
+export function getCodeSessionCompareUrl(sessionId: string): Promise<{ ok: true; compareUrl: string | null }> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/git/compare-url`)
 }

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -93,6 +93,10 @@ export interface CodeSessionDetail {
   /** The live turn's current checklist, if the run is active — reflects the daemon's in-memory
    *  state (reset per turn), same reconnect-resilience purpose as `queued`. */
   todos: TodoItem[]
+  /** Whether an AGENTS.md is loaded for this session (ADR-262 loaded-resources header) — `project`
+   *  = `<repoRoot>/AGENTS.md`, `global` = `~/.turbollm/agents.md`. Same lookup persona.ts injects
+   *  into the prompt, so this reflects what the model actually receives. */
+  hasAgentsMd: { project: boolean; global: boolean }
 }
 export function getCodeSession(id: string): Promise<CodeSessionDetail> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}`)

--- a/turbollm/web/src/lib/code-commands.test.ts
+++ b/turbollm/web/src/lib/code-commands.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { CODE_COMMANDS, matchCodeCommand, pickerCodeCommands } from './code-commands'
+
+describe('matchCodeCommand', () => {
+  it('matches /compact and captures its trailing instructions argument', () => {
+    const m = matchCodeCommand('/compact focus on the auth module')
+    expect(m?.id).toBe('compact')
+    expect(m?.match[1]).toBe('focus on the auth module')
+  })
+
+  it('matches a bare /compact with an empty argument', () => {
+    const m = matchCodeCommand('/compact')
+    expect(m?.id).toBe('compact')
+    expect(m?.match[1]?.trim() || undefined).toBeUndefined()
+  })
+
+  it('matches /clear and /resume (no argument)', () => {
+    expect(matchCodeCommand('/clear')?.id).toBe('clear')
+    expect(matchCodeCommand('/resume')?.id).toBe('resume')
+  })
+
+  it('matches the ADR-258 additions /init, /details, /thinking', () => {
+    expect(matchCodeCommand('/init')?.id).toBe('init')
+    expect(matchCodeCommand('/details')?.id).toBe('details')
+    expect(matchCodeCommand('/thinking')?.id).toBe('thinking')
+  })
+
+  it('matches a !command shell escape, capturing bang and command', () => {
+    const m = matchCodeCommand('!npm test')
+    expect(m?.id).toBe('shell')
+    expect(m?.match[1]).toBe('!')
+    expect(m?.match[2]).toBe('npm test')
+  })
+
+  it('distinguishes !! (no model context) from ! (feeds the model)', () => {
+    expect(matchCodeCommand('!!git status')?.match[1]).toBe('!!')
+    expect(matchCodeCommand('! ls -la')?.match[1]).toBe('!') // whitespace after the bang is allowed
+    expect(matchCodeCommand('! ls -la')?.match[2]).toBe('ls -la')
+  })
+
+  it('does NOT treat a lone bang (no command) as a shell command', () => {
+    expect(matchCodeCommand('!')).toBeNull()
+    expect(matchCodeCommand('!!  ')).toBeNull()
+  })
+
+  it('keeps the shell command out of the / picker (pickerVisible false)', () => {
+    expect(pickerCodeCommands({ cleared: true }).some((c) => c.id === 'shell')).toBe(false)
+  })
+
+  it('is case-insensitive on the trigger', () => {
+    expect(matchCodeCommand('/CLEAR')?.id).toBe('clear')
+  })
+
+  it('does not match /clear with trailing text (it takes no argument)', () => {
+    // The old CLEAR_RE was anchored `^/clear\s*$` — extra text means it is NOT the clear command
+    // (it falls through to a normal turn), so this must stay null to preserve that behavior.
+    expect(matchCodeCommand('/clear the whole thing please')).toBeNull()
+  })
+
+  it('returns null for a non-built-in slash input (e.g. a skill) so the caller handles it', () => {
+    expect(matchCodeCommand('/some-skill do the thing')).toBeNull()
+  })
+
+  it('returns null for ordinary prose', () => {
+    expect(matchCodeCommand('please refactor the parser')).toBeNull()
+  })
+})
+
+describe('pickerCodeCommands', () => {
+  it('offers the always-available built-ins but NOT resume when there is nothing to resume', () => {
+    const ids = pickerCodeCommands({ cleared: false }).map((c) => c.id)
+    expect(ids).toEqual(['compact', 'clear', 'init', 'details', 'thinking'])
+  })
+
+  it('offers resume too once the session has cleared/reverted history', () => {
+    const ids = pickerCodeCommands({ cleared: true }).map((c) => c.id)
+    expect(ids).toEqual(['compact', 'clear', 'resume', 'init', 'details', 'thinking'])
+  })
+
+  it('carries the human-readable description for each command', () => {
+    const compact = pickerCodeCommands({ cleared: false }).find((c) => c.id === 'compact')
+    expect(compact?.description).toMatch(/summarize/i)
+  })
+
+  it('resume stays PARSEABLE even while hidden from the picker (matches regardless of visibility)', () => {
+    // Visibility gates display only — typing /resume must still dispatch (the endpoint 409s when
+    // there is nothing to resume), so matchCodeCommand must not depend on picker state.
+    expect(pickerCodeCommands({ cleared: false }).some((c) => c.id === 'resume')).toBe(false)
+    expect(matchCodeCommand('/resume')?.id).toBe('resume')
+  })
+})
+
+describe('CODE_COMMANDS registry', () => {
+  it('has unique ids', () => {
+    const ids = CODE_COMMANDS.map((c) => c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('anchors every trigger pattern (^…$) so a command matches the WHOLE input, not a substring', () => {
+    for (const cmd of CODE_COMMANDS) {
+      expect(cmd.pattern.source.startsWith('^')).toBe(true)
+      expect(cmd.pattern.source.endsWith('$')).toBe(true)
+    }
+  })
+})

--- a/turbollm/web/src/lib/code-commands.ts
+++ b/turbollm/web/src/lib/code-commands.ts
@@ -1,0 +1,114 @@
+// The single canonical registry of the Code composer's BUILT-IN commands (ADR-260). Before this,
+// the same knowledge lived in two places that had to be hand-synced: the `/` picker's displayed
+// list (assembled inline where CodeComposer's `slashCommands` prop is passed) and CodeSessionScreen
+// `send()`'s standalone trigger regexes (COMPACT_RE/CLEAR_RE/RESUME_RE). Both now source from here,
+// so adding/removing a built-in is a single edit to CODE_COMMANDS.
+//
+// Deliberately plain TS, zero React — the picker and send() consume it, and a hypothetical future
+// `turbollm code` CLI (the same reusability motive as ADR-260's SSE-orchestration extraction) can
+// reuse the exact same triggers/descriptions. The per-command SIDE EFFECT (call the compact
+// endpoint, clear the session, …) stays with the caller: this module says WHICH command an input
+// is and WHETHER it belongs in the picker, the caller maps the id to its handler.
+//
+// NOT built-in and intentionally NOT here: dynamic skills (from the shared skill library) — those
+// are appended to the picker and matched separately (skillPromptOverride), since they're
+// data-driven, not a fixed part of the composer's command vocabulary.
+
+/** Session state that affects which built-ins are offered in the picker right now. */
+export interface CodeCommandContext {
+  /** The session has hidden history (a `/clear` or a revert) that `/resume` can bring back. */
+  cleared: boolean
+}
+
+export interface CodeCommandDef {
+  id: string
+  /** Shown in the `/` picker. */
+  description: string
+  /** Matches the WHOLE composer input when this command is invoked (anchored `^…$`). A capture
+   *  group, where present, carries the command's argument (e.g. `/compact <instructions>`). */
+  pattern: RegExp
+  /** Whether this command appears in the `/` picker for the given state — default: always. Note
+   *  this gates DISPLAY only; {@link matchCodeCommand} matches regardless of picker visibility
+   *  (e.g. `/resume` is always parseable; the endpoint 409s when there's nothing to resume, and
+   *  the picker just hides the entry so it isn't offered when it can't do anything). */
+  pickerVisible?: (ctx: CodeCommandContext) => boolean
+}
+
+// Order matters only for {@link matchCodeCommand}'s first-match scan; the built-ins have disjoint
+// triggers so today it's immaterial, but a new command should still be ordered so a more specific
+// trigger can't be shadowed by a broader earlier one.
+//
+// How each built-in is dispatched (in CodeSessionScreen's send()) differs by kind, but adding one
+// is still a SINGLE entry here + one dispatch arm — no second place to update:
+//   • compact/clear/resume → a dedicated endpoint, early-return (not a model turn).
+//   • init → a REAL agentic turn with a fixed promptOverride (the agent inspects the repo and
+//     writes AGENTS.md) — flows through startCodeRun, no early return.
+//   • details/thinking → an instant client-side display toggle (code-display-prefs.ts), early-return.
+//
+//   • shell (`!`/`!!`, ADR-258) → NOT a model turn: runs a user shell command via the exec
+//     endpoint. `pickerVisible: () => false` since it's `!`-triggered, never in the `/` list; still
+//     matched here so send() dispatches it. `match[1]` is the bang (`!` feeds output to the model,
+//     `!!` doesn't), `match[2]` the command.
+export const CODE_COMMANDS: CodeCommandDef[] = [
+  {
+    id: 'compact',
+    description: 'Summarize the conversation so far into one summary, to free up context',
+    pattern: /^\/compact\b\s*(.*)$/i,
+  },
+  {
+    id: 'clear',
+    description: 'Clear the chat — repo, worktree, and branch stay as they are',
+    pattern: /^\/clear\b\s*$/i,
+  },
+  {
+    id: 'resume',
+    description: 'Bring back a cleared or reverted chat',
+    pattern: /^\/resume\b\s*$/i,
+    pickerVisible: (ctx) => ctx.cleared,
+  },
+  {
+    id: 'init',
+    description: 'Set up an AGENTS.md — the agent inspects your repo and drafts one',
+    pattern: /^\/init\b\s*$/i,
+  },
+  {
+    id: 'details',
+    description: 'Toggle showing full tool-call details for every step',
+    pattern: /^\/details\b\s*$/i,
+  },
+  {
+    id: 'thinking',
+    description: "Toggle always showing the agent's reasoning",
+    pattern: /^\/thinking\b\s*$/i,
+  },
+  {
+    id: 'shell',
+    description: 'Run a shell command yourself (! feeds output to the model, !! does not)',
+    // `!` or `!!` followed by a non-empty command. match[1] = the bang(s), match[2] = the command.
+    // The `(?!!)` stops the bang group from giving a bang back to the command via backtracking (so
+    // `!!` + only whitespace is NOT read as single-bang command `!`); the `\S` guard means a lone
+    // `!`/`!!` with no command doesn't match at all — it stays a normal message.
+    pattern: /^(!{1,2})(?!!)\s*(\S[\s\S]*)$/,
+    pickerVisible: () => false,
+  },
+]
+
+/** The built-in command whose trigger matches this exact input, if any — with the raw regex match
+ *  so the caller can read a captured argument (e.g. `/compact foo` → `match[1] === 'foo'`).
+ *  Ignores picker visibility (a command is parseable whether or not it's currently offered). */
+export function matchCodeCommand(text: string): { id: string; match: RegExpExecArray } | null {
+  for (const cmd of CODE_COMMANDS) {
+    const m = cmd.pattern.exec(text)
+    if (m) return { id: cmd.id, match: m }
+  }
+  return null
+}
+
+/** The built-in commands to show in the `/` picker for the current session state, as the
+ *  `{ id, description }` shape CodeComposer's `slashCommands` prop expects. Callers append their
+ *  dynamic skills to this. */
+export function pickerCodeCommands(ctx: CodeCommandContext): { id: string; description: string }[] {
+  return CODE_COMMANDS
+    .filter((cmd) => !cmd.pickerVisible || cmd.pickerVisible(ctx))
+    .map((cmd) => ({ id: cmd.id, description: cmd.description }))
+}

--- a/turbollm/web/src/lib/code-display-prefs.test.ts
+++ b/turbollm/web/src/lib/code-display-prefs.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getDisplayPref, toggleDisplayPref } from './code-display-prefs'
+
+describe('code-display-prefs', () => {
+  beforeEach(() => { localStorage.clear() })
+
+  it('defaults both prefs to off', () => {
+    expect(getDisplayPref('details')).toBe(false)
+    expect(getDisplayPref('thinking')).toBe(false)
+  })
+
+  it('toggle flips the pref, returns the new value, and persists it', () => {
+    expect(toggleDisplayPref('details')).toBe(true)
+    expect(getDisplayPref('details')).toBe(true)
+    expect(toggleDisplayPref('details')).toBe(false)
+    expect(getDisplayPref('details')).toBe(false)
+  })
+
+  it('keeps the two prefs independent', () => {
+    toggleDisplayPref('thinking')
+    expect(getDisplayPref('thinking')).toBe(true)
+    expect(getDisplayPref('details')).toBe(false)
+  })
+})

--- a/turbollm/web/src/lib/code-display-prefs.ts
+++ b/turbollm/web/src/lib/code-display-prefs.ts
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from 'react'
+
+// Global display toggles for the Code transcript (`/details`, `/thinking` — ADR-258). These
+// complement the existing PER-card/PER-block expand (CodeToolCard's `expanded`, CodeReasoning's
+// `open`) with a single switch for reviewing a long run: `/details` force-expands every tool card's
+// detail, `/thinking` force-opens every reasoning block. Persisted in localStorage (same convention
+// as the thinking-budget slider) and browser-global (not per-session — it's a reviewing preference,
+// not session state). Subscribable so toggling updates every already-mounted card/block live, not
+// only ones rendered afterward.
+
+const KEYS = {
+  details: 'tllm.code.details',
+  thinking: 'tllm.code.thinking',
+} as const
+
+export type DisplayPref = keyof typeof KEYS
+
+const listeners = new Set<() => void>()
+
+function read(pref: DisplayPref): boolean {
+  return localStorage.getItem(KEYS[pref]) === '1'
+}
+
+export function getDisplayPref(pref: DisplayPref): boolean {
+  return read(pref)
+}
+
+/** Flip a display pref, persist it, and notify subscribers. Returns the new value (so a caller can
+ *  surface it, e.g. a "Details: on" toast). */
+export function toggleDisplayPref(pref: DisplayPref): boolean {
+  const next = !read(pref)
+  localStorage.setItem(KEYS[pref], next ? '1' : '0')
+  listeners.forEach((l) => l())
+  return next
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb)
+  return () => { listeners.delete(cb) }
+}
+
+/** Reactively read a display pref — re-renders the caller whenever the pref is toggled anywhere. */
+export function useDisplayPref(pref: DisplayPref): boolean {
+  return useSyncExternalStore(subscribe, () => read(pref), () => false)
+}

--- a/turbollm/web/src/lib/code-queries.export.test.tsx
+++ b/turbollm/web/src/lib/code-queries.export.test.tsx
@@ -1,0 +1,77 @@
+// Covers spec 16 §5's "double-click export — no duplicate downloads, no stuck loading state"
+// edge case for useExportCodeSession (code-queries.ts). code-api.test.ts already covers the
+// underlying downloadCodeSessionExport() fetch/Blob/filename logic in isolation; this exercises
+// the REAL defense mechanism the production menu item relies on (CodeSessionScreen.tsx wires its
+// "Export" item as `disabled={exportMut.isPending}`) — a tiny harness wired the exact same way,
+// not a mock of the guard itself.
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import { useExportCodeSession } from './code-queries'
+
+const downloadMock = vi.fn()
+let resolveDownload: (() => void) | undefined
+
+vi.mock('./code-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./code-api')>()
+  return {
+    ...actual,
+    downloadCodeSessionExport: (...args: unknown[]) => {
+      downloadMock(...args)
+      return new Promise<void>((resolve) => { resolveDownload = resolve })
+    },
+  }
+})
+
+function ExportButtonHarness({ sessionId }: { sessionId: string }) {
+  const mut = useExportCodeSession()
+  return (
+    <button disabled={mut.isPending} onClick={() => mut.mutate(sessionId)}>
+      {mut.isPending ? 'Exporting…' : 'Export'}
+    </button>
+  )
+}
+
+function renderHarness() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <ExportButtonHarness sessionId="sess-1" />
+    </QueryClientProvider>,
+  )
+}
+
+describe('useExportCodeSession — double-click guard (spec 16 §5)', () => {
+  it('a rapid double-click triggers only ONE download, because the button disables itself as soon as the first click sets isPending', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+    const button = screen.getByRole('button', { name: 'Export' })
+
+    await user.click(button)
+    // React has already committed the isPending:true re-render (disabling the button) before
+    // userEvent's next click is dispatched — the same ordering the real menu item relies on.
+    expect(screen.getByRole('button', { name: 'Exporting…' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Exporting…' }))
+
+    expect(downloadMock).toHaveBeenCalledTimes(1)
+
+    resolveDownload?.()
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Export' })).not.toBeDisabled())
+  })
+
+  it('isPending never gets stuck true after the download settles', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+    await user.click(screen.getByRole('button', { name: 'Export' }))
+    expect(await screen.findByRole('button', { name: 'Exporting…' })).toBeInTheDocument()
+
+    resolveDownload?.()
+
+    await waitFor(() => {
+      const button = screen.getByRole('button')
+      expect(button).toHaveTextContent('Export')
+      expect(button).not.toBeDisabled()
+    })
+  })
+})

--- a/turbollm/web/src/lib/code-queries.ts
+++ b/turbollm/web/src/lib/code-queries.ts
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  archiveCodeSession, clearCodeSession, deleteCodeSession, getCodeSession, getCodeStats, listCodeSessions,
-  resumeCodeSession, updateCodeSessionMode, updateCodeSessionTitle,
+  archiveCodeSession, clearCodeSession, commitCodeSessionGit, deleteCodeSession, downloadCodeSessionExport,
+  getCodeSession, getCodeSessionCompareUrl, getCodeSessionGitStatus, getCodeStats, listCodeSessions,
+  pushCodeSessionGit, resumeCodeSession, updateCodeSessionMode, updateCodeSessionTitle,
 } from './code-api'
 import type { CodeSessionFilter, CodeStatsRange } from './code-types'
+import { ApiError } from './api'
 import { toast } from '../components/ui/sonner'
 
 export const codeKeys = {
@@ -157,4 +159,68 @@ export function useCodeSessionRename(sessionId: string | undefined, currentTitle
   }
 
   return { editing, draft, setDraft, start, cancel, commit }
+}
+
+/** Triggers a session's Markdown export as a real browser download. A mutation (not a plain
+ *  click handler) purely for its built-in `isPending`/`isError` state — nothing here needs
+ *  cache invalidation, since export reads already-persisted data without changing it. */
+export function useExportCodeSession() {
+  return useMutation({
+    mutationFn: (sessionId: string) => downloadCodeSessionExport(sessionId),
+    onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not export this session.'),
+  })
+}
+
+/** Git status for the session's repoRoot (branch, per-file changes, ahead/behind, remote info) —
+ *  only fetched while `enabled` (the git actions dialog is open), not polled continuously: unlike
+ *  the session list/detail queries, nothing needs live git state while the dialog is closed. */
+export function useCodeSessionGitStatus(sessionId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: ['code-session-git-status', sessionId],
+    queryFn: () => getCodeSessionGitStatus(sessionId!),
+    enabled: !!sessionId && enabled,
+    retry: false,
+    staleTime: 0,
+  })
+}
+
+/** Commits, then invalidates this session's git status so the dialog immediately reflects the
+ *  now-clean (or partially-clean) working tree without a manual refetch. */
+export function useCommitCodeSessionGit() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (v: { sessionId: string; message: string; files?: string[] }) =>
+      commitCodeSessionGit(v.sessionId, v.message, v.files),
+    onSuccess: (_d, v) => void qc.invalidateQueries({ queryKey: ['code-session-git-status', v.sessionId] }),
+  })
+}
+
+/** Pushes the current branch. Resolves to a typed `PushGitResult` (never throws for the expected
+ *  rejection cases — see code-api.ts's pushCodeSessionGit) — invalidates git status AND the
+ *  compare-url lookup below on any attempt, successful or not, since even a rejected push can
+ *  change ahead/behind (a `git fetch` isn't run here, but a future status check should still
+ *  re-derive from the current repo state rather than serve a stale cached one). */
+export function usePushCodeSessionGit() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (sessionId: string) => pushCodeSessionGit(sessionId),
+    onSettled: (_d, _e, sessionId) => {
+      void qc.invalidateQueries({ queryKey: ['code-session-git-status', sessionId] })
+      void qc.invalidateQueries({ queryKey: ['code-session-compare-url', sessionId] })
+    },
+  })
+}
+
+/** Standalone "Create PR" link lookup — for a branch already pushed by an EARLIER session/turn,
+ *  so the dialog can offer it even before this session's own Push button is ever clicked. Only
+ *  fetched while the git dialog is open and the branch isn't detached (mirrors
+ *  useCodeSessionGitStatus's own enabled-gating). */
+export function useCodeSessionCompareUrl(sessionId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: ['code-session-compare-url', sessionId],
+    queryFn: () => getCodeSessionCompareUrl(sessionId!),
+    enabled: !!sessionId && enabled,
+    retry: false,
+    staleTime: 0,
+  })
 }

--- a/turbollm/web/src/lib/code-session-client.test.ts
+++ b/turbollm/web/src/lib/code-session-client.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from './api'
+import { CodeSessionClient, reduceLive, type CodeSessionClientHandlers, type CodeStreamFn, type LiveState } from './code-session-client'
+import type { CodeStreamEvent } from './code-types'
+import type { LiveToolCall } from './chat-types'
+
+function makeHandlers() {
+  const liveStates: (LiveState | null)[] = []
+  const handlers: CodeSessionClientHandlers = {
+    onLive: vi.fn((s) => { liveStates.push(s) }),
+    onQueue: vi.fn(),
+    onTurnStart: vi.fn(),
+    onTurnDone: vi.fn(),
+    onTurnError: vi.fn(),
+    onIdle: vi.fn(),
+    onLostConnection: vi.fn(),
+  }
+  return { handlers, liveStates }
+}
+
+/** A stream that yields the given frames (each with its `seq`) then completes. */
+function streamOf(frames: CodeStreamEvent[]): CodeStreamFn {
+  return async function* () {
+    for (const f of frames) yield f
+  }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('reduceLive', () => {
+  it('creates a base block anchored to the fallback id when none exists', () => {
+    const out = reduceLive(null, 'a1', (b) => ({ ...b, content: b.content + 'hi' }))
+    expect(out).toEqual({ assistantId: 'a1', content: 'hi', reasoning: '', timeline: [] })
+  })
+
+  it('applies fn to the existing block, keeping its id', () => {
+    const base: LiveState = { assistantId: 'a1', content: 'x', reasoning: '', timeline: [] }
+    const out = reduceLive(base, 'ignored', (b) => ({ ...b, content: b.content + 'y' }))
+    expect(out.assistantId).toBe('a1')
+    expect(out.content).toBe('xy')
+  })
+})
+
+describe('CodeSessionClient', () => {
+  afterEach(() => { vi.useRealTimers() })
+
+  it('reduces meta/reasoning/delta/tool_call into an interleaved live timeline', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'reasoning', data: { delta: 'thinking' }, seq: 1 },
+      { event: 'delta', data: { delta: 'Hello ' }, seq: 2 },
+      { event: 'tool_call', data: { id: 't1', name: 'read', args: { path: 'x' }, status: 'pending' }, seq: 3 },
+      { event: 'delta', data: { delta: 'world' }, seq: 4 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+
+    expect(handlers.onTurnStart).toHaveBeenCalledTimes(1)
+    // The stream completing emits a trailing null (idle) — assert on the last real turn state.
+    const final = liveStates.filter((s): s is LiveState => s !== null).at(-1)!
+    expect(final.assistantId).toBe('a1')
+    expect(final.reasoning).toBe('thinking')
+    expect(final.content).toBe('Hello world')
+    // Interleaving: text "Hello " → tool t1 → text "world" (two separate text blocks, not merged).
+    expect(final.timeline).toEqual([
+      { kind: 'text', text: 'Hello ' },
+      { kind: 'tool', call: { id: 't1', name: 'read', args: { path: 'x' }, status: 'pending', result: undefined, diff: undefined, patch: undefined, firstChangedLine: undefined } },
+      { kind: 'text', text: 'world' },
+    ])
+  })
+
+  it('preserves the live block when meta repeats the same assistant id (reconnect replay)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'delta', data: { delta: 'partial' }, seq: 1 },
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // The second meta must NOT wipe the accumulated 'partial' content.
+    const afterSecondMeta = liveStates.filter((s): s is LiveState => s !== null).at(-1)!
+    expect(afterSecondMeta.content).toBe('partial')
+  })
+
+  it('forwards queue frames without touching live state', async () => {
+    const { handlers } = makeHandlers()
+    const queued = [{ userMsgId: 'q1', task: 'later', kind: 'followUp' as const }]
+    const stream = streamOf([{ event: 'queue', data: { queued }, seq: 0 }] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(handlers.onQueue).toHaveBeenCalledWith(queued)
+  })
+
+  it('clears live and fires onTurnDone on a done frame, then onIdle when the stream completes', async () => {
+    const { handlers } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'done', data: { contextUsed: 1, contextMax: 2, aborted: false }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(handlers.onTurnDone).toHaveBeenCalledTimes(1)
+    expect(handlers.onIdle).toHaveBeenCalledTimes(1)
+    expect(handlers.onLive).toHaveBeenLastCalledWith(null)
+  })
+
+  it('surfaces an error frame via onTurnError', async () => {
+    const { handlers } = makeHandlers()
+    const stream = streamOf([
+      { event: 'error', data: { code: 'boom', message: 'it broke' }, seq: 0 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(handlers.onTurnError).toHaveBeenCalledWith('it broke')
+  })
+
+  it('is idle after the stream completes and connect() is a no-op while active', async () => {
+    const { handlers } = makeHandlers()
+    let calls = 0
+    const stream: CodeStreamFn = async function* () { calls++; yield { event: 'queue', data: { queued: [] }, seq: 0 } as CodeStreamEvent }
+    const client = new CodeSessionClient('s1', handlers, stream)
+    client.connect()
+    client.connect() // guarded: must not open a second stream
+    await flush()
+    expect(calls).toBe(1)
+    expect(client.isActive).toBe(false) // stream completed → idle
+  })
+
+  it('reconnects from the last consumed seq on a mid-run drop', async () => {
+    vi.useFakeTimers()
+    const { handlers } = makeHandlers()
+    const seenFromSeq: number[] = []
+    let attempt = 0
+    const stream: CodeStreamFn = async function* (_sid, fromSeq) {
+      seenFromSeq.push(fromSeq)
+      if (attempt++ === 0) {
+        yield { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 } as CodeStreamEvent
+        yield { event: 'delta', data: { delta: 'x' }, seq: 5 } as CodeStreamEvent
+        throw new Error('network drop')
+      }
+      yield { event: 'done', data: { contextUsed: 1, contextMax: 2, aborted: false }, seq: 6 } as CodeStreamEvent
+    }
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await vi.advanceTimersByTimeAsync(3000)
+    // First connect from 0; reconnect resumes from lastSeq = 5 + 1 = 6.
+    expect(seenFromSeq).toEqual([0, 6])
+    expect(handlers.onTurnDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a silent lost-connection for a 404 (run is gone)', async () => {
+    vi.useFakeTimers()
+    const { handlers } = makeHandlers()
+    const stream: CodeStreamFn = async function* () {
+      throw new ApiError('not_found', 'gone', 404)
+    }
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await vi.advanceTimersByTimeAsync(30_000) // drain all reconnect backoffs
+    expect(handlers.onLostConnection).toHaveBeenCalledWith(true)
+  })
+
+  it('abort() detaches and marks the client idle', async () => {
+    const { handlers } = makeHandlers()
+    // A stream that never completes on its own, so only abort() ends it.
+    const stream: CodeStreamFn = async function* (_sid, _seq, signal) {
+      yield { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 } as CodeStreamEvent
+      await new Promise((_r, rej) => signal.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError'))))
+    }
+    const client = new CodeSessionClient('s1', handlers, stream)
+    client.connect()
+    await flush()
+    expect(client.isActive).toBe(true)
+    client.abort()
+    await flush()
+    expect(client.isActive).toBe(false)
+    // Aborting must NOT trigger a lost-connection toast.
+    expect(handlers.onLostConnection).not.toHaveBeenCalled()
+  })
+})
+
+describe('CodeSessionClient — Phase 2 events (turn / retry / tool_progress)', () => {
+  const lastLive = (states: (LiveState | null)[]) => states.filter((s): s is LiveState => s !== null).at(-1)
+
+  it('folds a tool_progress snapshot into the matching tool block by id, REPLACING (cumulative)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending' }, seq: 1 },
+      { event: 'tool_progress', data: { id: 't1', name: 'bash', partial: 'line1\n' }, seq: 2 },
+      { event: 'tool_progress', data: { id: 't1', name: 'bash', partial: 'line1\nline2\n' }, seq: 3 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    const toolBlock = final.timeline.find((b) => b.kind === 'tool')
+    expect(toolBlock).toBeDefined()
+    // Cumulative: the second snapshot REPLACES the first (not appended), and name/args are preserved.
+    expect(toolBlock).toMatchObject({ kind: 'tool', call: { id: 't1', name: 'bash', partial: 'line1\nline2\n' } })
+    expect((toolBlock as { call: { args: unknown } }).call.args).toEqual({ command: 'ls' })
+  })
+
+  it('ignores a tool_progress snapshot for a tool block that is not in the timeline', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'tool_progress', data: { id: 'ghost', name: 'bash', partial: 'x' }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    // No synthesized nameless card — timeline stays empty.
+    expect(final.timeline).toEqual([])
+  })
+
+  it('inserts a turn divider before rounds AFTER the first (index > 0), never for index 0', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'turn', data: { phase: 'start', index: 0 }, seq: 1 }, // first round — no divider
+      { event: 'delta', data: { delta: 'round zero' }, seq: 2 },
+      { event: 'turn', data: { phase: 'start', index: 1 }, seq: 3 }, // second round — divider
+      { event: 'delta', data: { delta: 'round one' }, seq: 4 },
+      { event: 'turn', data: { phase: 'end', index: 1, toolResults: 0 }, seq: 5 }, // end carries no visual
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    expect(final.timeline).toEqual([
+      { kind: 'text', text: 'round zero' },
+      { kind: 'turn', index: 1 },
+      { kind: 'text', text: 'round one' },
+    ])
+  })
+
+  it('sets retry state on a retry start and clears it on the matching end', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'retry', data: { phase: 'start', attempt: 2, maxAttempts: 5, delayMs: 1500, message: 'rate limited' }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.retry).toEqual({ attempt: 2, maxAttempts: 5, message: 'rate limited' })
+
+    const { handlers: h2, liveStates: s2 } = makeHandlers()
+    const stream2 = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'retry', data: { phase: 'start', attempt: 2, maxAttempts: 5, delayMs: 1500, message: 'rate limited' }, seq: 1 },
+      { event: 'retry', data: { phase: 'end', attempt: 2, success: true }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', h2, stream2).connect()
+    await flush()
+    expect(lastLive(s2)!.retry).toBeNull()
+  })
+
+  it('updates the banner across back-to-back auto-retries (3 starts in a row), never stacking', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'retry', data: { phase: 'start', attempt: 1, maxAttempts: 5, delayMs: 500, message: 'overloaded' }, seq: 1 },
+      { event: 'retry', data: { phase: 'start', attempt: 2, maxAttempts: 5, delayMs: 1000, message: 'overloaded' }, seq: 2 },
+      { event: 'retry', data: { phase: 'start', attempt: 3, maxAttempts: 5, delayMs: 2000, message: 'still overloaded' }, seq: 3 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // retry is a single object, always the LATEST attempt — there's no array to stack duplicates in.
+    expect(lastLive(liveStates)!.retry).toEqual({ attempt: 3, maxAttempts: 5, message: 'still overloaded' })
+  })
+
+  it('clears the banner when a retry ultimately FAILS (end with success:false), not just on success', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'retry', data: { phase: 'start', attempt: 5, maxAttempts: 5, delayMs: 2000, message: 'overloaded' }, seq: 1 },
+      { event: 'retry', data: { phase: 'end', attempt: 5, success: false, finalError: 'gave up' }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // Any end frame clears the banner — a failed retry then surfaces as the turn's error frame, not
+    // a stuck "Retrying…" left hanging.
+    expect(lastLive(liveStates)!.retry).toBeNull()
+  })
+
+  it('lets retry state and an in-flight tool call coexist — neither clobbers the other', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending' }, seq: 1 },
+      { event: 'retry', data: { phase: 'start', attempt: 2, maxAttempts: 5, delayMs: 500, message: 'blip' }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    expect(final.retry).toEqual({ attempt: 2, maxAttempts: 5, message: 'blip' })
+    expect(final.timeline.find((b) => b.kind === 'tool')).toBeDefined() // the tool block survives the retry update
+  })
+
+  it('inserts a divider for every round after the first, across 3+ rounds (each with its own index)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'turn', data: { phase: 'start', index: 0 }, seq: 1 },
+      { event: 'delta', data: { delta: 'r0' }, seq: 2 },
+      { event: 'turn', data: { phase: 'start', index: 1 }, seq: 3 },
+      { event: 'delta', data: { delta: 'r1' }, seq: 4 },
+      { event: 'turn', data: { phase: 'start', index: 2 }, seq: 5 },
+      { event: 'delta', data: { delta: 'r2' }, seq: 6 },
+      { event: 'turn', data: { phase: 'start', index: 3 }, seq: 7 },
+      { event: 'delta', data: { delta: 'r3' }, seq: 8 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const markers = lastLive(liveStates)!.timeline.filter((b) => b.kind === 'turn')
+    // One divider per round after the first (indices 1,2,3) — round 0 opens the turn with no divider.
+    expect(markers).toEqual([{ kind: 'turn', index: 1 }, { kind: 'turn', index: 2 }, { kind: 'turn', index: 3 }])
+  })
+
+  it('preserves a tool call\'s streamed partial output when it then ERRORS mid-stream (nothing dropped)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'sleep 1' }, status: 'pending' }, seq: 1 },
+      { event: 'tool_progress', data: { id: 't1', name: 'bash', partial: 'partial line before the failure\n' }, seq: 2 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'sleep 1' }, status: 'error', result: 'killed' }, seq: 3 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const toolBlock = lastLive(liveStates)!.timeline.find((b) => b.kind === 'tool') as { call: LiveToolCall }
+    expect(toolBlock.call.status).toBe('error')
+    expect(toolBlock.call.result).toBe('killed')
+    // The partial captured before the error survives the error upsert (the merge keeps prior fields
+    // the terminal frame doesn't carry) — the pre-failure output is never silently dropped.
+    expect(toolBlock.call.partial).toBe('partial line before the failure\n')
+  })
+
+  it('a late, out-of-order tool_progress for an ALREADY-completed tool does not corrupt its terminal state', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending' }, seq: 1 },
+      { event: 'tool_call', data: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'done', result: 'final output' }, seq: 2 },
+      { event: 'tool_progress', data: { id: 't1', name: 'bash', partial: 'a late snapshot arriving after done' }, seq: 3 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const toolBlock = lastLive(liveStates)!.timeline.find((b) => b.kind === 'tool') as { call: LiveToolCall }
+    // The late progress can't revert status or drop the result — the terminal state stands (and the
+    // transcript already supersedes any partial with the result once a tool is done).
+    expect(toolBlock.call.status).toBe('done')
+    expect(toolBlock.call.result).toBe('final output')
+  })
+})
+
+describe('CodeSessionClient — todos (ADR-255)', () => {
+  const lastLive = (states: (LiveState | null)[]) => states.filter((s): s is LiveState => s !== null).at(-1)
+
+  it('reduces a todos frame into LiveState.todos, with mixed statuses preserved as-is', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const todos = [
+      { content: 'Read the file', status: 'completed' as const },
+      { content: 'Fix the bug', status: 'in_progress' as const },
+      { content: 'Add a test', status: 'pending' as const },
+    ]
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'todos', data: { todos }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toEqual(todos)
+  })
+
+  it('is undefined until the first todos frame arrives (nothing to render yet)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'delta', data: { delta: 'working on it' }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toBeUndefined()
+  })
+
+  it('a later todos frame REPLACES the list wholesale, not a merge', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'todos', data: { todos: [{ content: 'Step 1', status: 'in_progress' }, { content: 'Step 2', status: 'pending' }] }, seq: 1 },
+      { event: 'todos', data: { todos: [{ content: 'Step 1', status: 'completed' }, { content: 'Step 2', status: 'in_progress' }] }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toEqual([
+      { content: 'Step 1', status: 'completed' },
+      { content: 'Step 2', status: 'in_progress' },
+    ])
+  })
+
+  it('an explicit empty-array todos frame is a real (not undefined) empty list', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'todos', data: { todos: [{ content: 'Step 1', status: 'pending' }] }, seq: 1 },
+      { event: 'todos', data: { todos: [] }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toEqual([])
+  })
+
+  it('resets to undefined on a genuinely NEW turn (new assistantId) — mirrors the backend clearing its own todos per turn', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'todos', data: { todos: [{ content: 'Old plan step', status: 'completed' }] }, seq: 1 },
+      { event: 'done', data: { contextUsed: 1, contextMax: 2, aborted: false }, seq: 2 },
+      { event: 'meta', data: { userMessageId: 'u2', assistantMessageId: 'a2' }, seq: 3 }, // NEW turn
+      { event: 'delta', data: { delta: 'new turn, no plan yet' }, seq: 4 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toBeUndefined()
+  })
+
+  it('preserves todos across a reconnect replay (same assistantId meta repeats)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'todos', data: { todos: [{ content: 'Step 1', status: 'in_progress' }] }, seq: 1 },
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 2 }, // same turn, reconnect
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    expect(lastLive(liveStates)!.todos).toEqual([{ content: 'Step 1', status: 'in_progress' }])
+  })
+})

--- a/turbollm/web/src/lib/code-session-client.test.ts
+++ b/turbollm/web/src/lib/code-session-client.test.ts
@@ -435,3 +435,73 @@ describe('CodeSessionClient — todos (ADR-255)', () => {
     expect(lastLive(liveStates)!.todos).toEqual([{ content: 'Step 1', status: 'in_progress' }])
   })
 })
+
+describe('CodeSessionClient — prefill (llama.cpp /slots progress)', () => {
+  const lastLive = (states: (LiveState | null)[]) => states.filter((s): s is LiveState => s !== null).at(-1)
+
+  it('reduces a prefill frame into LiveState.prefill, latest snapshot winning', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'prefill', data: { processed: 512, total: 2048, pct: 25 }, seq: 1 },
+      { event: 'prefill', data: { processed: 1536, total: 2048, pct: 75 }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // Deduped/latest-wins: the second frame replaces the first.
+    expect(lastLive(liveStates)!.prefill).toEqual({ processed: 1536, total: 2048, pct: 75 })
+  })
+
+  it('clears prefill to null the instant the first content delta arrives', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'prefill', data: { processed: 2000, total: 2048, pct: 98 }, seq: 1 },
+      { event: 'delta', data: { delta: 'Hello' }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    expect(final.prefill).toBeNull()
+    expect(final.content).toBe('Hello')
+  })
+
+  it('clears prefill to null when the first token is a reasoning delta (thinking model)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'prefill', data: { processed: 1000, total: 1000, pct: 100 }, seq: 1 },
+      { event: 'reasoning', data: { delta: 'let me think' }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    const final = lastLive(liveStates)!
+    expect(final.prefill).toBeNull()
+    expect(final.reasoning).toBe('let me think')
+  })
+
+  it('clears prefill on turn end (done discards the whole live state → next turn has no stale bar)', async () => {
+    const { handlers } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'prefill', data: { processed: 500, total: 1000, pct: 50 }, seq: 1 },
+      { event: 'done', data: { contextUsed: 1, contextMax: 2, aborted: false }, seq: 2 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // The turn ended: live is null, so there's no prefill left to render.
+    expect(handlers.onLive).toHaveBeenLastCalledWith(null)
+  })
+
+  it('is undefined when no prefill frame ever arrives (non-llama.cpp / sub-poll prompt — the normal path)', async () => {
+    const { handlers, liveStates } = makeHandlers()
+    const stream = streamOf([
+      { event: 'meta', data: { userMessageId: 'u1', assistantMessageId: 'a1' }, seq: 0 },
+      { event: 'delta', data: { delta: 'straight to generation' }, seq: 1 },
+    ] as CodeStreamEvent[])
+    new CodeSessionClient('s1', handlers, stream).connect()
+    await flush()
+    // Falsy (never-set undefined, or nulled by the delta clear) — either way no bar renders.
+    expect(lastLive(liveStates)!.prefill).toBeFalsy()
+  })
+})

--- a/turbollm/web/src/lib/code-session-client.ts
+++ b/turbollm/web/src/lib/code-session-client.ts
@@ -1,0 +1,206 @@
+// The SSE-stream orchestration + event-to-state reduction for a live Code run, lifted OUT of
+// CodeSessionScreen.tsx (ADR-260). This is deliberately plain TS with ZERO React/DOM imports:
+// it owns the reconnectable GET /stream subscription, the ring-buffer seq cursor, and the
+// reduction of each SSE frame into a `LiveState`, and hands the host (today CodeSessionScreen,
+// tomorrow a hypothetical `turbollm code` CLI) only the framework-specific side effects — state
+// sync, query invalidation, toasts, scrolling — back through a handlers interface. The React
+// component becomes a thin adapter: it constructs one client per session, mirrors `onLive` into
+// its own useState, and drives connect()/abort() from its effects.
+import { ApiError } from './api'
+import { streamCodeSession } from './code-api'
+import type { CodeStreamEvent, QueuedTurn, TodoItem } from './code-types'
+import type { LiveToolCall } from './chat-types'
+import { appendTextDelta, appendTurnMarker, applyToolProgress, upsertToolCall, type LiveBlock } from './live-timeline'
+
+/** An in-progress auto-retry (Phase 2, ADR-250) — pi is waiting out a transient provider failure
+ *  before re-attempting the same turn. Present between a `retry` start and its matching end; null
+ *  otherwise. Drives the transcript's "Retrying…" status banner. */
+export interface RetryState {
+  attempt: number
+  maxAttempts: number
+  /** The error that triggered this retry (from the `start` frame), shown as the reason. */
+  message: string
+}
+
+export interface LiveState {
+  assistantId: string
+  content: string
+  reasoning: string
+  timeline: LiveBlock[]
+  /** True between a 'compaction' SSE event's start and end phases — pi's own AUTO-compaction
+   *  silently summarizing history mid-turn (distinct from the manual /compact command). Drives
+   *  CodeThinking's "Compacting conversation…" state instead of a blank/generic gap. */
+  compacting?: boolean
+  /** Set while an auto-retry is in flight (Phase 2) — cleared back to null on the retry's end
+   *  frame. Drives the "Retrying…" banner. */
+  retry?: RetryState | null
+  /** The model's current plan for THIS turn (ADR-255), from the latest `todos` frame — a full
+   *  replace each time, not a merge. Undefined until the model calls `update_todos` at least once
+   *  for the current turn; naturally resets to undefined on a genuinely NEW turn because the fresh
+   *  LiveState object below (`meta` with a new assistantId) omits it — the backend's own
+   *  reset-per-turn semantics need no separate client-side clear. */
+  todos?: TodoItem[]
+}
+
+/** Apply `fn` to the current live block, creating one (anchored to `fallbackId`) if none exists
+ *  yet — so a live delta/tool_call that arrives on a reconnect BEFORE a `meta` frame (e.g. the
+ *  real meta aged out of the daemon's ring buffer) still attaches to the right assistant turn
+ *  instead of being dropped. */
+export function reduceLive(l: LiveState | null, fallbackId: string, fn: (b: LiveState) => LiveState): LiveState {
+  const base = l ?? { assistantId: fallbackId, content: '', reasoning: '', timeline: [] }
+  return fn(base)
+}
+
+/** The framework-specific side effects the client can't perform itself. Every callback is a pure
+ *  "the host should now do X" signal — the client never touches React, react-query, toasts, or the
+ *  DOM directly. */
+export interface CodeSessionClientHandlers {
+  /** Sync the reduced live-turn state (or null when the turn ends) into the host's own state. */
+  onLive(state: LiveState | null): void
+  /** The server-side queue's current contents (a `queue` SSE frame). */
+  onQueue(queued: QueuedTurn[]): void
+  /** A `meta` frame — a turn just went live. The host reconciles its detail query. */
+  onTurnStart(): void
+  /** A `done` frame — the turn finished cleanly. The host reconciles + scrolls to latest. */
+  onTurnDone(): void
+  /** An `error` frame — the turn failed. The host reconciles and surfaces `message`. */
+  onTurnError(message: string): void
+  /** The stream ended (generator completed) = the daemon reports the session idle. The host
+   *  reconciles with the DB transcript. Distinct from onTurnDone: no stats invalidation/scroll. */
+  onIdle(): void
+  /** Reconnect attempts exhausted. `silent` is true for a 404 (the run is simply gone) so the
+   *  host can skip the "Lost connection" toast in that case. */
+  onLostConnection(silent: boolean): void
+}
+
+/** The async-generator factory the client consumes. Defaults to code-api.ts's `streamCodeSession`;
+ *  injectable so the module is unit-testable with a fake stream and no network. */
+export type CodeStreamFn = (sessionId: string, fromSeq: number, signal: AbortSignal) => AsyncGenerator<CodeStreamEvent>
+
+/** One reconnectable GET /stream subscription for a single Code session. Create one per session;
+ *  discard (after abort()) and make a fresh one on session change — that's what resets the seq
+ *  cursor and active-assistant id, so there's no explicit reset method. */
+export class CodeSessionClient {
+  private static readonly RECONNECT_MAX = 6
+
+  private live: LiveState | null = null
+  /** The last ring-buffer seq consumed, so a reconnect resumes from there. */
+  private lastSeq = 0
+  /** The in-flight turn's assistant message id (from the `meta` frame), so live deltas that arrive
+   *  after a reconnect (whose meta may have aged out of the buffer) still attach to the right turn. */
+  private activeAssistantId = ''
+  private active = false
+  private ac: AbortController | null = null
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly handlers: CodeSessionClientHandlers,
+    private readonly streamFn: CodeStreamFn = streamCodeSession,
+  ) {}
+
+  /** True while connected or mid-reconnect. Mirrors the old `streamActiveRef.current` — the host
+   *  reads it to decide whether to (re)connect on load and whether to seed queue state itself. */
+  get isActive(): boolean {
+    return this.active
+  }
+
+  private emitLive(state: LiveState | null): void {
+    this.live = state
+    this.handlers.onLive(state)
+  }
+
+  /** Start the single, reconnectable run subscription. It replays whatever the daemon already
+   *  buffered for the in-flight turn (from `lastSeq`) then live-tails; on a network drop it
+   *  reconnects from the last seq seen. It ends only when the daemon reports the session idle (the
+   *  async generator completing). Because the run is daemon-owned, this stream never drives it —
+   *  aborting only DETACHES. A no-op if already active (one active stream per client). */
+  connect(): void {
+    if (this.active) return
+    this.active = true
+    const ac = new AbortController()
+    this.ac = ac
+    let attempt = 0
+
+    const run = async (): Promise<void> => {
+      try {
+        for await (const evt of this.streamFn(this.sessionId, this.lastSeq, ac.signal)) {
+          if (typeof evt.seq === 'number') this.lastSeq = Math.max(this.lastSeq, evt.seq + 1)
+          if (evt.event === 'meta') {
+            attempt = 0 // a real frame means the connection is healthy again
+            this.activeAssistantId = evt.data.assistantMessageId
+            const id = evt.data.assistantMessageId
+            this.emitLive(this.live && this.live.assistantId === id
+              ? this.live
+              : { assistantId: id, content: '', reasoning: '', timeline: [] })
+            this.handlers.onTurnStart()
+          } else if (evt.event === 'queue') {
+            this.handlers.onQueue(evt.data.queued)
+          } else if (evt.event === 'compaction') {
+            const compacting = evt.data.phase === 'start'
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, compacting })))
+          } else if (evt.event === 'reasoning') {
+            const delta = evt.data.delta
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, reasoning: b.reasoning + delta })))
+          } else if (evt.event === 'delta') {
+            const delta = evt.data.delta
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, content: b.content + delta, timeline: appendTextDelta(b.timeline, delta) })))
+          } else if (evt.event === 'tool_call') {
+            const tc = evt.data
+            const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result, diff: tc.diff, patch: tc.patch, firstChangedLine: tc.firstChangedLine }
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, timeline: upsertToolCall(b.timeline, call) })))
+          } else if (evt.event === 'tool_progress') {
+            const { id, partial } = evt.data
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, timeline: applyToolProgress(b.timeline, id, partial) })))
+          } else if (evt.event === 'turn') {
+            // A round boundary — insert a divider before every round AFTER the first (the first
+            // round opens the turn and needs no leading separator). `end` frames carry no visual.
+            if (evt.data.phase === 'start' && evt.data.index > 0) {
+              const index = evt.data.index
+              this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, timeline: appendTurnMarker(b.timeline, index) })))
+            }
+          } else if (evt.event === 'retry') {
+            const retry: RetryState | null = evt.data.phase === 'start'
+              ? { attempt: evt.data.attempt, maxAttempts: evt.data.maxAttempts, message: evt.data.message }
+              : null
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, retry })))
+          } else if (evt.event === 'todos') {
+            // Full replace, not a merge — matches the backend's own "latest snapshot wins" shape
+            // (same as tool_progress's cumulative partial, just for the whole list at once).
+            const todos = evt.data.todos
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, todos })))
+          } else if (evt.event === 'done') {
+            this.emitLive(null)
+            this.handlers.onTurnDone()
+          } else if (evt.event === 'error') {
+            this.emitLive(null)
+            this.handlers.onTurnError(evt.data.message)
+          }
+        }
+        // Generator completed = the daemon says this session is idle. Stop and reconcile with DB.
+        this.active = false
+        this.emitLive(null)
+        this.handlers.onIdle()
+      } catch (e) {
+        if (ac.signal.aborted) { this.active = false; return }
+        // Network drop mid-run — the DAEMON kept executing. Reconnect from the last seq seen so
+        // we replay only what we missed and continue live.
+        attempt += 1
+        if (attempt <= CodeSessionClient.RECONNECT_MAX && this.ac === ac) {
+          setTimeout(() => { if (this.ac === ac && !ac.signal.aborted) void run() }, Math.min(500 * attempt, 3000))
+        } else {
+          this.active = false
+          this.emitLive(null)
+          this.handlers.onLostConnection(e instanceof ApiError && e.status === 404)
+        }
+      }
+    }
+    void run()
+  }
+
+  /** Detach this client from the run — aborts the in-flight stream WITHOUT stopping the
+   *  daemon-owned run. Call on unmount / before discarding the client. */
+  abort(): void {
+    this.ac?.abort()
+    this.active = false
+  }
+}

--- a/turbollm/web/src/lib/code-session-client.ts
+++ b/turbollm/web/src/lib/code-session-client.ts
@@ -40,6 +40,14 @@ export interface LiveState {
    *  LiveState object below (`meta` with a new assistantId) omits it — the backend's own
    *  reset-per-turn semantics need no separate client-side clear. */
   todos?: TodoItem[]
+  /** Prompt-processing (prefill) progress from a `prefill` SSE frame — llama.cpp only, present
+   *  ONLY before the first token of a turn. Cleared back to null the instant a real delta/reasoning
+   *  token arrives (the backend also stops firing prefill frames then) and on turn end (the whole
+   *  LiveState is discarded). Null/absent is the NORMAL path (non-llama.cpp engines, or a prompt
+   *  that prefills inside one poll interval and never gets a frame). Drives the transcript's
+   *  "Processing prompt NN%" bar, which takes the status-banner slot over retry/compacting/thinking
+   *  while active — prefill happens strictly before generation, so the two never co-render. */
+  prefill?: { processed: number; total: number; pct: number } | null
 }
 
 /** Apply `fn` to the current live block, creating one (anchored to `fallbackId`) if none exists
@@ -140,10 +148,16 @@ export class CodeSessionClient {
             this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, compacting })))
           } else if (evt.event === 'reasoning') {
             const delta = evt.data.delta
-            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, reasoning: b.reasoning + delta })))
+            // A real reasoning token = prefill is over; clear the bar (the backend also stops firing
+            // prefill frames at the first token, so this is belt-and-suspenders).
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, reasoning: b.reasoning + delta, prefill: null })))
+          } else if (evt.event === 'prefill') {
+            const prefill = evt.data
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, prefill })))
           } else if (evt.event === 'delta') {
             const delta = evt.data.delta
-            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, content: b.content + delta, timeline: appendTextDelta(b.timeline, delta) })))
+            // First real content token = prefill is over; clear the bar as generation takes over.
+            this.emitLive(reduceLive(this.live, this.activeAssistantId, (b) => ({ ...b, content: b.content + delta, timeline: appendTextDelta(b.timeline, delta), prefill: null })))
           } else if (evt.event === 'tool_call') {
             const tc = evt.data
             const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result, diff: tc.diff, patch: tc.patch, firstChangedLine: tc.firstChangedLine }

--- a/turbollm/web/src/lib/code-types.ts
+++ b/turbollm/web/src/lib/code-types.ts
@@ -28,6 +28,21 @@ export interface CodeSession {
    *  deactivated (not deleted; /resume reactivates it). Mutually exclusive with
    *  clearedUpToMessageId. Undefined = never reverted, or resumed back from one. */
   revertedFromMessageId?: string
+  /** True when a run is live in the daemon right now (not merely the persisted status, which
+   *  collapses 'running'/'queued' into 'review' for display) — drives the sidebar's live
+   *  indicator for a session running in the background, tab not open (ADR-256). Currently only
+   *  populated by GET /api/v1/code/sessions/:id (session detail); GET /api/v1/code/sessions (the
+   *  sidebar list) does not send it yet — undefined until that's added. */
+  running?: boolean
+}
+
+/** One step in the model's own plan for the CURRENT turn (ADR-255) — driven by pi's
+ *  `update_todos` custom tool, relayed live via the `todos` SSE event below. Ephemeral: the
+ *  backend clears its todos at the start of every new turn, so a checklist never carries over
+ *  from a prior turn (it won't re-assert until the model calls `update_todos` again). */
+export interface TodoItem {
+  content: string
+  status: 'pending' | 'in_progress' | 'completed'
 }
 
 export type CodeSessionFilter = 'active' | 'archived' | 'all'
@@ -47,12 +62,65 @@ export interface CreateCodeSessionParams {
   contextFiles?: string[]
 }
 
+/** How a submitted message is delivered when a run is already active (Phase 1, ADR-246):
+ *  'steer' redirects the CURRENTLY ACTIVE turn (pi's `session.steer`), 'followUp' queues a fresh
+ *  turn behind it. A 'steer' that arrives too late to inject falls back to the queue still tagged
+ *  'steer'. Backend defaults to 'followUp' (byte-for-byte the pre-ADR-246 behavior). */
+export type SteerKind = 'steer' | 'followUp'
+
 /** One entry in the server-side message queue (turns waiting behind the active one).
- *  `userMsgId` identifies the entry (not just its text) so a per-chip action — e.g. "Send now"
+ *  `userMsgId` identifies the entry (not just its text) so a per-entry action — e.g. "Send now"
  *  — can target one specific queued turn even if two queued tasks have identical text. */
 export interface QueuedTurn {
   userMsgId: string
   task: string
+  /** Which delivery the turn was submitted as — drives the inline queued card's steer-vs-follow-up
+   *  badge. Backend tags every queued entry (default 'followUp'). */
+  kind: SteerKind
+}
+
+/** POST /api/v1/code/sessions/:id/messages request body (start or queue a turn). */
+export interface CodeSendMessageBody {
+  content?: string
+  promptOverride?: string
+  contextFiles?: string[]
+  thinkingBudget?: number
+  /** Delivery mode when a run is already active — 'steer' redirects the live turn, 'followUp'
+   *  (default) queues behind it. Omitted = 'followUp'. */
+  kind?: SteerKind
+}
+
+/** POST .../messages response (202). `steered` is true ONLY when a 'steer' actually injected into
+ *  a live turn; a steer that fell back to the queue, or any 'followUp', reports `steered: false`. */
+export interface CodeSendMessageResponse {
+  ok: true
+  queued: boolean
+  steered: boolean
+  userMessageId: string
+}
+
+/** POST .../exec response — a user-run `!command`/`!!command` shell escape (ADR-258). `messageId`
+ *  is set only for the `!` variant (feedToModel), which persists the command+output as a user
+ *  message the model reads next turn; `!!` returns output for a transcript-only peek. */
+export interface CodeExecResponse {
+  ok: true
+  command: string
+  output: string
+  exitCode: number | null
+  timedOut: boolean
+  truncated: boolean
+  messageId?: string
+}
+
+/** One transcript-only `!!command` result (never persisted) — held in client state and rendered at
+ *  the transcript tail. `!command` results are NOT this shape; they come back as a persisted
+ *  message carrying a `shell` tool call. */
+export interface ShellRun {
+  id: string
+  command: string
+  output: string
+  exitCode: number | null
+  timedOut: boolean
 }
 
 // SSE event payloads for GET /api/v1/code/sessions/:id/stream (code-routes.ts). Reuses
@@ -67,6 +135,21 @@ export type CodeSseEvent =
   | { event: 'tool_call'; data: { id: string; name: string; args: Record<string, unknown>; status: 'pending' | 'done' | 'error' | 'awaiting_approval'; result?: string; diff?: string; patch?: string; firstChangedLine?: number } }
   | { event: 'queue';     data: { queued: QueuedTurn[] } }
   | { event: 'compaction'; data: { phase: 'start' | 'end'; reason: 'manual' | 'threshold' | 'overflow'; aborted?: boolean; tokensBefore?: number } }
+  // Phase 2 (ADR-249/250) — pi's own agentic-loop signals, relayed by code-session.ts:
+  //   'turn': an agentic ROUND boundary within one assistant turn (a model→tools→model cycle),
+  //     NOT a message delta. `toolResults` (end only) is how many tool results that round produced.
+  //   'retry': pi's auto-retry on a transient provider failure — `start` carries the triggering
+  //     error + backoff, `end` reports whether the retry eventually succeeded.
+  //   'tool_progress': a CUMULATIVE (not incremental) live-output snapshot from a tool that streams
+  //     progress (bash does; edit doesn't) — correlate to the live tool card by `id`, replace-not-append.
+  | { event: 'turn';      data: { phase: 'start'; index: number } | { phase: 'end'; index: number; toolResults: number } }
+  | { event: 'retry';     data: { phase: 'start'; attempt: number; maxAttempts: number; delayMs: number; message: string } | { phase: 'end'; attempt: number; success: boolean; message?: string } }
+  | { event: 'tool_progress'; data: { id: string; name: string; partial: string } }
+  // 'todos' (ADR-255): the model's current plan for THIS turn, via pi's `update_todos` tool.
+  // Full-list replace each time, not incremental — same "cumulative snapshot" shape as
+  // tool_progress. The backend resets its own todos at the start of every new turn, so this
+  // frame simply won't re-fire until the model calls update_todos again for the new one.
+  | { event: 'todos';     data: { todos: TodoItem[] } }
   | { event: 'done';      data: { contextUsed: number; contextMax: number; aborted: boolean } }
   | { event: 'error';     data: { code: string; message: string } }
 
@@ -98,3 +181,37 @@ export interface CodeStats {
   favoriteModel: string | null
   heatmap: CodeStatsDay[]
 }
+
+// ── Git actions (Phase 3, ADR-259) — GET/POST /api/v1/code/sessions/:id/git/* ──────────────────
+// Mirrors turbollm/src/code/git-actions.ts's own types exactly; see that file for the full
+// scope note (commit+push only, no gh/GitHub-API call, push never forces).
+
+export interface GitFileStatus {
+  path: string
+  /** Raw two-character porcelain status code (e.g. 'M ', '??', ' D', 'AM') — rendered as-is
+   *  rather than re-interpreted, so no meaning is lost or guessed at client-side. */
+  code: string
+}
+
+export interface GitStatusResult {
+  isRepo: boolean
+  /** '' for an unborn HEAD (brand-new repo, no commits yet) or a detached HEAD. */
+  branch: string
+  detached: boolean
+  files: GitFileStatus[]
+  hasRemote: boolean
+  hasUpstream: boolean
+  ahead: number
+  behind: number
+}
+
+export interface CommitGitResult {
+  hash: string
+  filesCommitted: number
+}
+
+export type PushGitReason = 'not_a_repo' | 'no_remote' | 'detached_head' | 'diverged' | 'push_failed'
+
+export type PushGitResult =
+  | { ok: true; remote: string; branch: string; compareUrl: string | null }
+  | { ok: false; reason: PushGitReason; message: string }

--- a/turbollm/web/src/lib/code-types.ts
+++ b/turbollm/web/src/lib/code-types.ts
@@ -145,6 +145,13 @@ export type CodeSseEvent =
   | { event: 'turn';      data: { phase: 'start'; index: number } | { phase: 'end'; index: number; toolResults: number } }
   | { event: 'retry';     data: { phase: 'start'; attempt: number; maxAttempts: number; delayMs: number; message: string } | { phase: 'end'; attempt: number; success: boolean; message?: string } }
   | { event: 'tool_progress'; data: { id: string; name: string; partial: string } }
+  // 'prefill' (llama.cpp only): prompt-processing progress BEFORE the first token, polled off
+  // the engine's /slots endpoint independently of the pi SDK. Emitted only on a `pct` change
+  // (deduped) and stops firing at completion or the first real token — so it's always done by the
+  // time any delta/reasoning arrives. Silently absent on non-llama.cpp engines or when /slots is
+  // unavailable: "no prefill frame ever arrives, generation just starts" is the NORMAL path, not
+  // an error. `processed`/`total` are prompt tokens; `pct` is the rounded percentage.
+  | { event: 'prefill';   data: { processed: number; total: number; pct: number } }
   // 'todos' (ADR-255): the model's current plan for THIS turn, via pi's `update_todos` tool.
   // Full-list replace each time, not incremental — same "cumulative snapshot" shape as
   // tool_progress. The backend resets its own todos at the start of every new turn, so this

--- a/turbollm/web/src/lib/live-timeline.ts
+++ b/turbollm/web/src/lib/live-timeline.ts
@@ -4,9 +4,13 @@ import type { LiveToolCall } from './chat-types'
 // emits and the tools it calls, in the exact order they arrive over SSE. This is
 // what makes the live bubble read like "wrote a bit → ran read_file → wrote more"
 // instead of a detached stack of tool cards above the text.
+// A `turn` block is a zero-content divider marking an agentic-round boundary within
+// one assistant turn (Phase 2, ADR-249) — inserted between rounds so a long multi-round
+// run reads as grouped rounds rather than one undifferentiated wall.
 export type LiveBlock =
   | { kind: 'text'; text: string }
   | { kind: 'tool'; call: LiveToolCall }
+  | { kind: 'turn'; index: number }
 
 /** Append a content delta, merging into the trailing text block when there is one. */
 export function appendTextDelta(timeline: LiveBlock[], delta: string): LiveBlock[] {
@@ -39,4 +43,24 @@ export function upsertToolCall(timeline: LiveBlock[], call: LiveToolCall): LiveB
     return updated
   }
   return [...timeline, { kind: 'tool', call }]
+}
+
+/** Fold a `tool_progress` snapshot into the matching tool-call block by id — the SAME upsert
+ *  mechanism, narrowed to the live-output field. `partial` is CUMULATIVE (a full snapshot each
+ *  time, not a delta), so it REPLACES rather than appends. A snapshot for a tool block that isn't
+ *  in the timeline yet (progress before its `pending` frame, e.g. after a reconnect that dropped
+ *  the opener) is ignored rather than synthesizing a nameless card. */
+export function applyToolProgress(timeline: LiveBlock[], id: string, partial: string): LiveBlock[] {
+  const idx = timeline.findIndex((b) => b.kind === 'tool' && b.call.id === id)
+  if (idx < 0) return timeline
+  const updated = timeline.slice()
+  const prev = updated[idx] as { kind: 'tool'; call: LiveToolCall }
+  updated[idx] = { kind: 'tool', call: { ...prev.call, partial } }
+  return updated
+}
+
+/** Append an agentic-round divider (Phase 2). Called on a `turn` start for rounds AFTER the first
+ *  (index > 0) — the first round needs no leading divider. */
+export function appendTurnMarker(timeline: LiveBlock[], index: number): LiveBlock[] {
+  return [...timeline, { kind: 'turn', index }]
 }

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -42,7 +42,9 @@ const TURBOLLM_KNOWLEDGE =
   '- **Persistent sessions**: archive/filter past runs, revert to any earlier message (with optional real file-edit reversal), attach files as context, transcript copy. A "Coding activity" dashboard (sessions, tasks shipped, files touched, diff shipped, streaks) is built from real history.\n' +
   '- **Real LSP integration** for TypeScript/JavaScript and Python — detects the language, installs the language server if needed, uses it for edits.\n' +
   '- **Same tools Chat gets from Customize**: any connected MCP server, plus the sandboxed run_code tool, alongside honest skill invocation and AGENTS.md/agents.md support.\n' +
-  '- Gated behind its own API key on non-host devices (independent of Chat\'s own gate).\n\n' +
+  '- Gated behind its own API key on non-host devices (independent of Chat\'s own gate).\n' +
+  '- **Live prefill progress**: while the model processes a large prompt, a progress bar shows processed/total tokens.\n' +
+  '- **Stuck-loop protection**: if the model repeats the exact same tool call too many times in a row even after being nudged to stop, the run auto-stops and reports itself as stopped rather than hanging forever.\n\n' +
 
   '**Models** — discover and manage local models.\n' +
   '- **All models** view: scans configured local directories for GGUF, MLX safetensors, vLLM safetensors; badges incompatible models for the active engine.\n' +

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -151,7 +151,7 @@ export function useStatus(): UseQueryResult<Status> {
     // Poll faster (1s) while an auto-tune sweep runs OR a completion is actively
     // streaming, so the inline progress and the live "Generating…" indicator stay live.
     refetchInterval: (q) =>
-      q.state.data?.bench.running ||
+      q.state.data?.bench?.running ||
       q.state.data?.engineBuild?.active ||
       (q.state.data?.engineStats?.activeRequests ?? 0) > 0
         ? 1000

--- a/turbollm/web/src/reduced-motion.test.ts
+++ b/turbollm/web/src/reduced-motion.test.ts
@@ -1,0 +1,66 @@
+// Final-gate item 5 (docs/specs/16-code-ui-redesign-test-plan.md §9): every real @keyframes-driven
+// animation in the app must respect prefers-reduced-motion. code-phase0-reduced-motion.spec.ts
+// (Playwright) drives the one case reachable interactively without heavy new fixture plumbing
+// (.tllm-pulse, via the sidebar's live running-indicator dot); this is the "simple assertion the
+// right media-query is present" check for the other real animation this audit found and fixed
+// (.tllm-sheet + its paired .app-shell layout-shift), following the exact same source-string-check
+// approach no-stray-hex.test.ts already uses for a different regression class.
+//
+// Deliberately narrow: this only guards the 5 real @keyframes-driven effects that exist today
+// (tllm-rise, tllm-pulse, tllm-rise-in, tllm-sheet-in-right, tllm-sheet-out-right — confirmed
+// exhaustive by grepping `@keyframes` across the whole src/ tree during this audit). Plain
+// transition-colors/transition-transform/animate-spin usages are NOT covered here — they're
+// consistently NOT gated anywhere in this app already (checked: animate-spin spinners across 17
+// files, transition-transform chevrons across 13 files, zero prefers-reduced-motion handling on
+// either anywhere), so adding it only inside index.css would be inventing a new, inconsistent
+// convention rather than following the established one.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const CSS = readFileSync(join(import.meta.dirname, 'index.css'), 'utf8')
+
+/** True iff `selector` appears inside SOME `@media (prefers-reduced-motion: reduce) { ... }`
+ *  block in the stylesheet — a plain substring/brace scan, not a real CSS parser, but sufficient
+ *  for this file's own hand-written, unminified structure (same trust level no-stray-hex.test.ts
+ *  already places in a regex-based check of this same file). */
+function hasReducedMotionOverrideFor(selector: string): boolean {
+  const blocks = CSS.split(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{/).slice(1)
+  return blocks.some((block) => {
+    // Take up to the block's own closing brace (the first top-level `}` after the opening one
+    // consumed by the split above) — a naive depth-1 scan, correct for this file's nesting depth.
+    let depth = 1
+    let end = 0
+    for (let i = 0; i < block.length; i++) {
+      if (block[i] === '{') depth++
+      else if (block[i] === '}') { depth--; if (depth === 0) { end = i; break } }
+    }
+    return block.slice(0, end).includes(selector)
+  })
+}
+
+describe('index.css: every real @keyframes-driven animation respects prefers-reduced-motion', () => {
+  it('every @keyframes definition has a reachable, real declaration (guards against this test silently checking nothing)', () => {
+    const keyframeNames = [...CSS.matchAll(/@keyframes\s+([\w-]+)/g)].map((m) => m[1])
+    expect(keyframeNames.sort()).toEqual(
+      ['tllm-pulse', 'tllm-rise', 'tllm-rise-in', 'tllm-sheet-in-right', 'tllm-sheet-out-right'].sort(),
+    )
+  })
+
+  it.each([
+    ['.tllm-rise', 'entrance fade+rise (Code launchpad sections)'],
+    ['.tllm-rise-in', 'entrance fade+rise (Code transcript rail entries, incl. queued cards)'],
+    ['.tllm-pulse', 'infinite pulse (running-state dots incl. the sidebar live indicator, ADR-256)'],
+  ])('%s (%s) has a prefers-reduced-motion override', (selector) => {
+    expect(hasReducedMotionOverrideFor(selector)).toBe(true)
+  })
+
+  it('.tllm-sheet\'s open/close slide (used by the model-config panel AND Code\'s ContextUsageRing detail sheet) has a prefers-reduced-motion override', () => {
+    expect(hasReducedMotionOverrideFor(`.tllm-sheet[data-state='open']`)).toBe(true)
+    expect(hasReducedMotionOverrideFor(`.tllm-sheet[data-state='closed']`)).toBe(true)
+  })
+
+  it('.app-shell\'s paired padding-right layout shift also stops under reduced motion, so the panel and the shell never fall out of sync', () => {
+    expect(hasReducedMotionOverrideFor('.app-shell')).toBe(true)
+  })
+})

--- a/turbollm/web/src/screens/chat/ConversationSidebar.test.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import { ConversationSidebar } from './ConversationSidebar'
+import type { CodeSession } from '../../lib/code-types'
+
+// Code mode is gated behind Settings → Experimental (ConversationSidebar.tsx:299) — force it on
+// so the sidebar actually renders CodeSessionsList instead of the chat folder/conversation list.
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>()
+  return {
+    ...actual,
+    getSettings: vi.fn(async () => ({ experimental: { code: true } }) as ReturnType<typeof actual.getSettings> extends Promise<infer T> ? T : never),
+  }
+})
+
+const RUNNING_SESSION: CodeSession = {
+  id: 's-running',
+  convId: 'c-running',
+  title: 'Refactor the build pipeline',
+  status: 'review',
+  branch: 'main',
+  when: '2m ago',
+  add: 12,
+  del: 3,
+  createdAt: new Date().toISOString(),
+  repoRoot: '/repo/turbollm',
+  running: true,
+}
+
+const IDLE_SESSION: CodeSession = {
+  id: 's-idle',
+  convId: 'c-idle',
+  title: 'Fix the flaky test',
+  status: 'review',
+  branch: 'main',
+  when: '1h ago',
+  add: 4,
+  del: 1,
+  createdAt: new Date().toISOString(),
+  repoRoot: '/repo/turbollm',
+  running: false,
+}
+
+// listCodeSessions is what useCodeSessions (ConversationSidebar's own CodeSessionsList) polls —
+// mocking here is the ADR-256 scenario itself: a session running in the DAEMON background, with
+// no locally-open SSE connection driving any client-side "generating" state for it.
+vi.mock('../../lib/code-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/code-api')>()
+  return {
+    ...actual,
+    listCodeSessions: vi.fn(async () => ({ sessions: [RUNNING_SESSION, IDLE_SESSION] })),
+  }
+})
+
+function renderSidebar() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/workspace/code']}>
+        <ConversationSidebar activeId={null} onSelect={() => {}} onNew={() => {}} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('ConversationSidebar — background-running Code sessions (ADR-256)', () => {
+  it('shows a live indicator for a session the daemon reports running, even with no tab open on it', async () => {
+    renderSidebar()
+    // Both sessions share the same underlying "Needs review" DB status (toSessionStatus
+    // collapses running/queued to 'review') — only the live `running` flag tells them apart.
+    // The running one gets a distinct "Running" label; the idle one keeps the plain status label.
+    expect(await screen.findByText(/Running/)).toBeInTheDocument()
+    expect(screen.getByText(/Needs review/)).toBeInTheDocument()
+  })
+
+  it('keeps the plain status label on a session that is not live, even though it shares the running one\'s DB status', async () => {
+    renderSidebar()
+    const idleTitle = await screen.findByText('Fix the flaky test')
+    const idleRow = idleTitle.closest('[role="button"]')
+    expect(idleRow).not.toBeNull()
+    expect(idleRow).toHaveTextContent('Needs review')
+    expect(idleRow).not.toHaveTextContent('Running')
+  })
+})

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -112,7 +112,18 @@ function CodeSessionItem({
       style={{ background: active ? 'color-mix(in srgb, var(--accent) 10%, transparent)' : 'transparent' }}
     >
       <div className="flex min-w-0 items-center gap-1.5">
-        <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: CODE_STATUS_DOT[session.status] }} aria-hidden />
+        {/* Live indicator (ADR-256) — overrides the static status dot whenever the daemon
+            reports this run as actually active right now, including sessions running in the
+            background (tab not open elsewhere). `session.running` comes from the polled sidebar
+            list query (useCodeSessions, 5s interval) — no per-open-tab tracking needed. Without
+            this, a background-running session's status collapses to the same amber "review" dot
+            as a long-finished, unreviewed one (toSessionStatus in code-routes.ts), indistinguishable
+            from actually generating. */}
+        <span
+          className={cn('h-1.5 w-1.5 shrink-0 rounded-full', session.running && 'tllm-pulse')}
+          style={{ background: session.running ? 'var(--ok)' : CODE_STATUS_DOT[session.status] }}
+          aria-hidden
+        />
         {rename.editing ? (
           <input
             autoFocus
@@ -134,7 +145,7 @@ function CodeSessionItem({
         )}
       </div>
       <span className="truncate text-[11px] text-faint">
-        {archived ? 'Archived · ' : ''}{CODE_STATUS_LABEL[session.status]} · {folderName(session.repoRoot)}{session.branch ? ` · ${session.branch}` : ''} · {session.when}
+        {archived ? 'Archived · ' : ''}{session.running ? 'Running' : CODE_STATUS_LABEL[session.status]} · {folderName(session.repoRoot)}{session.branch ? ` · ${session.branch}` : ''} · {session.when}
       </span>
       {/* Hover reveal: diff stats + actions menu + open affordance — same interaction
           language as ConvItem's hover-revealed folder-move/rename buttons. */}
@@ -153,6 +164,12 @@ function CodeSessionItem({
                 onClick={(e) => e.stopPropagation()}
                 className="rounded p-1 text-faint transition-colors hover:text-ink data-[state=open]:text-ink"
                 title="Session actions"
+                // Session-specific, not the generic "Session actions" the title tooltip uses —
+                // this button repeats once per row, so a shared name would be ambiguous to a
+                // screen reader across multiple sessions (final gate, spec 16 §9 item 4; also
+                // caught colliding with CodeSessionScreen.tsx's own header button of the same
+                // generic name when both are on screen at once).
+                aria-label={`Actions for ${session.title}`}
               >
                 <MoreHorizontal size={13} />
               </button>

--- a/turbollm/web/src/screens/chat/MessageBubble.tsx
+++ b/turbollm/web/src/screens/chat/MessageBubble.tsx
@@ -487,7 +487,9 @@ export function StreamingBubble({
           ? (b.text
               ? <div key={i} className="prose-tllm text-[15px] leading-[1.7] text-ink"><Markdown streaming>{b.text}</Markdown></div>
               : null)
-          : <InlineToolStep key={b.call.id} call={b.call} />,
+          : b.kind === 'tool'
+            ? <InlineToolStep key={b.call.id} call={b.call} />
+            : null, // 'turn' round-divider blocks are Code-only; chat never emits them
       )}
 
       {/* Prefill progress bar */}

--- a/turbollm/web/src/screens/code/CodeComposer.test.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.test.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { CodeComposer, type CodeComposerProps, type PendingImage } from './CodeComposer'
+import { CodeComposer, type CodeComposerProps, type PendingImage, type RepoPickerState } from './CodeComposer'
 import { AGENT_MODES } from './code-mock'
 import { steerOutcomeMessage } from '../../lib/code-api'
 import { toast } from '../../components/ui/sonner'
@@ -45,22 +45,42 @@ vi.mock('../../lib/api', async (importOriginal) => {
   }
 })
 
+/** Minimal RepoPickerState — enough to render the pre-session repo/worktree row without
+ *  crashing; individual fields overridden per-test where the exact displayed text matters. */
+function makeRepo(overrides: Partial<RepoPickerState> = {}): RepoPickerState {
+  return {
+    repoPath: '/repo', recentRepos: [], onChoose: () => {}, onBrowse: () => {},
+    branchLabel: 'main', branchTitle: 'main', useWorktree: false, onWorktreeChange: () => {},
+    branchName: '', onBranchNameChange: () => {}, branchNamePlaceholder: '',
+    baseBranch: 'main', onBaseBranchChange: () => {}, repoBranches: [], currentBranch: 'main',
+    ...overrides,
+  }
+}
+
 /** Minimal stateful wrapper — CodeComposer is a controlled component (value/onValueChange), so
  *  a real harness needs to actually apply the callback back into `value` for typing/selecting
  *  to behave like it does in the app, not just record calls. */
 function Harness({
-  repoRoot, onSubmit = () => {}, onImagesChange,
+  repoRoot, repo, repoBranch, onSubmit = () => {}, onImagesChange, onStop,
   mode = AGENT_MODES[0], ctxUsed = 0, ctxMax = 0, live, textareaDisabled, slashCommands,
+  thinkingBudget = -1, loadedName = null, lastPromptTokens, lastGenTokens,
 }: {
   repoRoot?: string
+  repo?: RepoPickerState
+  repoBranch?: string
   onSubmit?: () => void
   onImagesChange?: (images: PendingImage[]) => void
+  onStop?: () => void
   mode?: (typeof AGENT_MODES)[number]
   ctxUsed?: number
   ctxMax?: number
   live?: boolean
   textareaDisabled?: boolean
   slashCommands?: { id: string; description: string }[]
+  thinkingBudget?: number
+  loadedName?: string | null
+  lastPromptTokens?: number
+  lastGenTokens?: number
 }) {
   const [value, setValue] = useState('')
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -72,11 +92,13 @@ function Harness({
       onSubmit={onSubmit}
       placeholder="Describe a task…"
       repoRoot={repoRoot}
+      repo={repo}
+      repoBranch={repoBranch}
       mode={mode}
       onModeChange={() => {}}
       models={[]}
-      loadedKey={null}
-      loadedName={null}
+      loadedKey={loadedName ? 'k1' : null}
+      loadedName={loadedName}
       modelPending={false}
       ejecting={false}
       onLoadModel={() => {}}
@@ -84,13 +106,16 @@ function Harness({
       ctxUsed={ctxUsed}
       ctxMax={ctxMax}
       live={live}
+      onStop={onStop}
       textareaDisabled={textareaDisabled}
       sendDisabled={false}
       hintText="Enter to send"
-      thinkingBudget={-1}
+      thinkingBudget={thinkingBudget}
       onThinkingBudgetChange={() => {}}
       onImagesChange={onImagesChange}
       slashCommands={slashCommands}
+      lastPromptTokens={lastPromptTokens}
+      lastGenTokens={lastGenTokens}
     />
   )
 }
@@ -233,16 +258,64 @@ describe('CodeComposer image paste', () => {
   })
 })
 
-describe('CodeComposer persistent status/keybind footer', () => {
-  // Founder feedback (2026-07-24), testing the real UI: mode + context % duplicated in the
-  // footer what the toolbar's mode button and ContextUsageRing already show, right above it —
-  // pure clutter in practice, cut regardless of the original "mirrors pi's footer" rationale.
-  // The footer is keybind hints only now — the one thing genuinely not shown anywhere else.
-  it('does not duplicate the mode or context percentage the toolbar already shows', () => {
-    render(<Harness mode={AGENT_MODES[1]} ctxUsed={25} ctxMax={100} />)
-    // "Plan first" appears exactly once now — only the toolbar's mode-picker button.
+describe('CodeComposer real stats footer (ADR-262)', () => {
+  it('shows context %/max as real digits — genuinely new info, NOT a duplicate (ContextUsageRing never renders % as text)', () => {
+    render(<Harness ctxUsed={25} ctxMax={100} />)
+    expect(screen.getByText('25%/100')).toBeInTheDocument()
+  })
+
+  it('omits the context segment entirely when ctxMax is 0 (no NaN%, matches ContextUsageRing\'s own guard)', () => {
+    render(<Harness ctxUsed={0} ctxMax={0} />)
+    expect(screen.queryByText(/%\//)).not.toBeInTheDocument()
+  })
+
+  it('shows a compact thinking-effort readout — genuinely new info (the Brain icon never shows the value as text)', () => {
+    const { rerender } = render(<Harness thinkingBudget={-1} />)
+    expect(screen.getByText('Think: Unlimited')).toBeInTheDocument()
+    rerender(<Harness thinkingBudget={0} />)
+    expect(screen.getByText('Think: Off')).toBeInTheDocument()
+    rerender(<Harness thinkingBudget={4000} />)
+    expect(screen.getByText('Think: 4.0k')).toBeInTheDocument()
+  })
+
+  it('does NOT duplicate mode (toolbar button only) or model name (ModelLoadMenu trigger only)', () => {
+    render(<Harness mode={AGENT_MODES[1]} loadedName="Qwen3.6-35B" ctxUsed={25} ctxMax={100} />)
+    // "Plan first" appears exactly once — only the toolbar's mode-picker button, never repeated.
     expect(screen.getAllByText('Plan first')).toHaveLength(1)
-    expect(screen.queryByText(/% ctx/)).not.toBeInTheDocument()
+    // Model name is ALREADY always-visible text via ModelLoadMenu — the footer must never repeat it,
+    // even though ADR-262's own reference list mentions "model" (see CodeComposer.tsx's footer
+    // doc comment for why this one specifically stays toolbar-only).
+    expect(screen.getAllByText('Qwen3.6-35B')).toHaveLength(1)
+  })
+
+  it('shows branch/cwd ONLY mid-session (no `repo` prop) — pre-session, the repo-picker row already shows both', () => {
+    const { rerender } = render(<Harness repoRoot="/Users/me/projects/my-app" repoBranch="feature/x" />)
+    expect(screen.getByText('feature/x')).toBeInTheDocument()
+    expect(screen.getByText('my-app', { exact: false })).toBeInTheDocument()
+
+    // Pre-session: `repo` present → repo-picker row shows the folder name AND repo.branchLabel as
+    // its own chip already, so the footer must suppress its own copy to avoid a real duplicate.
+    rerender(<Harness repo={makeRepo({ repoPath: '/Users/me/projects/my-app', branchLabel: 'feature/x' })} repoBranch="feature/x" />)
+    // "feature/x" still legitimately appears once (the repo row's chip) — assert it did NOT
+    // become two after adding the footer's branch prop, i.e. the footer suppressed its own copy.
+    expect(screen.getAllByText('feature/x')).toHaveLength(1)
+  })
+
+  it('omits tokens ↑/↓ when not wired (undefined props) — never fabricates 0/0', () => {
+    render(<Harness />)
+    expect(screen.queryByText(/↑/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/↓/)).not.toBeInTheDocument()
+  })
+
+  it('shows real tokens ↑/↓ once a caller passes them', () => {
+    render(<Harness lastPromptTokens={4700} lastGenTokens={44} />)
+    expect(screen.getByText('↑4.7k ↓44')).toBeInTheDocument()
+  })
+
+  it('never shows a cost figure — local models have no per-token cost, so it is omitted, not a misleading $0.00', () => {
+    // ADR-249's own earlier finding, reaffirmed by ADR-262: cost stays out of scope regardless.
+    const { container } = render(<Harness ctxUsed={25} ctxMax={100} lastPromptTokens={100} lastGenTokens={10} live />)
+    expect(container.textContent).not.toContain('$')
   })
 
   it('shows the "/" and "@" hints only when those pickers are actually available', () => {
@@ -255,23 +328,18 @@ describe('CodeComposer persistent status/keybind footer', () => {
     expect(screen.getByText(/mention a file/)).toBeInTheDocument()
   })
 
-  it('drops the "/" and "@" hints while a run is live (both pickers gate on !live), but keeps the base hint text', () => {
+  it('drops the "/" and "@" hints while a run is live (both pickers gate on !live), shows "Esc to stop" instead', () => {
     render(<Harness repoRoot="/repo" slashCommands={[{ id: 'compact', description: 'x' }]} live />)
-    expect(screen.getByText('Enter to send')).toBeInTheDocument()
     expect(screen.queryByText(/for commands/)).not.toBeInTheDocument()
     expect(screen.queryByText(/mention a file/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Esc to stop/)).toBeInTheDocument()
   })
 
-  it('hides the keybind-hint segment entirely while the textarea is disabled (manual /compact) — "Enter to send" would be wrong then', () => {
-    render(<Harness textareaDisabled />)
+  it('the footer stays visible while textareaDisabled (permanent now, no more hide-while-busy) — only the "Enter to send" clause specifically is dropped, since it would be wrong then', () => {
+    render(<Harness textareaDisabled ctxUsed={25} ctxMax={100} />)
     expect(screen.queryByText('Enter to send')).not.toBeInTheDocument()
-  })
-
-  it('never shows a cost figure — local models have no per-token cost, so it is omitted, not a misleading $0.00', () => {
-    // Phase 2 resolved the open cost-field question by omitting it for Code (100%-local). Guard that
-    // no "$"-prefixed cost ever leaks into the composer/footer.
-    const { container } = render(<Harness ctxUsed={25} ctxMax={100} live />)
-    expect(container.textContent).not.toContain('$')
+    // Stats stay put — this was the whole point of making the footer permanent.
+    expect(screen.getByText('25%/100')).toBeInTheDocument()
   })
 
   it('keybind-hint honesty: the advertised "Enter to send" actually submits on Enter', async () => {
@@ -285,6 +353,27 @@ describe('CodeComposer persistent status/keybind footer', () => {
     expect(screen.getByText(/Enter to send/)).toBeInTheDocument()
     await user.type(textarea, '{Enter}')
     expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('keybind-hint honesty: the advertised "Esc to stop" actually stops on Escape while live', async () => {
+    const user = userEvent.setup()
+    const onStop = vi.fn()
+    render(<Harness live onStop={onStop} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+    expect(screen.getByText(/Esc to stop/)).toBeInTheDocument()
+    textarea.focus()
+    await user.keyboard('{Escape}')
+    expect(onStop).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape does NOT stop when not live (no false claim, nothing to stop)', async () => {
+    const user = userEvent.setup()
+    const onStop = vi.fn()
+    render(<Harness live={false} onStop={onStop} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+    textarea.focus()
+    await user.keyboard('{Escape}')
+    expect(onStop).not.toHaveBeenCalled()
   })
 })
 

--- a/turbollm/web/src/screens/code/CodeComposer.test.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.test.tsx
@@ -1,0 +1,384 @@
+import { useRef, useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { CodeComposer, type CodeComposerProps, type PendingImage } from './CodeComposer'
+import { AGENT_MODES } from './code-mock'
+import { steerOutcomeMessage } from '../../lib/code-api'
+import { toast } from '../../components/ui/sonner'
+
+// Deterministic + inspectable: real sonner needs a mounted <Toaster/> to do anything visible,
+// and the size-cap test below asserts a toast actually fired.
+vi.mock('../../components/ui/sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}))
+
+// The `@`-mention file index (ADR-259) walks the repo via the same local-only `browseFs`
+// FsBrowser/"Add context" already use (see CodeComposer.tsx's header comment on the walk) —
+// mock only that one export so every other real export (types, other helpers) still works if
+// anything else in the render tree happens to touch this module.
+vi.mock('../../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/api')>()
+  return {
+    ...actual,
+    browseFs: vi.fn(async (path?: string) => {
+      if (path === '/repo' || path === undefined) {
+        return {
+          path: '/repo',
+          parent: null,
+          entries: [
+            { name: 'CodeComposer.tsx', path: '/repo/CodeComposer.tsx', isDir: false },
+            { name: 'CodeSessionScreen.tsx', path: '/repo/CodeSessionScreen.tsx', isDir: false },
+            { name: 'lib', path: '/repo/lib', isDir: true },
+          ],
+        }
+      }
+      if (path === '/repo/lib') {
+        return {
+          path: '/repo/lib',
+          parent: '/repo',
+          entries: [{ name: 'utils.ts', path: '/repo/lib/utils.ts', isDir: false }],
+        }
+      }
+      return { path: path ?? '/repo', parent: null, entries: [] }
+    }),
+  }
+})
+
+/** Minimal stateful wrapper — CodeComposer is a controlled component (value/onValueChange), so
+ *  a real harness needs to actually apply the callback back into `value` for typing/selecting
+ *  to behave like it does in the app, not just record calls. */
+function Harness({
+  repoRoot, onSubmit = () => {}, onImagesChange,
+  mode = AGENT_MODES[0], ctxUsed = 0, ctxMax = 0, live, textareaDisabled, slashCommands,
+}: {
+  repoRoot?: string
+  onSubmit?: () => void
+  onImagesChange?: (images: PendingImage[]) => void
+  mode?: (typeof AGENT_MODES)[number]
+  ctxUsed?: number
+  ctxMax?: number
+  live?: boolean
+  textareaDisabled?: boolean
+  slashCommands?: { id: string; description: string }[]
+}) {
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  return (
+    <CodeComposer
+      inputRef={inputRef}
+      value={value}
+      onValueChange={setValue}
+      onSubmit={onSubmit}
+      placeholder="Describe a task…"
+      repoRoot={repoRoot}
+      mode={mode}
+      onModeChange={() => {}}
+      models={[]}
+      loadedKey={null}
+      loadedName={null}
+      modelPending={false}
+      ejecting={false}
+      onLoadModel={() => {}}
+      onEjectModel={() => {}}
+      ctxUsed={ctxUsed}
+      ctxMax={ctxMax}
+      live={live}
+      textareaDisabled={textareaDisabled}
+      sendDisabled={false}
+      hintText="Enter to send"
+      thinkingBudget={-1}
+      onThinkingBudgetChange={() => {}}
+      onImagesChange={onImagesChange}
+      slashCommands={slashCommands}
+    />
+  )
+}
+
+function makeImageFile(name: string, sizeBytes = 1024): File {
+  const file = new File([new Uint8Array(1)], name, { type: 'image/png' })
+  Object.defineProperty(file, 'size', { value: sizeBytes, configurable: true })
+  return file
+}
+
+/** jsdom doesn't emulate real OS clipboard paste, so `clipboardData` is built by hand — same
+ *  shape the component reads (`items[].kind`/`.type`/`.getAsFile()`). */
+function pasteFiles(textarea: HTMLElement, files: File[]) {
+  fireEvent.paste(textarea, {
+    clipboardData: { items: files.map((file) => ({ kind: 'file', type: file.type, getAsFile: () => file })) },
+  })
+}
+
+describe('CodeComposer @-mention popover', () => {
+  it('opens on "@", lists repo files (recursively, via the existing fs/browse endpoint), and narrows as you type', async () => {
+    const user = userEvent.setup()
+    render(<Harness repoRoot="/repo" />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    await user.type(textarea, '@')
+    await waitFor(() => expect(screen.getByText('CodeComposer.tsx')).toBeInTheDocument())
+    expect(screen.getByText('CodeSessionScreen.tsx')).toBeInTheDocument()
+    // The nested file (repo/lib/utils.ts) is included with its relative path — confirms the
+    // walk actually recurses into subdirectories, not just the root listing.
+    expect(screen.getByText('lib/utils.ts')).toBeInTheDocument()
+
+    await user.type(textarea, 'comp')
+    await waitFor(() => {
+      expect(screen.getByText('CodeComposer.tsx')).toBeInTheDocument()
+      expect(screen.queryByText('CodeSessionScreen.tsx')).not.toBeInTheDocument()
+      expect(screen.queryByText('lib/utils.ts')).not.toBeInTheDocument()
+    })
+  })
+
+  it('inserts the selected file as "@<relative path> " at the mention position, not a whole-value replace', async () => {
+    const user = userEvent.setup()
+    render(<Harness repoRoot="/repo" />)
+    const textarea = screen.getByPlaceholderText('Describe a task…') as HTMLTextAreaElement
+
+    await user.type(textarea, 'fix the bug in @comp')
+    await waitFor(() => expect(screen.getByText('CodeComposer.tsx')).toBeInTheDocument())
+    await user.click(screen.getByText('CodeComposer.tsx'))
+
+    await waitFor(() => expect(textarea.value).toBe('fix the bug in @CodeComposer.tsx '))
+  })
+
+  it('renders no popover at all when repoRoot is omitted (no data source wired)', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    await user.type(textarea, '@comp')
+    expect(screen.queryByText('CodeComposer.tsx')).not.toBeInTheDocument()
+  })
+})
+
+describe('CodeComposer image paste', () => {
+  it('attaches a pasted image as a thumbnail + name, reported via onImagesChange', async () => {
+    const onImagesChange = vi.fn()
+    render(<Harness onImagesChange={onImagesChange} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    pasteFiles(textarea, [makeImageFile('screenshot.png')])
+
+    await waitFor(() => expect(screen.getByText('screenshot.png')).toBeInTheDocument())
+    await waitFor(() => expect(onImagesChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ name: 'screenshot.png', dataUrl: expect.stringMatching(/^data:/) }),
+    ]))
+  })
+
+  it('attaches multiple images pasted in a single paste event', async () => {
+    render(<Harness />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    pasteFiles(textarea, [makeImageFile('one.png'), makeImageFile('two.png')])
+
+    await waitFor(() => {
+      expect(screen.getByText('one.png')).toBeInTheDocument()
+      expect(screen.getByText('two.png')).toBeInTheDocument()
+    })
+  })
+
+  it('removing an attached image drops it from the preview and notifies onImagesChange', async () => {
+    const user = userEvent.setup()
+    const onImagesChange = vi.fn()
+    render(<Harness onImagesChange={onImagesChange} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    pasteFiles(textarea, [makeImageFile('screenshot.png')])
+    await waitFor(() => expect(screen.getByText('screenshot.png')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Remove screenshot.png' }))
+
+    expect(screen.queryByText('screenshot.png')).not.toBeInTheDocument()
+    expect(onImagesChange).toHaveBeenLastCalledWith([])
+  })
+
+  it('rejects an oversized image with a toast and does not attach it', async () => {
+    render(<Harness />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    pasteFiles(textarea, [makeImageFile('huge.png', 9 * 1024 * 1024)])
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1))
+    expect(screen.queryByText('huge.png')).not.toBeInTheDocument()
+  })
+
+  it('clears attached images once submit fires (optimistic, same convention as the text value)', async () => {
+    const user = userEvent.setup()
+    const handleSubmit = vi.fn()
+    render(<Harness onSubmit={handleSubmit} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+
+    pasteFiles(textarea, [makeImageFile('screenshot.png')])
+    await waitFor(() => expect(screen.getByText('screenshot.png')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('screenshot.png')).not.toBeInTheDocument()
+  })
+
+  it('leaves a text-only paste untouched (no image items means no interception)', async () => {
+    render(<Harness />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+    const event = new Event('paste', { bubbles: true, cancelable: true })
+    Object.assign(event, { clipboardData: { items: [{ kind: 'string', type: 'text/plain', getAsFile: () => null }] } })
+
+    const notPrevented = textarea.dispatchEvent(event)
+
+    // dispatchEvent returns true when the event was NOT canceled — the component must not have
+    // called preventDefault() for a plain-text paste, or normal typing/paste would break.
+    expect(notPrevented).toBe(true)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+})
+
+describe('CodeComposer persistent status/keybind footer', () => {
+  // Founder feedback (2026-07-24), testing the real UI: mode + context % duplicated in the
+  // footer what the toolbar's mode button and ContextUsageRing already show, right above it —
+  // pure clutter in practice, cut regardless of the original "mirrors pi's footer" rationale.
+  // The footer is keybind hints only now — the one thing genuinely not shown anywhere else.
+  it('does not duplicate the mode or context percentage the toolbar already shows', () => {
+    render(<Harness mode={AGENT_MODES[1]} ctxUsed={25} ctxMax={100} />)
+    // "Plan first" appears exactly once now — only the toolbar's mode-picker button.
+    expect(screen.getAllByText('Plan first')).toHaveLength(1)
+    expect(screen.queryByText(/% ctx/)).not.toBeInTheDocument()
+  })
+
+  it('shows the "/" and "@" hints only when those pickers are actually available', () => {
+    const { rerender } = render(<Harness />) // no slashCommands, no repoRoot
+    expect(screen.queryByText(/for commands/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/mention a file/)).not.toBeInTheDocument()
+
+    rerender(<Harness repoRoot="/repo" slashCommands={[{ id: 'compact', description: 'x' }]} />)
+    expect(screen.getByText(/for commands/)).toBeInTheDocument()
+    expect(screen.getByText(/mention a file/)).toBeInTheDocument()
+  })
+
+  it('drops the "/" and "@" hints while a run is live (both pickers gate on !live), but keeps the base hint text', () => {
+    render(<Harness repoRoot="/repo" slashCommands={[{ id: 'compact', description: 'x' }]} live />)
+    expect(screen.getByText('Enter to send')).toBeInTheDocument()
+    expect(screen.queryByText(/for commands/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/mention a file/)).not.toBeInTheDocument()
+  })
+
+  it('hides the keybind-hint segment entirely while the textarea is disabled (manual /compact) — "Enter to send" would be wrong then', () => {
+    render(<Harness textareaDisabled />)
+    expect(screen.queryByText('Enter to send')).not.toBeInTheDocument()
+  })
+
+  it('never shows a cost figure — local models have no per-token cost, so it is omitted, not a misleading $0.00', () => {
+    // Phase 2 resolved the open cost-field question by omitting it for Code (100%-local). Guard that
+    // no "$"-prefixed cost ever leaks into the composer/footer.
+    const { container } = render(<Harness ctxUsed={25} ctxMax={100} live />)
+    expect(container.textContent).not.toContain('$')
+  })
+
+  it('keybind-hint honesty: the advertised "Enter to send" actually submits on Enter', async () => {
+    // A stale hint (advertising a shortcut that does nothing) is the exact regression the test plan
+    // calls out — tie the hint text to its real handler rather than just asserting it renders.
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<Harness onSubmit={onSubmit} />)
+    const textarea = screen.getByPlaceholderText('Describe a task…')
+    await user.type(textarea, 'ship it')
+    expect(screen.getByText(/Enter to send/)).toBeInTheDocument()
+    await user.type(textarea, '{Enter}')
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('CodeComposer steer/queue send affordance (ADR-246)', () => {
+  // Self-contained props (not the shared Harness above, which hardcodes sendDisabled=false) so
+  // the live + empty-field case can be exercised too.
+  function steerProps(overrides: Partial<CodeComposerProps> = {}): CodeComposerProps {
+    return {
+      inputRef: { current: null },
+      value: 'a follow-up',
+      onValueChange: () => {},
+      onSubmit: vi.fn(),
+      placeholder: 'Describe a task…',
+      mode: AGENT_MODES[0],
+      onModeChange: () => {},
+      models: [],
+      loadedKey: null,
+      loadedName: null,
+      modelPending: false,
+      ejecting: false,
+      onLoadModel: () => {},
+      onEjectModel: () => {},
+      ctxUsed: 0,
+      ctxMax: 0,
+      sendDisabled: false,
+      hintText: 'Enter to send',
+      thinkingBudget: -1,
+      onThinkingBudgetChange: () => {},
+      onStop: () => {},
+      ...overrides,
+    }
+  }
+
+  it('shows only a single Send button when NOT live (no steer/queue choice)', () => {
+    render(<CodeComposer {...steerProps({ live: false })} />)
+    expect(screen.getByLabelText('Send')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Steer the current turn')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Queue follow-up')).not.toBeInTheDocument()
+  })
+
+  it('submits with NO kind (caller default) from the idle Send button', () => {
+    const onSubmit = vi.fn()
+    render(<CodeComposer {...steerProps({ live: false, onSubmit })} />)
+    fireEvent.click(screen.getByLabelText('Send'))
+    expect(onSubmit).toHaveBeenCalledWith(undefined)
+  })
+
+  it('shows Steer + Queue + Stop (and no plain Send) while live with text', () => {
+    render(<CodeComposer {...steerProps({ live: true, sendDisabled: false })} />)
+    expect(screen.getByLabelText('Steer the current turn')).toBeInTheDocument()
+    expect(screen.getByLabelText('Queue follow-up')).toBeInTheDocument()
+    // Real accessible name, not just a title tooltip (final gate, spec 16 §9 item 4 — this was
+    // the one icon-only button in this describe block that had no aria-label until this gate).
+    expect(screen.getByLabelText('Stop this run')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Send')).not.toBeInTheDocument()
+  })
+
+  it('submits with kind "steer" from the Steer button', () => {
+    const onSubmit = vi.fn()
+    render(<CodeComposer {...steerProps({ live: true, sendDisabled: false, onSubmit })} />)
+    fireEvent.click(screen.getByLabelText('Steer the current turn'))
+    expect(onSubmit).toHaveBeenCalledWith('steer')
+  })
+
+  it('submits with kind "followUp" from the Queue button', () => {
+    const onSubmit = vi.fn()
+    render(<CodeComposer {...steerProps({ live: true, sendDisabled: false, onSubmit })} />)
+    fireEvent.click(screen.getByLabelText('Queue follow-up'))
+    expect(onSubmit).toHaveBeenCalledWith('followUp')
+  })
+
+  it('hides both send actions (only Stop remains) when live with an empty field', () => {
+    render(<CodeComposer {...steerProps({ live: true, sendDisabled: true })} />)
+    expect(screen.queryByLabelText('Steer the current turn')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Queue follow-up')).not.toBeInTheDocument()
+    // Real accessible name, not just a title tooltip (final gate, spec 16 §9 item 4 — this was
+    // the one icon-only button in this describe block that had no aria-label until this gate).
+    expect(screen.getByLabelText('Stop this run')).toBeInTheDocument()
+  })
+
+  it('Enter submits with no kind (queues by default) even while live', () => {
+    const onSubmit = vi.fn()
+    render(<CodeComposer {...steerProps({ live: true, sendDisabled: false, onSubmit })} />)
+    fireEvent.keyDown(screen.getByPlaceholderText('Describe a task…'), { key: 'Enter' })
+    expect(onSubmit).toHaveBeenCalledWith(undefined)
+  })
+})
+
+describe('steerOutcomeMessage', () => {
+  it('confirms a landed steer when steered is true', () => {
+    expect(steerOutcomeMessage(true)).toBe('Steered into the current turn.')
+  })
+
+  it('explains the queue fallback when steered is false', () => {
+    expect(steerOutcomeMessage(false)).toContain('Queued to run next')
+  })
+})

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type RefObject } from 'react'
-import { Check, ChevronDown, CircleDot, FileText, FolderGit2, FolderOpen, GitBranch, ListTodo, Loader2, Plus, SendHorizontal, Square, Wand2, X } from 'lucide-react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import { Check, ChevronDown, CornerDownRight, FileText, FolderGit2, FolderOpen, GitBranch, HelpCircle, ListTodo, Loader2, Plus, SendHorizontal, Square, Wand2, X } from 'lucide-react'
+import type { SteerKind } from '../../lib/code-types'
 import { Button } from '../../components/ui/button'
 import {
   DropdownMenu,
@@ -10,6 +11,8 @@ import {
 } from '../../components/ui/dropdown-menu'
 import { ModelLoadMenu } from '../../components/ModelLoadMenu'
 import { ThinkingBudgetSlider } from '../../components/ThinkingBudgetSlider'
+import { toast } from '../../components/ui/sonner'
+import { browseFs } from '../../lib/api'
 import type { ModelEntry } from '../../lib/types'
 import { cn } from '../../lib/utils'
 import { ContextUsageRing } from './ContextUsageRing'
@@ -40,10 +43,95 @@ import { AGENT_MODES, type AgentMode, type AgentModeId } from './code-mock'
 // models is possible "at any stage" (launchpad AND mid-session) via the exact
 // same control, with zero risk of the two screens' pickers drifting apart.
 
+// `ask` mode reuses the SAME icon as CodeTranscript's "awaiting approval" tool-card status
+// (founder feedback, 2026-07-24: they're the same concept — ask mode is what makes that status
+// possible — and used to have two unrelated icons with no visual link between them).
 const MODE_ICONS: Record<AgentModeId, typeof Wand2> = {
   auto: Wand2,
   plan: ListTodo,
-  ask: CircleDot,
+  ask: HelpCircle,
+}
+
+// ── `@`-mention file index (ADR-259) ─────────────────────────────────────────
+//
+// Backs the `@`-mention popover below. No dedicated repo-file-listing endpoint exists yet
+// (spec 15 §3 anticipates one, containment-checked against the session's repoRoot) — rather
+// than add new backend surface area from this composer-only task, this reuses the SAME
+// local-only `/api/v1/fs/browse` endpoint FsBrowser/"Add context" already call one directory
+// at a time (`browseFs`, lib/api.ts), just driven as a bounded breadth-first walk instead of
+// one click at a time. Noise directories are skipped outright, and the walk stops once either
+// cap is hit — cheap enough for a real repo, bounded enough that a huge one (or one full of
+// build output the server doesn't filter for us) can't hang the popover.
+const MENTION_SKIP_DIRS = new Set([
+  'node_modules', 'dist', 'build', 'out', 'coverage', 'target',
+  '.turbo', '.next', '.cache', '.venv', 'venv', '__pycache__', '.git',
+])
+const MENTION_MAX_FILES = 500
+const MENTION_MAX_DIRS = 150
+const MENTION_MAX_RESULTS = 8
+
+interface MentionFile { path: string; rel: string }
+
+async function walkRepoFiles(root: string): Promise<MentionFile[]> {
+  const files: MentionFile[] = []
+  let dirsVisited = 0
+  let level = [root]
+  while (level.length && dirsVisited < MENTION_MAX_DIRS && files.length < MENTION_MAX_FILES) {
+    const listings = await Promise.all(level.map((dir) => browseFs(dir).catch(() => null)))
+    const nextLevel: string[] = []
+    for (const listing of listings) {
+      if (!listing) continue
+      dirsVisited++
+      for (const entry of listing.entries) {
+        if (entry.isDir) {
+          if (!MENTION_SKIP_DIRS.has(entry.name)) nextLevel.push(entry.path)
+        } else if (files.length < MENTION_MAX_FILES) {
+          files.push({ path: entry.path, rel: relativeToRoot(root, entry.path) })
+        }
+      }
+      if (dirsVisited >= MENTION_MAX_DIRS || files.length >= MENTION_MAX_FILES) break
+    }
+    level = nextLevel
+  }
+  return files
+}
+
+function relativeToRoot(root: string, target: string): string {
+  const norm = (p: string) => p.replace(/\\/g, '/').replace(/\/+$/, '')
+  const r = norm(root)
+  const t = norm(target)
+  return t.startsWith(`${r}/`) ? t.slice(r.length + 1) : t
+}
+
+// ── Image/screenshot paste (ADR-259) ─────────────────────────────────────────
+//
+// Wire format matches Chat's own vision pipeline exactly (ChatScreen.tsx's `attachments` state +
+// chat-routes.ts's POST /messages `images?: string[]` field — a plain array of `data:image/...`
+// URLs, folded server-side into OpenAI-format `image_url` content parts and passed to the model;
+// image-only sends with no typed text are explicitly allowed there). Code has no equivalent
+// `images` field threaded through `startCodeRun`/`code-routes.ts`/`code-session.ts` yet — adding
+// that, plus updating `CodeSessionScreen.tsx`'s/`CodeHomeScreen.tsx`'s `send()` and `sendDisabled`
+// to use it, is a follow-up outside this composer-only task (see `onImagesChange` below).
+//
+// Chat's own attach path (the paperclip file-picker in ChatScreen.tsx) enforces NO size cap at
+// all. Paste/drop can silently attach a much larger screenshot than a click-driven file picker
+// discourages, so a real ceiling is picked here rather than inheriting "none".
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024
+
+export interface PendingImage {
+  id: string
+  name: string
+  dataUrl: string
+  size: number
+}
+
+function readImageAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const r = new FileReader()
+    r.onload = () => resolve(r.result as string)
+    r.onerror = () => reject(r.error)
+    r.readAsDataURL(file)
+  })
 }
 
 export interface RepoPickerState {
@@ -68,13 +156,24 @@ export interface CodeComposerProps {
   inputRef: RefObject<HTMLTextAreaElement | null>
   value: string
   onValueChange: (v: string) => void
-  onSubmit: () => void
+  /** Submit the composed message. `kind` (Phase 1, ADR-246) is only meaningful while a run is
+   *  live: 'steer' interjects into the CURRENT turn, 'followUp' queues a fresh turn after it.
+   *  Omitted (Enter key, the idle/launchpad Send button) = the caller's default ('followUp'),
+   *  byte-identical to the pre-ADR-246 behavior. */
+  onSubmit: (kind?: SteerKind) => void
   placeholder: string
   textareaDisabled?: boolean
 
   /** Present only pre-session (CodeHomeScreen) — the repo/worktree row. Absent
    *  mid-session, where the repo is already fixed. */
   repo?: RepoPickerState
+
+  /** Absolute path to the session's repo root — powers the `@`-mention file picker below.
+   *  Pre-session this is redundant with `repo.repoPath` (used automatically when `repoRoot`
+   *  itself is omitted); mid-session (CodeSessionScreen, which has no `repo` prop) a caller
+   *  needs to pass the session's own `repoRoot` explicitly for `@`-mention to have anything
+   *  to search. Omit entirely (both this and `repo`) to render no `@` picker at all. */
+  repoRoot?: string
 
   mode: AgentMode
   /** Editable at any stage — pre-session (sets the mode a new session will start
@@ -129,15 +228,24 @@ export interface CodeComposerProps {
    *  mirrors ChatScreen's own '/' skill picker exactly, so this reads as "the same feature" in
    *  both places rather than a lookalike. Omit/empty to render no picker at all. */
   slashCommands?: { id: string; description: string }[]
+
+  /** Fires whenever the pending pasted/dropped-image list changes (add, remove, or cleared on
+   *  submit) — the images themselves are tracked as this component's own internal state (there's
+   *  no lifted-state slot for them today, unlike `contextFiles`/`onRemoveContextFile` above,
+   *  since wiring one through requires touching `CodeSessionScreen.tsx`/`CodeHomeScreen.tsx`,
+   *  outside this task's scope). Optional: a caller that doesn't pass this simply won't observe
+   *  the images, but the paste/drop/preview/remove UX still works standalone. See the
+   *  `PendingImage`/`MAX_IMAGE_BYTES` comment above for the not-yet-wired backend side. */
+  onImagesChange?: (images: PendingImage[]) => void
 }
 
 export function CodeComposer({
   inputRef, value, onValueChange, onSubmit, placeholder, textareaDisabled,
-  repo, mode, onModeChange,
+  repo, repoRoot, mode, onModeChange,
   models, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
   ctxUsed, ctxMax, live, onStop, sendDisabled,
   onAddContext, contextFiles, onRemoveContextFile, hintText, statusText, slashCommands = [],
-  thinkingBudget, onThinkingBudgetChange,
+  thinkingBudget, onThinkingBudgetChange, onImagesChange,
 }: CodeComposerProps) {
   const ModeIcon = MODE_ICONS[mode.id]
 
@@ -169,6 +277,137 @@ export function CodeComposer({
     el.style.height = `${el.scrollHeight}px`
   }, [value, inputRef])
 
+  // '@' file-mention picker — matched against the text immediately before the CARET (not the
+  // whole input, unlike the '/' picker above), since a file mention can sit anywhere inside a
+  // longer message ("fix the bug in @composer.tsx"). Triggers on an `@` preceded by start-of-
+  // string or whitespace (so "email@domain" text never hijacks it) with no whitespace typed
+  // since. `caret` is kept fresh via the textarea's own onChange/onSelect below.
+  const effectiveRepoRoot = repo?.repoPath ?? repoRoot
+  const [caret, setCaret] = useState(0)
+  const beforeCaret = value.slice(0, caret)
+  const mentionMatch = /(?:^|\s)@([^\s@]*)$/.exec(beforeCaret)
+  const mentionQuery = mentionMatch?.[1]?.toLowerCase() ?? ''
+  const mentionStart = mentionMatch ? caret - mentionMatch[1].length - 1 : -1
+
+  // Escape dismisses the popover without touching the typed text (unlike the '/' picker's
+  // Escape, which can safely clear the whole input since a slash command IS the whole input).
+  // Reset the dismissal the moment a NEW mention starts (a fresh `@`), not on every keystroke
+  // of the same one, so re-typing after a dismissed one still offers to reopen it.
+  const [mentionDismissed, setMentionDismissed] = useState(false)
+  const prevMentionStartRef = useRef(-1)
+  useEffect(() => {
+    if (mentionStart !== prevMentionStartRef.current) {
+      setMentionDismissed(false)
+      prevMentionStartRef.current = mentionStart
+    }
+  }, [mentionStart])
+
+  // Lazy, cached-per-root file index — walked once the first time a mention is typed against a
+  // given repo root, not on mount (most sessions/messages never use '@' at all).
+  const [fileIndex, setFileIndex] = useState<MentionFile[] | null>(null)
+  const [indexing, setIndexing] = useState(false)
+  const indexedRootRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!effectiveRepoRoot || mentionStart === -1) return
+    if (indexedRootRef.current === effectiveRepoRoot) return
+    indexedRootRef.current = effectiveRepoRoot
+    setIndexing(true)
+    setFileIndex(null)
+    void walkRepoFiles(effectiveRepoRoot)
+      .then(setFileIndex)
+      .finally(() => setIndexing(false))
+  }, [effectiveRepoRoot, mentionStart])
+
+  const mentionResults = fileIndex
+    ? fileIndex.filter((f) => !mentionQuery || f.rel.toLowerCase().includes(mentionQuery)).slice(0, MENTION_MAX_RESULTS)
+    : []
+  const mentionPickerOpen =
+    mentionStart !== -1 && !mentionDismissed && !live && !!effectiveRepoRoot && (indexing || mentionResults.length > 0)
+  const [mentionIndex, setMentionIndex] = useState(0)
+  useEffect(() => { setMentionIndex(0) }, [mentionQuery, mentionPickerOpen])
+
+  // Splice `@<relative path> ` in at the mention's `@`, replacing the query typed so far —
+  // NOT a whole-value replace like the slash picker's, since the mention can sit mid-message.
+  // Caret restore happens in the effect below once React re-renders the textarea with the new
+  // value (setSelectionRange on the same render would race the DOM update).
+  const pendingCaretRef = useRef<number | null>(null)
+  const selectMention = (f: MentionFile) => {
+    if (mentionStart === -1) return
+    const before = value.slice(0, mentionStart)
+    const after = value.slice(caret)
+    const inserted = `@${f.rel} `
+    onValueChange(before + inserted + after)
+    pendingCaretRef.current = before.length + inserted.length
+    setMentionDismissed(true)
+  }
+  useEffect(() => {
+    if (pendingCaretRef.current == null) return
+    const pos = pendingCaretRef.current
+    pendingCaretRef.current = null
+    const el = inputRef.current
+    if (!el) return
+    el.focus()
+    el.setSelectionRange(pos, pos)
+    setCaret(pos)
+  }, [value, inputRef])
+
+  // Pasted/dropped image attachments — see the PendingImage/onImagesChange doc comments above
+  // for the wire format this mirrors and what's still unwired on the send path.
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
+  useEffect(() => { onImagesChange?.(pendingImages) }, [pendingImages]) // eslint-disable-line react-hooks/exhaustive-deps
+  const [dragOver, setDragOver] = useState(false)
+
+  const attachImageFile = async (file: File) => {
+    if (file.size > MAX_IMAGE_BYTES) {
+      toast.error(`${file.name || 'Image'} is too large (${(file.size / (1024 * 1024)).toFixed(1)} MB — max ${MAX_IMAGE_BYTES / (1024 * 1024)} MB).`)
+      return
+    }
+    const dataUrl = await readImageAsDataUrl(file)
+    setPendingImages((prev) => [...prev, {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      name: file.name || 'pasted-image.png',
+      dataUrl,
+      size: file.size,
+    }])
+  }
+  const removeImage = (id: string) => setPendingImages((prev) => prev.filter((img) => img.id !== id))
+
+  // Only intercepts the paste when it actually carries an image — a normal text/code paste
+  // (the overwhelmingly common case) falls through untouched.
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData?.items ?? [])
+    const imageFiles = items
+      .filter((it) => it.kind === 'file' && it.type.startsWith('image/'))
+      .map((it) => it.getAsFile())
+      .filter((f): f is File => !!f)
+    if (imageFiles.length === 0) return
+    e.preventDefault()
+    for (const file of imageFiles) void attachImageFile(file)
+  }
+
+  // Drag-and-drop onto the composer card — same attach path as paste, kept cheap since it's
+  // bonus scope: only wired on the card that already exists, no new drop zone/overlay chrome.
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer?.types ?? []).includes('Files')) return
+    e.preventDefault()
+    setDragOver(true)
+  }
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    const files = Array.from(e.dataTransfer?.files ?? []).filter((f) => f.type.startsWith('image/'))
+    for (const file of files) void attachImageFile(file)
+  }
+
+  // Optimistic clear, same as `value`/`contextFiles`' own clear-on-send convention in the
+  // callers — but self-contained here since `pendingImages` has no lifted-state slot to be
+  // cleared FROM (see PendingImage's doc comment: onSubmit still takes no arguments, so these
+  // aren't actually in the request payload yet either way).
+  const handleSubmit = (kind?: SteerKind) => {
+    setPendingImages([])
+    onSubmit(kind)
+  }
+
   return (
     <div>
       <div className="relative">
@@ -191,7 +430,45 @@ export function CodeComposer({
             ))}
           </div>
         )}
-      <div className="rounded-[var(--radius-lg)] border border-border bg-panel shadow-[var(--shadow-2)] transition-colors focus-within:border-[color:var(--accent)]">
+        {/* '@' file-mention picker — same popover shape as the '/' picker above */}
+        {mentionPickerOpen && (
+          <div className="absolute bottom-full left-0 mb-2 w-full max-w-sm overflow-hidden rounded-lg border border-border bg-panel shadow-[var(--shadow-2)]">
+            {indexing && mentionResults.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-muted">Indexing repo files…</div>
+            ) : mentionResults.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-muted">No matching files.</div>
+            ) : (
+              mentionResults.map((f, i) => (
+                <button
+                  key={f.path}
+                  type="button"
+                  onClick={() => selectMention(f)}
+                  className={cn(
+                    'flex w-full items-center gap-2 px-3 py-2 text-left text-[13px]',
+                    i === mentionIndex ? 'bg-panel-2' : 'hover:bg-panel-2',
+                  )}
+                >
+                  <FileText size={12} className="shrink-0 text-faint" />
+                  <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink" title={f.rel}>{f.rel}</span>
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      <div
+        className={cn(
+          // overflow-hidden: without it, the in-progress status banner's own square corners
+          // (it's the first child, no independent rounding) poke past this container's rounded
+          // top edge instead of following it — the "running highlight clips" bug, founder-caught
+          // testing live (2026-07-24). The `/`/`@` popovers are siblings of this div, not
+          // children, so clipping here doesn't touch them.
+          'overflow-hidden rounded-[var(--radius-lg)] border bg-panel shadow-[var(--shadow-2)] transition-colors focus-within:border-[color:var(--accent)]',
+          dragOver ? 'border-[color:var(--accent)]' : 'border-border',
+        )}
+        onDragOver={handleDragOver}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={handleDrop}
+      >
         {/* Repo/worktree row — pre-session only. Unticked (default) the task runs
             right in the repo folder on the checked-out branch; ticked, it gets its
             own worktree and a second row slides open for the new-branch name +
@@ -252,6 +529,11 @@ export function CodeComposer({
                     ? 'border-[color:var(--accent)] text-accent'
                     : 'border-border bg-panel-2 text-muted hover:border-border-strong hover:text-ink',
                 )}
+                // Phase 0 audit flagged this as --chip-active-bg (identical expression to
+                // ConversationSidebar.tsx's active-row highlight) but recommended defining it at
+                // the spec-11 app-wide level, not Code-scoped — that token wasn't part of task
+                // #2's landed set (only the 8 Code-surface ones), so left inline here rather than
+                // inventing it unilaterally outside this task's scope. See report for task #3.
                 style={repo.useWorktree ? { background: 'color-mix(in srgb, var(--accent) 10%, transparent)' } : undefined}
               >
                 <input
@@ -261,7 +543,7 @@ export function CodeComposer({
                   onChange={(e) => repo.onWorktreeChange(e.target.checked)}
                 />
                 <span
-                  className="grid h-[13px] w-[13px] place-items-center rounded-[3px] border transition-colors"
+                  className="grid h-3.5 w-3.5 place-items-center rounded-[3px] border transition-colors"
                   style={repo.useWorktree
                     ? { background: 'var(--accent)', borderColor: 'var(--accent)' }
                     : { borderColor: 'var(--border-strong)' }}
@@ -364,14 +646,44 @@ export function CodeComposer({
           </div>
         )}
 
+        {/* Pasted/dropped image attachments — thumbnail + name + remove, same shape as Chat's
+            own attachment preview (ChatScreen.tsx) so this reads as "the same feature" rather
+            than a lookalike. Not yet part of the actual send payload — see PendingImage's doc
+            comment above. */}
+        {pendingImages.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5 border-b border-border px-3 py-2">
+            {pendingImages.map((img) => (
+              <span
+                key={img.id}
+                title={img.name}
+                className="inline-flex items-center gap-1.5 rounded-md border border-border bg-panel-2 py-1 pl-1 pr-2 text-[12px] text-muted"
+              >
+                <img src={img.dataUrl} alt="" className="h-8 w-8 shrink-0 rounded object-cover" />
+                <span className="max-w-[120px] truncate">{img.name}</span>
+                <button
+                  type="button"
+                  onClick={() => removeImage(img.id)}
+                  aria-label={`Remove ${img.name}`}
+                  className="shrink-0 text-faint transition-colors hover:text-ink"
+                >
+                  <X size={11} />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Prominent in-progress banner (running / compacting) — directly above the textarea,
             accent-colored, its own row (not folded into the faint keyboard-hint text below). */}
         {statusText && (
           <div
             className="flex items-center gap-2 border-b px-3 py-2 text-[13px] font-medium"
             style={{
-              borderColor: 'color-mix(in srgb, var(--accent) 35%, var(--border))',
-              background: 'color-mix(in srgb, var(--accent) 12%, transparent)',
+              // Phase 0 token wiring (spec 14 appendix): identical math to --instruction-border
+              // (CodeTranscript's instruction-entry card), consolidated onto that one token
+              // rather than a separate --status-banner-border, per the appendix's own note.
+              borderColor: 'var(--instruction-border)',
+              background: 'var(--status-banner-bg)',
               color: 'var(--accent)',
             }}
           >
@@ -386,7 +698,9 @@ export function CodeComposer({
           rows={repo ? 2 : 1}
           value={value}
           disabled={textareaDisabled}
-          onChange={(e) => onValueChange(e.target.value)}
+          onChange={(e) => { onValueChange(e.target.value); setCaret(e.target.selectionStart ?? e.target.value.length) }}
+          onSelect={(e) => setCaret(e.currentTarget.selectionStart ?? 0)}
+          onPaste={handlePaste}
           onKeyDown={(e) => {
             if (slashPickerOpen) {
               if (e.key === 'ArrowDown') { e.preventDefault(); setSlashPickerIndex((i) => Math.min(i + 1, filteredCommands.length - 1)); return }
@@ -394,8 +708,14 @@ export function CodeComposer({
               if (e.key === 'Tab') { e.preventDefault(); selectSlashCommand(filteredCommands[Math.min(slashPickerIndex, filteredCommands.length - 1)]); return }
               if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); selectSlashCommand(filteredCommands[Math.min(slashPickerIndex, filteredCommands.length - 1)]); return }
               if (e.key === 'Escape') { e.preventDefault(); onValueChange(''); return }
+            } else if (mentionPickerOpen && mentionResults.length > 0) {
+              if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex((i) => Math.min(i + 1, mentionResults.length - 1)); return }
+              if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIndex((i) => Math.max(i - 1, 0)); return }
+              if (e.key === 'Tab') { e.preventDefault(); selectMention(mentionResults[Math.min(mentionIndex, mentionResults.length - 1)]); return }
+              if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); selectMention(mentionResults[Math.min(mentionIndex, mentionResults.length - 1)]); return }
+              if (e.key === 'Escape') { e.preventDefault(); setMentionDismissed(true); return }
             }
-            if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSubmit() }
+            if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmit() }
           }}
           placeholder={placeholder}
           className={cn(
@@ -473,44 +793,80 @@ export function CodeComposer({
             align="end"
           />
           {live ? (
-            // Mid-run: Stop controls the live run; a Send button also appears when
-            // there's text to submit, so a follow-up can be QUEUED (fires after the
-            // current run settles — see CodeSessionScreen's queue). Hidden when the
-            // field is empty so the launchpad/idle look is unaffected.
+            // Mid-run: Stop controls the live run; when there's text to submit, TWO send actions
+            // appear (ADR-246) — Steer interjects into the CURRENT turn (redirects what it's doing
+            // right now), Queue sends a fresh turn that runs AFTER it. Both are one click and both
+            // visible (steer isn't hidden in a menu — it's a key new capability worth surfacing).
+            // Enter still queues (the safe default, via handleSubmit() with no kind). Hidden when
+            // the field is empty so the idle look is unaffected.
             <>
               {!sendDisabled && (
-                <Button
-                  size="icon"
-                  className="h-8 w-8 shrink-0"
-                  onClick={onSubmit}
-                  aria-label="Queue follow-up"
-                  title="Queue this follow-up — runs after the current run finishes"
-                >
-                  <SendHorizontal size={15} />
-                </Button>
+                <>
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    className="h-8 w-8 shrink-0"
+                    onClick={() => handleSubmit('steer')}
+                    aria-label="Steer the current turn"
+                    title="Steer — interject into the current turn, redirecting what it's doing right now"
+                  >
+                    <CornerDownRight size={15} />
+                  </Button>
+                  <Button
+                    size="icon"
+                    className="h-8 w-8 shrink-0"
+                    onClick={() => handleSubmit('followUp')}
+                    aria-label="Queue follow-up"
+                    title="Queue — runs as a new turn after the current one finishes"
+                  >
+                    <SendHorizontal size={15} />
+                  </Button>
+                </>
               )}
-              <Button size="icon" variant="outline" className="h-8 w-8 shrink-0" onClick={onStop} title="Stop this run">
+              <Button size="icon" variant="outline" className="h-8 w-8 shrink-0" onClick={onStop} aria-label="Stop this run" title="Stop this run">
                 <Square size={15} />
               </Button>
             </>
           ) : (
-            <Button size="icon" className="h-8 w-8 shrink-0" onClick={onSubmit} disabled={sendDisabled} aria-label="Send">
+            <Button size="icon" className="h-8 w-8 shrink-0" onClick={() => handleSubmit()} disabled={sendDisabled} aria-label="Send">
               <SendHorizontal size={15} />
             </Button>
           )}
         </div>
       </div>
       </div>
-      {/* Persistent, always-visible busy indicator (founder-reported gap, 2026-07-13; moved to
-          its own prominent banner ABOVE the textarea, 2026-07-17 — a second founder report that
-          folding it into this tiny 11px faint-gray hint made it too easy to miss for a real
-          in-progress state like manual /compact, which disables the whole composer). This line is
-          now ONLY the idle keyboard-shortcut copy — hidden entirely while `statusText` is
-          showing, since "Enter to send" is irrelevant (and wrong) while the composer is
-          disabled. */}
-      {!statusText && (
-        <p className="mt-2 text-center text-[11px] text-faint">{hintText}</p>
-      )}
+      {/* Persistent status/keybind footer (task #8, ADR-249) — ALWAYS rendered now, replacing
+          the old `{!statusText && <p>{hintText}</p>}` this block used to be. That version hid
+          for the FULL duration of every live run (statusText is set whenever `live` is true, not
+          just during manual /compact), which is exactly the "hide-while-busy" behavior spec 15
+          §4 calls out to fix — a persistent terminal-status-line footer (spec 14 §2.3's
+          reference: pi's own "1.7%/272k (auto)") should stay put. Mode + context stay accurate
+          regardless of state; only the keybind-hint segment still hides, and only while
+          `textareaDisabled` (manual /compact) — that's the one state "Enter to send" is
+          genuinely WRONG (the textarea can't be typed into at all), the same case the founder's
+          2026-07-17 report originally flagged.
+          Mode and context % are already visible in the toolbar above (the mode button, the
+          ContextUsageRing) — repeating them here read as pure clutter in real use (founder
+          feedback, 2026-07-24), so this footer is keybind hints only, the one thing that ISN'T
+          shown anywhere else. `/`/`@` hints only appear when those pickers can actually open
+          right now (real slashCommands present, a repo root to search, and not `live` — both
+          pickers gate on `!live` themselves) — no hint for a key that doesn't do anything in this
+          composer instance.
+          `flex-wrap` instead of the toolbar's own `overflow-x-auto` (flagged in the original
+          audit as a narrow-phone workaround, not a pattern worth repeating): on a narrow
+          viewport this wraps to a second line rather than clipping or requiring horizontal
+          scroll. */}
+      <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-0.5 px-1 text-[11px] text-faint">
+        {!textareaDisabled && (
+          <span className="min-w-0 truncate">
+            {[
+              hintText,
+              !live && slashCommands.length > 0 ? '/ for commands' : null,
+              !live && effectiveRepoRoot ? '@ to mention a file' : null,
+            ].filter(Boolean).join(' · ')}
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -14,7 +14,7 @@ import { ThinkingBudgetSlider } from '../../components/ThinkingBudgetSlider'
 import { toast } from '../../components/ui/sonner'
 import { browseFs } from '../../lib/api'
 import type { ModelEntry } from '../../lib/types'
-import { cn } from '../../lib/utils'
+import { cn, folderName } from '../../lib/utils'
 import { ContextUsageRing } from './ContextUsageRing'
 import { AGENT_MODES, type AgentMode, type AgentModeId } from './code-mock'
 
@@ -101,6 +101,24 @@ function relativeToRoot(root: string, target: string): string {
   const r = norm(root)
   const t = norm(target)
   return t.startsWith(`${r}/`) ? t.slice(r.length + 1) : t
+}
+
+// ── Stats footer (ADR-262) ────────────────────────────────────────────────────
+//
+// Local, tiny formatters — deliberately NOT imported from ContextUsageRing.tsx's fmtTokens or
+// ThinkingBudgetSlider.tsx's formatBudget, since neither is exported and this task is scoped to
+// CodeComposer.tsx only (no edits to either sibling component). Same simple k/M convention as
+// ContextUsageRing's own fmtTokens for consistency across the app.
+function fmtCompactTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function thinkingCompactLabel(budget: number): string {
+  if (budget < 0) return 'Think: Unlimited'
+  if (budget === 0) return 'Think: Off'
+  return `Think: ${fmtCompactTokens(budget)}`
 }
 
 // ── Image/screenshot paste (ADR-259) ─────────────────────────────────────────
@@ -222,6 +240,23 @@ export interface CodeComposerProps {
   thinkingBudget: number
   onThinkingBudgetChange: (v: number) => void
 
+  /** The session's checked-out branch — mid-session only (CodeSessionScreen, which has no
+   *  `repo` prop). Powers the stats footer's branch readout (ADR-262); omit entirely to render
+   *  no branch segment. Not needed pre-session — the launchpad's own repo-picker row already
+   *  shows the branch as a chip (`repo.branchLabel`), so the footer skips it there to avoid
+   *  showing the same branch name twice in one composer. */
+  repoBranch?: string
+
+  /** The most recently COMPLETED turn's real token counts (`MessageStats.promptTokens`/
+   *  `genTokens`, chat-types.ts — real, backend-tracked data, not an estimate). Powers the stats
+   *  footer's `↑`/`↓` readout (ADR-262). Both undefined (the default) renders no token segment
+   *  at all rather than a misleading 0/0 — this is genuinely not wired from any caller yet (no
+   *  per-turn stats are threaded into this component today), so it stays invisible until a
+   *  caller starts passing real numbers. See CodeComposer's footer doc comment for the exact
+   *  follow-up this needs (a `CodeSessionScreen.tsx` change, outside this task's scope). */
+  lastPromptTokens?: number
+  lastGenTokens?: number
+
   /** '/' commands this composer variant supports (e.g. compact only applies mid-session, not on
    *  the launchpad's "start a new session" composer — see CodeSessionScreen/CodeHomeScreen for
    *  which list each passes). Selecting one INSERTS the token (`/id `), it does not submit —
@@ -241,11 +276,11 @@ export interface CodeComposerProps {
 
 export function CodeComposer({
   inputRef, value, onValueChange, onSubmit, placeholder, textareaDisabled,
-  repo, repoRoot, mode, onModeChange,
+  repo, repoRoot, repoBranch, mode, onModeChange,
   models, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
   ctxUsed, ctxMax, live, onStop, sendDisabled,
   onAddContext, contextFiles, onRemoveContextFile, hintText, statusText, slashCommands = [],
-  thinkingBudget, onThinkingBudgetChange, onImagesChange,
+  thinkingBudget, onThinkingBudgetChange, onImagesChange, lastPromptTokens, lastGenTokens,
 }: CodeComposerProps) {
   const ModeIcon = MODE_ICONS[mode.id]
 
@@ -714,6 +749,13 @@ export function CodeComposer({
               if (e.key === 'Tab') { e.preventDefault(); selectMention(mentionResults[Math.min(mentionIndex, mentionResults.length - 1)]); return }
               if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); selectMention(mentionResults[Math.min(mentionIndex, mentionResults.length - 1)]); return }
               if (e.key === 'Escape') { e.preventDefault(); setMentionDismissed(true); return }
+            } else if (e.key === 'Escape' && live && onStop) {
+              // Real, functional shortcut (not just advertised) — matches pi's own "escape
+              // interrupt" convention (spec 14 §2.3). Gated behind the picker checks above so it
+              // never fires while a popover is open and Escape's job there is to dismiss it.
+              e.preventDefault()
+              onStop()
+              return
             }
             if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSubmit() }
           }}
@@ -835,37 +877,73 @@ export function CodeComposer({
         </div>
       </div>
       </div>
-      {/* Persistent status/keybind footer (task #8, ADR-249) — ALWAYS rendered now, replacing
-          the old `{!statusText && <p>{hintText}</p>}` this block used to be. That version hid
-          for the FULL duration of every live run (statusText is set whenever `live` is true, not
-          just during manual /compact), which is exactly the "hide-while-busy" behavior spec 15
-          §4 calls out to fix — a persistent terminal-status-line footer (spec 14 §2.3's
-          reference: pi's own "1.7%/272k (auto)") should stay put. Mode + context stay accurate
-          regardless of state; only the keybind-hint segment still hides, and only while
-          `textareaDisabled` (manual /compact) — that's the one state "Enter to send" is
-          genuinely WRONG (the textarea can't be typed into at all), the same case the founder's
-          2026-07-17 report originally flagged.
-          Mode and context % are already visible in the toolbar above (the mode button, the
-          ContextUsageRing) — repeating them here read as pure clutter in real use (founder
-          feedback, 2026-07-24), so this footer is keybind hints only, the one thing that ISN'T
-          shown anywhere else. `/`/`@` hints only appear when those pickers can actually open
-          right now (real slashCommands present, a repo root to search, and not `live` — both
-          pickers gate on `!live` themselves) — no hint for a key that doesn't do anything in this
-          composer instance.
-          `flex-wrap` instead of the toolbar's own `overflow-x-auto` (flagged in the original
-          audit as a narrow-phone workaround, not a pattern worth repeating): on a narrow
-          viewport this wraps to a second line rather than clipping or requiring horizontal
-          scroll. */}
+      {/* Persistent stats/keybind footer (ADR-262) — the REAL footer ADR-249 originally intended
+          and task #8 shipped as a keybind-only placeholder for. Audited against every other
+          display in this file first (founder-specified hard constraint — this composer already
+          shipped and had to walk back one duplication today: the old version of THIS footer
+          repeating the toolbar's mode label + ContextUsageRing's context%):
+            - Mode is NOT repeated here — the toolbar's mode dropdown button is still the one
+              place it's shown, unchanged.
+            - Model name is NOT repeated here either, even though ADR-262's own reference list
+              includes "model" — ModelLoadMenu's trigger already shows `loadedName` as permanent
+              visible text (not just an icon), so adding it here would be the exact literal-text
+              duplication class of bug, not a judgment call.
+            - Context %/max IS shown here, as the actual digits — ContextUsageRing communicates
+              roughly the same information via ring color + a hover tooltip, but never renders the
+              percentage as always-visible text; this is genuinely the one place you can read the
+              precise number without hovering or opening the Sheet, matching how pi/opencode's own
+              footers are the ONLY place their percentage appears.
+            - Thinking effort IS shown here, compactly — the toolbar's Brain icon color-codes
+              on/off but never shows the actual budget value except in its title tooltip or its own
+              open dropdown; this is new information, not a repeat.
+            - Branch/cwd render ONLY in the mid-session variant (no `repo` prop) — pre-session, the
+              launchpad's own repo-picker row already shows both (repoPath's folder name in the
+              trigger, `repo.branchLabel` as a chip), so repeating them here would duplicate that
+              row specifically.
+            - Tokens ↑/↓ (`lastPromptTokens`/`lastGenTokens`) are real backend-tracked data
+              (`MessageStats.promptTokens`/`genTokens`, chat-types.ts) — NOT fabricated, NOT an
+              estimate — but nothing feeds these props yet (no per-turn stats are threaded into
+              this component today); they simply render nothing until a caller (CodeSessionScreen.tsx,
+              outside this composer-only task's scope) starts passing real numbers. Left as a ready
+              receiving end rather than omitted outright, so wiring it later is a small follow-up
+              rather than new composer-side plumbing.
+          Keybinds are now genuinely PERMANENT (no more hiding while `textareaDisabled`) — each
+          clause instead governs its own accuracy: "Enter to send" only claims true when the
+          textarea can actually be typed into; "Esc to stop" only appears once a run is actually
+          live (and is now a REAL handler on the textarea above, not just an advertised label).
+          `flex-wrap` instead of the toolbar's own `overflow-x-auto` (flagged in the original audit
+          as a narrow-phone workaround, not a pattern worth repeating): on a narrow viewport this
+          wraps to a second line rather than clipping or requiring horizontal scroll.
+          `font-mono tabular-nums` on the stats segment specifically — genuinely data/stats
+          content, the same carve-out the context stat already established (ADR-252/262). */}
       <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-0.5 px-1 text-[11px] text-faint">
-        {!textareaDisabled && (
-          <span className="min-w-0 truncate">
-            {[
-              hintText,
-              !live && slashCommands.length > 0 ? '/ for commands' : null,
-              !live && effectiveRepoRoot ? '@ to mention a file' : null,
-            ].filter(Boolean).join(' · ')}
+        <span className="inline-flex shrink-0 items-center gap-2 font-mono tabular-nums">
+          <span title={thinkingCompactLabel(thinkingBudget)}>{thinkingCompactLabel(thinkingBudget)}</span>
+          {ctxMax > 0 && (
+            <span title={`Context: ${ctxUsed.toLocaleString()} / ${ctxMax.toLocaleString()} tokens`}>
+              {Math.round(Math.min(1, ctxUsed / ctxMax) * 100)}%/{fmtCompactTokens(ctxMax)}
+            </span>
+          )}
+          {lastPromptTokens !== undefined && lastGenTokens !== undefined && (
+            <span title={`Last turn: ${lastPromptTokens.toLocaleString()} prompt, ${lastGenTokens.toLocaleString()} generated`}>
+              &uarr;{fmtCompactTokens(lastPromptTokens)} &darr;{fmtCompactTokens(lastGenTokens)}
+            </span>
+          )}
+        </span>
+        {!repo && (repoBranch || effectiveRepoRoot) && (
+          <span className="inline-flex min-w-0 shrink-0 items-center gap-1 truncate">
+            {repoBranch && <span className="truncate">{repoBranch}</span>}
+            {effectiveRepoRoot && <span className="truncate text-faint">{repoBranch ? ' · ' : ''}{folderName(effectiveRepoRoot)}</span>}
           </span>
         )}
+        <span className="ml-auto min-w-0 truncate">
+          {[
+            !textareaDisabled ? hintText : null,
+            !live && slashCommands.length > 0 ? '/ for commands' : null,
+            !live && effectiveRepoRoot ? '@ to mention a file' : null,
+            live ? 'Esc to stop' : null,
+          ].filter(Boolean).join(' · ')}
+        </span>
       </div>
     </div>
   )

--- a/turbollm/web/src/screens/code/CodeGitDialog.test.tsx
+++ b/turbollm/web/src/screens/code/CodeGitDialog.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CodeGitDialog } from './CodeGitDialog'
+import { ApiError } from '../../lib/api'
+import type { GitStatusResult } from '../../lib/code-types'
+
+// jsdom's environment doesn't wire up a working localStorage (authHeaders() reads it on every
+// call, same gap as CodeComposer.test.tsx and code-api.test.ts).
+beforeEach(() => {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => store.clear(),
+  })
+})
+
+const DIRTY_STATUS: GitStatusResult = {
+  isRepo: true,
+  branch: 'main',
+  detached: false,
+  files: [{ path: 'src/index.ts', code: ' M' }, { path: 'README.md', code: '??' }],
+  hasRemote: true,
+  hasUpstream: true,
+  ahead: 0,
+  behind: 0,
+}
+
+const getGitStatus = vi.fn()
+const commitGit = vi.fn()
+const pushGit = vi.fn()
+const compareUrl = vi.fn()
+
+vi.mock('../../lib/code-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/code-api')>()
+  return {
+    ...actual,
+    getCodeSessionGitStatus: (...args: unknown[]) => getGitStatus(...args),
+    commitCodeSessionGit: (...args: unknown[]) => commitGit(...args),
+    pushCodeSessionGit: (...args: unknown[]) => pushGit(...args),
+    getCodeSessionCompareUrl: (...args: unknown[]) => compareUrl(...args),
+  }
+})
+
+function renderDialog() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <CodeGitDialog sessionId="sess-1" open onOpenChange={() => {}} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  getGitStatus.mockReset()
+  commitGit.mockReset()
+  pushGit.mockReset()
+  compareUrl.mockReset()
+  compareUrl.mockResolvedValue({ ok: true, compareUrl: null })
+})
+
+describe('CodeGitDialog', () => {
+  it('shows a non-alarming empty state for a clean working tree', async () => {
+    getGitStatus.mockResolvedValue({ ok: true, status: { ...DIRTY_STATUS, files: [] } })
+    renderDialog()
+    expect(await screen.findByText(/Working tree is clean/)).toBeInTheDocument()
+  })
+
+  it('shows the not-a-repo empty state, not an error', async () => {
+    getGitStatus.mockResolvedValue({ ok: true, status: { ...DIRTY_STATUS, isRepo: false, files: [] } })
+    renderDialog()
+    expect(await screen.findByText(/isn't a git repository/)).toBeInTheDocument()
+  })
+
+  it('lists changed files with their status codes and commits the happy path', async () => {
+    const user = userEvent.setup()
+    getGitStatus.mockResolvedValue({ ok: true, status: DIRTY_STATUS })
+    commitGit.mockResolvedValue({ ok: true, hash: 'a'.repeat(40), filesCommitted: 2 })
+    renderDialog()
+
+    expect(await screen.findByText('src/index.ts')).toBeInTheDocument()
+    expect(screen.getByText('README.md')).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText('Commit message'), 'fix the thing')
+    await user.click(screen.getByRole('button', { name: /^Commit$/ }))
+
+    await waitFor(() => {
+      expect(commitGit).toHaveBeenCalledWith('sess-1', 'fix the thing', undefined)
+    })
+  })
+
+  it('commits only the checked subset when a file is deselected', async () => {
+    const user = userEvent.setup()
+    getGitStatus.mockResolvedValue({ ok: true, status: DIRTY_STATUS })
+    commitGit.mockResolvedValue({ ok: true, hash: 'a'.repeat(40), filesCommitted: 1 })
+    renderDialog()
+
+    const readmeRow = (await screen.findByText('README.md')).closest('label')!
+    await user.click(within(readmeRow).getByRole('checkbox'))
+
+    await user.type(screen.getByPlaceholderText('Commit message'), 'only index.ts')
+    await user.click(screen.getByRole('button', { name: /^Commit$/ }))
+
+    await waitFor(() => {
+      expect(commitGit).toHaveBeenCalledWith('sess-1', 'only index.ts', ['src/index.ts'])
+    })
+  })
+
+  it('pushes successfully and shows the Create PR link from the response compareUrl', async () => {
+    const user = userEvent.setup()
+    getGitStatus.mockResolvedValue({ ok: true, status: { ...DIRTY_STATUS, files: [], ahead: 1 } })
+    pushGit.mockResolvedValue({ ok: true, remote: 'origin', branch: 'main', compareUrl: 'https://github.com/acme/widgets/compare/main?expand=1' })
+    renderDialog()
+
+    await user.click(await screen.findByRole('button', { name: /Push/ }))
+
+    const link = await screen.findByRole('link', { name: /Create PR/ })
+    expect(link).toHaveAttribute('href', 'https://github.com/acme/widgets/compare/main?expand=1')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('surfaces the diverged rejection as a specific message, not a generic failure', async () => {
+    const user = userEvent.setup()
+    getGitStatus.mockResolvedValue({ ok: true, status: { ...DIRTY_STATUS, files: [] } })
+    pushGit.mockResolvedValue({ ok: false, reason: 'diverged', message: 'rejected [rejected]' })
+    renderDialog()
+
+    await user.click(await screen.findByRole('button', { name: /Push/ }))
+
+    expect(await screen.findByText(/Push rejected: your branch has diverged from the remote/)).toBeInTheDocument()
+  })
+
+  it('shows a specific commit error message from the backend, not a generic one', async () => {
+    const user = userEvent.setup()
+    getGitStatus.mockResolvedValue({ ok: true, status: DIRTY_STATUS })
+    commitGit.mockRejectedValue(new ApiError('nothing_to_commit', 'Nothing to commit — the working tree is clean.', 400))
+    renderDialog()
+
+    await screen.findByText('src/index.ts')
+    await user.type(screen.getByPlaceholderText('Commit message'), 'msg')
+    await user.click(screen.getByRole('button', { name: /^Commit$/ }))
+
+    // toast.error is mocked implicitly via sonner's own test-safe no-DOM behavior; assert the
+    // mutation was actually attempted with the expected args instead of asserting toast content,
+    // which this component doesn't render inline for commit (git-actions.ts's own error text is
+    // still what reaches the toast — verified at the code-api layer's own ApiError contract).
+    expect(commitGit).toHaveBeenCalledWith('sess-1', 'msg', undefined)
+  })
+})

--- a/turbollm/web/src/screens/code/CodeGitDialog.tsx
+++ b/turbollm/web/src/screens/code/CodeGitDialog.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react'
+import { Check, ExternalLink, GitBranch, UploadCloud } from 'lucide-react'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../../components/ui/dialog'
+import { Button } from '../../components/ui/button'
+import { toast } from '../../components/ui/sonner'
+import { cn } from '../../lib/utils'
+import { useCodeSessionCompareUrl, useCodeSessionGitStatus, useCommitCodeSessionGit, usePushCodeSessionGit } from '../../lib/code-queries'
+import { ApiError } from '../../lib/api'
+import type { PushGitReason, PushGitResult } from '../../lib/code-types'
+
+/** Every rejection reason `pushGitBranch` (git-actions.ts) can return, mapped to a clear,
+ *  specific sentence — never a generic "push failed" for an expected case. `push_failed` has no
+ *  entry: it's a genuinely unexpected git error, so the route's own message (real git stderr,
+ *  already specific) is shown as-is rather than replaced with something vaguer. */
+const PUSH_REJECTION_MESSAGE: Partial<Record<PushGitReason, string>> = {
+  diverged: 'Push rejected: your branch has diverged from the remote. Pull or rebase first — nothing is ever force-pushed automatically.',
+  no_remote: 'This repo has no remote configured — add one (e.g. `git remote add origin <url>`) before pushing.',
+  detached_head: 'Can\'t push from a detached HEAD — check out a branch first.',
+  not_a_repo: 'This folder isn\'t a git repository.',
+}
+
+function pushErrorMessage(result: Extract<PushGitResult, { ok: false }>): string {
+  return PUSH_REJECTION_MESSAGE[result.reason] ?? result.message
+}
+
+/** Session header's "Git" action — status, commit (all changes or a selection), push, and a
+ *  "Create PR" link once a compare URL is resolvable (Phase 3, ADR-259). Read-then-act: status
+ *  (and any existing compare URL) is fetched fresh every time the dialog opens rather than
+ *  assumed, so it never shows stale state from a previous open. */
+export function CodeGitDialog({
+  sessionId,
+  open,
+  onOpenChange,
+}: {
+  sessionId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const statusQ = useCodeSessionGitStatus(sessionId, open)
+  const status = statusQ.data?.status
+  const compareUrlQ = useCodeSessionCompareUrl(sessionId, open && !!status && !status.detached && !!status.branch)
+  const commitMut = useCommitCodeSessionGit()
+  const pushMut = usePushCodeSessionGit()
+
+  const [message, setMessage] = useState('')
+  // Paths the user has manually UNCHECKED — empty means "commit everything" (the default), which
+  // maps to omitting `files` entirely so the backend's own "stage all" path is used rather than
+  // enumerating every path back at it.
+  const [deselected, setDeselected] = useState<Set<string>>(new Set())
+  const [pushResult, setPushResult] = useState<PushGitResult | null>(null)
+
+  // Reset per-open, local UI-only state — a stale commit message or selection from a previous
+  // open (possibly of a DIFFERENT session, if the dialog is ever reused) must never survive.
+  useEffect(() => {
+    if (open) { setMessage(''); setDeselected(new Set()); setPushResult(null) }
+  }, [open, sessionId])
+
+  const files = status?.files ?? []
+  const toggleFile = (path: string) => {
+    setDeselected((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
+  const selectedCount = files.length - deselected.size
+  const allSelected = deselected.size === 0
+
+  const handleCommit = () => {
+    const trimmed = message.trim()
+    if (!trimmed) { toast.error('A commit message is required.'); return }
+    const filesArg = allSelected ? undefined : files.map((f) => f.path).filter((p) => !deselected.has(p))
+    commitMut.mutate(
+      { sessionId, message: trimmed, files: filesArg },
+      {
+        onSuccess: (r) => {
+          toast.success(`Committed ${r.filesCommitted} file${r.filesCommitted === 1 ? '' : 's'}.`)
+          setMessage('')
+          setDeselected(new Set())
+        },
+        onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Commit failed.'),
+      },
+    )
+  }
+
+  const handlePush = () => {
+    setPushResult(null)
+    pushMut.mutate(sessionId, {
+      onSuccess: (r) => {
+        setPushResult(r)
+        if (r.ok) toast.success(`Pushed to ${r.remote}/${r.branch}.`)
+      },
+      onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Push failed.'),
+    })
+  }
+
+  // A PR link is offered from whichever is freshest: a push made in THIS dialog session wins
+  // (it's the most current possible signal), otherwise fall back to the standalone lookup (a
+  // branch pushed by an earlier session/turn).
+  const compareUrl = (pushResult?.ok ? pushResult.compareUrl : undefined) ?? compareUrlQ.data?.compareUrl ?? null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranch size={16} className="text-muted" /> Git
+          </DialogTitle>
+          <DialogDescription>
+            {status?.branch ? `On ${status.branch}${status.detached ? ' (detached)' : ''}` : 'Commit and push changes for this session.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {statusQ.isLoading && <p className="py-6 text-center text-[13px] text-muted">Checking git status…</p>}
+
+        {!statusQ.isLoading && status && !status.isRepo && (
+          <p className="py-6 text-center text-[13px] text-muted">This session's folder isn't a git repository.</p>
+        )}
+
+        {!statusQ.isLoading && status?.isRepo && (
+          <div className="flex flex-col gap-4">
+            {files.length === 0 ? (
+              <p className="rounded-md border border-border bg-panel-2 px-3 py-2 text-[13px] text-muted">
+                Working tree is clean — nothing to commit.
+              </p>
+            ) : (
+              <div className="flex max-h-48 flex-col gap-0.5 overflow-y-auto rounded-md border border-border p-1.5">
+                {files.map((f) => {
+                  const checked = !deselected.has(f.path)
+                  return (
+                    <label
+                      key={f.path}
+                      className="flex cursor-pointer select-none items-center gap-2 rounded px-1.5 py-1 text-[12px] hover:bg-panel-2"
+                    >
+                      <input
+                        type="checkbox"
+                        className="sr-only"
+                        checked={checked}
+                        onChange={() => toggleFile(f.path)}
+                      />
+                      <span
+                        className="grid h-3.5 w-3.5 shrink-0 place-items-center rounded-[3px] border transition-colors"
+                        style={checked ? { background: 'var(--accent)', borderColor: 'var(--accent)' } : { borderColor: 'var(--border-strong)' }}
+                        aria-hidden
+                      >
+                        {checked && <Check size={9} strokeWidth={3.5} style={{ color: 'var(--on-accent)' }} />}
+                      </span>
+                      <span className="rounded bg-panel-2 px-1 py-0.5 font-mono text-[10px] text-muted">{f.code.trim() || '?'}</span>
+                      <span className="min-w-0 flex-1 truncate text-ink">{f.path}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+
+            {files.length > 0 && (
+              <div className="flex flex-col gap-1.5">
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Commit message"
+                  rows={2}
+                  className="w-full resize-none rounded-md border border-border bg-panel px-2.5 py-1.5 text-[13px] text-ink outline-none focus-visible:border-accent"
+                />
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-faint">{selectedCount} of {files.length} file{files.length === 1 ? '' : 's'} selected</span>
+                  <Button
+                    size="sm"
+                    onClick={handleCommit}
+                    disabled={commitMut.isPending || selectedCount === 0 || !message.trim()}
+                  >
+                    {commitMut.isPending ? 'Committing…' : 'Commit'}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2 border-t border-border pt-3">
+              <div className="flex items-center justify-between">
+                <span className="text-[12px] text-muted">
+                  {!status.hasRemote
+                    ? 'No remote configured'
+                    : status.ahead > 0
+                      ? `${status.ahead} commit${status.ahead === 1 ? '' : 's'} ahead of ${status.hasUpstream ? 'origin' : '(not yet pushed)'}`
+                      : status.hasUpstream ? 'Up to date with origin' : 'Not yet pushed'}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handlePush}
+                  disabled={pushMut.isPending || !status.hasRemote || status.detached}
+                >
+                  <UploadCloud size={13} /> {pushMut.isPending ? 'Pushing…' : 'Push'}
+                </Button>
+              </div>
+              {pushResult && !pushResult.ok && (
+                <p
+                  className="rounded-md border px-2.5 py-1.5 text-[12px]"
+                  style={{ borderColor: 'var(--err)', background: 'color-mix(in srgb, var(--err) 8%, transparent)', color: 'var(--err)' }}
+                >
+                  {pushErrorMessage(pushResult)}
+                </p>
+              )}
+              {compareUrl && (
+                <a
+                  href={compareUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={cn('inline-flex items-center gap-1.5 self-start text-[12px] font-medium text-accent hover:underline')}
+                >
+                  Create PR <ExternalLink size={11} />
+                </a>
+              )}
+            </div>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/turbollm/web/src/screens/code/CodeResourcesHeader.test.tsx
+++ b/turbollm/web/src/screens/code/CodeResourcesHeader.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { CodeResourcesHeader } from './CodeResourcesHeader'
+
+const NONE = { project: false, global: false }
+const toggle = () => screen.getByRole('button', { name: 'Loaded resources' })
+
+describe('CodeResourcesHeader', () => {
+  it('is collapsed by default — shows the one-line summary and hides the detail rows', () => {
+    render(<CodeResourcesHeader skillCount={12} hasAgentsMd={{ project: true, global: false }} />)
+    expect(screen.getByText('AGENTS.md')).toBeInTheDocument()
+    expect(screen.getByText('12 skills')).toBeInTheDocument()
+    // Detail rows only exist once expanded.
+    expect(screen.queryByText('Project')).not.toBeInTheDocument()
+    expect(screen.queryByText(/reachable via invoke_skill/)).not.toBeInTheDocument()
+    expect(toggle()).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands on click to show the project / global / skills breakdown', async () => {
+    const user = userEvent.setup()
+    render(<CodeResourcesHeader skillCount={12} hasAgentsMd={{ project: true, global: true }} />)
+    await user.click(toggle())
+    expect(toggle()).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Project')).toBeInTheDocument()
+    expect(screen.getByText('Global')).toBeInTheDocument()
+    expect(screen.getByText('AGENTS.md loaded')).toBeInTheDocument()
+    expect(screen.getByText('agents.md loaded')).toBeInTheDocument()
+    expect(screen.getByText('12 skills reachable via invoke_skill')).toBeInTheDocument()
+  })
+
+  it('shows "No AGENTS.md" collapsed, and "not found" for BOTH files when none is loaded', async () => {
+    const user = userEvent.setup()
+    render(<CodeResourcesHeader skillCount={5} hasAgentsMd={NONE} />)
+    expect(screen.getByText('No AGENTS.md')).toBeInTheDocument()
+    expect(screen.queryByText('AGENTS.md')).not.toBeInTheDocument()
+    await user.click(toggle())
+    expect(screen.getAllByText('not found')).toHaveLength(2)
+  })
+
+  it('distinguishes a project-only AGENTS.md from a global-only one', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<CodeResourcesHeader skillCount={0} hasAgentsMd={{ project: true, global: false }} />)
+    await user.click(toggle())
+    expect(screen.getByText('AGENTS.md loaded')).toBeInTheDocument() // project loaded
+    expect(screen.getByText('not found')).toBeInTheDocument()        // global missing (exactly one)
+
+    // Same mounted instance stays expanded across the prop flip.
+    rerender(<CodeResourcesHeader skillCount={0} hasAgentsMd={{ project: false, global: true }} />)
+    expect(screen.getByText('agents.md loaded')).toBeInTheDocument() // global loaded now
+  })
+
+  it('pluralizes the skill count and renders "none available" for zero skills', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<CodeResourcesHeader skillCount={1} hasAgentsMd={NONE} />)
+    expect(screen.getByText('1 skill')).toBeInTheDocument() // singular
+
+    rerender(<CodeResourcesHeader skillCount={0} hasAgentsMd={NONE} />)
+    expect(screen.getByText('0 skills')).toBeInTheDocument()
+    await user.click(toggle())
+    expect(screen.getByText('none available')).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/screens/code/CodeResourcesHeader.tsx
+++ b/turbollm/web/src/screens/code/CodeResourcesHeader.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, FileText, Sparkles } from 'lucide-react'
+
+export interface CodeResourcesHeaderProps {
+  /** How many skills are available to the session — the shared SkillStore catalog (every one is
+   *  reachable via invoke_skill; Code has no per-session enabled subset, unlike Chat). */
+  skillCount: number
+  /** Whether a project (`<repoRoot>/AGENTS.md`) and/or global (`~/.turbollm/agents.md`) AGENTS.md
+   *  is loaded for this session — from the session-detail response (code-api.ts). */
+  hasAgentsMd: { project: boolean; global: boolean }
+}
+
+/**
+ * Collapsible loaded-resources header (ADR-262) — surfaces what pi's own
+ * `[Context]/[Skills]/[Prompts]` startup dump shows: the standing context (AGENTS.md) and the skill
+ * library actually loaded for this session, which persona.ts already assembles server-side but the
+ * UI never showed anywhere.
+ *
+ * Deliberately shows ONLY these two resources — NOT mode, model, or context stats. Those already
+ * have a single on-screen home (the composer's editable mode picker and the stats footer), and
+ * ADR-262's hard constraint is that no stat/state renders in more than one place; AGENTS.md and the
+ * skill count are the two things that had no on-screen home at all, so they're the whole job here.
+ * Collapsed to one line by default, matching pi's compact "one-line, expand for detail" convention.
+ */
+export function CodeResourcesHeader({ skillCount, hasAgentsMd }: CodeResourcesHeaderProps) {
+  const [expanded, setExpanded] = useState(false)
+  const agentsLoaded = hasAgentsMd.project || hasAgentsMd.global
+  const skillsLabel = `${skillCount} skill${skillCount === 1 ? '' : 's'}`
+
+  return (
+    <div className="shrink-0 border-b border-border text-[11px] text-muted">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-label="Loaded resources"
+        className="flex w-full items-center gap-2 px-4 py-1.5 transition-colors hover:text-ink md:px-8"
+      >
+        {expanded
+          ? <ChevronDown size={12} className="shrink-0 text-faint" />
+          : <ChevronRight size={12} className="shrink-0 text-faint" />}
+        <span className="inline-flex items-center gap-1">
+          <FileText size={11} className="shrink-0 text-faint" />
+          {agentsLoaded ? 'AGENTS.md' : 'No AGENTS.md'}
+        </span>
+        <span aria-hidden className="text-faint">·</span>
+        <span className="inline-flex items-center gap-1">
+          <Sparkles size={11} className="shrink-0 text-faint" />
+          {skillsLabel}
+        </span>
+      </button>
+
+      {expanded && (
+        <dl className="flex flex-col gap-1 px-4 pb-2 pl-9 md:px-8 md:pl-[3.25rem]">
+          <div className="flex items-center gap-2">
+            <dt className="w-16 shrink-0 text-faint">Project</dt>
+            <dd>{hasAgentsMd.project ? 'AGENTS.md loaded' : 'not found'}</dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="w-16 shrink-0 text-faint">Global</dt>
+            <dd>{hasAgentsMd.global ? 'agents.md loaded' : 'not found'}</dd>
+          </div>
+          <div className="flex items-center gap-2">
+            <dt className="w-16 shrink-0 text-faint">Skills</dt>
+            <dd>{skillCount === 0 ? 'none available' : `${skillsLabel} reachable via invoke_skill`}</dd>
+          </div>
+        </dl>
+      )}
+    </div>
+  )
+}

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -1,23 +1,27 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowDown, Clock, Diff, Eraser, FolderOpen, GitBranch, PanelLeft, Pencil, RotateCcw, SendHorizontal } from 'lucide-react'
+import { ArrowDown, Diff, Download, Eraser, FolderOpen, GitBranch, MoreHorizontal, PanelLeft, Pencil, RotateCcw } from 'lucide-react'
 import { ApiError } from '../../lib/api'
 import { skillKeys, fetchSkills } from '../../lib/agent-api'
 import { useModelActions, useModels, useStatus } from '../../lib/queries'
-import { compactCodeSession, revertCodeSession, sendCodeQueuedTurnNow, startCodeRun, streamCodeSession, stopCodeSession } from '../../lib/code-api'
-import type { QueuedTurn } from '../../lib/code-types'
+import { compactCodeSession, execShellCommand, revertCodeSession, sendCodeQueuedTurnNow, startCodeRun, steerOutcomeMessage, stopCodeSession } from '../../lib/code-api'
+import type { QueuedTurn, ShellRun, SteerKind } from '../../lib/code-types'
 import {
-  codeKeys, useClearCodeSession, useCodeSession, useCodeSessionRename, useResumeCodeSession,
-  useUpdateCodeSessionMode,
+  codeKeys, useClearCodeSession, useCodeSession, useCodeSessionRename, useExportCodeSession,
+  useResumeCodeSession, useUpdateCodeSessionMode,
 } from '../../lib/code-queries'
-import type { LiveToolCall } from '../../lib/chat-types'
-import { appendTextDelta, upsertToolCall, type LiveBlock } from '../../lib/live-timeline'
+import { CodeSessionClient, type LiveState } from '../../lib/code-session-client'
+import { matchCodeCommand, pickerCodeCommands } from '../../lib/code-commands'
+import { toggleDisplayPref } from '../../lib/code-display-prefs'
 import { Button, buttonVariants } from '../../components/ui/button'
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '../../components/ui/alert-dialog'
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from '../../components/ui/dropdown-menu'
 import { toast } from '../../components/ui/sonner'
 import { useIsDesktop } from '../../lib/useIsDesktop'
 import { cn, folderName, formatDiff, writeLastCodeSessionId } from '../../lib/utils'
@@ -27,28 +31,21 @@ import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle 
 import { ModelDetailDialog } from '../models/ModelDetailDialog'
 import { FsBrowser } from '../engines/FsBrowser'
 import { CodeComposer } from './CodeComposer'
-import { CodeTranscript, CodeTranscriptSkeleton } from './CodeTranscript'
+import { CodeGitDialog } from './CodeGitDialog'
+import { CodeTranscript, CodeTranscriptSkeleton, TodoChecklist } from './CodeTranscript'
 import { AGENT_MODES, type AgentModeId } from './code-mock'
 
-interface LiveState {
-  assistantId: string
-  content: string
-  reasoning: string
-  timeline: LiveBlock[]
-  /** True between a 'compaction' SSE event's start and end phases — pi's own AUTO-compaction
-   *  silently summarizing history mid-turn (distinct from the manual /compact command). Drives
-   *  CodeThinking's "Compacting conversation…" state instead of a blank/generic gap. */
-  compacting?: boolean
-}
-
-/** Apply `fn` to the current live block, creating one (anchored to `fallbackId`) if none exists
- *  yet — so a live delta/tool_call that arrives on a reconnect BEFORE a `meta` frame (e.g. the
- *  real meta aged out of the daemon's ring buffer) still attaches to the right assistant turn
- *  instead of being dropped. */
-function reduceLive(l: LiveState | null, fallbackId: string, fn: (b: LiveState) => LiveState): LiveState {
-  const base = l ?? { assistantId: fallbackId, content: '', reasoning: '', timeline: [] }
-  return fn(base)
-}
+/** The fixed prompt `/init` sends (ADR-258) — drives the agent to inspect the repo and author an
+ *  AGENTS.md, which persona.ts's agentsMdBlock then picks up on every later turn. Sent as this
+ *  turn's promptOverride only; the stored user message stays the literal "/init". */
+const INIT_AGENTS_PROMPT =
+  'Create or update an AGENTS.md file at the root of this repository. First inspect the project — ' +
+  'its README, package/build manifests, test and lint scripts, directory layout, and dominant ' +
+  'conventions — then write a concise AGENTS.md capturing: how to build, test, run, and lint the ' +
+  'project; the key commands; the code style and conventions a contributor should follow; and ' +
+  'anything non-obvious about the architecture. If an AGENTS.md already exists, review and improve ' +
+  'it rather than overwriting it wholesale. Keep it practical and specific to THIS repo — no ' +
+  'generic boilerplate.'
 
 /** The real execution view for a Code session (Phase 1 plan §5) — streams from
  *  the real pi-SDK run via code-api.ts. Renders CodeTranscript.tsx (a
@@ -68,16 +65,11 @@ export function CodeSessionScreen() {
   const detailQ = useCodeSession(sessionId ?? null)
   const session = detailQ.data?.session
   const conversation = detailQ.data?.conversation
-  const allMessages = conversation?.messages ?? []
-  // /clear hides everything at/before clearedUpToMessageId from the transcript (the messages
-  // themselves are never deleted — /resume un-hides them again). `messages` below is what the
-  // rest of this screen renders/measures (context ring, transcript); server-side history replay
-  // for the MODEL applies the same cut via resolveEffectiveHistory (code-session.ts).
-  const clearedIdx = session?.clearedUpToMessageId
-    ? allMessages.findIndex((m) => m.id === session.clearedUpToMessageId)
-    : -1
-  const messages = clearedIdx === -1 ? allMessages : allMessages.slice(clearedIdx + 1)
-  const clearedCount = clearedIdx === -1 ? 0 : clearedIdx + 1
+  // /clear now DEACTIVATES its messages server-side (is_active=0, v34/ADR-261), the same mechanism
+  // /revert uses — so the API already omits cleared history from `conversation.messages` (getMessages
+  // filters is_active=1). No client-side cut is needed anymore; `messages` is just the active set the
+  // screen renders/measures. /resume reactivates the range and the messages reappear on the next fetch.
+  const messages = conversation?.messages ?? []
 
   // Rename — same shared hook/UX as the sidebar's CodeSessionItem (ConversationSidebar.tsx),
   // surfaced here too since the header is the bigger, always-visible spot for a session's title.
@@ -89,7 +81,7 @@ export function CodeSessionScreen() {
   // the query refetch reconciles `session.mode` to match. Reset whenever the
   // session itself changes so a stale override never survives a navigation.
   const [modeOverride, setModeOverride] = useState<AgentModeId | null>(null)
-  useEffect(() => { setModeOverride(null) }, [sessionId])
+  useEffect(() => { setModeOverride(null); setShellRuns([]) }, [sessionId])
 
   // Remember this as the last-opened Code session, so switching to Chat and back
   // via the Workspace mode pill (ConversationSidebar.tsx) restores it.
@@ -120,6 +112,8 @@ export function CodeSessionScreen() {
     engineState === 'starting' ||
     engineState === 'stopping'
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
+  const [gitDialogOpen, setGitDialogOpen] = useState(false)
+  const exportMut = useExportCodeSession()
   const handleLoadModel = (key: string) => {
     modelActions.load.mutate(
       { key },
@@ -157,36 +151,41 @@ export function CodeSessionScreen() {
   }, [sessionId])
 
   const [live, setLive] = useState<LiveState | null>(null)
-  // A queued follow-up's user message is persisted (POST /messages) the moment it's SUBMITTED,
-  // not when its own turn actually starts — code-routes.ts's `enqueue` can leave it waiting
-  // behind the active run for a while. Since `messages` renders in seq order, that follow-up's
-  // instruction card used to appear ABOVE the still-streaming current turn's live content
-  // (which always renders last, after the full `messages` list) — reading as if the queued
-  // message had jumped ahead. The existing "Queued" chips below the composer already show
-  // what's waiting, so cut the transcript off at the current live turn's own assistant
-  // placeholder — anything after it (an already-persisted but not-yet-started queued follow-up)
-  // stays hidden from the transcript until it actually starts running.
-  const liveBoundaryIdx = live ? messages.findIndex((m) => m.id === live.assistantId) : -1
-  const transcriptMessages = liveBoundaryIdx === -1 ? messages : messages.slice(0, liveBoundaryIdx + 1)
-  const [input, setInput] = useState('')
-  // "Add context" — absolute paths picked via a file browser, sent alongside the next follow-up
-  // as contextFiles (see code-api.ts's startCodeRun / code-routes.ts's contextFilesBlock).
-  const [contextFiles, setContextFiles] = useState<string[]>([])
-  const [contextBrowserOpen, setContextBrowserOpen] = useState(false)
   // The SERVER-side message queue's contents (tasks waiting behind the active run). Driven by
   // the daemon — `queue` SSE frames while streaming, plus the session detail on load — NOT
   // browser memory, so queued follow-ups survive a disconnect/reload and still fire in order
   // server-side. (Previously this was a client-only array that was lost on navigation.)
   const [queued, setQueued] = useState<QueuedTurn[]>([])
-  // The GET /stream subscription. Aborting it only DETACHES this client from the run — the
-  // daemon keeps executing it — so it never stops the run. One active stream per mounted session.
-  const streamAbortRef = useRef<AbortController | null>(null)
-  const streamActiveRef = useRef(false)
-  // The last ring-buffer seq this client has consumed, so a reconnect resumes from there.
-  const lastSeqRef = useRef(0)
-  // The in-flight turn's assistant message id (from the `meta` frame), so live deltas that arrive
-  // after a reconnect (whose meta may have aged out of the buffer) still attach to the right turn.
-  const activeAssistantIdRef = useRef('')
+  // Transcript-only `!!command` results (ADR-258) — client-side, never persisted, rendered at the
+  // transcript tail. `!command` results are NOT here; they come back as a persisted message.
+  const [shellRuns, setShellRuns] = useState<ShellRun[]>([])
+  // A queued follow-up's user message is persisted (POST /messages) the moment it's SUBMITTED,
+  // not when its own turn actually starts — code-routes.ts's `enqueue` can leave it waiting
+  // behind the active run for a while. Since `messages` renders in seq order, that follow-up's
+  // instruction card would appear ABOVE the still-streaming current turn's live content (which
+  // always renders last, after the full `messages` list) — reading as if the queued message had
+  // jumped ahead (the ADR-199 ordering fix). Two cuts keep queued turns strictly at the tail:
+  //   1. cut the transcript at the current live turn's own assistant placeholder — anything after
+  //      it (an already-persisted but not-yet-started queued follow-up) stays out of `messages`;
+  //   2. also drop any message whose id is a live queue entry — belt-and-suspenders for the brief
+  //      on-load/reconnect window where the queue is seeded but `live` isn't set yet (cut #1's
+  //      boundary doesn't exist), so a queued message never renders BOTH as a normal transcript
+  //      card and as its inline translucent queued card (CodeTranscript renders those from
+  //      `queued` directly, at the tail).
+  const queuedIds = new Set(queued.map((q) => q.userMsgId))
+  const liveBoundaryIdx = live ? messages.findIndex((m) => m.id === live.assistantId) : -1
+  const cutMessages = liveBoundaryIdx === -1 ? messages : messages.slice(0, liveBoundaryIdx + 1)
+  const transcriptMessages = queuedIds.size ? cutMessages.filter((m) => !queuedIds.has(m.id)) : cutMessages
+  const [input, setInput] = useState('')
+  // "Add context" — absolute paths picked via a file browser, sent alongside the next follow-up
+  // as contextFiles (see code-api.ts's startCodeRun / code-routes.ts's contextFilesBlock).
+  const [contextFiles, setContextFiles] = useState<string[]>([])
+  const [contextBrowserOpen, setContextBrowserOpen] = useState(false)
+  // The GET /stream subscription, owned by a React-free client (code-session-client.ts). It owns
+  // the reconnect loop, the ring-buffer seq cursor, and the event-to-LiveState reduction; this
+  // screen only mirrors its `onLive` into `live` state and drives connect()/abort(). Aborting only
+  // DETACHES this client from the run — the daemon keeps executing it — so it never stops the run.
+  const clientRef = useRef<CodeSessionClient | null>(null)
   const autoStartedRef = useRef<string | null>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -222,81 +221,47 @@ export function CodeSessionScreen() {
   useEffect(() => { if (live) scrollToBottom() }, [live, scrollToBottom])
 
   // ── the single, reconnectable run subscription ────────────────────────────────
-  // ONE persistent GET /stream per mounted session (not one-per-turn). It replays whatever the
-  // daemon already buffered for the in-flight turn (from lastSeqRef) then live-tails; on a
-  // network drop it reconnects from the last seq seen. It ends only when the daemon reports the
-  // session idle (the async generator completing) — at which point we reconcile with the DB
-  // transcript. Because the run is daemon-owned, closing this stream never stops the run.
-  const RECONNECT_MAX = 6
-  const connect = useCallback(() => {
-    if (!sessionId || streamActiveRef.current) return
-    streamActiveRef.current = true
-    const ac = new AbortController()
-    streamAbortRef.current = ac
-    let attempt = 0
-
-    const run = async () => {
-      try {
-        for await (const evt of streamCodeSession(sessionId, lastSeqRef.current, ac.signal)) {
-          if (typeof evt.seq === 'number') lastSeqRef.current = Math.max(lastSeqRef.current, evt.seq + 1)
-          if (evt.event === 'meta') {
-            attempt = 0 // a real frame means the connection is healthy again
-            activeAssistantIdRef.current = evt.data.assistantMessageId
-            setLive((l) => (l && l.assistantId === evt.data.assistantMessageId
-              ? l
-              : { assistantId: evt.data.assistantMessageId, content: '', reasoning: '', timeline: [] }))
-            void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
-          } else if (evt.event === 'queue') {
-            setQueued(evt.data.queued)
-          } else if (evt.event === 'compaction') {
-            const compacting = evt.data.phase === 'start'
-            setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, compacting })))
-          } else if (evt.event === 'reasoning') {
-            const delta = evt.data.delta
-            setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, reasoning: b.reasoning + delta })))
-          } else if (evt.event === 'delta') {
-            const delta = evt.data.delta
-            setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, content: b.content + delta, timeline: appendTextDelta(b.timeline, delta) })))
-          } else if (evt.event === 'tool_call') {
-            const tc = evt.data
-            const call: LiveToolCall = { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result, diff: tc.diff, patch: tc.patch, firstChangedLine: tc.firstChangedLine }
-            setLive((l) => reduceLive(l, activeAssistantIdRef.current, (b) => ({ ...b, timeline: upsertToolCall(b.timeline, call) })))
-          } else if (evt.event === 'done') {
-            setLive(null)
-            void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
-            void qc.invalidateQueries({ queryKey: ['code-sessions'] })
-            void qc.invalidateQueries({ queryKey: ['code-stats'] })
-            setTimeout(() => scrollToBottom(true), 80)
-          } else if (evt.event === 'error') {
-            setLive(null)
-            void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
-            void qc.invalidateQueries({ queryKey: ['code-sessions'] })
-            void qc.invalidateQueries({ queryKey: ['code-stats'] })
-            toast.error(evt.data.message)
-          }
-        }
-        // Generator completed = the daemon says this session is idle. Stop and reconcile with DB.
-        streamActiveRef.current = false
-        setLive(null)
+  // Build/tear down ONE React-free CodeSessionClient per mounted session. The client owns the
+  // persistent GET /stream (replay-from-seq + live-tail + reconnect) and the event-to-LiveState
+  // reduction; this screen only supplies the framework side effects (state sync, query
+  // invalidation, toasts, scroll) and mirrors `onLive` into `live`. Recreating it per session is
+  // what resets the seq cursor / active-assistant id (the old teardown effect's manual resets),
+  // and its abort() DETACHES without stopping the daemon-owned run. Declared BEFORE the auto-start
+  // / reconnect-on-load effects so clientRef.current is populated by the time they run.
+  useEffect(() => {
+    if (!sessionId) return
+    const client = new CodeSessionClient(sessionId, {
+      onLive: setLive,
+      onQueue: setQueued,
+      onTurnStart: () => { void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) }) },
+      onTurnDone: () => {
         void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
         void qc.invalidateQueries({ queryKey: ['code-sessions'] })
-      } catch (e) {
-        if (ac.signal.aborted) { streamActiveRef.current = false; return }
-        // Network drop mid-run — the DAEMON kept executing. Reconnect from the last seq seen so
-        // we replay only what we missed and continue live.
-        attempt += 1
-        if (attempt <= RECONNECT_MAX && streamAbortRef.current === ac) {
-          setTimeout(() => { if (streamAbortRef.current === ac && !ac.signal.aborted) void run() }, Math.min(500 * attempt, 3000))
-        } else {
-          streamActiveRef.current = false
-          setLive(null)
-          if (!(e instanceof ApiError && e.status === 404)) toast.error('Lost connection to the run.')
-        }
-      }
+        void qc.invalidateQueries({ queryKey: ['code-stats'] })
+        setTimeout(() => scrollToBottom(true), 80)
+      },
+      onTurnError: (message) => {
+        void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
+        void qc.invalidateQueries({ queryKey: ['code-sessions'] })
+        void qc.invalidateQueries({ queryKey: ['code-stats'] })
+        toast.error(message)
+      },
+      onIdle: () => {
+        void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
+        void qc.invalidateQueries({ queryKey: ['code-sessions'] })
+      },
+      onLostConnection: (silent) => { if (!silent) toast.error('Lost connection to the run.') },
+    })
+    clientRef.current = client
+    return () => {
+      // DETACHES this client without stopping the daemon-owned run; discarding the instance resets
+      // the reconnect cursor for the next session.
+      client.abort()
+      clientRef.current = null
+      setLive(null)
     }
-    void run()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, qc, scrollToBottom])
+  }, [sessionId])
 
   // Auto-start the first run of a freshly-created session (one seeded user message, no reply,
   // nothing live in the daemon). POST kicks it off server-side; then we connect to watch it.
@@ -314,7 +279,7 @@ export function CodeSessionScreen() {
       // would still hold the PREVIOUS session's value. readThinkingBudget is a synchronous
       // localStorage read, immune to that ordering race.
       void startCodeRun(sessionId, '', readThinkingBudget(sessionId))
-        .then(() => { void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) }); connect() })
+        .then(() => { void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) }); clientRef.current?.connect() })
         .catch((e) => { autoStartedRef.current = null; toast.error(e instanceof ApiError ? e.message : 'Could not start the run.') })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -325,28 +290,17 @@ export function CodeSessionScreen() {
   // buffered history and continuing live — instead of assuming a fresh page has nothing in flight.
   useEffect(() => {
     if (!sessionId || !detailQ.isSuccess) return
-    if (detailQ.data?.running && !streamActiveRef.current) connect()
+    if (detailQ.data?.running && !clientRef.current?.isActive) clientRef.current?.connect()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, detailQ.isSuccess, detailQ.data?.running])
 
-  // Seed the queued chips from the session detail on load, until the stream's own `queue` frames
-  // take over as the live source of truth.
+  // Seed the queued turns from the session detail on load, until the stream's own `queue` frames
+  // take over as the live source of truth. (Rendered inline as cards at the transcript tail now,
+  // not the old below-composer chip strip — see CodeTranscript's CodeQueuedEntry.)
   useEffect(() => {
-    if (!streamActiveRef.current) setQueued(detailQ.data?.queued ?? [])
+    if (!clientRef.current?.isActive) setQueued(detailQ.data?.queued ?? [])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, detailQ.data?.queued])
-
-  // Tear down the subscription on unmount / session change — DETACHES this client without
-  // stopping the daemon-owned run, and resets the reconnect cursor for the next session.
-  useEffect(() => {
-    return () => {
-      streamAbortRef.current?.abort()
-      streamActiveRef.current = false
-      setLive(null)
-      lastSeqRef.current = 0
-      activeAssistantIdRef.current = ''
-    }
-  }, [sessionId])
 
   // `/compact [focus instructions]` — a composer command, not a normal turn: it never reaches
   // startCodeRun/the daemon queue, just the dedicated compact endpoint. Case-insensitive,
@@ -379,10 +333,11 @@ export function CodeSessionScreen() {
   // ever fires for AUTO-compaction's SSE event mid-turn; the manual command is a separate,
   // non-streaming POST with no live state of its own until now.
   const [manualCompacting, setManualCompacting] = useState(false)
-  const COMPACT_RE = /^\/compact\b\s*(.*)$/i
   const runCompact = async (text: string) => {
     if (!sessionId) return
-    const instructions = COMPACT_RE.exec(text)?.[1]?.trim() || undefined
+    // `text` is always a /compact input here (send() dispatched on it) — read its captured
+    // argument (pi's customInstructions) back off the same registry pattern that matched it.
+    const instructions = matchCodeCommand(text)?.match[1]?.trim() || undefined
     setInput('')
     setManualCompacting(true)
     try {
@@ -400,8 +355,7 @@ export function CodeSessionScreen() {
 
   // `/clear` hides the conversation so far (repo/worktree/branch untouched, nothing deleted);
   // `/resume` un-hides it. Same "composer command, not a real turn" shape as /compact above.
-  const CLEAR_RE = /^\/clear\b\s*$/i
-  const RESUME_RE = /^\/resume\b\s*$/i
+  // Their triggers live in the shared registry (code-commands.ts) — see send()'s dispatch.
   const clearMut = useClearCodeSession()
   const resumeMut = useResumeCodeSession()
   const runClear = async () => {
@@ -457,13 +411,67 @@ export function CodeSessionScreen() {
     }
   }
 
-  const send = async () => {
+  // `!command`/`!!command` shell escape (ADR-258): run the command in the repo, not a model turn.
+  // `!` (feedToModel) persists the command+output as a user message the model reads next turn — it
+  // shows up in the transcript via the detail refetch (as a `shell` tool call on that message). `!!`
+  // is transcript-only: its result is held in ephemeral client state and never persisted or fed to
+  // the model.
+  const runShell = async (bang: string, command: string) => {
+    if (!sessionId || !command) return
+    const feedToModel = bang === '!'
+    setInput('')
+    userScrolledUp.current = false
+    try {
+      const res = await execShellCommand(sessionId, command, feedToModel)
+      if (feedToModel) {
+        void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
+      } else {
+        setShellRuns((r) => [...r, { id: `sh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, command: res.command, output: res.output, exitCode: res.exitCode, timedOut: res.timedOut }])
+      }
+      setTimeout(() => scrollToBottom(true), 60)
+    } catch (e) {
+      setInput(`${bang}${command}`) // restore so the command isn't lost
+      toast.error(e instanceof ApiError ? e.message : 'Could not run the command.')
+    }
+  }
+
+  // `kind` (Phase 1, ADR-246) picks how this message is delivered when a run is already active:
+  // 'followUp' (the default — byte-identical to pre-ADR-246 behavior) queues a fresh turn behind
+  // the active one; 'steer' redirects the CURRENTLY ACTIVE turn. The UI trigger that chooses which
+  // is being built separately in CodeComposer.tsx — this signature is the plumbing it calls into.
+  const send = async (kind: SteerKind = 'followUp') => {
     const text = input.trim()
     if (!text || !sessionId) return
-    if (COMPACT_RE.test(text)) { await runCompact(text); return }
-    if (CLEAR_RE.test(text)) { await runClear(); return }
-    if (RESUME_RE.test(text)) { await runResume(); return }
-    const promptOverride = skillPromptOverride(text)
+    // Built-in composer commands — matched against the ONE shared registry (code-commands.ts) that
+    // also feeds the '/' picker's list, then dispatched by id. Most never reach startCodeRun (their
+    // own endpoint / an instant client-side toggle); `/init` is the exception — a real agentic turn
+    // with a fixed prompt (falls through below). Anything not a built-in becomes a normal turn (with
+    // skillPromptOverride still steering an invoke_skill for a "/skillid task").
+    const command = matchCodeCommand(text)
+    if (command) {
+      if (command.id === 'compact') { await runCompact(text); return }
+      if (command.id === 'clear') { await runClear(); return }
+      if (command.id === 'resume') { await runResume(); return }
+      // `/details` + `/thinking` (ADR-258) — instant global display toggles, not a turn. The
+      // literal command text is never stored/sent; it just flips a persisted UI preference.
+      if (command.id === 'details' || command.id === 'thinking') {
+        const on = toggleDisplayPref(command.id)
+        setInput('')
+        toast.success(command.id === 'details'
+          ? `Tool-call details ${on ? 'shown' : 'collapsed'} for every step.`
+          : `Reasoning ${on ? 'always shown' : 'hidden by default'}.`)
+        return
+      }
+      // `!command` / `!!command` (ADR-258) — run a shell command in the repo, not a model turn.
+      // match[1] is the bang ('!' feeds output to the model as context, '!!' doesn't), match[2] the
+      // command. Never reaches startCodeRun.
+      if (command.id === 'shell') { await runShell(command.match[1], command.match[2].trim()); return }
+    }
+    // `/init` (ADR-258) is a real turn: the composer text stays "/init" (shown verbatim, per the
+    // founder's don't-rewrite-my-message rule) while a fixed instruction is what's actually prompted
+    // — the agent inspects the repo and writes AGENTS.md, which persona.ts's agentsMdBlock reads back
+    // on every subsequent turn. Same promptOverride mechanism the "/skillid task" shorthand uses.
+    const promptOverride = command?.id === 'init' ? INIT_AGENTS_PROMPT : skillPromptOverride(text)
     const filesToSend = contextFiles
     setInput('')
     setContextFiles([])
@@ -472,9 +480,12 @@ export function CodeSessionScreen() {
     // run. Either way it's owned server-side, so a queued follow-up survives a disconnect. The
     // open stream reflects the result (a new `queue` frame, or the turn going live when it runs).
     try {
-      await startCodeRun(sessionId, text, thinkingBudget, promptOverride, filesToSend)
+      const res = await startCodeRun(sessionId, text, thinkingBudget, promptOverride, filesToSend, kind)
+      // `steered` reports whether a steer actually injected into the live turn vs. was queued —
+      // confirm the real outcome. followUp needs no toast: its queued card already shows inline.
+      if (kind === 'steer') toast.success(steerOutcomeMessage(res.steered))
       void qc.invalidateQueries({ queryKey: codeKeys.detail(sessionId) })
-      connect()
+      clientRef.current?.connect()
     } catch (e) {
       setInput(text) // restore so the message isn't lost
       setContextFiles(filesToSend)
@@ -490,7 +501,7 @@ export function CodeSessionScreen() {
     await stopCodeSession(sessionId).catch(() => {})
   }
 
-  // "Send now" on a queued chip: stops the active turn and promotes this one to run next,
+  // "Send now" on a queued card: stops the active turn and promotes this one to run next,
   // WITHOUT dropping the rest of the queue (unlike handleStop above). No optimistic setQueued
   // here — the reordered queue comes back as a fresh `queue` SSE frame moments later, and
   // guessing the reorder client-side risks a flash of the wrong order if it doesn't match.
@@ -590,7 +601,7 @@ export function CodeSessionScreen() {
               {rename.editing ? (
                 <input
                   autoFocus
-                  className="min-w-0 flex-1 bg-transparent text-[13px] font-medium text-ink outline-none"
+                  className="min-w-[80px] flex-1 bg-transparent text-[13px] font-medium text-ink outline-none"
                   value={rename.draft}
                   onChange={(e) => rename.setDraft(e.target.value)}
                   onBlur={rename.commit}
@@ -598,7 +609,7 @@ export function CodeSessionScreen() {
                 />
               ) : (
                 <span
-                  className="min-w-0 flex-1 truncate text-[13px] font-medium text-ink"
+                  className="min-w-[80px] flex-1 truncate text-[13px] font-medium text-ink"
                   title={session.title}
                   onDoubleClick={rename.start}
                 >
@@ -610,41 +621,85 @@ export function CodeSessionScreen() {
                   type="button"
                   onClick={rename.start}
                   className="shrink-0 rounded p-1 text-faint transition-colors hover:text-ink"
+                  aria-label="Rename session"
                   title="Rename session"
                 >
                   <Pencil size={13} />
                 </button>
               )}
-              {/* Repo/branch context — shown at every width (previously md:-only, hiding it
-                  entirely on mobile with no other way to see it in this screen). The title's
-                  own min-w-0 flex-1 truncate yields space to these before anything gets fully
-                  cut off — but that alone isn't enough: these chips are shrink-0 (fixed to
-                  their natural width) with no cap, so a genuinely long repo path + branch name
-                  can still claim ALL the row's width and squeeze the title to literally 0px,
-                  invisible (caught live, not by inspection — measured 0px with a real long
-                  repo/branch pair at 375px). Capping each chip's own text at a small max-width
-                  on mobile (relaxed back to fully visible at md: and up, unchanged from before
-                  this fix) guarantees the title always keeps a real minimum, at the cost of the
-                  chip text itself truncating instead. */}
-              <span
-                className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted"
-                title={session.repoRoot}
-              >
-                <FolderOpen size={11} className="shrink-0" />
-                <span className="max-w-[70px] truncate md:max-w-none">{folderName(session.repoRoot)}</span>
-              </span>
-              {session.branch && (
-                <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted">
-                  <GitBranch size={11} className="shrink-0" />
-                  <span className="max-w-[70px] truncate md:max-w-none">{session.branch}</span>
+              {/* Repo/branch/diff-stat chips + the session-actions menu, grouped into one
+                  shrinkable, horizontally-scrollable strip — NOT siblings-of-title directly
+                  anymore. Root cause of a real regression (caught live by Playwright at 375px/
+                  320px, spec 16 §2): every chip here is shrink-0 (a fixed-size pill; only its
+                  OWN inner text truncates via max-w-[70px]), and the title above was `min-w-0
+                  flex-1` — in flexbox, `min-w-0` means the title has NO real floor, so it's the
+                  only element that can be squeezed, all the way to literally 0px, the instant the
+                  shrink-0 siblings' total natural width exceeds the row's available space. That
+                  was already fragile with just two chips (repo+branch); adding the diff-stat chip
+                  and the Export/Git overflow menu (Phase 3) pushed the fixed total past the
+                  container width even on a single long repo+branch pair, reproducing the exact
+                  original 0px bug. The real fix is structural, not "cap one more thing": the title
+                  now has a genuine min-width floor (`min-w-[80px]`, not `min-w-0`) so flexbox's own
+                  shrink algorithm has a hard stop it will never squeeze past, and everything else
+                  that used to compete with it directly is moved into ITS OWN flex child
+                  (`min-w-0 shrink overflow-x-auto`, no `flex-1`) — a plain flex item, so once the
+                  title claims its guaranteed minimum, 100% of any further squeeze lands on this
+                  group instead. Nothing is ever clipped/hidden: `overflow-x-auto` (the same pattern
+                  CodeComposer.tsx's own toolbar row already uses for the same reason) lets the
+                  chips/menu scroll horizontally within their own strip when they don't all fit,
+                  so Export/Git stays reachable rather than disappearing off-screen. This holds
+                  regardless of how many chips end up present — it's the shrink/min-width
+                  RELATIONSHIP between the title and the group that's now correct, not a count of
+                  today's specific chips. */}
+              <div className="flex min-w-0 shrink items-center gap-1.5 overflow-x-auto">
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted"
+                  title={session.repoRoot}
+                >
+                  <FolderOpen size={11} className="shrink-0" />
+                  <span className="max-w-[70px] truncate md:max-w-none">{folderName(session.repoRoot)}</span>
                 </span>
-              )}
-              {(session.add > 0 || session.del > 0) && (
-                <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted">
-                  <Diff size={11} className="shrink-0" />
-                  <span className="max-w-[70px] truncate md:max-w-none">{formatDiff(session.add, session.del)}</span>
-                </span>
-              )}
+                {session.branch && (
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted">
+                    <GitBranch size={11} className="shrink-0" />
+                    <span className="max-w-[70px] truncate md:max-w-none">{session.branch}</span>
+                  </span>
+                )}
+                {(session.add > 0 || session.del > 0) && (
+                  <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border px-2 py-0.5 text-[11px] text-muted">
+                    <Diff size={11} className="shrink-0" />
+                    <span className="max-w-[70px] truncate md:max-w-none">{formatDiff(session.add, session.del)}</span>
+                  </span>
+                )}
+                {/* Session actions (Phase 3, ADR-251/259) — Export + Git grouped into one overflow
+                    menu rather than two more standalone buttons: neither action is frequent
+                    enough to earn its own always-visible icon. Works regardless of run state —
+                    export reads only already-persisted messages, and the git dialog fetches live
+                    status itself when opened. */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="shrink-0 rounded p-1 text-faint transition-colors hover:text-ink data-[state=open]:text-ink"
+                      title="Session actions"
+                      aria-label="Session actions"
+                    >
+                      <MoreHorizontal size={15} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      disabled={exportMut.isPending}
+                      onSelect={() => exportMut.mutate(session.id)}
+                    >
+                      <Download size={13} /> {exportMut.isPending ? 'Exporting…' : 'Export'}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setGitDialogOpen(true)}>
+                      <GitBranch size={13} /> Git…
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </>
           )}
         </div>
@@ -665,9 +720,7 @@ export function CodeSessionScreen() {
             {!notFound && session?.clearedUpToMessageId && (
               <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2 text-[12px] text-muted">
                 <Eraser size={13} className="shrink-0 text-faint" />
-                <span className="flex-1">
-                  Chat cleared — {clearedCount} earlier message{clearedCount === 1 ? '' : 's'} hidden.
-                </span>
+                <span className="flex-1">Chat cleared — earlier messages hidden.</span>
                 <button
                   type="button"
                   onClick={() => void runResume()}
@@ -699,8 +752,11 @@ export function CodeSessionScreen() {
               <CodeTranscript
                 messages={transcriptMessages}
                 liveAssistantId={live?.assistantId}
-                live={live ? { timeline: live.timeline, reasoning: live.reasoning, compacting: live.compacting } : null}
+                live={live ? { timeline: live.timeline, reasoning: live.reasoning, compacting: live.compacting, retry: live.retry } : null}
                 onRevert={live || queued.length > 0 ? undefined : openRevertConfirm}
+                queued={queued}
+                onSendNowQueued={(id) => void handleSendNow(id)}
+                shellRuns={shellRuns}
               />
             )}
           </div>
@@ -720,39 +776,28 @@ export function CodeSessionScreen() {
           <ToolApprovalBar key={pendingApproval.id} pending={pendingApproval} convId={session?.convId ?? ''} onResolved={() => {}} />
         )}
 
+        {/* The live turn's plan — pinned here, OUTSIDE the scrolling transcript above and
+            directly above the composer, so it never scrolls out of view mid-turn (founder
+            feedback, 2026-07-24: rendering it inline in the transcript, per the original #16
+            build, meant it scrolled away the moment there was enough reasoning/tool output to
+            push it off-screen — exactly wrong for something meant to stay visible as a reference
+            while the turn runs). `bg-panel-2` + its own border gives it a clearly distinct band
+            between the conversation and the input, rather than blending into either. */}
+        {!!live?.todos?.length && (
+          <div className="border-t border-border bg-panel-2 px-3 py-2 md:px-8">
+            <TodoChecklist todos={live.todos} />
+          </div>
+        )}
+
         {/* Composer — the SAME CodeComposer CodeHomeScreen.tsx renders (no
             `repo`: the repo is fixed for the session's lifetime). Mode and
             model are both editable here too — see the handlers above. */}
         <div className="px-3 pb-3 md:px-8 md:pb-5">
-          {queued.length > 0 && (
-            <div className="mb-2 flex flex-wrap items-center gap-1.5">
-              <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted">
-                <Clock size={11} className="text-faint" /> Queued
-              </span>
-              {queued.map((q) => (
-                <span
-                  key={q.userMsgId}
-                  className="inline-flex max-w-[280px] items-center gap-1 rounded-full border border-border bg-panel-2 py-1 pr-1 pl-2.5 text-[12px] text-muted"
-                >
-                  <span className="min-w-0 truncate" title={q.task}>{q.task}</span>
-                  <button
-                    type="button"
-                    onClick={() => void handleSendNow(q.userMsgId)}
-                    title="Send now — stop the current run and run this one next"
-                    aria-label="Send now"
-                    className="grid h-5 w-5 shrink-0 place-items-center rounded-full text-faint transition-colors hover:bg-panel hover:text-ink"
-                  >
-                    <SendHorizontal size={11} />
-                  </button>
-                </span>
-              ))}
-            </div>
-          )}
           <CodeComposer
             inputRef={inputRef}
             value={input}
             onValueChange={setInput}
-            onSubmit={() => void send()}
+            onSubmit={(kind) => void send(kind)}
             placeholder={live ? 'Queue a follow-up…' : 'Send a follow-up…'}
             textareaDisabled={manualCompacting}
             mode={modeInfo}
@@ -776,9 +821,9 @@ export function CodeSessionScreen() {
             contextFiles={contextFiles}
             onRemoveContextFile={(p) => setContextFiles((cf) => cf.filter((x) => x !== p))}
             slashCommands={[
-              { id: 'compact', description: 'Summarize the conversation so far into one summary, to free up context' },
-              { id: 'clear', description: 'Clear the chat — repo, worktree, and branch stay as they are' },
-              ...(session?.clearedUpToMessageId || session?.revertedFromMessageId ? [{ id: 'resume', description: 'Bring back a cleared or reverted chat' }] : []),
+              // Built-ins from the shared registry (code-commands.ts) — the same source send()
+              // parses against — then the dynamic skills appended after.
+              ...pickerCodeCommands({ cleared: !!(session?.clearedUpToMessageId || session?.revertedFromMessageId) }),
               ...(skillsQ.data ?? []).map((s) => ({ id: s.id, description: s.description })),
             ]}
             // Prominent, accent-colored banner above the textarea for any real in-progress
@@ -797,6 +842,7 @@ export function CodeSessionScreen() {
         </div>
       </div>
       <ModelDetailDialog modelKey={settingsKey} onClose={() => setSettingsKey(null)} />
+      {session && <CodeGitDialog sessionId={session.id} open={gitDialogOpen} onOpenChange={setGitDialogOpen} />}
       <FsBrowser
         open={contextBrowserOpen}
         onOpenChange={setContextBrowserOpen}

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -31,6 +31,7 @@ import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle 
 import { ModelDetailDialog } from '../models/ModelDetailDialog'
 import { FsBrowser } from '../engines/FsBrowser'
 import { CodeComposer } from './CodeComposer'
+import { CodeResourcesHeader } from './CodeResourcesHeader'
 import { CodeGitDialog } from './CodeGitDialog'
 import { CodeTranscript, CodeTranscriptSkeleton, TodoChecklist } from './CodeTranscript'
 import { AGENT_MODES, type AgentModeId } from './code-mock'
@@ -704,6 +705,18 @@ export function CodeSessionScreen() {
           )}
         </div>
 
+        {/* Loaded-resources header (ADR-262) — a collapsible strip surfacing the AGENTS.md +
+            skills persona.ts loads server-side but the UI never showed. Fixed below the title bar
+            (not scrolling with the transcript) so it stays a glanceable resource indicator.
+            Deliberately no mode/model/context here — those have their single home in the composer
+            (ADR-262's no-duplication constraint). */}
+        {session && !notFound && (
+          <CodeResourcesHeader
+            skillCount={skillsQ.data?.length ?? 0}
+            hasAgentsMd={detailQ.data?.hasAgentsMd ?? { project: false, global: false }}
+          />
+        )}
+
         {/* Transcript — activity-log presentation (CodeTranscript.tsx), not
             chat's bubble stack. See that file's header comment for the full
             rationale. */}
@@ -752,7 +765,7 @@ export function CodeSessionScreen() {
               <CodeTranscript
                 messages={transcriptMessages}
                 liveAssistantId={live?.assistantId}
-                live={live ? { timeline: live.timeline, reasoning: live.reasoning, compacting: live.compacting, retry: live.retry } : null}
+                live={live ? { timeline: live.timeline, reasoning: live.reasoning, compacting: live.compacting, retry: live.retry, prefill: live.prefill } : null}
                 onRevert={live || queued.length > 0 ? undefined : openRevertConfirm}
                 queued={queued}
                 onSendNowQueued={(id) => void handleSendNow(id)}
@@ -781,10 +794,12 @@ export function CodeSessionScreen() {
             feedback, 2026-07-24: rendering it inline in the transcript, per the original #16
             build, meant it scrolled away the moment there was enough reasoning/tool output to
             push it off-screen — exactly wrong for something meant to stay visible as a reference
-            while the turn runs). `bg-panel-2` + its own border gives it a clearly distinct band
-            between the conversation and the input, rather than blending into either. */}
+            while the turn runs). Just a top border sets it off from the transcript above — the
+            old bordered-card + bg-panel-2 band read as a floating card next to the flat log
+            (founder feedback, 2026-07-24); flat now (ADR-262), so it reads as a pinned strip of
+            the same log, not a separate panel. */}
         {!!live?.todos?.length && (
-          <div className="border-t border-border bg-panel-2 px-3 py-2 md:px-8">
+          <div className="border-t border-border px-3 py-1.5 md:px-8">
             <TodoChecklist todos={live.todos} />
           </div>
         )}

--- a/turbollm/web/src/screens/code/CodeTranscript.test.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.test.tsx
@@ -215,7 +215,7 @@ describe('CodeTranscript — Phase 2 live rendering', () => {
     expect(screen.getByText('streaming output here')).toBeInTheDocument()
   })
 
-  it('supersedes the live partial with the terminal result across the pending→done transition', () => {
+  it('supersedes the live partial with the terminal result across the pending→done transition (while manually expanded)', () => {
     const { rerender } = render(
       <CodeTranscript
         messages={[]}
@@ -225,10 +225,13 @@ describe('CodeTranscript — Phase 2 live rendering', () => {
         }}
       />,
     )
-    // While running, the card auto-opens and shows the streaming partial.
+    // While running, the card auto-opens and shows the streaming partial — no click needed.
     expect(screen.getByText('stale partial')).toBeInTheDocument()
-    // The same tool call finishes (same id → same card instance, so it stays open): the terminal
-    // result takes over and the now-stale partial is gone.
+    // A user watching it click to keep it open explicitly (simulates them having expanded it —
+    // see the next test for the DEFAULT collapse-on-finish behavior when they haven't). This
+    // flips `expanded` true, which PERSISTS across the rerender below (same call id → same
+    // component instance → same state), so no second click is needed after it.
+    fireEvent.click(screen.getByText('ls'))
     rerender(
       <CodeTranscript
         messages={[]}
@@ -240,6 +243,36 @@ describe('CodeTranscript — Phase 2 live rendering', () => {
     )
     expect(screen.getByText('final result')).toBeInTheDocument()
     expect(screen.queryByText('stale partial')).not.toBeInTheDocument()
+  })
+
+  it('collapses back to the default (no diff → closed) once a streamed command finishes, unless the user expanded it themselves', () => {
+    // Founder feedback, 2026-07-24: an earlier version force-expanded and NEVER reverted once a
+    // command streamed live output, so every bash call stayed open forever after finishing —
+    // this is the actual regression guard for the fix.
+    const { rerender } = render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending', partial: 'live output' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    expect(screen.getByText('live output')).toBeInTheDocument() // visible while actually streaming
+    rerender(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'done', result: 'final result' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    // Finished, no diff, never manually expanded — collapsed by default, same as any other call.
+    expect(screen.queryByText('final result')).not.toBeInTheDocument()
+    // Still reachable by clicking — collapsed is the default, not a removed capability.
+    fireEvent.click(screen.getByText('ls'))
+    expect(screen.getByText('final result')).toBeInTheDocument()
   })
 
   it('shows the Retrying banner and NOT the Compacting one when a retry and compaction overlap', () => {
@@ -264,6 +297,57 @@ describe('CodeTranscript — Phase 2 live rendering', () => {
   it('never shows a "Round N" label at any round index, however high', () => {
     render(<CodeTranscript messages={[]} live={{ timeline: [{ kind: 'turn', index: 3 }], reasoning: '' }} />)
     expect(screen.queryByText(/Round \d/)).not.toBeInTheDocument()
+  })
+})
+
+describe('CodeTranscript — prefill progress bar (llama.cpp /slots)', () => {
+  it('shows the "Processing prompt NN%" line and a bar filled to the pct while prefill is active', () => {
+    const { container } = render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [], reasoning: '', prefill: { processed: 750, total: 1000, pct: 75 } }}
+      />,
+    )
+    expect(screen.getByText('Processing prompt')).toBeInTheDocument()
+    expect(screen.getByText('75%')).toBeInTheDocument()
+    // The bar's fill width tracks the pct (the second inner div is the --accent fill).
+    const fill = container.querySelector('div[style*="width: 75%"]')
+    expect(fill).toBeInTheDocument()
+  })
+
+  it('shows NO prefill line when no prefill frame ever arrived (normal path — falls to the thinking placeholder)', () => {
+    render(<CodeTranscript messages={[]} live={{ timeline: [], reasoning: '' }} />)
+    expect(screen.queryByText('Processing prompt')).not.toBeInTheDocument()
+    // The default empty-live path shows the generic thinking placeholder instead.
+    expect(screen.getByText('thinking…')).toBeInTheDocument()
+  })
+
+  it('takes priority over the thinking placeholder while active (only the bar shows, not both)', () => {
+    render(<CodeTranscript messages={[]} live={{ timeline: [], reasoning: '', prefill: { processed: 100, total: 1000, pct: 10 } }} />)
+    expect(screen.getByText('Processing prompt')).toBeInTheDocument()
+    expect(screen.queryByText('thinking…')).not.toBeInTheDocument()
+  })
+
+  it('takes priority over the retry banner while active (prefill precedes generation)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [], reasoning: '', prefill: { processed: 100, total: 1000, pct: 10 }, retry: { attempt: 1, maxAttempts: 3, message: 'blip' } }}
+      />,
+    )
+    expect(screen.getByText('Processing prompt')).toBeInTheDocument()
+    expect(screen.queryByText(/Retrying…/)).not.toBeInTheDocument()
+  })
+
+  it('clears (bar gone) once real content has arrived and prefill is nulled', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [{ kind: 'text', text: 'generated text' }], reasoning: '', prefill: null }}
+      />,
+    )
+    expect(screen.queryByText('Processing prompt')).not.toBeInTheDocument()
+    expect(screen.getByText('generated text')).toBeInTheDocument()
   })
 })
 
@@ -371,5 +455,125 @@ describe('CodeTranscript — !command / !!command shell escape (ADR-258)', () =>
   it('marks a timed-out shell run', () => {
     render(<CodeTranscript messages={[]} shellRuns={[{ id: 'sh1', command: 'sleep 99', output: '', exitCode: null, timedOut: true }]} />)
     expect(screen.getByText('timed out')).toBeInTheDocument()
+  })
+})
+
+describe('CodeTranscript — grouping consecutive similar terminal commands', () => {
+  // A live-timeline `bash` tool block. Grouping happens in ToolRun, which both the live and
+  // persisted paths render through, so exercising it via `live` covers both.
+  function bashBlock(id: string, command: string, opts?: { status?: 'pending' | 'done' | 'error'; result?: string }) {
+    return { kind: 'tool' as const, call: { id, name: 'bash', args: { command }, status: opts?.status ?? 'done', result: opts?.result } }
+  }
+  function readBlock(id: string, path: string) {
+    return { kind: 'tool' as const, call: { id, name: 'read', args: { path }, status: 'done' as const } }
+  }
+
+  it('groups 3 consecutive git commands into one collapsed line with the right count', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [
+            bashBlock('t1', 'git status'),
+            bashBlock('t2', 'git add .'),
+            bashBlock('t3', 'git commit -m "fix"'),
+          ],
+          reasoning: '',
+        }}
+      />,
+    )
+    expect(screen.getByText('3 git commands')).toBeInTheDocument()
+    // Collapsed by default — the individual command lines are hidden until the group is expanded.
+    expect(screen.queryByText('git status')).not.toBeInTheDocument()
+    expect(screen.queryByText('git add .')).not.toBeInTheDocument()
+  })
+
+  it('leaves a lone git command ungrouped when its neighbours are different commands', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [
+            bashBlock('t1', 'npm test'),
+            bashBlock('t2', 'git status'),
+            bashBlock('t3', 'ls -la'),
+          ],
+          reasoning: '',
+        }}
+      />,
+    )
+    // No group formed — every command has a distinct leading word, so each stays its own line.
+    expect(screen.queryByText(/\d+ git commands/)).not.toBeInTheDocument()
+    expect(screen.getByText('git status')).toBeInTheDocument()
+    expect(screen.getByText('npm test')).toBeInTheDocument()
+    expect(screen.getByText('ls -la')).toBeInTheDocument()
+  })
+
+  it('produces two separate groups for two different consecutive-similar runs (2 git then 2 npm)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [
+            bashBlock('t1', 'git status'),
+            bashBlock('t2', 'git add .'),
+            bashBlock('t3', 'npm install'),
+            bashBlock('t4', 'npm test'),
+          ],
+          reasoning: '',
+        }}
+      />,
+    )
+    expect(screen.getByText('2 git commands')).toBeInTheDocument()
+    expect(screen.getByText('2 npm commands')).toBeInTheDocument()
+    // Not merged into one group.
+    expect(screen.queryByText('4 git commands')).not.toBeInTheDocument()
+  })
+
+  it('expands a group to reveal each command as its own independently-expandable line', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [
+            bashBlock('t1', 'git status', { result: 'on branch main' }),
+            bashBlock('t2', 'git add .', { result: 'staged 1 file' }),
+            bashBlock('t3', 'git log', { result: 'commit abc123' }),
+          ],
+          reasoning: '',
+        }}
+      />,
+    )
+    // Collapsed: neither the command lines nor their outputs are visible.
+    expect(screen.queryByText('git status')).not.toBeInTheDocument()
+    expect(screen.queryByText('on branch main')).not.toBeInTheDocument()
+
+    // Expand the group → the three command lines appear, but each keeps ITS OWN output collapsed.
+    fireEvent.click(screen.getByText('3 git commands'))
+    expect(screen.getByText('git status')).toBeInTheDocument()
+    expect(screen.getByText('git add .')).toBeInTheDocument()
+    expect(screen.getByText('git log')).toBeInTheDocument()
+    expect(screen.queryByText('on branch main')).not.toBeInTheDocument()
+
+    // Each inner line is still independently expandable for its own output.
+    fireEvent.click(screen.getByText('git status'))
+    expect(screen.getByText('on branch main')).toBeInTheDocument()
+    // Expanding one does not reveal another's output.
+    expect(screen.queryByText('staged 1 file')).not.toBeInTheDocument()
+  })
+
+  it('never groups non-bash tool calls (consecutive reads stay separate lines)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [readBlock('t1', 'a.ts'), readBlock('t2', 'b.ts')],
+          reasoning: '',
+        }}
+      />,
+    )
+    expect(screen.getByText('a.ts')).toBeInTheDocument()
+    expect(screen.getByText('b.ts')).toBeInTheDocument()
+    expect(screen.queryByText(/commands$/)).not.toBeInTheDocument()
   })
 })

--- a/turbollm/web/src/screens/code/CodeTranscript.test.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.test.tsx
@@ -1,0 +1,375 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { CodeTranscript, TodoChecklist } from './CodeTranscript'
+import { toggleDisplayPref } from '../../lib/code-display-prefs'
+import type { Message } from '../../lib/chat-types'
+import type { QueuedTurn, SteerKind } from '../../lib/code-types'
+
+function userMessage(content: string, id: string): Message {
+  return {
+    id, convId: 'c1', seq: 0, role: 'user', content, reasoning: '',
+    attachments: [], textAttachments: [], toolCalls: [], stats: {}, createdAt: '2026-07-24T00:00:00Z',
+    variantGroup: null, isActive: true, edited: false,
+  }
+}
+
+function queuedTurn(task: string, userMsgId: string, kind: SteerKind): QueuedTurn {
+  return { task, userMsgId, kind }
+}
+
+describe('CodeTranscript — inline queued cards', () => {
+  it('renders no queued card (and no "Send now") when the queue is empty', () => {
+    render(<CodeTranscript messages={[]} queued={[]} onSendNowQueued={() => {}} />)
+    expect(screen.queryByText('Send now')).not.toBeInTheDocument()
+    expect(screen.queryByText('Runs next')).not.toBeInTheDocument()
+    expect(screen.queryByText('Steers this turn')).not.toBeInTheDocument()
+  })
+
+  it('renders a follow-up queued card with its task text and a "Runs next" badge', () => {
+    render(<CodeTranscript messages={[]} queued={[queuedTurn('do the thing', 'q1', 'followUp')]} onSendNowQueued={() => {}} />)
+    expect(screen.getByText('do the thing')).toBeInTheDocument()
+    expect(screen.getByText('Runs next')).toBeInTheDocument()
+    expect(screen.queryByText('Steers this turn')).not.toBeInTheDocument()
+  })
+
+  it('renders a steer queued card with a "Steers this turn" badge', () => {
+    render(<CodeTranscript messages={[]} queued={[queuedTurn('go left instead', 'q1', 'steer')]} onSendNowQueued={() => {}} />)
+    expect(screen.getByText('go left instead')).toBeInTheDocument()
+    expect(screen.getByText('Steers this turn')).toBeInTheDocument()
+    expect(screen.queryByText('Runs next')).not.toBeInTheDocument()
+  })
+
+  it('renders three queued cards in send order', () => {
+    const queued = [
+      queuedTurn('first', 'q1', 'followUp'),
+      queuedTurn('second', 'q2', 'followUp'),
+      queuedTurn('third', 'q3', 'followUp'),
+    ]
+    render(<CodeTranscript messages={[]} queued={queued} onSendNowQueued={() => {}} />)
+    const first = screen.getByText('first')
+    const second = screen.getByText('second')
+    const third = screen.getByText('third')
+    // eslint-disable-next-line no-bitwise
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    // eslint-disable-next-line no-bitwise
+    expect(second.compareDocumentPosition(third) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('distinguishes a steer from a follow-up when both are queued together', () => {
+    const queued = [
+      queuedTurn('redirect now', 'q1', 'steer'),
+      queuedTurn('and then this', 'q2', 'followUp'),
+    ]
+    render(<CodeTranscript messages={[]} queued={queued} onSendNowQueued={() => {}} />)
+    expect(screen.getByText('Steers this turn')).toBeInTheDocument()
+    expect(screen.getByText('Runs next')).toBeInTheDocument()
+  })
+
+  it('fires onSendNowQueued with the entry\'s userMsgId when "Send now" is clicked', () => {
+    const onSendNow = vi.fn()
+    render(<CodeTranscript messages={[]} queued={[queuedTurn('promote me', 'q42', 'followUp')]} onSendNowQueued={onSendNow} />)
+    fireEvent.click(screen.getByText('Send now'))
+    expect(onSendNow).toHaveBeenCalledWith('q42')
+  })
+
+  it('omits the "Send now" affordance when no handler is given (card still renders)', () => {
+    render(<CodeTranscript messages={[]} queued={[queuedTurn('waiting', 'q1', 'followUp')]} />)
+    expect(screen.getByText('waiting')).toBeInTheDocument()
+    expect(screen.queryByText('Send now')).not.toBeInTheDocument()
+  })
+
+  it('renders queued cards at the tail — after existing transcript messages (ADR-199 ordering)', () => {
+    render(
+      <CodeTranscript
+        messages={[userMessage('PAST TASK', 'm1')]}
+        queued={[queuedTurn('FUTURE TASK', 'q1', 'followUp')]}
+        onSendNowQueued={() => {}}
+      />,
+    )
+    const past = screen.getByText('PAST TASK')
+    const future = screen.getByText('FUTURE TASK')
+    // The queued card must come AFTER the already-rendered transcript message, never above it.
+    // eslint-disable-next-line no-bitwise
+    expect(past.compareDocumentPosition(future) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('defaults an untagged queued entry (older cached shape) to the follow-up treatment', () => {
+    // Backend always tags `kind`, but a queue entry cached before that field existed would arrive
+    // without it — the card must still render (as a follow-up) rather than crash.
+    const untagged = { task: 'legacy', userMsgId: 'q1' } as unknown as QueuedTurn
+    render(<CodeTranscript messages={[]} queued={[untagged]} onSendNowQueued={() => {}} />)
+    expect(screen.getByText('legacy')).toBeInTheDocument()
+    expect(screen.getByText('Runs next')).toBeInTheDocument()
+  })
+
+  // test plan §3 basic requirement: queued renders "NOT above the still-streaming live turn" —
+  // the existing tail-ordering test above only checks ordering against PAST (persisted) messages;
+  // this checks it against an actually-live entry, the real ADR-199 scenario.
+  it('renders a queued card AFTER the still-streaming live turn, never above it (live + queued together)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [{ kind: 'text', text: 'LIVE TURN CONTENT' }], reasoning: '' }}
+        queued={[queuedTurn('QUEUED FOLLOW-UP', 'q1', 'followUp')]}
+        onSendNowQueued={() => {}}
+      />,
+    )
+    const liveContent = screen.getByText('LIVE TURN CONTENT')
+    const queuedContent = screen.getByText('QUEUED FOLLOW-UP')
+    // eslint-disable-next-line no-bitwise
+    expect(liveContent.compareDocumentPosition(queuedContent) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  // test plan §3 basic requirement: "A queued item transitions translucent → full opacity the
+  // instant it actually starts running." At this presentational component's level that's: the
+  // item leaves `queued` and the SAME content now renders as the live entry — no orphaned
+  // translucent card left behind, no double-render of the same task.
+  it('a queued item promoted to live disappears from the queue — no orphaned card, no double-render', () => {
+    const { rerender } = render(
+      <CodeTranscript messages={[]} queued={[queuedTurn('run the fix', 'q1', 'followUp')]} onSendNowQueued={() => {}} />,
+    )
+    expect(screen.getByText('run the fix')).toBeInTheDocument()
+    expect(screen.getByText('Runs next')).toBeInTheDocument()
+
+    // The queue drains server-side the instant this turn goes live — same task, now live instead.
+    rerender(
+      <CodeTranscript
+        messages={[]}
+        queued={[]}
+        live={{ timeline: [{ kind: 'text', text: 'run the fix' }], reasoning: '' }}
+        onSendNowQueued={() => {}}
+      />,
+    )
+    expect(screen.queryByText('Runs next')).not.toBeInTheDocument()
+    expect(screen.getAllByText('run the fix')).toHaveLength(1)
+  })
+
+  // test plan §3 edge case: "Stop while a message is queued — the translucent card must not
+  // orphan in the transcript once the queue is cleared server-side." Distinct from the promotion
+  // case above: here nothing takes its place (stopped, not run).
+  it('clearing the queue (e.g. Stop) removes the translucent card entirely — nothing orphaned', () => {
+    const { rerender } = render(
+      <CodeTranscript messages={[]} queued={[queuedTurn('cancel me', 'q1', 'followUp')]} onSendNowQueued={() => {}} />,
+    )
+    expect(screen.getByText('cancel me')).toBeInTheDocument()
+    rerender(<CodeTranscript messages={[]} queued={[]} onSendNowQueued={() => {}} />)
+    expect(screen.queryByText('cancel me')).not.toBeInTheDocument()
+  })
+
+  // test plan §3 edge case: unicode/emoji/RTL text isn't subject to the app's "no emoji in UI
+  // chrome" rule (that's chrome, not user content) — just needs to render faithfully.
+  it('renders unicode/emoji/RTL content in a queued card without mangling it', () => {
+    const text = '修复错误 🐛 שלום עולם — fix the الخطأ'
+    render(<CodeTranscript messages={[]} queued={[queuedTurn(text, 'q1', 'followUp')]} onSendNowQueued={() => {}} />)
+    expect(screen.getByText(text)).toBeInTheDocument()
+  })
+
+  // test plan §3 edge case: a long multi-paragraph queued message wraps/renders in full, the same
+  // as a normal CodeInstructionEntry — not truncated. compareDocumentPosition-style getByText on
+  // the full string is brittle across a multi-paragraph blob (whitespace-pre-wrap can produce
+  // several DOM nodes/ancestors that all "contain" the same textContent), so this checks the
+  // first and last paragraph both survived instead of asserting on the raw concatenated string.
+  it('renders a long multi-paragraph queued message in full, not truncated', () => {
+    const long = Array.from({ length: 6 }, (_, i) => `Paragraph ${i + 1} with enough text to wrap across multiple lines in a narrow card.`).join('\n\n')
+    const { container } = render(<CodeTranscript messages={[]} queued={[queuedTurn(long, 'q1', 'followUp')]} onSendNowQueued={() => {}} />)
+    expect(container.textContent).toContain('Paragraph 1 with enough text')
+    expect(container.textContent).toContain('Paragraph 6 with enough text')
+  })
+})
+
+describe('CodeTranscript — Phase 2 live rendering', () => {
+  it('shows a "Retrying…" banner with attempt count and reason from retry state', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [], reasoning: '', retry: { attempt: 2, maxAttempts: 5, message: 'rate limited' } }}
+      />,
+    )
+    expect(screen.getByText('Retrying… attempt 2 of 5 — rate limited')).toBeInTheDocument()
+  })
+
+  it('renders a round divider for a turn block in the live timeline, as a plain line with no "Round N" text', () => {
+    // No text label (founder feedback, 2026-07-24) — the divider is a bare rule now, so this
+    // guards the actual regression: the label must never come back.
+    const { container } = render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [{ kind: 'turn', index: 1 }], reasoning: '' }}
+      />,
+    )
+    expect(screen.queryByText(/Round \d/)).not.toBeInTheDocument()
+    expect(container.querySelector('span[aria-hidden].block.h-px')).toBeInTheDocument()
+  })
+
+  it('streams a running tool call\'s live partial output into its card', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending', partial: 'streaming output here' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    // The live snapshot shows in the card before any terminal result exists.
+    expect(screen.getByText('streaming output here')).toBeInTheDocument()
+  })
+
+  it('supersedes the live partial with the terminal result across the pending→done transition', () => {
+    const { rerender } = render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'pending', partial: 'stale partial' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    // While running, the card auto-opens and shows the streaming partial.
+    expect(screen.getByText('stale partial')).toBeInTheDocument()
+    // The same tool call finishes (same id → same card instance, so it stays open): the terminal
+    // result takes over and the now-stale partial is gone.
+    rerender(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'done', result: 'final result', partial: 'stale partial' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    expect(screen.getByText('final result')).toBeInTheDocument()
+    expect(screen.queryByText('stale partial')).not.toBeInTheDocument()
+  })
+
+  it('shows the Retrying banner and NOT the Compacting one when a retry and compaction overlap', () => {
+    // The transcript has one shared status-banner slot; retry is the more salient transient state
+    // and must take priority so the two are never confused (test plan: "distinct, not confused").
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{ timeline: [], reasoning: '', compacting: true, retry: { attempt: 1, maxAttempts: 3, message: 'blip' } }}
+      />,
+    )
+    expect(screen.getByText(/Retrying…/)).toBeInTheDocument()
+    expect(screen.queryByText('Compacting conversation…')).not.toBeInTheDocument()
+  })
+
+  it('shows the Compacting banner (distinct copy) when compacting with no retry in flight', () => {
+    render(<CodeTranscript messages={[]} live={{ timeline: [], reasoning: '', compacting: true }} />)
+    expect(screen.getByText('Compacting conversation…')).toBeInTheDocument()
+    expect(screen.queryByText(/Retrying…/)).not.toBeInTheDocument()
+  })
+
+  it('never shows a "Round N" label at any round index, however high', () => {
+    render(<CodeTranscript messages={[]} live={{ timeline: [{ kind: 'turn', index: 3 }], reasoning: '' }} />)
+    expect(screen.queryByText(/Round \d/)).not.toBeInTheDocument()
+  })
+})
+
+describe('TodoChecklist (ADR-255) — pinned above the composer by CodeSessionScreen.tsx, not rendered inline in the transcript', () => {
+  // Moved out of CodeTranscript entirely (founder feedback, 2026-07-24: a plan rendered inline
+  // scrolled out of view the moment there was enough content to push it off-screen) — tested here
+  // as the standalone exported component CodeSessionScreen.tsx now renders directly.
+  it('renders nothing when todos is empty', () => {
+    const { container } = render(<TodoChecklist todos={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a populated checklist with mixed statuses and a done/total count', () => {
+    render(
+      <TodoChecklist
+        todos={[
+          { content: 'Read the failing test', status: 'completed' },
+          { content: 'Fix the off-by-one bug', status: 'in_progress' },
+          { content: 'Re-run the suite', status: 'pending' },
+        ]}
+      />,
+    )
+    expect(screen.getByText('Plan')).toBeInTheDocument()
+    expect(screen.getByText('1/3')).toBeInTheDocument()
+    expect(screen.getByText('Read the failing test')).toBeInTheDocument()
+    expect(screen.getByText('Fix the off-by-one bug')).toBeInTheDocument()
+    expect(screen.getByText('Re-run the suite')).toBeInTheDocument()
+  })
+})
+
+describe('CodeTranscript — /details + /thinking global display toggles (ADR-258)', () => {
+  // These toggles persist in localStorage; reset so a flipped pref never leaks across tests.
+  afterEach(() => { localStorage.clear() })
+
+  it('/details force-expands a collapsed tool card (and collapses again when toggled off)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: { command: 'ls' }, status: 'done', result: 'collapsed output' } }],
+          reasoning: '',
+        }}
+      />,
+    )
+    // A finished non-diff tool card starts collapsed — its output is hidden.
+    expect(screen.queryByText('collapsed output')).not.toBeInTheDocument()
+    act(() => { toggleDisplayPref('details') })
+    expect(screen.getByText('collapsed output')).toBeInTheDocument()
+    act(() => { toggleDisplayPref('details') })
+    expect(screen.queryByText('collapsed output')).not.toBeInTheDocument()
+  })
+
+  it('/thinking force-opens a collapsed reasoning block', () => {
+    render(<CodeTranscript messages={[]} live={{ timeline: [], reasoning: 'my private reasoning' }} />)
+    // Reasoning is collapsed by default — the label shows, the content does not.
+    expect(screen.queryByText('my private reasoning')).not.toBeInTheDocument()
+    act(() => { toggleDisplayPref('thinking') })
+    expect(screen.getByText('my private reasoning')).toBeInTheDocument()
+  })
+
+  it('the two toggles are independent (/details does not open reasoning)', () => {
+    render(
+      <CodeTranscript
+        messages={[]}
+        live={{
+          timeline: [{ kind: 'tool', call: { id: 't1', name: 'bash', args: {}, status: 'done', result: 'the output' } }],
+          reasoning: 'the reasoning',
+        }}
+      />,
+    )
+    act(() => { toggleDisplayPref('details') })
+    expect(screen.getByText('the output')).toBeInTheDocument()
+    expect(screen.queryByText('the reasoning')).not.toBeInTheDocument()
+  })
+})
+
+describe('CodeTranscript — !command / !!command shell escape (ADR-258)', () => {
+  it('renders a persisted ! shell result as a "$ command" terminal entry (not a chat bubble)', () => {
+    const msg: Message = {
+      ...userMessage('I ran a shell command in the repo:\n\n$ npm test\n\nall tests passed', 'm1'),
+      toolCalls: [{ id: 'shell-1', name: 'shell', args: { command: 'npm test', exitCode: 0, timedOut: false }, result: 'all tests passed' }],
+    }
+    render(<CodeTranscript messages={[msg]} />)
+    expect(screen.getByText('$ npm test')).toBeInTheDocument()
+    expect(screen.getByText('all tests passed')).toBeInTheDocument()
+    // The framed model-context content is NOT surfaced as an instruction bubble.
+    expect(screen.queryByText(/I ran a shell command in the repo/)).not.toBeInTheDocument()
+  })
+
+  it('surfaces a non-zero exit code on a failed persisted shell command', () => {
+    const msg: Message = {
+      ...userMessage('x', 'm1'),
+      toolCalls: [{ id: 's', name: 'shell', args: { command: 'false', exitCode: 1, timedOut: false }, result: '' }],
+    }
+    render(<CodeTranscript messages={[msg]} />)
+    expect(screen.getByText('exit 1')).toBeInTheDocument()
+  })
+
+  it('renders ephemeral !! shell runs at the transcript tail', () => {
+    render(<CodeTranscript messages={[]} shellRuns={[{ id: 'sh1', command: 'ls -la', output: 'file.txt', exitCode: 0, timedOut: false }]} />)
+    expect(screen.getByText('$ ls -la')).toBeInTheDocument()
+    expect(screen.getByText('file.txt')).toBeInTheDocument()
+  })
+
+  it('marks a timed-out shell run', () => {
+    render(<CodeTranscript messages={[]} shellRuns={[{ id: 'sh1', command: 'sleep 99', output: '', exitCode: null, timedOut: true }]} />)
+    expect(screen.getByText('timed out')).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/screens/code/CodeTranscript.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
-  Brain,
   CheckCircle2,
-  ChevronDown,
   ChevronRight,
   Circle,
   Clock,
@@ -12,10 +10,8 @@ import {
   FileText,
   FolderTree,
   HelpCircle,
-  Layers,
   ListChecks,
   Loader2,
-  MessageSquare,
   RotateCcw,
   Search,
   SendHorizontal,
@@ -30,44 +26,34 @@ import { useDisplayPref } from '../../lib/code-display-prefs'
 import type { LiveBlock } from '../../lib/live-timeline'
 import { friendlyName } from '../../lib/tool-explain'
 import { cn } from '../../lib/utils'
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '../../components/ui/sheet'
 import { CopyButton } from '../../components/ui/copy-button'
 import { Skeleton } from '../../components/ui/skeleton'
 import { Markdown } from '../chat/MessageBubble'
 
 // ── Code session transcript ──────────────────────────────────────────────────
 //
-// A DELIBERATELY different visual language from chat/MessageBubble.tsx's bubbles
-// — built after the founder's own critique: "when I start chatting, it feels
-// like a chat and not code. I can't feel the diff between the two." Same real
-// data (genuine diffs/tool calls/reasoning/text off the SSE stream, nothing
-// faked) presented as an activity log instead of a conversation:
-//   - a vertical rail connects entries (build-log / commit-graph grammar, not a
-//     left/right message stack)
-//   - the user's task/follow-ups render as an instruction callout, not a chat
-//     bubble aimed at "you"
-//   - tool calls are the PRIMARY visual unit — a real file-path header, and for
-//     edits, a two-gutter line-numbered diff panel, not a small card nested
-//     inside a bubble
-//   - a RUN of 2+ consecutive tool calls collapses into one scannable summary
-//     ("5 tool calls · 3 edits · 2 reads") instead of a wall of cards — click it
-//     to open a side panel (the same Sheet primitive/pattern ContextUsageRing.tsx
-//     already uses) listing every call, each individually expandable to its full
-//     detail. A lone tool call still renders inline in full, since there's
-//     nothing to declutter for just one.
-//   - assistant prose is commentary between actions — plain flowing text with a
-//     small marker, not another bubble
-//   - tool output/diffs use the SAME near-black log-panel tokens
-//     (--log-bg/--log-ink) EngineLogPanel.tsx already uses for terminal output,
-//     so it reads as "console", and reasoning gets the same monospace treatment
-//     (it's the agent's internal narration, not its final answer) — while
-//     commentary stays in the app's normal prose type, so the eye can tell
-//     "code/activity" from "explanation" at a glance, per the founder's own
-//     suggestion.
-// Carries the launchpad's own identity through rather than dropping it the
-// moment a task starts: SquareTerminal marks the task entry (same icon
-// CodeHomeScreen/the sidebar use for Code mode throughout), and the accent
-// token colors the rail's active/in-progress states.
+// A dense, flat activity log (ADR-262) — modelled on opencode/pi's terminal FEEL,
+// the tools this redesign was commissioned against, NOT on chat/MessageBubble.tsx's
+// bubbles. Same real data (genuine diffs/tool calls/reasoning/text off the SSE
+// stream, nothing faked), presented as a log:
+//   - tool calls are FLAT glyph-prefixed lines (a leading tool icon + the file
+//     path/command), not bordered cards, and not collapsed into a group→side-panel.
+//     Each line expands inline to its diff/output — the reference's "click to
+//     expand" pattern, not a separate Sheet.
+//   - the user's task/follow-ups stay a right-aligned instruction callout;
+//     everything the agent does stays left-aligned. Sender is distinguished by
+//     alignment + color alone (Chat already proves this works), NO vertical rail —
+//     the rail was a TurboLLM-only construct with no analog in either reference,
+//     dropped per ADR-262.
+//   - tool output/diffs use the near-black --log-bg/--log-ink + --diff-* tokens
+//     (spec 11 / Phase 0), so they read as a console; reasoning gets the same
+//     monospace log treatment (agent narration, not its final answer); assistant
+//     commentary stays in normal prose type, so the eye tells "code/activity" from
+//     "explanation" at a glance.
+//   - density is tight (small gaps, one-line tool entries) toward the reference's
+//     look — deliberately less airy than the old card-and-rail layout, without
+//     going cramped/illegible. ADR-252 still holds: prose stays sans (mono only
+//     where it earns it), light+dark both first-class, no literal terminal chrome.
 
 type ToolStatus = 'pending' | 'done' | 'error' | 'awaiting_approval'
 
@@ -106,25 +92,7 @@ function toolIcon(name: string) {
   return Terminal
 }
 
-/** A one-word kind used for the group summary's breakdown ("3 edits · 2 reads"). */
-function toolKind(name: string): 'edit' | 'write' | 'command' | 'read' | 'search' | 'listing' | 'call' {
-  if (EDIT_TOOLS.has(name)) return 'edit'
-  if (WRITE_TOOLS.has(name)) return 'write'
-  if (BASH_TOOLS.has(name)) return 'command'
-  if (READ_TOOLS.has(name)) return 'read'
-  if (SEARCH_TOOLS.has(name)) return 'search'
-  if (name === 'ls') return 'listing'
-  return 'call'
-}
-const KIND_PLURAL: Record<string, string> = {
-  edit: 'edits', write: 'writes', command: 'commands', read: 'reads', search: 'searches', listing: 'listings', call: 'calls',
-}
-/** Present-participle verb for the group summary's live "what's happening now" line. */
-const KIND_VERB: Record<string, string> = {
-  edit: 'Editing', write: 'Writing', command: 'Running', read: 'Reading', search: 'Searching', listing: 'Listing', call: 'Calling',
-}
-
-/** A file-taking tool's `path` arg, for a card's header — falls back to the
+/** A file-taking tool's `path` arg, for the flat line's label — falls back to the
  *  friendly tool name when there's no path (bash, or an odd/legacy call shape).
  *  invoke_skill has neither a path nor a command, just a skillId, so without this it would
  *  render as the unhelpfully generic "invoke skill" for every skill call alike. */
@@ -144,12 +112,6 @@ const STATUS_COLOR: Record<ToolStatus, string> = {
   error: 'var(--err)',
   awaiting_approval: 'var(--warn)',
 }
-const STATUS_LABEL: Record<ToolStatus, string> = {
-  pending: 'Running',
-  done: 'Done',
-  error: 'Error',
-  awaiting_approval: 'Awaiting approval',
-}
 
 function StatusIcon({ status }: { status: ToolStatus }) {
   if (status === 'pending') return <Loader2 size={13} className="shrink-0 animate-spin" style={{ color: STATUS_COLOR.pending }} />
@@ -158,7 +120,7 @@ function StatusIcon({ status }: { status: ToolStatus }) {
   return <HelpCircle size={13} className="shrink-0" style={{ color: STATUS_COLOR.awaiting_approval }} />
 }
 
-/** Count +/- lines for the header's compact stat chip (skips the +++/--- file
+/** Count +/- lines for the line's compact stat chip (skips the +++/--- file
  *  headers, which start with the same characters but aren't real changes). */
 function diffStats(diff: string): { add: number; del: number } {
   let add = 0, del = 0
@@ -173,13 +135,15 @@ function diffStats(diff: string): { add: number; del: number } {
 /** Two-gutter (old-line# | new-line#), line-colored unified-diff panel — real
  *  line numbers reconstructed from the diff's own `@@ -a,b +c,d @@` hunk
  *  headers, IDE-style. No diffing computed client-side; this only lays out
- *  pi's own diff output (turbollm/src/code/code-session.ts). */
+ *  pi's own diff output (turbollm/src/code/code-session.ts). The diff CONTENT
+ *  stays fully readable (line numbers + add/del coloring) — ADR-262 flattened the
+ *  chrome AROUND tool calls, not the usefulness of the diff itself. */
 function CodeDiffPanel({ diff }: { diff: string }) {
   const lines = diff.replace(/\n$/, '').split('\n')
   let oldLine = 0
   let newLine = 0
   return (
-    <div className="max-h-[420px] overflow-auto border-t border-border">
+    <div className="max-h-[420px] overflow-auto rounded-md border border-border">
       <table className="w-full border-collapse font-mono text-[12px] leading-relaxed">
         <tbody>
           {lines.map((line, i) => {
@@ -235,15 +199,15 @@ function CodeDiffPanel({ diff }: { diff: string }) {
 
 /** Non-diff tool output (bash stdout, read/grep/find/ls results) — the SAME
  *  near-black log tokens EngineLogPanel.tsx uses for real process output, so
- *  this reads as a console, not a chat attachment. When `streaming` (a live
- *  `tool_progress` snapshot, Phase 2) it follows the TAIL (newest output, like a
- *  real terminal) instead of the head, and shows a pulsing cursor. */
+ *  this reads as a console. When `streaming` (a live `tool_progress` snapshot,
+ *  Phase 2) it follows the TAIL (newest output, like a real terminal) instead of
+ *  the head, and shows a pulsing cursor. */
 function CodeOutputPanel({ text, streaming }: { text: string; streaming?: boolean }) {
   const truncated = text.length > 4000
     ? (streaming ? `…(earlier output hidden)\n${text.slice(-4000)}` : `${text.slice(0, 4000)}\n…(truncated)`)
     : text
   return (
-    <div className="max-h-80 overflow-auto border-t border-border" style={{ background: 'var(--log-bg)' }}>
+    <div className="max-h-80 overflow-auto rounded-md" style={{ background: 'var(--log-bg)' }}>
       <pre className="whitespace-pre-wrap px-3 py-2 font-mono text-[12px] leading-relaxed" style={{ color: 'var(--log-ink)' }}>
         {truncated || <span style={{ color: 'var(--log-faint)' }}>{streaming ? '' : '(no output)'}</span>}
         {streaming && <span className="tllm-pulse" style={{ color: 'var(--log-faint)' }}>▋</span>}
@@ -252,13 +216,14 @@ function CodeOutputPanel({ text, streaming }: { text: string; streaming?: boolea
   )
 }
 
-/** The primary visual unit for a LONE tool call — a real file/command header
- *  (monospace, like an editor tab) over either a diff panel (edit) or a
- *  console-style output panel (everything else). Edits/writes start expanded
- *  (they ARE the point of a code session); reads/searches/bash start collapsed
- *  (useful, but not the headline). Only rendered for runs of exactly one call —
- *  2+ in a row collapse into ToolCallGroup below instead. */
-function CodeToolCard({ call }: { call: NormalizedCall }) {
+/** One tool call as a FLAT glyph-prefixed line (ADR-262) — a leading tool icon +
+ *  the file path/command on one row, a trailing status glyph, click to expand its
+ *  diff/output inline BELOW (indented under the label). No card border, no
+ *  group→Sheet: every call in a run renders as its own dense line, matching
+ *  opencode/pi. Edits/writes (which carry a diff) auto-expand — they ARE the point
+ *  of a code session; reads/searches/bash start collapsed. `/details` (ADR-258)
+ *  force-opens every line globally; the per-line toggle still works when it's off. */
+function CodeToolLine({ call }: { call: NormalizedCall }) {
   const Icon = toolIcon(call.name)
   const label = toolLabel(call.name, call.args)
   const hasDiff = !!call.diff?.trim()
@@ -267,28 +232,23 @@ function CodeToolCard({ call }: { call: NormalizedCall }) {
   const streamingPartial = call.status === 'pending' && !!call.partial?.length && !call.result?.length
   const hasOutput = !!call.result?.length || hasDiff || !!call.partial?.length
   const [expanded, setExpanded] = useState(hasDiff)
-  // `/details` (ADR-258) is a global override that force-opens every card's detail for reviewing a
-  // long run; the per-card toggle still works when it's off. `open` is what actually drives the
-  // panels below.
   const detailsPref = useDisplayPref('details')
-  const open = expanded || detailsPref
-  // Auto-open while live output is streaming in, and STAY open once it finalizes (so the panel the
-  // user was already watching doesn't collapse out from under them the instant the tool finishes).
-  useEffect(() => { if (streamingPartial) setExpanded(true) }, [streamingPartial])
+  // `streamingPartial` makes it visible WHILE actively running, without persisting into
+  // `expanded` — once the real result lands and streaming ends, this drops out and the panel
+  // reverts to the user's own manual choice (or `hasDiff`'s default). Collapsed by default for a
+  // finished command with no diff, same as any other tool call (founder feedback, 2026-07-24: an
+  // earlier version force-expanded `expanded` itself on stream-start and never reverted it, so
+  // every bash call that streamed output stayed open forever after finishing too).
+  const open = expanded || detailsPref || streamingPartial
   const stats = hasDiff ? diffStats(call.diff!) : null
 
   return (
-    <div
-      className="overflow-hidden rounded-lg border"
-      style={call.status === 'awaiting_approval'
-        ? { borderColor: 'var(--warn)', background: 'var(--toolcard-approval-bg)' }
-        : { borderColor: 'var(--border)' }}
-    >
+    <div>
       <button
         type="button"
         onClick={() => hasOutput && setExpanded((e) => !e)}
         disabled={!hasOutput}
-        className="flex w-full items-center gap-2 bg-panel-2 px-3 py-1.5 text-left disabled:cursor-default"
+        className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-panel-2 disabled:cursor-default disabled:hover:bg-transparent"
       >
         <Icon size={13} className="shrink-0 text-muted" />
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{label}</span>
@@ -300,147 +260,123 @@ function CodeToolCard({ call }: { call: NormalizedCall }) {
         )}
         <StatusIcon status={call.status} />
       </button>
-      {open && hasDiff && <CodeDiffPanel diff={call.diff!} />}
-      {open && !hasDiff && call.result && <CodeOutputPanel text={call.result} />}
-      {/* Live stream — the terminal result (above) supersedes it the moment it arrives. */}
-      {open && !hasDiff && !call.result && call.partial && <CodeOutputPanel text={call.partial} streaming />}
+      {/* Expanded content, indented under the label (icon 13px + gap 8px). The result supersedes a
+          live partial the moment it arrives. */}
+      {open && hasDiff && <div className="ml-[21px] mb-1 mt-0.5"><CodeDiffPanel diff={call.diff!} /></div>}
+      {open && !hasDiff && call.result && <div className="ml-[21px] mb-1 mt-0.5"><CodeOutputPanel text={call.result} /></div>}
+      {open && !hasDiff && !call.result && call.partial && <div className="ml-[21px] mb-1 mt-0.5"><CodeOutputPanel text={call.partial} streaming /></div>}
     </div>
   )
 }
 
-/** One row inside the group side panel — richer than CodeToolCard: also shows
- *  raw arguments and a spelled-out status, since this is the "full detail" view
- *  the compact summary exists to keep out of the main transcript. */
-function ToolCallDetailRow({ call }: { call: NormalizedCall }) {
-  const [expanded, setExpanded] = useState(false)
-  const Icon = toolIcon(call.name)
-  const label = toolLabel(call.name, call.args)
-  const hasArgs = call.args && Object.keys(call.args).length > 0
-  const hasDiff = !!call.diff?.trim()
+/** The leading subcommand word of a `bash` tool call's command — `git` for `git status`, `npm`
+ *  for `npm install .` — used to decide which consecutive terminal commands are "similar" enough
+ *  to group. Null for any NON-bash tool call (edit/write/read/grep/find/ls never group; they read
+ *  distinctly by icon and the founder ask was specifically about terminal commands) or a bash call
+ *  with no usable command string. */
+function bashLeadWord(call: NormalizedCall): string | null {
+  if (!BASH_TOOLS.has(call.name)) return null
+  const cmd = call.args.command
+  if (typeof cmd !== 'string') return null
+  const first = cmd.trim().split(/\s+/)[0]
+  return first || null
+}
 
+type ToolRunItem =
+  | { kind: 'single'; call: NormalizedCall }
+  | { kind: 'group'; lead: string; calls: NormalizedCall[] }
+
+/** Partition a run of consecutive tool calls into single lines and GROUPS of 2+ consecutive `bash`
+ *  commands sharing the same leading subcommand word (a run of `git …`/`git …`/`git …` collapses
+ *  into one "3 git commands" unit). A lone bash command — even flanked by other, differently-led
+ *  bash commands — stays its own line (nothing similar adjacent to group with). This is NARROWER
+ *  than the retired 2+→Sheet grouping ADR-262 killed: only SIMILAR commands group, and the group
+ *  expands INLINE (see CodeToolGroup), never into a side panel. Runs through ToolRun, so it applies
+ *  to BOTH the live (chunkTimeline) and persisted (chunkPersistedTimeline) tool sequences alike. */
+function groupToolCalls(calls: NormalizedCall[]): ToolRunItem[] {
+  const items: ToolRunItem[] = []
+  let i = 0
+  while (i < calls.length) {
+    const lead = bashLeadWord(calls[i])
+    if (lead !== null) {
+      let j = i + 1
+      while (j < calls.length && bashLeadWord(calls[j]) === lead) j++
+      const run = calls.slice(i, j)
+      if (run.length >= 2) items.push({ kind: 'group', lead, calls: run })
+      else items.push({ kind: 'single', call: calls[i] })
+      i = j
+    } else {
+      items.push({ kind: 'single', call: calls[i] })
+      i++
+    }
+  }
+  return items
+}
+
+/** A run of 2+ consecutive SIMILAR terminal commands (same leading subcommand — see groupToolCalls)
+ *  collapsed into one expandable line, e.g. "3 git commands" (founder feedback, 2026-07-24: a burst
+ *  of consecutive git/npm commands each on its own flat line read as noise). Collapsed by default —
+ *  nothing in this redesign default-opens anymore — with a status glyph rolled up from its members
+ *  (error if any errored, else pending if any still running, else done). Expands INLINE to each
+ *  command as its OWN CodeToolLine, each still independently clickable for ITS own output: expanding
+ *  the group reveals the list, not one flattened blob, and not the retired side-Sheet. `/details`
+ *  force-opens the group (and, transitively, each inner line) just like a single CodeToolLine. */
+function CodeToolGroup({ lead, calls }: { lead: string; calls: NormalizedCall[] }) {
+  const [expanded, setExpanded] = useState(false)
+  const detailsPref = useDisplayPref('details')
+  const open = expanded || detailsPref
+  const status: ToolStatus = calls.some((c) => c.status === 'error')
+    ? 'error'
+    : calls.some((c) => c.status === 'pending')
+      ? 'pending'
+      : calls.some((c) => c.status === 'awaiting_approval')
+        ? 'awaiting_approval'
+        : 'done'
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
+    <div>
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
-        className="flex w-full items-center gap-2 bg-panel-2 px-3 py-2 text-left"
+        className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-panel-2"
       >
-        <Icon size={13} className="shrink-0 text-muted" />
-        <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{label}</span>
-        <span className="shrink-0 text-[11px] font-medium" style={{ color: STATUS_COLOR[call.status] }}>{STATUS_LABEL[call.status]}</span>
-        <ChevronDown size={12} className={cn('shrink-0 text-faint transition-transform', expanded && 'rotate-180')} />
+        <ChevronRight size={13} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
+        <Terminal size={13} className="shrink-0 text-muted" />
+        <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{calls.length} {lead} commands</span>
+        <StatusIcon status={status} />
       </button>
-      {expanded && (
-        <div className="border-t border-border">
-          {hasArgs && (
-            <div className="border-b border-border px-3 py-2">
-              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-faint">Arguments</div>
-              <pre className="overflow-auto font-mono text-[11px] leading-relaxed text-muted">{JSON.stringify(call.args, null, 2)}</pre>
-            </div>
-          )}
-          {hasDiff ? (
-            <CodeDiffPanel diff={call.diff!} />
-          ) : call.result ? (
-            <CodeOutputPanel text={call.result} />
-          ) : call.partial ? (
-            <CodeOutputPanel text={call.partial} streaming />
-          ) : (
-            <div className="px-3 py-2 text-[12px] text-faint">No output.</div>
-          )}
+      {open && (
+        <div className="ml-[21px] flex flex-col">
+          {calls.map((c) => <CodeToolLine key={c.id} call={c} />)}
         </div>
       )}
     </div>
   )
 }
 
-/** A run of 2+ consecutive tool calls: one scannable summary row in the main
- *  transcript ("5 tool calls · 3 edits · 2 reads"), click to open a side panel
- *  (same Sheet primitive ContextUsageRing.tsx uses) listing every call in the
- *  run, each individually expandable to its full detail. */
-function ToolCallGroup({ calls, batchTime }: { calls: NormalizedCall[]; batchTime?: string }) {
-  const [open, setOpen] = useState(false)
-  const errorCount = calls.filter((c) => c.status === 'error').length
-  const pendingCount = calls.filter((c) => c.status === 'pending' || c.status === 'awaiting_approval').length
-  const overallColor = pendingCount > 0 ? STATUS_COLOR.pending : errorCount > 0 ? STATUS_COLOR.error : STATUS_COLOR.done
-  // The most recently STARTED call that hasn't finished yet — calls run in order, so this
-  // is the one actually executing right now, not necessarily the first one in the array.
-  const activeCall = [...calls].reverse().find((c) => c.status === 'pending' || c.status === 'awaiting_approval')
-
-  const counts = new Map<string, number>()
-  for (const c of calls) {
-    const k = toolKind(c.name)
-    counts.set(k, (counts.get(k) ?? 0) + 1)
-  }
-  const breakdown = [...counts.entries()].map(([k, n]) => `${n} ${n === 1 ? k : KIND_PLURAL[k]}`).join(' · ')
-  // While something's actively running, lead with WHAT it's doing (the thing you can't see
-  // otherwise until it's done) rather than a static count; falls back to the count once idle.
-  const summary = activeCall
-    ? `${KIND_VERB[toolKind(activeCall.name)]} ${toolLabel(activeCall.name, activeCall.args)}…`
-    : `${calls.length} tool calls · ${breakdown}`
-
+/** A run of consecutive tool calls (from the chunker) rendered as a tight stack of
+ *  flat lines (ADR-262 — no more 1→card / 2+→group-Sheet split; every call is its
+ *  own line). Consecutive SIMILAR terminal commands are first folded into one expandable
+ *  CodeToolGroup (see groupToolCalls); everything else stays its own CodeToolLine. The lines pack
+ *  tightly (their own py-0.5 is the spacing); the outer turn container's gap separates this run
+ *  from adjacent commentary/reasoning. */
+function ToolRun({ calls }: { calls: NormalizedCall[] }) {
+  if (calls.length === 0) return null
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="flex w-full items-center gap-2 rounded-lg border border-border bg-panel-2 px-3 py-2 text-left transition-colors hover:border-border-strong"
-      >
-        <div className="flex -space-x-1.5">
-          {calls.slice(-3).map((c, i) => {
-            const Icon = toolIcon(c.name)
-            return (
-              <span key={c.id} className="grid h-5 w-5 shrink-0 place-items-center rounded-full border-2 bg-panel" style={{ borderColor: 'var(--panel-2)', zIndex: 3 - i }}>
-                <Icon size={10} className="text-muted" />
-              </span>
-            )
-          })}
-        </div>
-        <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{summary}</span>
-        {pendingCount > 0
-          ? <Loader2 size={13} className="shrink-0 animate-spin" style={{ color: overallColor }} />
-          : <StatusIcon status={errorCount > 0 ? 'error' : 'done'} />}
-        <ChevronRight size={13} className="shrink-0 text-faint" />
-      </button>
-
-      <Sheet open={open} onOpenChange={setOpen} modal={false}>
-        <SheetContent className="overflow-y-auto p-5">
-          <SheetHeader>
-            <SheetTitle>{calls.length} tool calls</SheetTitle>
-            <SheetDescription>
-              {breakdown}{batchTime ? ` · ${new Date(batchTime).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}` : pendingCount > 0 ? ' · in progress' : ''}
-            </SheetDescription>
-          </SheetHeader>
-          <div className="mt-3 flex flex-col gap-2">
-            {calls.map((c) => <ToolCallDetailRow key={c.id} call={c} />)}
-          </div>
-        </SheetContent>
-      </Sheet>
-    </>
+    <div className="flex flex-col">
+      {groupToolCalls(calls).map((it) =>
+        it.kind === 'group'
+          ? <CodeToolGroup key={`g:${it.calls[0].id}`} lead={it.lead} calls={it.calls} />
+          : <CodeToolLine key={it.call.id} call={it.call} />,
+      )}
+    </div>
   )
 }
 
-/** Renders a run of tool calls as either a single full card (1 call) or a
- *  collapsed group summary + side panel (2+). */
-function ToolRun({ calls, batchTime }: { calls: NormalizedCall[]; batchTime?: string }) {
-  if (calls.length === 0) return null
-  if (calls.length === 1) return <CodeToolCard call={calls[0]} />
-  return <ToolCallGroup calls={calls} batchTime={batchTime} />
-}
-
-function runTone(calls: NormalizedCall[]): 'accent' | 'ok' | 'err' {
-  if (calls.some((c) => c.status === 'pending' || c.status === 'awaiting_approval')) return 'accent'
-  if (calls.some((c) => c.status === 'error')) return 'err'
-  return 'ok'
-}
-function runIcon(calls: NormalizedCall[]) {
-  return calls.length === 1 ? toolIcon(calls[0].name) : Layers
-}
-
-/** The user's task (session-starting prompt or a follow-up "steer"). No label —
- *  right-aligned, pushed to the far side of the rail (`ml-auto`), width-capped
- *  the same way chat's own user bubble is (`min(88%,900px)`, see MessageBubble.tsx)
- *  so alone that's enough to read as "yours" against the agent's left-aligned
- *  activity, without a heading or reverting to full chat-bubble chrome. */
+/** The user's task (session-starting prompt or a follow-up). No label —
+ *  right-aligned (`ml-auto w-fit`), width-capped the same way chat's own user
+ *  bubble is (`min(88%,900px)`, see MessageBubble.tsx) so alone that's enough to
+ *  read as "yours" against the agent's left-aligned activity (ADR-262 keeps this
+ *  alignment convention deliberately; only the rail was dropped). */
 function CodeInstructionEntry({
   content, contextFiles, onRevert,
 }: {
@@ -452,27 +388,34 @@ function CodeInstructionEntry({
   onRevert?: () => void
 }) {
   return (
-    <div
-      className="group ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border px-4 py-3"
-      style={{ borderColor: 'var(--instruction-border)', background: 'var(--instruction-bg)' }}
-    >
-      {!!contextFiles?.length && (
-        <div className="mb-2 flex flex-wrap justify-end gap-1.5">
-          {contextFiles.map((p) => (
-            <span
-              key={p}
-              title={p}
-              className="inline-flex max-w-[200px] items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted"
-              style={{ borderColor: 'var(--instruction-chip-border)' }}
-            >
-              <FileText size={10} className="shrink-0 text-faint" />
-              <span className="min-w-0 truncate">{p.split(/[\\/]/).filter(Boolean).pop() || p}</span>
-            </span>
-          ))}
-        </div>
-      )}
-      <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{content}</p>
-      <div className="hover-actions mt-1 flex items-center justify-end gap-0.5">
+    // `group` on the OUTER wrapper (not the box) — the action row is a sibling BELOW the box, not
+    // a child inside it, so it no longer pads out the box's own height (founder feedback,
+    // 2026-07-24: buttons living inside the box read as an odd extra inch of empty space under
+    // the text). Hovering the box still reveals it, since `.group:hover .hover-actions` matches
+    // any descendant of this wrapper.
+    <div className="group ml-auto flex w-fit max-w-[min(88%,900px)] flex-col items-end gap-1">
+      <div
+        className="w-full rounded-lg border px-4 py-3"
+        style={{ borderColor: 'var(--instruction-border)', background: 'var(--instruction-bg)' }}
+      >
+        {!!contextFiles?.length && (
+          <div className="mb-2 flex flex-wrap justify-end gap-1.5">
+            {contextFiles.map((p) => (
+              <span
+                key={p}
+                title={p}
+                className="inline-flex max-w-[200px] items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted"
+                style={{ borderColor: 'var(--instruction-chip-border)' }}
+              >
+                <FileText size={10} className="shrink-0 text-faint" />
+                <span className="min-w-0 truncate">{p.split(/[\\/]/).filter(Boolean).pop() || p}</span>
+              </span>
+            ))}
+          </div>
+        )}
+        <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{content}</p>
+      </div>
+      <div className="hover-actions flex items-center gap-0.5 px-0.5">
         <CopyButton text={content} size={12} />
         {onRevert && (
           <button
@@ -497,9 +440,9 @@ function CodeInstructionEntry({
 function CodeShellEntry({ command, output, exitCode, timedOut }: { command: string; output: string; exitCode: number | null; timedOut?: boolean }) {
   const failed = timedOut || (exitCode !== null && exitCode !== 0)
   return (
-    <div className="overflow-hidden rounded-lg border" style={{ borderColor: failed ? 'color-mix(in srgb, var(--err) 40%, var(--border))' : 'var(--border)' }}>
-      <div className="flex items-center gap-2 bg-panel-2 px-3 py-1.5">
-        <SquareTerminal size={13} className="shrink-0 text-muted" />
+    <div>
+      <div className="flex items-center gap-2 px-1 py-0.5">
+        <SquareTerminal size={13} className="shrink-0" style={{ color: failed ? 'var(--err)' : 'var(--muted)' }} />
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">$ {command}</span>
         {timedOut
           ? <span className="shrink-0 font-mono text-[11px]" style={{ color: 'var(--err)' }}>timed out</span>
@@ -507,7 +450,7 @@ function CodeShellEntry({ command, output, exitCode, timedOut }: { command: stri
             ? <span className="shrink-0 font-mono text-[11px]" style={{ color: 'var(--err)' }}>exit {exitCode}</span>
             : null}
       </div>
-      {output.trim() && <CodeOutputPanel text={output} />}
+      {output.trim() && <div className="ml-[21px] mb-1 mt-0.5"><CodeOutputPanel text={output} /></div>}
     </div>
   )
 }
@@ -525,38 +468,36 @@ function CodeQueuedEntry({ task, kind, onSendNow }: { task: string; kind: SteerK
   const Badge = isSteer ? CornerDownRight : Clock
   return (
     <div className="tllm-rise-in">
-      <RailEntry icon={MessageSquare} tone="muted">
-        <div
-          className="group ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border border-dashed px-4 py-3 opacity-70"
-          style={{ borderColor: 'var(--instruction-chip-border)', background: 'var(--instruction-bg)' }}
-        >
-          <div className="mb-1.5 flex items-center justify-end">
-            <span
-              className="inline-flex items-center gap-1 rounded-full border border-dashed px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted"
-              style={{ borderColor: 'var(--instruction-chip-border)' }}
-              title={isSteer
-                ? 'Queued as a steer — it will redirect the current turn when it runs'
-                : 'Queued — it will run as a new turn after the current one finishes'}
-            >
-              <Badge size={10} className="shrink-0" />
-              {isSteer ? 'Steers this turn' : 'Runs next'}
-            </span>
-          </div>
-          <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{task}</p>
-          {onSendNow && (
-            <div className="mt-1 flex items-center justify-end">
-              <button
-                type="button"
-                onClick={onSendNow}
-                title="Send now — stop the current run and run this one next"
-                className="inline-flex items-center gap-1 rounded p-1 text-[11px] font-medium text-faint transition-colors hover:text-ink"
-              >
-                <SendHorizontal size={12} /> Send now
-              </button>
-            </div>
-          )}
+      <div
+        className="group ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border border-dashed px-4 py-3 opacity-70"
+        style={{ borderColor: 'var(--instruction-chip-border)', background: 'var(--instruction-bg)' }}
+      >
+        <div className="mb-1.5 flex items-center justify-end">
+          <span
+            className="inline-flex items-center gap-1 rounded-full border border-dashed px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted"
+            style={{ borderColor: 'var(--instruction-chip-border)' }}
+            title={isSteer
+              ? 'Queued as a steer — it will redirect the current turn when it runs'
+              : 'Queued — it will run as a new turn after the current one finishes'}
+          >
+            <Badge size={10} className="shrink-0" />
+            {isSteer ? 'Steers this turn' : 'Runs next'}
+          </span>
         </div>
-      </RailEntry>
+        <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{task}</p>
+        {onSendNow && (
+          <div className="mt-1 flex items-center justify-end">
+            <button
+              type="button"
+              onClick={onSendNow}
+              title="Send now — stop the current run and run this one next"
+              className="inline-flex items-center gap-1 rounded p-1 text-[11px] font-medium text-faint transition-colors hover:text-ink"
+            >
+              <SendHorizontal size={12} /> Send now
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   )
 }
@@ -570,18 +511,18 @@ function CodeReasoning({ reasoning, streaming }: { reasoning: string; streaming?
   const thinkingPref = useDisplayPref('thinking')
   const show = open || thinkingPref
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
+    <div>
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-1.5 bg-panel-2 px-3 py-1.5 text-left font-mono text-[11px] text-muted hover:text-ink"
+        className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left font-mono text-[11px] text-muted transition-colors hover:text-ink"
       >
         {streaming ? 'reasoning…' : 'reasoning'}
         {streaming && !show && <span className="tllm-pulse">·</span>}
       </button>
       {show && (
         <pre
-          className="max-h-48 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-[11px] leading-relaxed"
+          className="ml-[21px] mb-1 mt-0.5 max-h-48 overflow-auto whitespace-pre-wrap rounded-md px-3 py-2 font-mono text-[11px] leading-relaxed"
           style={{ background: 'var(--log-bg)', color: 'var(--log-faint)' }}
         >
           {reasoning}
@@ -611,23 +552,6 @@ function CodeCommentary({ content, streaming }: { content: string; streaming?: b
   )
 }
 
-/** One rail entry: a marker icon anchored on the vertical line, the content to
- *  its right. `tone` picks the marker's ring/icon color. */
-function RailEntry({ icon: Icon, tone = 'muted', children }: { icon: typeof SquareTerminal; tone?: 'accent' | 'muted' | 'ok' | 'err'; children: React.ReactNode }) {
-  const color = tone === 'accent' ? 'var(--accent)' : tone === 'ok' ? 'var(--ok)' : tone === 'err' ? 'var(--err)' : 'var(--faint)'
-  return (
-    <div className="relative">
-      <div
-        className="absolute -left-[25px] top-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full border bg-panel"
-        style={{ borderColor: color, color }}
-      >
-        <Icon size={10} />
-      </div>
-      {children}
-    </div>
-  )
-}
-
 /** Quiet fade + rise on arrival for a persisted transcript entry — deliberately NOT applied to
  *  CodeStreamingEntry's live chunks below, whose index-keyed shape shifts constantly while
  *  tokens stream in; retriggering this on every reflow there would be distracting flicker, not
@@ -641,22 +565,18 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
       const args = shell.args as { command?: unknown; exitCode?: unknown; timedOut?: unknown }
       return (
         <div className="tllm-rise-in">
-          <RailEntry icon={SquareTerminal} tone="muted">
-            <CodeShellEntry
-              command={typeof args.command === 'string' ? args.command : ''}
-              output={shell.result ?? ''}
-              exitCode={typeof args.exitCode === 'number' ? args.exitCode : null}
-              timedOut={args.timedOut === true}
-            />
-          </RailEntry>
+          <CodeShellEntry
+            command={typeof args.command === 'string' ? args.command : ''}
+            output={shell.result ?? ''}
+            exitCode={typeof args.exitCode === 'number' ? args.exitCode : null}
+            timedOut={args.timedOut === true}
+          />
         </div>
       )
     }
     return (
       <div className="tllm-rise-in">
-        <RailEntry icon={MessageSquare} tone="accent">
-          <CodeInstructionEntry content={message.content} contextFiles={message.textAttachments} onRevert={onRevert} />
-        </RailEntry>
+        <CodeInstructionEntry content={message.content} contextFiles={message.textAttachments} onRevert={onRevert} />
       </div>
     )
   }
@@ -669,56 +589,34 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
   // pre-fix grouped rendering below (same shape this component has always used).
   const chunks = message.timeline?.length ? chunkPersistedTimeline(message.timeline, message.toolCalls ?? []) : null
   return (
-    <div className="tllm-rise-in flex flex-col gap-3">
-      {message.reasoning?.trim() && (
-        <RailEntry icon={Brain}>
-          <CodeReasoning reasoning={message.reasoning} />
-        </RailEntry>
-      )}
+    <div className="tllm-rise-in flex flex-col gap-2">
+      {message.reasoning?.trim() && <CodeReasoning reasoning={message.reasoning} />}
       {chunks
         ? chunks.map((c, i) =>
           c.kind === 'text'
-            ? (
-                <RailEntry key={i} icon={MessageSquare}>
-                  <CodeCommentary content={c.text} />
-                </RailEntry>
-              )
+            ? <CodeCommentary key={i} content={c.text} />
             : c.kind === 'tools'
-              ? (
-                  <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
-                    <ToolRun calls={c.calls} batchTime={message.createdAt} />
-                  </RailEntry>
-                )
+              ? <ToolRun key={i} calls={c.calls} />
               : null, // a persisted message never carries live-only turn dividers
         )
         : (
             <>
-              {calls.length > 0 && (
-                <RailEntry icon={runIcon(calls)} tone={runTone(calls)}>
-                  <ToolRun calls={calls} batchTime={message.createdAt} />
-                </RailEntry>
-              )}
-              {message.content?.trim() && (
-                <RailEntry icon={MessageSquare}>
-                  <CodeCommentary content={message.content} />
-                </RailEntry>
-              )}
+              {calls.length > 0 && <ToolRun calls={calls} />}
+              {message.content?.trim() && <CodeCommentary content={message.content} />}
             </>
           )}
       {isEmpty && (
-        <RailEntry icon={XCircle} tone="err">
-          <p className="text-[13px]" style={{ color: 'var(--err)' }}>
-            {message.stats.aborted ? 'Run stopped or failed.' : 'No output for this turn.'}
-          </p>
-        </RailEntry>
+        <p className="px-1 text-[13px]" style={{ color: 'var(--err)' }}>
+          {message.stats.aborted ? 'Run stopped or failed.' : 'No output for this turn.'}
+        </p>
       )}
     </div>
   )
 }
 
 // Chunk a live SSE timeline into text blocks and RUNS of consecutive tool
-// blocks (so a burst of tool calls between two bits of commentary collapses
-// into one group, live, the same as a finished message's toolCalls array does).
+// blocks (so a burst of tool calls between two bits of commentary stays a
+// contiguous run, live, the same as a finished message's toolCalls array does).
 type StreamChunk =
   | { kind: 'text'; text: string }
   | { kind: 'tools'; calls: NormalizedCall[] }
@@ -755,10 +653,10 @@ function chunkTimeline(timeline: LiveBlock[]): StreamChunk[] {
  *  walks the ordered text/tool-call blocks a completed turn was saved with, grouping consecutive
  *  tool blocks into one run and starting a fresh run the instant a text block appears — so a tool
  *  call that comes after some text never merges backward into an earlier group, matching the true
- *  order the turn actually ran in rather than today's fixed "all tool calls in one group"
- *  rendering. `{type:'tool', id}` blocks are resolved against `toolCalls` by id; a dangling id
- *  (shouldn't happen — both are written together in the same updateMessage call) is skipped
- *  rather than crashing the render. */
+ *  order the turn actually ran in rather than a fixed "all tool calls in one group" rendering.
+ *  `{type:'tool', id}` blocks are resolved against `toolCalls` by id; a dangling id (shouldn't
+ *  happen — both are written together in the same updateMessage call) is skipped rather than
+ *  crashing the render. */
 function chunkPersistedTimeline(timeline: MessageTimelineBlock[], toolCalls: ToolCallRecord[]): StreamChunk[] {
   const byId = new Map(toolCalls.map((tc) => [tc.id, tc]))
   const chunks: StreamChunk[] = []
@@ -793,22 +691,44 @@ function chunkPersistedTimeline(timeline: MessageTimelineBlock[], toolCalls: Too
  *  long compaction pause doesn't read as a stuck/dead run. */
 function CodeThinking({ label = 'thinking…', tone = 'accent' }: { label?: string; tone?: 'accent' | 'warn' }) {
   return (
-    <div className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
+    <div className="flex items-center gap-1.5 px-1 font-mono text-[11px] text-muted">
       <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: tone === 'warn' ? 'var(--warn)' : 'var(--accent)' }} />
       <span>{label}</span>
     </div>
   )
 }
 
+/** Prompt-processing (prefill) progress before the first token — llama.cpp only, polled off the
+ *  engine's /slots (see LiveState.prefill). Deliberately the SAME compact "Processing prompt NN%"
+ *  line + real 3px --accent progress bar chat already uses (MessageBubble.tsx), reused rather than
+ *  inventing a second visual language for the identical concept. Sits in the status-banner slot and
+ *  clears itself the instant the first token arrives, so it never co-renders with the
+ *  retry/compacting/thinking placeholder. */
+function CodePrefill({ prefill }: { prefill: { processed: number; total: number; pct: number } }) {
+  return (
+    <div className="space-y-1 px-1">
+      <div className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
+        <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />
+        <span>Processing prompt</span>
+        <span className="font-medium text-ink">{prefill.pct}%</span>
+      </div>
+      <div className="h-[3px] w-full overflow-hidden rounded-full" style={{ background: 'var(--border)' }}>
+        <div
+          className="h-full rounded-full transition-all duration-200"
+          style={{ width: `${prefill.pct}%`, background: 'var(--accent)' }}
+        />
+      </div>
+    </div>
+  )
+}
+
 /** A subtle divider between agentic rounds within one live assistant turn (Phase 2, ADR-249) —
  *  just a thin tokenized rule, deliberately low-weight (this is grouping, not a hard section
- *  break). Rendered outside the rail (no marker dot) so it reads as a separator spanning the
- *  rounds rather than another activity entry. Live-only: a persisted turn has no round markers,
- *  so the finished transcript reads as one continuous log.
- *  No "Round N" text label (dropped per founder feedback, 2026-07-24 — the line alone is the
- *  grouping signal; a literal round counter read as unwanted clutter). `index` stays a param
- *  even though it's now unused for display, so the call site doesn't need to change if a label
- *  (e.g. a tooltip) is ever wanted back. */
+ *  break). Live-only: a persisted turn has no round markers, so the finished transcript reads as
+ *  one continuous log. No "Round N" text label (dropped per founder feedback, 2026-07-24 — the
+ *  line alone is the grouping signal; a literal round counter read as unwanted clutter). `index`
+ *  stays a param even though it's now unused for display, so the call site doesn't need to change
+ *  if a label (e.g. a tooltip) is ever wanted back. */
 function TurnDivider({ index: _index }: { index: number }) {
   return <span className="block h-px" style={{ background: 'var(--border)' }} aria-hidden />
 }
@@ -837,14 +757,18 @@ function TodoStatusIcon({ status }: { status: TodoItem['status'] }) {
 export function TodoChecklist({ todos }: { todos: TodoItem[] }) {
   if (todos.length === 0) return null
   const done = todos.filter((t) => t.status === 'completed').length
+  // Flat (ADR-262) — no bordered card / bg-panel-2 header. A quiet "Plan · N/total" header line
+  // (same weight as the reasoning label / a CodeToolLine) over a plain list, so it reads as part of
+  // the flat log rather than a floating card. The pinned band CodeSessionScreen.tsx wraps it in
+  // provides the separation from the transcript/composer, so this component adds none of its own.
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
-      <div className="flex items-center gap-1.5 bg-panel-2 px-3 py-1.5 text-[11px] font-medium text-muted">
+    <div>
+      <div className="flex items-center gap-1.5 px-1 py-0.5 text-[11px] font-medium text-muted">
         <ListChecks size={12} className="shrink-0" />
         <span>Plan</span>
         <span className="ml-auto font-mono text-[10px] tabular-nums text-faint">{done}/{todos.length}</span>
       </div>
-      <ul className="flex flex-col gap-1.5 px-3 py-2">
+      <ul className="flex flex-col gap-1 px-1 pt-0.5">
         {todos.map((t, i) => (
           <li key={i} className="flex items-start gap-1.5 text-[12px] leading-snug">
             <TodoStatusIcon status={t.status} />
@@ -859,56 +783,37 @@ export function TodoChecklist({ todos }: { todos: TodoItem[] }) {
 }
 
 function CodeStreamingEntry({
-  timeline, reasoning, compacting, retry,
+  timeline, reasoning, compacting, retry, prefill,
 }: {
   timeline: LiveBlock[]
   reasoning: string
   compacting?: boolean
   retry?: RetryState | null
+  prefill?: { processed: number; total: number; pct: number } | null
 }) {
   const chunks = chunkTimeline(timeline)
   const hasContent = !!reasoning?.trim() || chunks.length > 0
   return (
-    <div className="flex flex-col gap-3">
-      {reasoning?.trim() && (
-        <RailEntry icon={Brain} tone="accent">
-          <CodeReasoning reasoning={reasoning} streaming />
-        </RailEntry>
-      )}
+    <div className="flex flex-col gap-2">
+      {reasoning?.trim() && <CodeReasoning reasoning={reasoning} streaming />}
       {chunks.map((c, i) =>
         c.kind === 'text'
-          ? (
-              <RailEntry key={i} icon={MessageSquare} tone="accent">
-                <CodeCommentary content={c.text} streaming />
-              </RailEntry>
-            )
+          ? <CodeCommentary key={i} content={c.text} streaming />
           : c.kind === 'turn'
             ? <TurnDivider key={i} index={c.index} />
-            : (
-                <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
-                  <ToolRun calls={c.calls} />
-                </RailEntry>
-              ),
+            : <ToolRun key={i} calls={c.calls} />,
       )}
-      {/* One shared status-banner slot (ADR-250) — retry is the most salient transient state so it
-          takes priority over compaction and the generic "thinking" placeholder. */}
-      {retry
-        ? (
-            <RailEntry icon={RotateCcw} tone="accent">
-              <CodeThinking tone="warn" label={`Retrying… attempt ${retry.attempt} of ${retry.maxAttempts}${retry.message ? ` — ${retry.message}` : ''}`} />
-            </RailEntry>
-          )
-        : compacting
-          ? (
-              <RailEntry icon={Brain} tone="accent">
-                <CodeThinking label="Compacting conversation…" />
-              </RailEntry>
-            )
-          : !hasContent && (
-              <RailEntry icon={Brain} tone="accent">
-                <CodeThinking />
-              </RailEntry>
-            )}
+      {/* One shared status-banner slot (ADR-250). Prefill happens strictly BEFORE generation begins,
+          so it wins the slot while active; it self-clears at the first token (backend stops firing
+          the frames, and the reducer nulls it on the first delta/reasoning), handing back to the
+          existing retry > compacting > thinking priority. So no two of these ever co-render. */}
+      {prefill
+        ? <CodePrefill prefill={prefill} />
+        : retry
+          ? <CodeThinking tone="warn" label={`Retrying… attempt ${retry.attempt} of ${retry.maxAttempts}${retry.message ? ` — ${retry.message}` : ''}`} />
+          : compacting
+            ? <CodeThinking label="Compacting conversation…" />
+            : !hasContent && <CodeThinking />}
     </div>
   )
 }
@@ -918,7 +823,7 @@ export function CodeTranscript({
 }: {
   messages: Message[]
   liveAssistantId?: string
-  live?: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean; retry?: RetryState | null } | null
+  live?: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean; retry?: RetryState | null; prefill?: { processed: number; total: number; pct: number } | null } | null
   /** Revert affordance on each user message — omitted entirely (via `undefined`) while a run
    *  is live, and never shown on the FIRST message (nothing before it to revert to; `messages`
    *  here is already cut at any existing /clear point, so index 0 is always correct). */
@@ -934,11 +839,13 @@ export function CodeTranscript({
    *  result is NOT here; it's a persisted message rendered inline by CodeMessageEntry. */
   shellRuns?: ShellRun[]
 }) {
+  // Flat, rail-less log (ADR-262): a plain vertical stack. Ordering is load-bearing — persisted
+  // messages, then the live turn, then queued cards, then transcript-only shell peeks. The live
+  // turn is ALWAYS rendered before the queued cards, so a queued follow-up never appears above the
+  // still-streaming turn (the ADR-199 invariant; `messages` is already cut at the live boundary and
+  // has queued ids removed by the caller, so a queued turn renders exactly once, here at the tail).
   return (
-    <div className="relative flex flex-col gap-5 pl-8">
-      {/* The rail — a continuous line behind every marker, build-log grammar
-          instead of a left/right bubble stack. */}
-      <div className="absolute left-[2px] top-2 bottom-2 w-px" style={{ background: 'var(--border)' }} aria-hidden />
+    <div className="flex flex-col gap-3">
       {messages
         .filter((m) => m.id !== liveAssistantId)
         .map((m, i) => (
@@ -949,7 +856,7 @@ export function CodeTranscript({
           />
         ))}
       {live && (
-        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} compacting={live.compacting} retry={live.retry} />
+        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} compacting={live.compacting} retry={live.retry} prefill={live.prefill} />
       )}
       {queued?.map((q) => (
         <CodeQueuedEntry
@@ -961,34 +868,24 @@ export function CodeTranscript({
       ))}
       {shellRuns?.map((s) => (
         <div key={s.id} className="tllm-rise-in">
-          <RailEntry icon={SquareTerminal} tone="muted">
-            <CodeShellEntry command={s.command} output={s.output} exitCode={s.exitCode} timedOut={s.timedOut} />
-          </RailEntry>
+          <CodeShellEntry command={s.command} output={s.output} exitCode={s.exitCode} timedOut={s.timedOut} />
         </div>
       ))}
     </div>
   )
 }
 
-/** Loading placeholder for a session's FIRST load (before any real data has arrived) — matches
- *  the transcript's own rail language (marker + content block) rather than a bare spinner or
- *  blank space, per spec 11 §8. Not used for reconnects/refetches, only the initial GET. */
+/** Loading placeholder for a session's FIRST load (before any real data has arrived) — a
+ *  right-aligned instruction placeholder + a couple of activity lines, matching the flat
+ *  transcript's own shape (spec 11 §8: never a bare spinner/blank void). Not used for
+ *  reconnects/refetches, only the initial GET. */
 export function CodeTranscriptSkeleton() {
   return (
-    <div className="relative flex flex-col gap-5 pl-8">
-      <div className="absolute left-[2px] top-2 bottom-2 w-px" style={{ background: 'var(--border)' }} aria-hidden />
-      <div className="relative">
-        <div className="absolute -left-[25px] top-0.5 h-5 w-5 shrink-0 rounded-full">
-          <Skeleton className="h-full w-full rounded-full" />
-        </div>
-        <div className="ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border border-border px-4 py-3">
-          <Skeleton className="h-3.5 w-64" />
-        </div>
+    <div className="flex flex-col gap-3">
+      <div className="ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border border-border px-4 py-3">
+        <Skeleton className="h-3.5 w-64" />
       </div>
-      <div className="relative flex flex-col gap-2">
-        <div className="absolute -left-[25px] top-0.5 h-5 w-5 shrink-0 rounded-full">
-          <Skeleton className="h-full w-full rounded-full" />
-        </div>
+      <div className="flex flex-col gap-2 px-1">
         <Skeleton className="h-3.5 w-[80%]" />
         <Skeleton className="h-3.5 w-[55%]" />
       </div>

--- a/turbollm/web/src/screens/code/CodeTranscript.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.tsx
@@ -1,22 +1,32 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
+  Brain,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Circle,
+  Clock,
+  CornerDownRight,
   FileEdit,
   FilePlus,
   FileText,
   FolderTree,
   HelpCircle,
   Layers,
+  ListChecks,
   Loader2,
+  MessageSquare,
   RotateCcw,
   Search,
+  SendHorizontal,
   SquareTerminal,
   Terminal,
   XCircle,
 } from 'lucide-react'
 import type { LiveToolCall, Message, MessageTimelineBlock, ToolCallRecord } from '../../lib/chat-types'
+import type { QueuedTurn, ShellRun, SteerKind, TodoItem } from '../../lib/code-types'
+import type { RetryState } from '../../lib/code-session-client'
+import { useDisplayPref } from '../../lib/code-display-prefs'
 import type { LiveBlock } from '../../lib/live-timeline'
 import { friendlyName } from '../../lib/tool-explain'
 import { cn } from '../../lib/utils'
@@ -68,13 +78,16 @@ interface NormalizedCall {
   status: ToolStatus
   result?: string
   diff?: string
+  /** Live cumulative output snapshot while a streaming tool (bash) is still running (Phase 2) —
+   *  only ever present on a live call, never a persisted one. */
+  partial?: string
 }
 
 function toRecordCall(tc: ToolCallRecord): NormalizedCall {
   return { id: tc.id, name: tc.name, args: tc.args, status: tc.error ? 'error' : 'done', result: tc.error ?? tc.result, diff: tc.diff }
 }
 function toLiveCall(tc: LiveToolCall): NormalizedCall {
-  return { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result, diff: tc.diff }
+  return { id: tc.id, name: tc.name, args: tc.args, status: tc.status, result: tc.result, diff: tc.diff, partial: tc.partial }
 }
 
 const EDIT_TOOLS = new Set(['edit'])
@@ -179,7 +192,7 @@ function CodeDiffPanel({ diff }: { diff: string }) {
                   <td
                     colSpan={3}
                     className="select-none whitespace-pre px-3 py-1"
-                    style={{ color: 'var(--accent)', background: 'color-mix(in srgb, var(--accent) 8%, transparent)' }}
+                    style={{ color: 'var(--accent)', background: 'var(--diff-hunk-bg)' }}
                   >
                     {line}
                   </td>
@@ -201,9 +214,9 @@ function CodeDiffPanel({ diff }: { diff: string }) {
             if (!isAdd && !isNoNewline) oldLine++
             if (!isDel && !isNoNewline) newLine++
             const bg = isAdd
-              ? 'color-mix(in srgb, var(--ok) 10%, transparent)'
+              ? 'var(--diff-add-bg)'
               : isDel
-                ? 'color-mix(in srgb, var(--err) 10%, transparent)'
+                ? 'var(--diff-del-bg)'
                 : undefined
             const fg = isAdd ? 'var(--ok)' : isDel ? 'var(--err)' : 'var(--ink)'
             return (
@@ -222,13 +235,18 @@ function CodeDiffPanel({ diff }: { diff: string }) {
 
 /** Non-diff tool output (bash stdout, read/grep/find/ls results) — the SAME
  *  near-black log tokens EngineLogPanel.tsx uses for real process output, so
- *  this reads as a console, not a chat attachment. */
-function CodeOutputPanel({ text }: { text: string }) {
-  const truncated = text.length > 4000 ? `${text.slice(0, 4000)}\n…(truncated)` : text
+ *  this reads as a console, not a chat attachment. When `streaming` (a live
+ *  `tool_progress` snapshot, Phase 2) it follows the TAIL (newest output, like a
+ *  real terminal) instead of the head, and shows a pulsing cursor. */
+function CodeOutputPanel({ text, streaming }: { text: string; streaming?: boolean }) {
+  const truncated = text.length > 4000
+    ? (streaming ? `…(earlier output hidden)\n${text.slice(-4000)}` : `${text.slice(0, 4000)}\n…(truncated)`)
+    : text
   return (
     <div className="max-h-80 overflow-auto border-t border-border" style={{ background: 'var(--log-bg)' }}>
       <pre className="whitespace-pre-wrap px-3 py-2 font-mono text-[12px] leading-relaxed" style={{ color: 'var(--log-ink)' }}>
-        {truncated || <span style={{ color: 'var(--log-faint)' }}>(no output)</span>}
+        {truncated || <span style={{ color: 'var(--log-faint)' }}>{streaming ? '' : '(no output)'}</span>}
+        {streaming && <span className="tllm-pulse" style={{ color: 'var(--log-faint)' }}>▋</span>}
       </pre>
     </div>
   )
@@ -244,15 +262,26 @@ function CodeToolCard({ call }: { call: NormalizedCall }) {
   const Icon = toolIcon(call.name)
   const label = toolLabel(call.name, call.args)
   const hasDiff = !!call.diff?.trim()
-  const hasOutput = !!call.result?.length || hasDiff
+  // Live cumulative output while the tool is still running (bash) — shown before the terminal
+  // `result` exists (Phase 2). Once the real result lands it takes over.
+  const streamingPartial = call.status === 'pending' && !!call.partial?.length && !call.result?.length
+  const hasOutput = !!call.result?.length || hasDiff || !!call.partial?.length
   const [expanded, setExpanded] = useState(hasDiff)
+  // `/details` (ADR-258) is a global override that force-opens every card's detail for reviewing a
+  // long run; the per-card toggle still works when it's off. `open` is what actually drives the
+  // panels below.
+  const detailsPref = useDisplayPref('details')
+  const open = expanded || detailsPref
+  // Auto-open while live output is streaming in, and STAY open once it finalizes (so the panel the
+  // user was already watching doesn't collapse out from under them the instant the tool finishes).
+  useEffect(() => { if (streamingPartial) setExpanded(true) }, [streamingPartial])
   const stats = hasDiff ? diffStats(call.diff!) : null
 
   return (
     <div
       className="overflow-hidden rounded-lg border"
       style={call.status === 'awaiting_approval'
-        ? { borderColor: 'var(--warn)', background: 'color-mix(in srgb, var(--warn) 6%, transparent)' }
+        ? { borderColor: 'var(--warn)', background: 'var(--toolcard-approval-bg)' }
         : { borderColor: 'var(--border)' }}
     >
       <button
@@ -271,8 +300,10 @@ function CodeToolCard({ call }: { call: NormalizedCall }) {
         )}
         <StatusIcon status={call.status} />
       </button>
-      {expanded && hasDiff && <CodeDiffPanel diff={call.diff!} />}
-      {expanded && !hasDiff && call.result && <CodeOutputPanel text={call.result} />}
+      {open && hasDiff && <CodeDiffPanel diff={call.diff!} />}
+      {open && !hasDiff && call.result && <CodeOutputPanel text={call.result} />}
+      {/* Live stream — the terminal result (above) supersedes it the moment it arrives. */}
+      {open && !hasDiff && !call.result && call.partial && <CodeOutputPanel text={call.partial} streaming />}
     </div>
   )
 }
@@ -311,6 +342,8 @@ function ToolCallDetailRow({ call }: { call: NormalizedCall }) {
             <CodeDiffPanel diff={call.diff!} />
           ) : call.result ? (
             <CodeOutputPanel text={call.result} />
+          ) : call.partial ? (
+            <CodeOutputPanel text={call.partial} streaming />
           ) : (
             <div className="px-3 py-2 text-[12px] text-faint">No output.</div>
           )}
@@ -421,7 +454,7 @@ function CodeInstructionEntry({
   return (
     <div
       className="group ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border px-4 py-3"
-      style={{ borderColor: 'color-mix(in srgb, var(--accent) 35%, var(--border))', background: 'color-mix(in srgb, var(--accent) 6%, transparent)' }}
+      style={{ borderColor: 'var(--instruction-border)', background: 'var(--instruction-bg)' }}
     >
       {!!contextFiles?.length && (
         <div className="mb-2 flex flex-wrap justify-end gap-1.5">
@@ -430,7 +463,7 @@ function CodeInstructionEntry({
               key={p}
               title={p}
               className="inline-flex max-w-[200px] items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted"
-              style={{ borderColor: 'color-mix(in srgb, var(--accent) 25%, var(--border))' }}
+              style={{ borderColor: 'var(--instruction-chip-border)' }}
             >
               <FileText size={10} className="shrink-0 text-faint" />
               <span className="min-w-0 truncate">{p.split(/[\\/]/).filter(Boolean).pop() || p}</span>
@@ -457,10 +490,85 @@ function CodeInstructionEntry({
   )
 }
 
+/** A user-run shell command (`!command`/`!!command`, ADR-258) — the `$ cmd` header over a
+ *  console-style output panel (the SAME --log-* tokens tool output uses, so it reads as a real
+ *  terminal). Renders both a persisted `!` result (from a message's `shell` tool call) and an
+ *  ephemeral `!!` result (client-only), identically. */
+function CodeShellEntry({ command, output, exitCode, timedOut }: { command: string; output: string; exitCode: number | null; timedOut?: boolean }) {
+  const failed = timedOut || (exitCode !== null && exitCode !== 0)
+  return (
+    <div className="overflow-hidden rounded-lg border" style={{ borderColor: failed ? 'color-mix(in srgb, var(--err) 40%, var(--border))' : 'var(--border)' }}>
+      <div className="flex items-center gap-2 bg-panel-2 px-3 py-1.5">
+        <SquareTerminal size={13} className="shrink-0 text-muted" />
+        <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">$ {command}</span>
+        {timedOut
+          ? <span className="shrink-0 font-mono text-[11px]" style={{ color: 'var(--err)' }}>timed out</span>
+          : failed
+            ? <span className="shrink-0 font-mono text-[11px]" style={{ color: 'var(--err)' }}>exit {exitCode}</span>
+            : null}
+      </div>
+      {output.trim() && <CodeOutputPanel text={output} />}
+    </div>
+  )
+}
+
+/** A message the user has submitted that hasn't run yet — the server-side queue's contents,
+ *  rendered INLINE at the transcript tail (after the live turn) instead of the old separate
+ *  "Queued" chip strip below the composer (the founder read that strip as a bug — a message you
+ *  sent seeming to vanish from the conversation). Same right-aligned instruction grammar as
+ *  CodeInstructionEntry so it reads as "yours", but translucent + dashed to say "not sent yet",
+ *  with a badge distinguishing a queued STEER (will redirect the current turn) from a FOLLOW-UP
+ *  (runs after it) — information the old chip never surfaced. Reuses the --instruction-* tokens
+ *  (Phase 0) at reduced opacity rather than introducing queue-specific hex. */
+function CodeQueuedEntry({ task, kind, onSendNow }: { task: string; kind: SteerKind; onSendNow?: () => void }) {
+  const isSteer = kind === 'steer'
+  const Badge = isSteer ? CornerDownRight : Clock
+  return (
+    <div className="tllm-rise-in">
+      <RailEntry icon={MessageSquare} tone="muted">
+        <div
+          className="group ml-auto w-fit max-w-[min(88%,900px)] rounded-lg border border-dashed px-4 py-3 opacity-70"
+          style={{ borderColor: 'var(--instruction-chip-border)', background: 'var(--instruction-bg)' }}
+        >
+          <div className="mb-1.5 flex items-center justify-end">
+            <span
+              className="inline-flex items-center gap-1 rounded-full border border-dashed px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted"
+              style={{ borderColor: 'var(--instruction-chip-border)' }}
+              title={isSteer
+                ? 'Queued as a steer — it will redirect the current turn when it runs'
+                : 'Queued — it will run as a new turn after the current one finishes'}
+            >
+              <Badge size={10} className="shrink-0" />
+              {isSteer ? 'Steers this turn' : 'Runs next'}
+            </span>
+          </div>
+          <p className="whitespace-pre-wrap text-[14px] leading-relaxed text-ink">{task}</p>
+          {onSendNow && (
+            <div className="mt-1 flex items-center justify-end">
+              <button
+                type="button"
+                onClick={onSendNow}
+                title="Send now — stop the current run and run this one next"
+                className="inline-flex items-center gap-1 rounded p-1 text-[11px] font-medium text-faint transition-colors hover:text-ink"
+              >
+                <SendHorizontal size={12} /> Send now
+              </button>
+            </div>
+          )}
+        </div>
+      </RailEntry>
+    </div>
+  )
+}
+
 /** The agent's internal reasoning — monospace/log-toned (it's narration of a
  *  process, closer to "activity" than a final answer), collapsed by default. */
 function CodeReasoning({ reasoning, streaming }: { reasoning: string; streaming?: boolean }) {
   const [open, setOpen] = useState(false)
+  // `/thinking` (ADR-258) force-opens every reasoning block globally for reviewing a long run; the
+  // per-block toggle still works when it's off. `show` is what actually drives the panel.
+  const thinkingPref = useDisplayPref('thinking')
+  const show = open || thinkingPref
   return (
     <div className="overflow-hidden rounded-lg border border-border">
       <button
@@ -469,9 +577,9 @@ function CodeReasoning({ reasoning, streaming }: { reasoning: string; streaming?
         className="flex w-full items-center gap-1.5 bg-panel-2 px-3 py-1.5 text-left font-mono text-[11px] text-muted hover:text-ink"
       >
         {streaming ? 'reasoning…' : 'reasoning'}
-        {streaming && !open && <span className="tllm-pulse">·</span>}
+        {streaming && !show && <span className="tllm-pulse">·</span>}
       </button>
-      {open && (
+      {show && (
         <pre
           className="max-h-48 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-[11px] leading-relaxed"
           style={{ background: 'var(--log-bg)', color: 'var(--log-faint)' }}
@@ -526,9 +634,27 @@ function RailEntry({ icon: Icon, tone = 'muted', children }: { icon: typeof Squa
  *  polish. A finished message mounts once and stays put, so this only ever plays once. */
 function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: () => void }) {
   if (message.role === 'user') {
+    // A persisted `!command` (ADR-258) is a user message carrying a `shell` tool call — render it
+    // as a terminal entry, not a chat-style instruction bubble.
+    const shell = (message.toolCalls ?? []).find((tc) => tc.name === 'shell')
+    if (shell) {
+      const args = shell.args as { command?: unknown; exitCode?: unknown; timedOut?: unknown }
+      return (
+        <div className="tllm-rise-in">
+          <RailEntry icon={SquareTerminal} tone="muted">
+            <CodeShellEntry
+              command={typeof args.command === 'string' ? args.command : ''}
+              output={shell.result ?? ''}
+              exitCode={typeof args.exitCode === 'number' ? args.exitCode : null}
+              timedOut={args.timedOut === true}
+            />
+          </RailEntry>
+        </div>
+      )
+    }
     return (
       <div className="tllm-rise-in">
-        <RailEntry icon={SquareTerminal} tone="accent">
+        <RailEntry icon={MessageSquare} tone="accent">
           <CodeInstructionEntry content={message.content} contextFiles={message.textAttachments} onRevert={onRevert} />
         </RailEntry>
       </div>
@@ -545,7 +671,7 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
   return (
     <div className="tllm-rise-in flex flex-col gap-3">
       {message.reasoning?.trim() && (
-        <RailEntry icon={Terminal}>
+        <RailEntry icon={Brain}>
           <CodeReasoning reasoning={message.reasoning} />
         </RailEntry>
       )}
@@ -553,15 +679,17 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
         ? chunks.map((c, i) =>
           c.kind === 'text'
             ? (
-                <RailEntry key={i} icon={SquareTerminal}>
+                <RailEntry key={i} icon={MessageSquare}>
                   <CodeCommentary content={c.text} />
                 </RailEntry>
               )
-            : (
-                <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
-                  <ToolRun calls={c.calls} batchTime={message.createdAt} />
-                </RailEntry>
-              ),
+            : c.kind === 'tools'
+              ? (
+                  <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
+                    <ToolRun calls={c.calls} batchTime={message.createdAt} />
+                  </RailEntry>
+                )
+              : null, // a persisted message never carries live-only turn dividers
         )
         : (
             <>
@@ -571,7 +699,7 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
                 </RailEntry>
               )}
               {message.content?.trim() && (
-                <RailEntry icon={SquareTerminal}>
+                <RailEntry icon={MessageSquare}>
                   <CodeCommentary content={message.content} />
                 </RailEntry>
               )}
@@ -594,6 +722,7 @@ function CodeMessageEntry({ message, onRevert }: { message: Message; onRevert?: 
 type StreamChunk =
   | { kind: 'text'; text: string }
   | { kind: 'tools'; calls: NormalizedCall[] }
+  | { kind: 'turn'; index: number }
 
 function chunkTimeline(timeline: LiveBlock[]): StreamChunk[] {
   const chunks: StreamChunk[] = []
@@ -605,6 +734,11 @@ function chunkTimeline(timeline: LiveBlock[]): StreamChunk[] {
       i++
       continue
     }
+    if (b.kind === 'turn') {
+      chunks.push({ kind: 'turn', index: b.index })
+      i++
+      continue
+    }
     const run: NormalizedCall[] = []
     while (i < timeline.length) {
       const cur = timeline[i]
@@ -612,7 +746,7 @@ function chunkTimeline(timeline: LiveBlock[]): StreamChunk[] {
       run.push(toLiveCall(cur.call))
       i++
     }
-    chunks.push({ kind: 'tools', calls: run })
+    if (run.length) chunks.push({ kind: 'tools', calls: run })
   }
   return chunks
 }
@@ -657,63 +791,148 @@ function chunkPersistedTimeline(timeline: MessageTimelineBlock[], toolCalls: Too
  *  auto-compaction (which silently summarizes history mid-turn with no other
  *  signal) from ordinary "no content yet" — same spinner, different text, so a
  *  long compaction pause doesn't read as a stuck/dead run. */
-function CodeThinking({ label = 'thinking…' }: { label?: string }) {
+function CodeThinking({ label = 'thinking…', tone = 'accent' }: { label?: string; tone?: 'accent' | 'warn' }) {
   return (
     <div className="flex items-center gap-1.5 font-mono text-[11px] text-muted">
-      <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: 'var(--accent)' }} />
+      <Loader2 size={12} className="shrink-0 animate-spin" style={{ color: tone === 'warn' ? 'var(--warn)' : 'var(--accent)' }} />
       <span>{label}</span>
     </div>
   )
 }
 
-function CodeStreamingEntry({ timeline, reasoning, compacting }: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean }) {
+/** A subtle divider between agentic rounds within one live assistant turn (Phase 2, ADR-249) —
+ *  just a thin tokenized rule, deliberately low-weight (this is grouping, not a hard section
+ *  break). Rendered outside the rail (no marker dot) so it reads as a separator spanning the
+ *  rounds rather than another activity entry. Live-only: a persisted turn has no round markers,
+ *  so the finished transcript reads as one continuous log.
+ *  No "Round N" text label (dropped per founder feedback, 2026-07-24 — the line alone is the
+ *  grouping signal; a literal round counter read as unwanted clutter). `index` stays a param
+ *  even though it's now unused for display, so the call site doesn't need to change if a label
+ *  (e.g. a tooltip) is ever wanted back. */
+function TurnDivider({ index: _index }: { index: number }) {
+  return <span className="block h-px" style={{ background: 'var(--border)' }} aria-hidden />
+}
+
+const TODO_STATUS_COLOR: Record<TodoItem['status'], string> = {
+  pending: 'var(--faint)',
+  in_progress: 'var(--accent)',
+  completed: 'var(--ok)',
+}
+
+function TodoStatusIcon({ status }: { status: TodoItem['status'] }) {
+  if (status === 'completed') return <CheckCircle2 size={12} className="mt-0.5 shrink-0" style={{ color: TODO_STATUS_COLOR.completed }} />
+  if (status === 'in_progress') return <Loader2 size={12} className="mt-0.5 shrink-0 animate-spin" style={{ color: TODO_STATUS_COLOR.in_progress }} />
+  return <Circle size={12} className="mt-0.5 shrink-0" style={{ color: TODO_STATUS_COLOR.pending }} />
+}
+
+/** The model's own plan for the CURRENT live turn (ADR-255, `update_todos`) — a compact
+ *  checklist, not another chat-style card: a quiet header ("Plan · N/total") over a plain list,
+ *  same visual weight as CodeReasoning/CodeThinking rather than a heavier new pattern. Ephemeral
+ *  and live-only by design (the backend never persists todos past a turn, and resets them at the
+ *  start of every new one — see LiveState.todos's doc comment) — renders nothing once `todos` is
+ *  empty/undefined, so a finished turn's transcript entry never carries a stale plan.
+ *  Pinned above the composer by CodeSessionScreen.tsx, NOT rendered inline in the scrolling
+ *  transcript (founder feedback, 2026-07-24: a plan you have to scroll to find isn't a plan) —
+ *  exported so the screen can render it directly, outside CodeStreamingEntry. */
+export function TodoChecklist({ todos }: { todos: TodoItem[] }) {
+  if (todos.length === 0) return null
+  const done = todos.filter((t) => t.status === 'completed').length
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="flex items-center gap-1.5 bg-panel-2 px-3 py-1.5 text-[11px] font-medium text-muted">
+        <ListChecks size={12} className="shrink-0" />
+        <span>Plan</span>
+        <span className="ml-auto font-mono text-[10px] tabular-nums text-faint">{done}/{todos.length}</span>
+      </div>
+      <ul className="flex flex-col gap-1.5 px-3 py-2">
+        {todos.map((t, i) => (
+          <li key={i} className="flex items-start gap-1.5 text-[12px] leading-snug">
+            <TodoStatusIcon status={t.status} />
+            <span className={cn(t.status === 'completed' ? 'text-faint line-through' : t.status === 'in_progress' ? 'text-ink' : 'text-muted')}>
+              {t.content}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function CodeStreamingEntry({
+  timeline, reasoning, compacting, retry,
+}: {
+  timeline: LiveBlock[]
+  reasoning: string
+  compacting?: boolean
+  retry?: RetryState | null
+}) {
   const chunks = chunkTimeline(timeline)
   const hasContent = !!reasoning?.trim() || chunks.length > 0
   return (
     <div className="flex flex-col gap-3">
       {reasoning?.trim() && (
-        <RailEntry icon={Terminal} tone="accent">
+        <RailEntry icon={Brain} tone="accent">
           <CodeReasoning reasoning={reasoning} streaming />
         </RailEntry>
       )}
       {chunks.map((c, i) =>
         c.kind === 'text'
           ? (
-              <RailEntry key={i} icon={SquareTerminal} tone="accent">
+              <RailEntry key={i} icon={MessageSquare} tone="accent">
                 <CodeCommentary content={c.text} streaming />
               </RailEntry>
             )
-          : (
-              <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
-                <ToolRun calls={c.calls} />
-              </RailEntry>
-            ),
+          : c.kind === 'turn'
+            ? <TurnDivider key={i} index={c.index} />
+            : (
+                <RailEntry key={i} icon={runIcon(c.calls)} tone={runTone(c.calls)}>
+                  <ToolRun calls={c.calls} />
+                </RailEntry>
+              ),
       )}
-      {compacting
+      {/* One shared status-banner slot (ADR-250) — retry is the most salient transient state so it
+          takes priority over compaction and the generic "thinking" placeholder. */}
+      {retry
         ? (
-            <RailEntry icon={Terminal} tone="accent">
-              <CodeThinking label="Compacting conversation…" />
+            <RailEntry icon={RotateCcw} tone="accent">
+              <CodeThinking tone="warn" label={`Retrying… attempt ${retry.attempt} of ${retry.maxAttempts}${retry.message ? ` — ${retry.message}` : ''}`} />
             </RailEntry>
           )
-        : !hasContent && (
-            <RailEntry icon={Terminal} tone="accent">
-              <CodeThinking />
-            </RailEntry>
-          )}
+        : compacting
+          ? (
+              <RailEntry icon={Brain} tone="accent">
+                <CodeThinking label="Compacting conversation…" />
+              </RailEntry>
+            )
+          : !hasContent && (
+              <RailEntry icon={Brain} tone="accent">
+                <CodeThinking />
+              </RailEntry>
+            )}
     </div>
   )
 }
 
 export function CodeTranscript({
-  messages, liveAssistantId, live, onRevert,
+  messages, liveAssistantId, live, onRevert, queued, onSendNowQueued, shellRuns,
 }: {
   messages: Message[]
   liveAssistantId?: string
-  live?: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean } | null
+  live?: { timeline: LiveBlock[]; reasoning: string; compacting?: boolean; retry?: RetryState | null } | null
   /** Revert affordance on each user message — omitted entirely (via `undefined`) while a run
    *  is live, and never shown on the FIRST message (nothing before it to revert to; `messages`
    *  here is already cut at any existing /clear point, so index 0 is always correct). */
   onRevert?: (messageId: string) => void
+  /** The server-side message queue (turns waiting behind the active run), rendered inline as
+   *  translucent cards at the tail — AFTER the live turn, in send order — never interleaved above
+   *  it (the ADR-199 ordering invariant; the caller has already excluded these from `messages`). */
+  queued?: QueuedTurn[]
+  /** "Send now" on a queued card — stops the active turn and promotes this one to run next.
+   *  Omitted disables the affordance (the card still renders). */
+  onSendNowQueued?: (userMsgId: string) => void
+  /** Transcript-only `!!command` results (ADR-258) — client-only, rendered at the very tail. A `!`
+   *  result is NOT here; it's a persisted message rendered inline by CodeMessageEntry. */
+  shellRuns?: ShellRun[]
 }) {
   return (
     <div className="relative flex flex-col gap-5 pl-8">
@@ -730,8 +949,23 @@ export function CodeTranscript({
           />
         ))}
       {live && (
-        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} compacting={live.compacting} />
+        <CodeStreamingEntry timeline={live.timeline} reasoning={live.reasoning} compacting={live.compacting} retry={live.retry} />
       )}
+      {queued?.map((q) => (
+        <CodeQueuedEntry
+          key={q.userMsgId}
+          task={q.task}
+          kind={q.kind ?? 'followUp'}
+          onSendNow={onSendNowQueued ? () => onSendNowQueued(q.userMsgId) : undefined}
+        />
+      ))}
+      {shellRuns?.map((s) => (
+        <div key={s.id} className="tllm-rise-in">
+          <RailEntry icon={SquareTerminal} tone="muted">
+            <CodeShellEntry command={s.command} output={s.output} exitCode={s.exitCode} timedOut={s.timedOut} />
+          </RailEntry>
+        </div>
+      ))}
     </div>
   )
 }

--- a/turbollm/web/src/screens/code/no-stray-hex.test.ts
+++ b/turbollm/web/src/screens/code/no-stray-hex.test.ts
@@ -1,0 +1,41 @@
+// Stray-hex regression check (spec 11 acceptance criterion #1, spec 16 §7 — promoted from a
+// one-time manual audit to a real, always-running test rather than trusting a single pass to
+// stay true forever). The Code screen source must never hardcode a color literal that bypasses
+// index.css's token system (`var(--token)` only) — confirmed clean by the original Phase 0 audit
+// (spec 14 §1.2: "font-mono is correctly scoped... no changes needed"; the audit found the same
+// for color usage), so this test is a guard against future drift, not a currently-failing check.
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const CODE_SCREENS_DIR = join(import.meta.dirname, '.')
+
+// `#`-prefixed hex color literals (3/4/6/8 hex digits, word-boundaried so this doesn't false-hit
+// on things like URL fragments or non-color hex-looking tokens) and raw rgba()/hsla() function
+// calls — the two ways to bypass `var(--token)` and inline a color directly.
+const HEX_PATTERN = /#[0-9a-fA-F]{3,8}\b/
+const FUNCTIONAL_COLOR_PATTERN = /\b(rgba?|hsla?)\(/
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.tsx'))
+    .map((e) => join(dir, e.name))
+}
+
+describe('Code screens: no stray hex/rgba/hsla outside the token system', () => {
+  const files = tsxFiles(CODE_SCREENS_DIR)
+
+  it('found at least one .tsx file to check (guards against this test silently checking nothing)', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  for (const file of files) {
+    it(`${file.split(/[\\/]/).pop()} uses only var(--token) for color, no inline hex/rgba/hsla`, () => {
+      const src = readFileSync(file, 'utf8')
+      const hexMatch = src.match(HEX_PATTERN)
+      const funcMatch = src.match(FUNCTIONAL_COLOR_PATTERN)
+      expect(hexMatch, `found a hardcoded hex color: ${hexMatch?.[0]}`).toBeNull()
+      expect(funcMatch, `found a hardcoded rgba()/hsla() color: ${funcMatch?.[0]}`).toBeNull()
+    })
+  }
+})

--- a/turbollm/web/src/test/setup.ts
+++ b/turbollm/web/src/test/setup.ts
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom'
+
+// Real localStorage polyfill — NOT covered by vite.config.ts's jsdom `url` option. That option
+// fixes jsdom's OWN localStorage (which needs a non-opaque origin), but Node 22+'s experimental
+// global `localStorage` shadows jsdom's entirely and throws "localStorage.getItem is not a
+// function" without a `--localstorage-file` path configured (the `--localstorage-file was
+// provided without a valid path` warning every test run prints is this same feature, half-wired).
+// Confirmed empirically: even with the jsdom url fix in place, a bare `localStorage.getItem()`
+// still throws in this environment. stores/ui.ts's zustand store reads localStorage eagerly at
+// MODULE-EVAL time (inside its top-level `create(...)` call), so this must be a real, working
+// implementation in place before ANY test file's imports resolve — setupFiles run before that,
+// so a plain module-scope assignment here (no vi.hoisted needed) is early enough. `configurable:
+// true` so an individual test can still override it (e.g. to assert on stored values) if needed.
+if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {
+  const store = new Map<string, string>()
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, String(v)) },
+      removeItem: (k: string) => { store.delete(k) },
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() { return store.size },
+    },
+  })
+}
+
+// jsdom never implements window.matchMedia (throws "not implemented" — unlike localStorage,
+// there's no config flag that fixes this). stores/ui.ts's resolveDark() calls it for the
+// 'system' theme, and main.tsx wires an OS-theme-change listener via
+// matchMedia(...).addEventListener — both run at module init for any component that imports
+// the ui store, so every component test needs a working stub, not just theme-focused ones. A
+// fixed "always light" stub is enough: nothing in this suite exercises real OS theme switching.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+}

--- a/turbollm/web/src/test/setup.ts
+++ b/turbollm/web/src/test/setup.ts
@@ -2,16 +2,32 @@ import '@testing-library/jest-dom'
 
 // Real localStorage polyfill — NOT covered by vite.config.ts's jsdom `url` option. That option
 // fixes jsdom's OWN localStorage (which needs a non-opaque origin), but Node 22+'s experimental
-// global `localStorage` shadows jsdom's entirely and throws "localStorage.getItem is not a
-// function" without a `--localstorage-file` path configured (the `--localstorage-file was
-// provided without a valid path` warning every test run prints is this same feature, half-wired).
-// Confirmed empirically: even with the jsdom url fix in place, a bare `localStorage.getItem()`
-// still throws in this environment. stores/ui.ts's zustand store reads localStorage eagerly at
-// MODULE-EVAL time (inside its top-level `create(...)` call), so this must be a real, working
-// implementation in place before ANY test file's imports resolve — setupFiles run before that,
-// so a plain module-scope assignment here (no vi.hoisted needed) is early enough. `configurable:
-// true` so an individual test can still override it (e.g. to assert on stored values) if needed.
-if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {
+// global `localStorage` shadows jsdom's entirely and can expose a getItem that IS a function but
+// THROWS when invoked, without a `--localstorage-file` path configured (the `--localstorage-file
+// was provided without a valid path` warning every test run prints is this same feature,
+// half-wired). `execArgv: ['--no-experimental-webstorage']` in vite.config.ts's test block
+// disables this Node feature on Vitest's worker processes, so this shouldn't fire in that
+// configuration — but `localStorageWorks()` below PROBES by actually calling `getItem` rather
+// than trusting a `typeof` check (which sees "function" and wrongly concludes the real
+// implementation is usable even when it throws), so a future config/environment drift that
+// re-exposes the throwing implementation gets caught here instead of crashing every component
+// test at import time. stores/ui.ts's zustand store reads localStorage eagerly at MODULE-EVAL
+// time (inside its top-level `create(...)` call), so a working implementation must be in place
+// before ANY test file's imports resolve — setupFiles run before that, so a plain module-scope
+// check here (no vi.hoisted needed) is early enough. `configurable: true` so an individual test
+// can still override it (e.g. to assert on stored values) if needed.
+function localStorageWorks(): boolean {
+  try {
+    const ls = globalThis.localStorage
+    if (!ls || typeof ls.getItem !== 'function') return false
+    ls.getItem('__setup_probe__')
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (!localStorageWorks()) {
   const store = new Map<string, string>()
   Object.defineProperty(globalThis, 'localStorage', {
     configurable: true,

--- a/turbollm/web/vite.config.ts
+++ b/turbollm/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -12,6 +12,38 @@ export default defineConfig({
       '/healthz': 'http://127.0.0.1:6996',
       '/v1': 'http://127.0.0.1:6996',
     },
+  },
+  test: {
+    environment: 'jsdom',
+    // jsdom's default document origin is the opaque `about:blank` — its own localStorage
+    // implementation throws "not accessible" under an opaque origin, which crashes any
+    // component test that (transitively) imports stores/ui.ts at module init (reads
+    // localStorage for the persisted theme/font-size). A real http(s) URL gives it a real
+    // origin, so localStorage behaves like an actual browser instead of needing a hand-rolled
+    // polyfill (setup.ts still stubs matchMedia separately — jsdom never implements that one).
+    environmentOptions: { jsdom: { url: 'http://localhost:3000' } },
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    // Node 22+ ships its own global `localStorage` (the `--webstorage` flag, on by default),
+    // which shadows jsdom's implementation entirely and throws without a `--localstorage-file`
+    // path configured — the root cause setup.ts's polyfill works around at the JS layer. That
+    // polyfill wins functionally (it overwrites the global before any test file's imports run),
+    // but Node still prints its own startup warning about the unset flag regardless, since the
+    // warning fires independently of whether the global later gets overwritten. Disabling the
+    // feature outright on the actual worker processes Vitest spawns removes the warning at the
+    // source instead of just working around its symptom.
+    execArgv: ['--no-experimental-webstorage'],
+    // engine-groups/personas/tool-explain/vram already use `node:test` and run via the
+    // repo root's `tsx --test` (backend convention) — leave them to that runner rather
+    // than having Vitest try (and fail) to collect them too.
+    exclude: [
+      '**/node_modules/**',
+      '**/e2e/**',
+      'src/lib/engine-groups.test.ts',
+      'src/lib/personas.test.ts',
+      'src/lib/tool-explain.test.ts',
+      'src/lib/vram.test.ts',
+    ],
   },
   build: {
     outDir: '../src/webdist',


### PR DESCRIPTION
## Summary
- Redesigns the Code feature's UI/UX toward opencode/pi's dense terminal feel (ADR-262) while keeping left/right message alignment
- Adds a hard-stop escalation for repeated identical tool-call loops (ADR-263)
- Adds a real prefill-progress bar for Code by polling llama.cpp's `/slots` endpoint, independent of the pi SDK
- Groups consecutive similar terminal commands into one expandable unit
- Various live-testing fixes: user-message card layout, status-banner clipping, terminal-command default-collapse, duplicate composer stats removed

## Test plan
- [x] Backend: `npm test` (1225/1228 pass, 3 pre-existing skips), `npx tsc --noEmit` clean
- [x] Frontend: `npx tsc --noEmit` clean, `npx vitest run` (165/165 pass)
- [ ] Opus code-reviewer pass (next step)
- [ ] User verification before merge