### PR TITLE
release: v1.9.0 — Code generally available, MCP server exposure, Developer-pane security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,6 @@ the detail:
 
 <details>
 <summary><strong>🧑‍💻 Code — a local coding agent, in a real project directory</strong></summary>
-<em>(experimental, off by default — Settings → Experimental)</em>
 
 <br/>
 
@@ -307,7 +306,11 @@ there. Entirely local; nothing leaves your machine.
   `run_code` tool — are available to Code too, alongside honest skill invocation and
   `AGENTS.md`/`agents.md` support.
 - **Independent access control** — gated behind its own API key on non-host devices, separate
-  from Chat's gate, and hidden entirely until you opt in from Settings → Experimental.
+  from Chat's gate.
+- **Expose it to other tools over MCP** — `turbollm mcp-server` runs a stdio MCP server so any
+  MCP-compatible tool (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and more) can
+  delegate a real coding task to Code, not just chat completions. Setup snippets for any host are
+  in the Developer tab.
 
 </details>
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,50 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.9.0] - 2026-07-25
+
+**Code is now available to everyone by default, and can be exposed to other AI coding tools over MCP.**
+
+### Added
+- **Code is generally available.** No longer an opt-in experimental toggle — it's on for every
+  install, no setup required.
+- **`turbollm mcp-server`** — exposes Code as an MCP tool (`delegate_code_task`) so other
+  MCP-compatible tools (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and more — not
+  TurboLLM-specific) can hand off real coding tasks to your local model. A new "TurboLLM MCP"
+  section in Developer walks through setup for any of them.
+- **MCP marketplace:** added Context7 and Firecrawl to the built-in MCP server catalog.
+- **AGENTS.md support is now configurable** — set your own project and global AGENTS.md file
+  paths instead of only the default location.
+- **Real token/sec stats for Code**, shown per turn instead of missing entirely.
+- **Tool-call lines in Code now visually distinguish reads from writes**, so it's easier to see at
+  a glance what the agent actually changed.
+
+### Changed
+- **Reverting further back in Code now just works**, instead of requiring you to resume first —
+  a second revert cleanly supersedes the first.
+- **The Developer pane's Server URL now shows your LAN address** when sharing is on, instead of
+  `localhost` (which only works from this machine).
+
+### Fixed
+- **Two real security gaps closed in the Developer pane's API key management:** while LAN sharing
+  is on and "Require an API key" is off, key management (viewing, creating, and revoking keys, and
+  the per-CLI connect setup snippets that embed a live key) is now restricted to this machine only
+  — previously any device on the network could reach it with no credential at all.
+- **A rare crash during very long, continuous Code turns** — the daemon now proactively stops a
+  turn just before it would hit the model's real context limit, instead of erroring out.
+- **AGENTS.md/CLAUDE.md content was being sent to the model twice every turn** in Code — now sent
+  once.
+
+### Discord
+- Code just graduated from "experimental" to on-by-default for everyone.
+- You can now plug TurboLLM's Code agent into Claude Desktop, Cursor, Windsurf, Cline, or any other
+  MCP-compatible tool — not just Claude Code — via a new `turbollm mcp-server` command. Setup
+  instructions are right there in the Developer tab.
+- Closed two real security holes: on an open, unauthenticated LAN, another device could previously
+  view/create/revoke your API keys or grab a live one from the connect-setup snippets just by
+  loading the page. Both now require you to be on the host machine (or have auth turned on).
+- Reverting further back in a Code session now just works, instead of demanding you resume first.
+
 ## [1.8.7] - 2026-07-24
 
 **Code feature: a denser, more familiar terminal-style redesign, a real prefill progress bar, and a fix for a rare stuck-loop bug.**

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -286,7 +286,6 @@ the detail:
 
 <details>
 <summary><strong>🧑‍💻 Code — a local coding agent, in a real project directory</strong></summary>
-<em>(experimental, off by default — Settings → Experimental)</em>
 
 <br/>
 
@@ -307,7 +306,11 @@ there. Entirely local; nothing leaves your machine.
   `run_code` tool — are available to Code too, alongside honest skill invocation and
   `AGENTS.md`/`agents.md` support.
 - **Independent access control** — gated behind its own API key on non-host devices, separate
-  from Chat's gate, and hidden entirely until you opt in from Settings → Experimental.
+  from Chat's gate.
+- **Expose it to other tools over MCP** — `turbollm mcp-server` runs a stdio MCP server so any
+  MCP-compatible tool (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and more) can
+  delegate a real coding task to Code, not just chat completions. Setup snippets for any host are
+  in the Developer tab.
 
 </details>
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/keys-network.test.ts
+++ b/turbollm/src/api/keys-network.test.ts
@@ -15,8 +15,9 @@ import type { Deps } from '../deps'
 type FakeConfig = { daemon: { lanBind: boolean; requireApiKey: boolean; port: number }; apiKeys: Array<{ id: string; name: string; hash: string; prefix: string; createdAt: string; lastUsedAt: string | null }> }
 
 /** Minimal Deps double: registerApi only touches these fields at ROUTE-HANDLER time (lazy
- *  closures), never at registration time (confirmed by reading routes.ts's top), so a store-only
- *  double is sufficient for exercising /api/v1/keys and /api/v1/settings/network specifically. */
+ *  closures), never at registration time (confirmed by reading routes.ts's top), so a store +
+ *  manager double is sufficient for exercising /api/v1/keys, /api/v1/settings/network, and
+ *  /api/v1/connect/:cli specifically. */
 function fakeApp(cfg: FakeConfig): { app: Hono; cfg: FakeConfig } {
   const app = new Hono()
   const d = {
@@ -25,6 +26,7 @@ function fakeApp(cfg: FakeConfig): { app: Hono; cfg: FakeConfig } {
       snapshot: () => cfg,
       update: (fn: (c: FakeConfig) => void) => fn(cfg),
     },
+    manager: { status: () => ({ state: 'stopped', model: null }) },
   } as unknown as Deps
   registerApi(app, d)
   return { app, cfg }
@@ -101,4 +103,27 @@ test('GET /api/v1/settings/network: requireApiKey field reflects the live config
   const res = await app.request('/api/v1/settings/network')
   const body = (await res.json()) as { requireApiKey: boolean }
   assert.equal(body.requireApiKey, true)
+})
+
+// ── GET /api/v1/connect/:cli — worse than the list/create case: this route MINTS a fresh live
+// key on every call while lanBind is on, and (in the real UI) fires automatically the instant
+// the Developer page loads, with no explicit click required at all.
+
+test('GET /api/v1/connect/:cli: 403 for a non-host caller while the LAN is open and unauthenticated — no key minted', async () => {
+  const { app, cfg } = fakeApp(baseConfig({ lanBind: true, requireApiKey: false }))
+  const res = await app.request('/api/v1/connect/claude-code')
+  assert.equal(res.status, 403)
+  assert.equal(cfg.apiKeys.length, 0, 'no key must have actually been minted by the blocked request')
+})
+
+test('GET /api/v1/connect/:cli: 200 with a real live key when lanBind is off (loopback-only — always local)', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: false }))
+  const res = await app.request('/api/v1/connect/claude-code')
+  assert.equal(res.status, 200)
+})
+
+test('GET /api/v1/connect/:cli: 200 for a non-host caller once requireApiKey is already on (self-service is fine post-auth)', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: true, requireApiKey: true }))
+  const res = await app.request('/api/v1/connect/claude-code')
+  assert.equal(res.status, 200)
 })

--- a/turbollm/src/api/keys-network.test.ts
+++ b/turbollm/src/api/keys-network.test.ts
@@ -1,0 +1,104 @@
+// Route-level tests for the API-key host gate added alongside the Developer pane fix: while the
+// LAN is open and unauthenticated (lanBind on, requireApiKey off), lanAuth's own bypassesAuth
+// deliberately lets ANY request through with zero credential (spec 06 §5's "opted into open LAN
+// access") — which meant, before this fix, a non-host device on the LAN could list key names or
+// mint itself a durable `tllm-...` API key with no credential at all, a real self-escalation (see
+// routes.ts's keysHostGate comment). These tests exercise the actual HTTP routes on a real Hono
+// app, mirroring code-routes.export.test.ts's "real app, minimal Deps double" discipline — a pure
+// function test can't reach this, since the decision depends on a real request Context.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerApi } from './routes'
+import type { Deps } from '../deps'
+
+type FakeConfig = { daemon: { lanBind: boolean; requireApiKey: boolean; port: number }; apiKeys: Array<{ id: string; name: string; hash: string; prefix: string; createdAt: string; lastUsedAt: string | null }> }
+
+/** Minimal Deps double: registerApi only touches these fields at ROUTE-HANDLER time (lazy
+ *  closures), never at registration time (confirmed by reading routes.ts's top), so a store-only
+ *  double is sufficient for exercising /api/v1/keys and /api/v1/settings/network specifically. */
+function fakeApp(cfg: FakeConfig): { app: Hono; cfg: FakeConfig } {
+  const app = new Hono()
+  const d = {
+    version: 'test',
+    store: {
+      snapshot: () => cfg,
+      update: (fn: (c: FakeConfig) => void) => fn(cfg),
+    },
+  } as unknown as Deps
+  registerApi(app, d)
+  return { app, cfg }
+}
+
+function baseConfig(overrides: Partial<FakeConfig['daemon']> = {}): FakeConfig {
+  return { daemon: { lanBind: false, requireApiKey: false, port: 6996, ...overrides }, apiKeys: [] }
+}
+
+// app.request() carries no real TCP connection, so getConnInfo (auth.ts's isLoopback) cannot
+// resolve an address — isLoopback fails closed to null, and isLocalRequest treats an
+// undetermined address as remote WHENEVER lanBind is true. That's exactly the "non-host viewer"
+// case these tests need; the lanBind:false branch below is unconditionally local by a separate,
+// address-independent shortcut in isLocalRequest, so it isn't relying on that same resolution.
+
+test('GET /api/v1/keys: 200 when lanBind is off (loopback-only bind — always local)', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: false, requireApiKey: false }))
+  const res = await app.request('/api/v1/keys')
+  assert.equal(res.status, 200)
+})
+
+test('GET /api/v1/keys: 200 for a non-host caller once requireApiKey is already on (self-service is fine post-auth)', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: true, requireApiKey: true }))
+  const res = await app.request('/api/v1/keys')
+  assert.equal(res.status, 200)
+})
+
+test('GET /api/v1/keys: 403 for a non-host caller while the LAN is open and unauthenticated', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: true, requireApiKey: false }))
+  const res = await app.request('/api/v1/keys')
+  assert.equal(res.status, 403)
+  const body = (await res.json()) as { error?: { code?: string } }
+  assert.equal(body.error?.code, 'forbidden')
+})
+
+test('POST /api/v1/keys: 403 for a non-host caller while the LAN is open and unauthenticated — cannot self-mint a key', async () => {
+  const { app, cfg } = fakeApp(baseConfig({ lanBind: true, requireApiKey: false }))
+  const res = await app.request('/api/v1/keys', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'sneaky' }),
+  })
+  assert.equal(res.status, 403)
+  assert.equal(cfg.apiKeys.length, 0, 'no key must have actually been created')
+})
+
+test('POST /api/v1/keys: 201 when lanBind is off (host use is unaffected by the new gate)', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: false, requireApiKey: false }))
+  const res = await app.request('/api/v1/keys', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'my-key' }),
+  })
+  assert.equal(res.status, 201)
+  const body = (await res.json()) as { key?: string }
+  assert.match(body.key ?? '', /^tllm-/)
+})
+
+test('GET /api/v1/settings/network: isHost is true when lanBind is off, false for a non-host-looking caller while lanBind is on', async () => {
+  const { app: localApp } = fakeApp(baseConfig({ lanBind: false }))
+  const localRes = await localApp.request('/api/v1/settings/network')
+  const localBody = (await localRes.json()) as { isHost: boolean; requireApiKey: boolean }
+  assert.equal(localBody.isHost, true)
+
+  const { app: lanApp } = fakeApp(baseConfig({ lanBind: true, requireApiKey: false }))
+  const lanRes = await lanApp.request('/api/v1/settings/network')
+  const lanBody = (await lanRes.json()) as { isHost: boolean; requireApiKey: boolean }
+  assert.equal(lanBody.isHost, false)
+  assert.equal(lanBody.requireApiKey, false)
+})
+
+test('GET /api/v1/settings/network: requireApiKey field reflects the live config', async () => {
+  const { app } = fakeApp(baseConfig({ lanBind: true, requireApiKey: true }))
+  const res = await app.request('/api/v1/settings/network')
+  const body = (await res.json()) as { requireApiKey: boolean }
+  assert.equal(body.requireApiKey, true)
+})

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -2118,7 +2118,15 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   // ── CLI connect snippets (spec 06 §6) ────────────────────────────────────
+  // Same host gate as /api/v1/keys above, and for the same reason — arguably more urgent here:
+  // this route doesn't just expose existing key metadata, it MINTS a brand-new live key (below)
+  // and returns its full raw value embedded in the setup snippets on every single call while
+  // lanBind is on, with no action beyond loading the page (ConnectSection queries it eagerly for
+  // the default-selected CLI). Ungated, a non-host viewer on an open, unauthenticated LAN could
+  // get a real credential just by opening Developer — worse than the list/create case, since it
+  // requires no explicit "create" click at all.
   app.get('/api/v1/connect/:cli', (c) => {
+    if (!keysHostGate(c)) return err(c, 403, 'forbidden', 'Connect setup is only available from this machine until "Require an API key" is turned on.')
     const cli = c.req.param('cli')
     const cfg = d.store.snapshot()
     const { port, lanBind } = cfg.daemon

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1559,6 +1559,7 @@ export function registerApi(app: Hono, d: Deps): void {
       tavilyApiKey?: string
       search?: { provider?: string; tavilyApiKey?: string; kagiApiKey?: string; searxngUrl?: string }
       build?: { toolchainDirs?: string[] }
+      code?: { agentsMdProjectCandidates?: string[]; agentsMdGlobalCandidates?: string[] }
       toolPolicies?: Record<string, string>
       autoAllowAll?: boolean
       cloudDeploy?: { runpodTemplateId?: string }
@@ -1688,6 +1689,30 @@ export function registerApi(app: Hono, d: Deps): void {
       toolchainDirs = dirs
     }
 
+    // AGENTS.md candidate lists (Code's standing-context injection, persona.ts) — the OPPOSITE
+    // constraint from toolchainDirs: must be RELATIVE, not absolute. Clean-400 convenience only;
+    // persona.ts containment-checks each entry again at read time regardless (see config.ts's
+    // CodeConfig doc comment for why route-level validation alone isn't the real boundary).
+    const MAX_AGENTS_MD_CANDIDATES = 8
+    let agentsMdProjectCandidates: string[] | undefined
+    let agentsMdGlobalCandidates: string[] | undefined
+    for (const [key, out] of [
+      ['agentsMdProjectCandidates', (v: string[]) => { agentsMdProjectCandidates = v }],
+      ['agentsMdGlobalCandidates', (v: string[]) => { agentsMdGlobalCandidates = v }],
+    ] as const) {
+      const raw = b.code?.[key]
+      if (raw === undefined) continue
+      if (!Array.isArray(raw)) return err(c, 400, 'invalid_config_value', `code.${key} must be an array of filenames.`)
+      const list = raw.map((p) => String(p).trim()).filter(Boolean)
+      if (list.length > MAX_AGENTS_MD_CANDIDATES) return err(c, 400, 'invalid_config_value', `code.${key}: at most ${MAX_AGENTS_MD_CANDIDATES} candidates.`)
+      for (const entry of list) {
+        if (/^([a-zA-Z]:[\\/]|[\\/])/.test(entry)) {
+          return err(c, 400, 'invalid_config_value', `code.${key}: "${entry}" must be a relative filename/path, not absolute.`)
+        }
+      }
+      out(list)
+    }
+
     // Tool-call approval gate: global per-tool policy map. Validate every value is
     // one of 'ask' | 'allow' | 'deny' so a garbled patch gets a clean 400, not a
     // silently-dropped/garbage config.
@@ -1713,6 +1738,8 @@ export function registerApi(app: Hono, d: Deps): void {
       Object.assign(cfg.comfyui, cuUpdates)
       Object.assign(cfg.gateway, gwUpdates)
       if (toolchainDirs !== undefined) cfg.build.toolchainDirs = toolchainDirs
+      if (agentsMdProjectCandidates !== undefined) cfg.code.agentsMdProjectCandidates = agentsMdProjectCandidates
+      if (agentsMdGlobalCandidates !== undefined) cfg.code.agentsMdGlobalCandidates = agentsMdGlobalCandidates
       if (toolPolicies !== undefined) cfg.tools.toolPolicies = toolPolicies
       if (b.autoAllowAll !== undefined) cfg.tools.autoAllowAll = !!b.autoAllowAll
       if (b.autoLoadOnStart !== undefined) cfg.autoLoadOnStart = !!b.autoLoadOnStart
@@ -2219,6 +2246,9 @@ function settingsPayload(d: Deps) {
     // Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
     // conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back.
     build: { toolchainDirs: cfg.build.toolchainDirs },
+    // Code's AGENTS.md-style standing-context candidate lists (config.ts's CodeConfig):
+    // not secret — echoed back.
+    code: cfg.code,
     // Cloud Launch deploy-link settings (ADR-153): not secret — echoed back.
     cloudDeploy: cfg.cloudDeploy,
     // Experimental feature flags (2026-07-14): not secret — echoed back for Settings →

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -2109,6 +2109,11 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   app.delete('/api/v1/keys/:id', (c) => {
+    // Same host gate as GET/POST above (found missing here in the v1.9.0 pre-release review):
+    // without it, a non-host device on an open, unauthenticated LAN could revoke ANY key by id —
+    // breaking another device's already-configured access — protected by nothing but an
+    // unguessable UUID rather than an actual credential check.
+    if (!keysHostGate(c)) return err(c, 403, 'forbidden', 'API keys can only be revoked from this machine until "Require an API key" is turned on.')
     const id = c.req.param('id')
     d.store.update((cfg) => {
       cfg.apiKeys = cfg.apiKeys.filter((k) => k.id !== id)

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1884,13 +1884,17 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   // ── network info (spec 08 §2): LAN expose state + the reachable LAN URL + whether
-  // an API key exists (non-local access requires one).
+  // an API key exists (non-local access requires one). `requireApiKey` + `isHost` (added
+  // alongside the /api/v1/keys host gate above) let the UI honestly reflect that same rule
+  // instead of just hiding a button while the underlying route is still reachable.
   app.get('/api/v1/settings/network', (c) => {
     const cfg = d.store.snapshot()
     return c.json({
       lanBind: cfg.daemon.lanBind,
       lanUrl: `http://${getLanIp()}:${cfg.daemon.port}`,
       hasApiKey: cfg.apiKeys.length > 0,
+      requireApiKey: cfg.daemon.requireApiKey,
+      isHost: isLocalRequest(c, d),
     })
   })
 
@@ -2060,7 +2064,20 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   // ── API keys (spec 06 §5) ────────────────────────────────────────────────
+  // Host-only while the LAN is open and unauthenticated (lanBind on, requireApiKey off):
+  // lanAuth's bypassesAuth deliberately lets that combination through with NO credential at
+  // all (spec 06 §5's "opted into open LAN access"), which is fine for chat/models but would
+  // let any device that can merely load the page list key names or mint itself a durable
+  // `tllm-...` key with zero credential — a real self-escalation (that key keeps working even
+  // after requireApiKey is later turned on), not just an info leak. Once requireApiKey IS on,
+  // a non-host caller only reaches this handler at all by already having presented a valid key
+  // (lanAuth ran first), so self-service key management from another device is fine then.
+  function keysHostGate(c: Context): boolean {
+    return isLocalRequest(c, d) || d.store.snapshot().daemon.requireApiKey
+  }
+
   app.get('/api/v1/keys', (c) => {
+    if (!keysHostGate(c)) return err(c, 403, 'forbidden', 'API keys are only visible from this machine until "Require an API key" is turned on.')
     const keys = d.store.snapshot().apiKeys.map(({ id, name, prefix, createdAt, lastUsedAt }) => ({
       id,
       name,
@@ -2072,6 +2089,7 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   app.post('/api/v1/keys', async (c) => {
+    if (!keysHostGate(c)) return err(c, 403, 'forbidden', 'API keys can only be created from this machine until "Require an API key" is turned on.')
     const b = await body<{ name?: string }>(c)
     const name = (b.name ?? '').trim()
     if (!name) return err(c, 400, 'invalid_config_value', 'name is required.')

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1563,7 +1563,7 @@ export function registerApi(app: Hono, d: Deps): void {
       toolPolicies?: Record<string, string>
       autoAllowAll?: boolean
       cloudDeploy?: { runpodTemplateId?: string }
-      experimental?: { memory?: boolean; code?: boolean; cloudDeploy?: boolean }
+      experimental?: { memory?: boolean; cloudDeploy?: boolean }
     }>(c)
 
     const updates: Record<string, unknown> = {}
@@ -1755,7 +1755,6 @@ export function registerApi(app: Hono, d: Deps): void {
       // the other back to whatever `updates.experimental` would otherwise silently overwrite it
       // with (same reasoning as cloudDeploy's own per-field handling just above).
       if (b.experimental?.memory !== undefined) cfg.daemon.experimental.memory = !!b.experimental.memory
-      if (b.experimental?.code !== undefined) cfg.daemon.experimental.code = !!b.experimental.code
       if (b.experimental?.cloudDeploy !== undefined) cfg.daemon.experimental.cloudDeploy = !!b.experimental.cloudDeploy
       // HF token (spec 10 §4): write-only. An explicit '' clears it. Never logged.
       if (b.hfToken !== undefined) cfg.hf.token = String(b.hfToken).trim()

--- a/turbollm/src/auth.ts
+++ b/turbollm/src/auth.ts
@@ -230,20 +230,3 @@ export function codeAuth(d: Deps): MiddlewareHandler {
     )
   }
 }
-
-/** Experimental-feature gate (2026-07-14, preparing for wider distribution): Code is now an
- *  opt-in experimental feature (Settings → Experimental), off by default for new/distributed
- *  installs. This is INDEPENDENT of codeAuth above — codeAuth answers "is this caller allowed
- *  to reach Code at all", this answers "is Code even turned on" — both must pass. Register on
- *  /api/v1/code/* alongside codeAuth in server.ts. A 403 (not 401): the caller may be fully
- *  authenticated and simply have the feature turned off, which is a different failure mode from
- *  a missing/invalid credential. */
-export function requireExperimentalCode(d: Deps): MiddlewareHandler {
-  return async (c, next) => {
-    if (d.store.snapshot().daemon.experimental.code) return next()
-    return c.json(
-      { error: { code: 'feature_disabled', message: 'Code is an experimental feature. Enable it in Settings → Experimental.' } },
-      403,
-    )
-  }
-}

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -1020,6 +1020,20 @@ export class ConversationStore {
     return (this.db.prepare(`SELECT * FROM messages WHERE conv_id = $id AND is_active = 1 ORDER BY seq ASC`).all({ $id: convId } as P) as unknown as MsgRow[]).map(rowToMsg)
   }
 
+  /** Like {@link deactivateMessagesFrom}'s own range (seq >= fromMessageId's seq) — but returns
+   *  the actual rows regardless of is_active, unlike getMessages' unconditional is_active=1
+   *  filter. Needed for Code's /revert file-revert path: a SUPERSEDING revert (ADR-278) that
+   *  passes revertFiles=true must be able to see edit-tool patches from a PREVIOUSLY reverted,
+   *  already-inactive range too — getMessages alone would silently drop that range, making
+   *  revertFileEdits skip files a prior chat-only revert never touched, while the caller's
+   *  success toast still claims everything from the new cut onward was reverted. */
+  getMessagesFromIncludingInactive(convId: string, fromMessageId: string): Message[] {
+    const from = this.db.prepare(`SELECT seq FROM messages WHERE id = $id AND conv_id = $cid`).get({ $id: fromMessageId, $cid: convId } as P) as unknown as { seq: number } | undefined
+    if (!from) return []
+    return (this.db.prepare(`SELECT * FROM messages WHERE conv_id = $cid AND seq >= $seq ORDER BY seq ASC`)
+      .all({ $cid: convId, $seq: from.seq } as P) as unknown as MsgRow[]).map(rowToMsg)
+  }
+
   addMessage(convId: string, role: 'user' | 'assistant', content: string, extra?: Partial<Pick<Message, 'reasoning' | 'attachments' | 'textAttachments' | 'toolCalls' | 'stats' | 'variantGroup'>>): Message {
     const id = randomUUID()
     const now = new Date().toISOString()

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -31,6 +31,7 @@ import { GenerationGate } from './agents/gate'
 import { AgentTaskState } from './agents/task-state'
 import { launchCli } from './cli-launch'
 import { writePidfile, removePidfile, stopDaemon, resolveDaemonPort } from './daemon-pid'
+import { runMcpServer } from './mcp-server'
 import { createApp } from './server'
 import { provisionTunnelApiKey } from './auth'
 import { TunnelManager, reapStaleTunnels, killTrackedTunnelsSync } from './tunnel/manager'
@@ -132,6 +133,24 @@ if (argv[0] === 'launch') {
   process.exit(code)
 }
 
+// ── `turbollm mcp-server` — expose Code as an MCP tool over stdio (TODO.md item 4) ──────
+// A thin bridge to an ALREADY-RUNNING daemon's existing HTTP API — deliberately does NOT
+// start a daemon, load a model, or touch ConfigStore/Manager itself, so it stays a fast,
+// side-effect-free process an MCP host can spawn per connection. See mcp-server.ts for the
+// full scope rationale. Handled here (before the heavy daemon bootstrap below) for the same
+// reason `launch` is: this process's job ends at stdio, it never needs Registry/Manager/etc.
+if (argv[0] === 'mcp-server') {
+  const mcpConfigPath = argValue('--config', defaultConfigPath())
+  const mcpExplicitPort = Number(argValue('--port', '')) || undefined
+  const mcpPort = resolveDaemonPort(
+    dirname(mcpConfigPath),
+    mcpExplicitPort,
+    configuredDaemonPort(mcpConfigPath),
+  )
+  await runMcpServer(`http://127.0.0.1:${mcpPort}`, version)
+  process.exit(0)
+}
+
 // ── --help / -h ───────────────────────────────────────────────────────────────
 if (hasFlag('--help', '-h')) {
   process.stdout.write(
@@ -146,7 +165,11 @@ if (hasFlag('--help', '-h')) {
     `                                   Claude Code to whatever model is loaded.\n` +
     `  launch claude --model <key>      Load a specific model by key or name, then launch\n` +
     `  launch opencode|kilo|openclaw|hermes\n` +
-    `                                   Wire that CLI to TurboLLM (writes its config file)\n\n` +
+    `                                   Wire that CLI to TurboLLM (writes its config file)\n` +
+    `  mcp-server                       Run an MCP server over stdio, bridging to an already-\n` +
+    `                                   running TurboLLM daemon so other agentic CLIs can\n` +
+    `                                   delegate tasks to Code. Add to a host's MCP config as:\n` +
+    `                                   { "command": "npx", "args": ["turbollm", "mcp-server"] }\n\n` +
     `Options:\n` +
     `  --port <n>     Port to listen on / connect to (default: 6996)\n` +
     `  --addr <h:p>   Full host:port override (e.g. 0.0.0.0:6996)\n` +

--- a/turbollm/src/code/code-routes.export.test.ts
+++ b/turbollm/src/code/code-routes.export.test.ts
@@ -6,13 +6,15 @@
 // composes with real DB state (a /clear'd session, an "active" run).
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { createPatch } from 'diff'
 import { Hono } from 'hono'
 import { ConversationStore } from '../chat/db'
 import { registerCodeRoutes } from './code-routes'
 import type { Deps } from '../deps'
+import type { ToolCallRecord } from '../chat/db'
 
 function tmp(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix))
@@ -210,4 +212,54 @@ test('the mutual-exclusion lock releases: /clear → /resume → /revert all suc
   // permanent lock) — reverting to the now-reactivated 'second' user message.
   const revert = await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: target.id }), headers: { 'Content-Type': 'application/json' } })
   assert.equal(revert.status, 200)
+})
+
+// ── HIGH finding, v1.9.0 pre-release review: a superseding revert with revertFiles:true must
+// reach edit patches from a PRIOR revert's already-deactivated range too, not just the newly-
+// exposed active range — see code-routes.ts's /revert handler comment for the full mechanism.
+test('POST .../revert (superseding, revertFiles: true) reaches an edit patch from a PRIOR chat-only revert\'s already-hidden range', async () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'tllm-revert-supersede-files-'))
+  const db = new ConversationStore(tmp('tllm-revert-supersede-files-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db, { repoRoot })
+
+  const v0 = 'line1\nold\nline3\n'
+  const v1 = 'line1\nnew\nline3\n'
+  writeFileSync(join(repoRoot, 'a.txt'), v1)
+  const patch = createPatch('a.txt', v0, v1)
+  const editToolCall: ToolCallRecord = { id: 'tc-1', name: 'edit', args: { path: 'a.txt' }, patch }
+
+  const first = db.addMessage(conv.id, 'user', 'first')
+  const second = db.addMessage(conv.id, 'user', 'second') // the SECOND (further-back) revert target
+  const third = db.addMessage(conv.id, 'user', 'third') // the FIRST (chat-only) revert target
+  db.addMessage(conv.id, 'assistant', 'reply with an edit', { toolCalls: [editToolCall] })
+
+  // First revert — "Chat only" (revertFiles: false). Hides 'third' + the edit-carrying reply;
+  // the file is deliberately left untouched on disk (v1), matching the real UI's "Chat only" path.
+  const r1 = await app.request(`/api/v1/code/sessions/${run.id}/revert`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messageId: third.id, revertFiles: false }),
+  })
+  assert.equal(r1.status, 200)
+  assert.equal(readFileSync(join(repoRoot, 'a.txt'), 'utf8'), v1, 'chat-only revert must not touch the file')
+
+  // Second revert — SUPERSEDES, further back to 'second', WITH revertFiles: true. The naive
+  // `messages.slice(idx)` (is_active=1 only) would see only ['second'] here — no tool calls at
+  // all, since the edit-carrying reply is already deactivated by the first revert — and silently
+  // report nothing to revert. getMessagesFromIncludingInactive must reach past that hidden range.
+  const r2 = await app.request(`/api/v1/code/sessions/${run.id}/revert`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messageId: second.id, revertFiles: true }),
+  })
+  assert.equal(r2.status, 200)
+  const body = (await r2.json()) as { revertedFiles: string[]; failedFiles: string[] }
+  assert.deepEqual(body.revertedFiles, ['a.txt'], 'must actually revert the file this time, not silently no-op')
+  assert.deepEqual(body.failedFiles, [])
+  assert.equal(readFileSync(join(repoRoot, 'a.txt'), 'utf8'), v0, 'file walked all the way back to its pre-edit content')
+
+  const conv2 = db.getConversation(conv.id, true)!
+  const active = new Set((conv2.messages ?? []).map((m) => m.id))
+  assert.ok(active.has(first.id))
+  assert.ok(!active.has(second.id))
+  assert.ok(!active.has(third.id))
 })

--- a/turbollm/src/code/code-routes.export.test.ts
+++ b/turbollm/src/code/code-routes.export.test.ts
@@ -166,6 +166,36 @@ test('POST .../clear is refused (409 session_reverted) while the session has a p
   assert.equal(((await res.json()) as { error?: { code?: string } }).error?.code, 'session_reverted')
 })
 
+test('POST .../revert while already reverted SUPERSEDES (200, not 409) when reverting further back', async () => {
+  const db = new ConversationStore(tmp('tllm-revert-supersede-'))
+  const { app } = makeApp(db)
+  const { conv, run } = seedSession(db, { repoRoot: '/repo' })
+  const first = db.addMessage(conv.id, 'user', 'first')
+  db.addMessage(conv.id, 'assistant', 'reply one')
+  const second = db.addMessage(conv.id, 'user', 'second')
+  db.addMessage(conv.id, 'assistant', 'reply two')
+  const third = db.addMessage(conv.id, 'user', 'third')
+  db.addMessage(conv.id, 'assistant', 'reply three')
+
+  // First revert — cuts back to 'third'.
+  const r1 = await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: third.id }), headers: { 'Content-Type': 'application/json' } })
+  assert.equal(r1.status, 200)
+  assert.equal(db.getAgentRun(run.id)?.revertedFromMessageId, third.id)
+
+  // Second revert, further back to 'second' — must SUPERSEDE, not 409. 'second' is still
+  // is_active=1 (it's before the first cut), so it's exactly the case the UI can actually submit.
+  const r2 = await app.request(`/api/v1/code/sessions/${run.id}/revert`, { method: 'POST', body: JSON.stringify({ messageId: second.id }), headers: { 'Content-Type': 'application/json' } })
+  assert.equal(r2.status, 200)
+  assert.equal(db.getAgentRun(run.id)?.revertedFromMessageId, second.id)
+
+  // 'first' stays active (before both cuts); 'second' and everything after is now deactivated.
+  const conv2 = db.getConversation(conv.id, true)!
+  const active = new Set((conv2.messages ?? []).map((m) => m.id))
+  assert.ok(active.has(first.id))
+  assert.ok(!active.has(second.id))
+  assert.ok(!active.has(third.id))
+})
+
 test('the mutual-exclusion lock releases: /clear → /resume → /revert all succeed in sequence', async () => {
   const db = new ConversationStore(tmp('tllm-clear-revert-'))
   const { app } = makeApp(db)

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -458,8 +458,7 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     // revertedFromMessageId cut (that cut and everything after it is already is_active=0 and thus
     // unreachable through the normal UI). "Revert again" can therefore only ever mean "revert
     // further back," never forward into already-hidden history — deactivateMessagesFrom below is
-    // idempotent-safe to call again with an earlier cutoff, and revertFileEdits' slice naturally
-    // covers the superset (the previously-reverted range plus the newly-included earlier range).
+    // idempotent-safe to call again with an earlier cutoff.
     // /compact and /clear keep their own hard stop while reverted (line 381 above, and the
     // clearedUpToMessageId guard above) — losing hidden history to a compaction/clear is a bigger,
     // less-reversible deal than superseding one revert cursor with another.
@@ -477,8 +476,16 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     let revertedFiles: string[] = []
     let failedFiles: string[] = []
     if (b.revertFiles) {
-      const idx = messages.findIndex((m) => m.id === messageId)
-      const result = revertFileEdits(messages.slice(idx), run.repoRoot)
+      // NOT messages.slice(idx) — `messages` came from getConversation's is_active=1 filter, so
+      // it silently EXCLUDES any range a PRIOR revert already deactivated. Superseding a prior
+      // chat-only revert (revertFiles=false) with a further-back one that DOES ask for file
+      // reverts must still reach that earlier range's edit patches, or files it touched are
+      // silently left edited on disk while the success toast below claims otherwise (found in
+      // Opus PR review, pre-release gate for v1.9.0). getMessagesFromIncludingInactive walks the
+      // real seq-ordered row range regardless of is_active — the same range deactivateMessagesFrom
+      // itself operates on below.
+      const rangeMessages = db.getMessagesFromIncludingInactive(run.convId, messageId)
+      const result = revertFileEdits(rangeMessages, run.repoRoot)
       revertedFiles = result.reverted
       failedFiles = result.failed
     }

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -213,7 +213,12 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
       // with the SAME lookup persona.ts injects into the prompt, so "shown as loaded" == "actually
       // fed to the model". Both false when the session has no repoRoot.
       hasAgentsMd: run.repoRoot
-        ? agentsMdPresence(run.repoRoot, d.store.dir())
+        ? agentsMdPresence(
+          run.repoRoot,
+          d.store.dir(),
+          d.store.snapshot().code.agentsMdProjectCandidates,
+          d.store.snapshot().code.agentsMdGlobalCandidates,
+        )
         : { project: false, global: false },
     })
   })
@@ -444,7 +449,20 @@ export function registerCodeRoutes(app: Hono, d: Deps): void {
     if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
     if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before reverting.')
     if (run.clearedUpToMessageId) return err(c, 409, 'session_cleared', 'Resume this session before reverting — it currently has cleared messages pending.')
-    if (run.revertedFromMessageId) return err(c, 409, 'session_reverted', 'Resume this session before reverting again — it already has a reverted message pending.')
+    // A second revert while one is already pending SUPERSEDES it rather than 409ing (founder
+    // feedback, 2026-07-24 — the earlier hard stop cost real friction on "revert, try again,
+    // doesn't work, revert further back", a common iterative-debugging pattern). Safe by
+    // construction, not just by convention: the revert affordance only ever renders on a message
+    // getMessages() actually returned, which filters is_active=1 — so any messageId this handler
+    // receives is necessarily STILL ACTIVE, which by definition means it sits BEFORE the current
+    // revertedFromMessageId cut (that cut and everything after it is already is_active=0 and thus
+    // unreachable through the normal UI). "Revert again" can therefore only ever mean "revert
+    // further back," never forward into already-hidden history — deactivateMessagesFrom below is
+    // idempotent-safe to call again with an earlier cutoff, and revertFileEdits' slice naturally
+    // covers the superset (the previously-reverted range plus the newly-included earlier range).
+    // /compact and /clear keep their own hard stop while reverted (line 381 above, and the
+    // clearedUpToMessageId guard above) — losing hidden history to a compaction/clear is a bigger,
+    // less-reversible deal than superseding one revert cursor with another.
     const conv = db.getConversation(run.convId, true)
     if (!conv) return err(c, 404, 'not_found', 'Session conversation not found.')
 

--- a/turbollm/src/code/code-run-manager.ts
+++ b/turbollm/src/code/code-run-manager.ts
@@ -390,7 +390,14 @@ export class CodeRunManager {
         reasoning,
         toolCalls,
         timeline,
-        stats: { ctxUsed: ctxStats.ctxUsed, ctxMax: ctxStats.ctxMax, model: model?.key, aborted: result.aborted },
+        stats: {
+          ctxUsed: ctxStats.ctxUsed, ctxMax: ctxStats.ctxMax, model: model?.key, aborted: result.aborted,
+          // Real per-turn token/timing stats (foldTurnUsage, code-session.ts) — omitted by
+          // runCodeSession (not zeroed) when the engine returned no usable usage at all.
+          promptTokens: result.promptTokens, genTokens: result.genTokens, cachedTokens: result.cachedTokens,
+          promptMs: result.promptMs, genMs: result.genMs, promptTps: result.promptTps, tps: result.tps,
+          ttftMs: result.ttftMs, totalMs: result.totalMs,
+        },
       })
       if (result.finalText.trim()) this.d.db.upsertRunDoc(sessionId, result.finalText.trim())
       this.d.db.updateAgentRun(sessionId, { status: result.aborted ? 'interrupted' : 'done', endedAt: new Date().toISOString() })

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
 import { toSessionStatus, resolveRevertCut } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, WRITE_PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, lookbackPreCompactionHistory, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, LOOP_ABORT_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, pickPrefillProgress, PREFILL_POLL_MS, type TodoItem } from './code-session'
+import { MUTATING_TOOLS, PATH_TOOLS, WRITE_PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, lookbackPreCompactionHistory, isDependencyAddCommand, compactionSettingsFor, nearOverflowReserveTokens, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, LOOP_ABORT_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, pickPrefillProgress, PREFILL_POLL_MS, type TodoItem } from './code-session'
 import { ConversationStore, type Message } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
@@ -274,6 +274,23 @@ test('compactionSettingsFor: caps at pi\'s own defaults for a large-context loca
   const s = compactionSettingsFor(200_000)
   assert.equal(s.reserveTokens, 16384)
   assert.equal(s.keepRecentTokens, 20000)
+})
+
+test('nearOverflowReserveTokens: never below a sane floor, even for a tiny context', () => {
+  assert.equal(nearOverflowReserveTokens(2048), 256)
+})
+
+test('nearOverflowReserveTokens: scales to 5% of the context window above the floor', () => {
+  assert.equal(nearOverflowReserveTokens(200_000), 10_000)
+})
+
+test('nearOverflowReserveTokens: deliberately tighter than compactionSettingsFor\'s own reserveTokens at every context size — it must only fire AFTER the normal reserve is already crossed', () => {
+  for (const ctx of [2048, 8192, 32768, 128_000, 200_000]) {
+    assert.ok(
+      nearOverflowReserveTokens(ctx) <= compactionSettingsFor(ctx).reserveTokens,
+      `at ctx=${ctx}, near-overflow margin (${nearOverflowReserveTokens(ctx)}) must not exceed the normal compaction reserve (${compactionSettingsFor(ctx).reserveTokens})`,
+    )
+  }
 })
 
 test('compactionSettingsFor: monotonically non-decreasing with contextWindow (below the cap)', () => {

--- a/turbollm/src/code/code-session.test.ts
+++ b/turbollm/src/code/code-session.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { toolsForMode, buildAppendPrompt, skillsBlock, skillCatalogBlock, type CodeMode } from './persona'
 import { toSessionStatus, resolveRevertCut } from './code-routes'
-import { MUTATING_TOOLS, PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, LOOP_ABORT_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, pickPrefillProgress, PREFILL_POLL_MS, type TodoItem } from './code-session'
+import { MUTATING_TOOLS, PATH_TOOLS, WRITE_PATH_TOOLS, resolveEffectiveHistory, compactCodeSession, lookbackPreCompactionHistory, isDependencyAddCommand, compactionSettingsFor, keepRecentTokensFor, ToolLoopTracker, toolCallSignature, LOOP_BREAK_AFTER, LOOP_ABORT_AFTER, codeEventToFrame, validateDelegateTask, normalizeDelegateResult, DELEGATE_SUBAGENT_TIMEOUT_MS, normalizeTodos, summarizeTodos, MAX_TODOS, pickPrefillProgress, PREFILL_POLL_MS, type TodoItem } from './code-session'
 import { ConversationStore, type Message } from '../chat/db'
 import type { Deps } from '../deps'
 import type { Skill } from '../agents/skills'
@@ -234,6 +234,18 @@ test('PATH_TOOLS: path-checked tools include the fs tools but NOT bash', () => {
   assert.deepEqual([...PATH_TOOLS].sort(), ['edit', 'find', 'grep', 'ls', 'read', 'write'])
   // bash takes `command`, not `path` — it must not be containment-checked by path.
   assert.ok(!PATH_TOOLS.has('bash'))
+})
+
+test('WRITE_PATH_TOOLS: only edit/write are actually CONFINED to repoRoot (2026-07-25 loosening)', () => {
+  assert.deepEqual([...WRITE_PATH_TOOLS].sort(), ['edit', 'write'])
+  // read/grep/find/ls are in PATH_TOOLS (still path-checked for "is a path required") but must
+  // NOT be in WRITE_PATH_TOOLS (no longer confined to repoRoot) — this is the actual loosening.
+  for (const t of ['read', 'grep', 'find', 'ls']) {
+    assert.ok(PATH_TOOLS.has(t), `${t} should still be in PATH_TOOLS`)
+    assert.ok(!WRITE_PATH_TOOLS.has(t), `${t} should NOT be confined to repoRoot`)
+  }
+  // WRITE_PATH_TOOLS must be a subset of PATH_TOOLS, never wider.
+  for (const t of WRITE_PATH_TOOLS) assert.ok(PATH_TOOLS.has(t))
 })
 
 // GitHub #60: "ran out of context... it just failed, no attempt to roll up context." pi's own
@@ -656,6 +668,33 @@ test('compactCodeSession: rejects with session_cleared when the session has an a
   await assert.rejects(
     () => compactCodeSession({ d, convId, sessionId, repoRoot: '/repo' }),
     /session_cleared/,
+  )
+})
+
+test('lookbackPreCompactionHistory: rejects with nothing_compacted when the session was never compacted, before touching the model', async () => {
+  const { d, store, convId, sessionId } = makeCodeConv()
+  store.addMessage(convId, 'user', 'task')
+  store.addMessage(convId, 'assistant', 'reply')
+  // No compactionUpToMessageId set — same "no d.manager/d.registry configured, so touching the
+  // model would throw a different TypeError instead" pin as compactCodeSession's own test above.
+  await assert.rejects(
+    () => lookbackPreCompactionHistory({ d, convId, sessionId, repoRoot: '/repo', question: 'what did we decide?' }),
+    /nothing_compacted/,
+  )
+})
+
+test('lookbackPreCompactionHistory: an UNRESOLVABLE cut (marker points at a deleted message) still finds real history to answer from, rather than throwing', async () => {
+  const { d, store, convId, sessionId } = makeCodeConv()
+  store.addMessage(convId, 'user', 'task')
+  store.addMessage(convId, 'assistant', 'reply')
+  store.updateAgentRun(sessionId, { compactionSummary: 'summary', compactionUpToMessageId: 'deleted-id', compactionTokensBefore: 100 })
+  // Mirrors resolveEffectiveHistory's own stated policy for the same situation: an unresolvable
+  // cut (cutIdx === -1) falls back to the FULL message list rather than an empty one — real data
+  // is still there, so this must reach the model_not_loaded guard (no d.manager on this fake
+  // Deps), NOT nothing_compacted. Confirms the fallback path doesn't silently swallow real history.
+  await assert.rejects(
+    () => lookbackPreCompactionHistory({ d, convId, sessionId, repoRoot: '/repo', question: 'what did we decide?' }),
+    (e: unknown) => e instanceof TypeError, // d.manager.status() throws — proves it got past both guards
   )
 })
 

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -187,6 +187,21 @@ export function compactionSettingsFor(contextWindow: number): { enabled: boolean
   return { enabled: true, reserveTokens, keepRecentTokens }
 }
 
+/** Hard-abort safety margin for the near-overflow check below — deliberately TIGHTER than
+ *  compactionSettingsFor's own reserveTokens (~15% of contextWindow). That reserve is the normal
+ *  "compact soon" signal pi's own threshold check already handles correctly BETWEEN turns; this
+ *  is a separate, later, genuine last-resort "about to actually overflow and error" signal for
+ *  the one case a turn-boundary-only check structurally cannot reach — a single CONTINUOUS turn
+ *  running dozens of rounds with no boundary to trigger at (root-caused, see decision log: pi's
+ *  _checkCompaction is only ever invoked before a new session.prompt() or after the whole
+ *  agentic loop settles, never mid-loop). Small and fixed-fraction rather than reusing
+ *  reserveTokens, so this only fires meaningfully AFTER the normal reserve has already been
+ *  crossed within one unbroken turn — proof the boundary check truly never got a chance to run,
+ *  not a duplicate of it firing early. */
+export function nearOverflowReserveTokens(contextWindow: number): number {
+  return Math.max(256, Math.round(contextWindow * 0.05))
+}
+
 /** Rough chars/4 token estimate for one DB message + its tool calls' args/results — mirrors pi's
  *  own heuristic (compaction.js's estimateTokens) closely enough to size a safety margin against
  *  (see keepRecentTokensFor below), not to reproduce pi's count exactly. */
@@ -1252,6 +1267,11 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
           'in a row, including after being told to stop — this run has been stopped automatically ' +
           'rather than continue looping. Start a new turn with different instructions to try again.]'
         await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
+        // Pre-existing gap, fixed alongside the near-overflow check below (both call session.abort()
+        // directly, not through the external `signal` the `aborted` flag was originally wired to):
+        // without this, the comment above ("surfaces as... stats.aborted") was not actually true —
+        // `aborted` was only ever set by the Stop-button/connection-drop listener.
+        aborted = true
         void session.abort()
         return { block: true, reason }
       }
@@ -1400,6 +1420,32 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
             // Best-effort — see comment above.
           }
         }
+      }
+
+      // Near-overflow hard-abort, root-caused and decided 2026-07-25 (see decision log) — a long
+      // CONTINUOUS turn can run dozens of rounds without ever hitting a turn boundary, so pi's own
+      // auto-compaction threshold check (only ever invoked before a new session.prompt() or after
+      // the whole agentic loop settles) structurally never gets a chance to run. Rather than let
+      // the NEXT round's request genuinely overflow and error, check the real live context usage
+      // after every round and abort cleanly — same session.abort() path the loop breaker above
+      // uses, so this surfaces as a real stopped run (stats.aborted), not a crash. The next turn
+      // then starts through the normal, already-working turn-boundary compaction path. Uses
+      // session.getContextUsage() directly (pi's real provider-reported usage, not an estimate) —
+      // NOT session.compact() — a mid-loop compact() call was investigated and found NOT to
+      // actually prevent this turn's own request from continuing to grow (runLoop snapshots the
+      // message context once at turn start; nothing re-syncs it mid-loop), so this deliberately
+      // does not attempt that. worst case is a turn stopping a bit early with partial progress
+      // instead of a hard overflow crash.
+      const usage = session.getContextUsage()
+      if (typeof usage?.tokens === 'number' && usage.tokens > usage.contextWindow - nearOverflowReserveTokens(usage.contextWindow)) {
+        event.content.push({
+          type: 'text',
+          text: '\n\n[SYSTEM: this turn is approaching the model\'s real context limit and has been ' +
+            'stopped automatically to avoid a hard overflow error. Continue the task in a new message ' +
+            '— the next turn starts from freshly compacted history.]',
+        })
+        aborted = true
+        void session.abort()
       }
 
       const text = event.content

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -270,15 +270,63 @@ export interface RunCodeResult {
   contextUsed: number
   contextMax: number
   aborted: boolean
+  /** Real per-turn token/timing stats — see foldTurnUsage's doc comment. Omitted entirely
+   *  (not zeroed) when the engine returned no usable usage at all. */
+  promptTokens?: number
+  genTokens?: number
+  cachedTokens?: number
+  promptMs?: number
+  genMs?: number
+  promptTps?: number
+  tps?: number
+  ttftMs?: number
+  totalMs?: number
+}
+
+/** Folds pi's own SessionStats.tokens (already turn-scoped — replayed prior-turn history is
+ *  seeded with ZERO_USAGE, see below, so the sum reflects only this turn's real provider
+ *  rounds) together with wall-clock timing accumulated across every agentic round of this turn
+ *  into the same MessageStats shape Chat's own engine-agnostic fallback produces
+ *  (chat-routes.ts's `else` branch) — no llama.cpp-specific `timings` object is available here,
+ *  since Code goes through pi's OpenAI-compatible client rather than a raw fetch. Never
+ *  fabricates a 0: if the engine returned no real usage at all (e.g. ignores
+ *  `include_usage`), every field is omitted so the UI leaves the stat off rather than showing a
+ *  misleadingly precise zero (mirrors CodeComposer's own `!== undefined` render guard). */
+export function foldTurnUsage(
+  tokens: { input: number; output: number; cacheRead: number; cacheWrite: number },
+  timing: { promptMsTotal: number; genMsTotal: number; ttftMs?: number; totalMs: number },
+): Pick<RunCodeResult, 'promptTokens' | 'genTokens' | 'cachedTokens' | 'promptMs' | 'genMs' | 'promptTps' | 'tps' | 'ttftMs' | 'totalMs'> {
+  const promptTokens = tokens.input + tokens.cacheRead + tokens.cacheWrite
+  const genTokens = tokens.output
+  if (promptTokens === 0 && genTokens === 0) return {}
+  return {
+    promptTokens,
+    genTokens,
+    cachedTokens: tokens.cacheRead,
+    promptMs: timing.promptMsTotal,
+    genMs: timing.genMsTotal,
+    promptTps: timing.promptMsTotal > 0 ? Math.round((promptTokens / timing.promptMsTotal) * 1000 * 10) / 10 : 0,
+    tps: timing.genMsTotal > 0 ? Math.round((genTokens / timing.genMsTotal) * 1000 * 10) / 10 : 0,
+    ttftMs: timing.ttftMs,
+    totalMs: timing.totalMs,
+  }
 }
 
 // pi's built-in mutating tools that require approval in ASK mode. read/grep/find/ls are
 // read-only and never gated. bash has no path argument, so containment can't confine it —
 // the mode system is its only guard (ask = approval, plan = not in toolset, auto = unconfined).
 export const MUTATING_TOOLS = new Set(['edit', 'write', 'bash'])
-// Tools whose path argument must pass the containment check before executing (plan §3b).
-// bash is deliberately absent — it takes `command`, not `path` (see risk flag 1).
+// Tools whose path argument routes through the containment gate below (plan §3b) — not all of
+// them are actually BLOCKED by it, see WRITE_PATH_TOOLS. bash is deliberately absent — it takes
+// `command`, not `path` (see risk flag 1).
 export const PATH_TOOLS = new Set(['read', 'edit', 'write', 'grep', 'find', 'ls'])
+// The subset of PATH_TOOLS actually CONFINED to repoRoot (loosened 2026-07-25, founder ask:
+// "allow reads outside the repo folder while keeping writes confined to it"). edit/write stay
+// hard-confined — writing outside the project is the real safety boundary. read/grep/find/ls may
+// now target any path on the host filesystem: referencing a sibling repo, a shared lib, or system
+// docs while investigating is a normal, safe read. containment.ts's isContainedFromRoot is only
+// actually enforced (as a block) for entries in this set — see the shared PATH_TOOLS gate below.
+export const WRITE_PATH_TOOLS = new Set(['edit', 'write'])
 
 // ── Consecutive identical tool-call loop breaker (founder-reported) ────────────
 // A weak local model can get stuck firing the SAME tool with the SAME arguments over and over,
@@ -783,11 +831,13 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
         const input = event.input as Record<string, unknown>
         await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'pending' } })
 
+        // Only WRITE_PATH_TOOLS members (edit/write) are actually confined to repoRoot — same
+        // loosened boundary as the outer session's own hook (2026-07-25).
         if (PATH_TOOLS.has(toolName)) {
           const p = input.path
           const pathRequired = toolName === 'read' || toolName === 'edit' || toolName === 'write'
           if (p !== undefined && typeof p === 'string') {
-            if (!isContainedFromRoot(p, repoRoot)) {
+            if (WRITE_PATH_TOOLS.has(toolName) && !isContainedFromRoot(p, repoRoot)) {
               const reason = 'path is outside the allowed repo root'
               await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
               return { block: true, reason }
@@ -834,6 +884,16 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       extensionFactories: [{ name: 'turbollm-skill', factory: skillExtension }],
       appendSystemPrompt: [skill.instructions.trim()],
       noSkills: true,
+      // pi's own DefaultResourceLoader has a BUILT-IN AGENTS.md/CLAUDE.md loader
+      // (loadProjectContextFiles, resource-loader.js) that injects a second, separate
+      // <project_context> block into the system prompt — on top of, and overlapping with,
+      // persona.ts's own hand-rolled version (buildAppendPrompt's agentsMd block, fed via
+      // appendSystemPrompt above). Found 2026-07-25 (pi-SDK audit): any repo with a top-level
+      // AGENTS.md/CLAUDE.md was getting its content sent to the model TWICE every turn. pi's
+      // native path is also uncapped (no MAX_AGENTS_MD_CHARS) and ignores containment entirely —
+      // persona.ts's version is strictly better, so disable pi's native one rather than the
+      // reverse. Same fix at all 5 DefaultResourceLoader construction sites in this file.
+      noContextFiles: true,
       noPromptTemplates: true,
       noThemes: true,
     })
@@ -950,11 +1010,13 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
         const input = event.input as Record<string, unknown>
         await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'pending' } })
 
+        // Only WRITE_PATH_TOOLS members (edit/write) are actually confined to repoRoot — same
+        // loosened boundary as the outer session's own hook (2026-07-25).
         if (PATH_TOOLS.has(toolName)) {
           const p = input.path
           const pathRequired = toolName === 'read' || toolName === 'edit' || toolName === 'write'
           if (p !== undefined && typeof p === 'string') {
-            if (!isContainedFromRoot(p, repoRoot)) {
+            if (WRITE_PATH_TOOLS.has(toolName) && !isContainedFromRoot(p, repoRoot)) {
               const reason = 'path is outside the allowed repo root'
               await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
               return { block: true, reason }
@@ -1001,8 +1063,16 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       extensionFactories: [{ name: 'turbollm-delegate', factory: subExtension }],
       // The normal mode persona (no skill catalog — a delegated sub-agent can't invoke skills),
       // plus the delegation preamble that frames it as a focused, summary-returning worker.
-      appendSystemPrompt: [...buildAppendPrompt(subMode, [], { repoRoot, globalDir: d.store.dir() }, !!d.tools), DELEGATED_SUBAGENT_PREAMBLE],
+      appendSystemPrompt: [...buildAppendPrompt(subMode, [], {
+        repoRoot,
+        globalDir: d.store.dir(),
+        projectCandidates: d.store.snapshot().code.agentsMdProjectCandidates,
+        globalCandidates: d.store.snapshot().code.agentsMdGlobalCandidates,
+      }, !!d.tools), DELEGATED_SUBAGENT_PREAMBLE],
       noSkills: true,
+      // Disables pi's own native AGENTS.md/CLAUDE.md loader — see the skill sub-session's
+      // identical construction above for the full double-injection writeup.
+      noContextFiles: true,
       noPromptTemplates: true,
       noThemes: true,
     })
@@ -1067,6 +1137,20 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // odd shape is swallowed, because prefill telemetry must never break the actual generation.
   let prefillTimer: ReturnType<typeof setTimeout> | undefined
   let prefillActive = false
+
+  // ── real per-turn token/timing stats (foldTurnUsage above) ────────────────────
+  // Wall-clock timing accumulated across every agentic ROUND of this turn (a Code turn can run
+  // dozens of rounds — see runLoop in pi-agent-core). Each round: roundStartedAt is set the
+  // instant the gate is acquired and the request is about to go out (before_provider_request,
+  // below); roundFirstTokenAt is set on that round's first message_update; the round closes out
+  // on message_end, folding (firstToken - start) into promptMsTotal and (end - firstToken) into
+  // genMsTotal. ttftMs is captured once, on the very first token of the whole turn.
+  let turnStartedAt = 0
+  let promptMsTotal = 0
+  let genMsTotal = 0
+  let ttftMs: number | undefined
+  let roundStartedAt: number | undefined
+  let roundFirstTokenAt: number | undefined
   const stopPrefillPoll = (): void => {
     prefillActive = false
     if (prefillTimer) { clearTimeout(prefillTimer); prefillTimer = undefined }
@@ -1108,6 +1192,8 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       // Gate acquired, request is about to go out — begin polling /slots for prefill progress for
       // THIS round (stopped on first token / completion / response end / abort). Best-effort.
       startPrefillPoll()
+      roundStartedAt = Date.now()
+      roundFirstTokenAt = undefined
       const payload = { ...(event.payload as Record<string, unknown>) }
       // Strip the completion-length cap pi derives from this model's declared `maxTokens` (a
       // fixed ceiling set once in the model metadata above, at model-load time). Sent verbatim as
@@ -1179,7 +1265,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       }
 
       // 1. Containment (plan §3b) — BEFORE any mode logic, so it applies in every mode
-      //    including auto. Only tools that take a `path` are checkable here.
+      //    including auto. Only tools that take a `path` are checkable here. Only
+      //    WRITE_PATH_TOOLS members (edit/write) are actually confined to repoRoot — read/grep/
+      //    find/ls may target any path on the host filesystem (loosened 2026-07-25).
       if (PATH_TOOLS.has(toolName)) {
         const p = input.path
         // grep/find/ls accept an optional path defaulting to cwd (contained by definition);
@@ -1189,7 +1277,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
           // Resolve a RELATIVE path against the session repoRoot, NOT the daemon's own cwd —
           // pi's read/edit/write/ls tools emit repo-relative paths, and resolving those against
           // process.cwd() falsely rejected legitimate in-bounds calls in every mode.
-          if (!isContainedFromRoot(p, repoRoot)) {
+          if (WRITE_PATH_TOOLS.has(toolName) && !isContainedFromRoot(p, repoRoot)) {
             const reason = 'path is outside the allowed repo root'
             await sink({ event: 'tool_call', data: { id: toolCallId, name: toolName, args: input, status: 'error', result: reason } })
             return { block: true, reason }
@@ -1407,6 +1495,39 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       },
     })
 
+    // Look back past a prior /compact without replaying the whole raw history inline
+    // (lookback_history) — the pre-compaction messages are still sitting in the DB, unreferenced;
+    // this answers a targeted question against them via an isolated sub-session (see
+    // lookbackPreCompactionHistory's own doc comment) and returns ONLY the answer.
+    pi.registerTool({
+      name: 'lookback_history',
+      label: 'Look back before compaction',
+      description: 'If this session has been compacted (its earlier history was summarized to save ' +
+        'context), ask a targeted question about what happened in that summarized-away part — e.g. ' +
+        '"what did we decide about X" or "what was the exact error message before we compacted". ' +
+        'Answers from the ORIGINAL messages, not just the summary, without loading them into your ' +
+        'own context. Returns an error if this session has never been compacted (nothing to look ' +
+        'back at) — check the compaction summary already in your context first.',
+      promptSnippet: 'lookback_history(question) - ask a targeted question about this session\'s pre-compaction history',
+      parameters: Type.Object({
+        question: Type.String({ description: 'The specific question to answer from the pre-compaction history.' }),
+      }),
+      async execute(_toolCallId, params) {
+        const q = (params.question ?? '').trim()
+        if (!q) return { content: [{ type: 'text', text: 'lookback_history: `question` must be non-empty.' }], details: {} }
+        try {
+          const { answer } = await lookbackPreCompactionHistory({ d, convId, sessionId, repoRoot, question: q, signal })
+          return { content: [{ type: 'text', text: answer }], details: {} }
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e)
+          if (message === 'nothing_compacted') {
+            return { content: [{ type: 'text', text: 'This session has not been compacted — there is no summarized-away history to look back at. Everything is already in your own context.' }], details: {} }
+          }
+          return { content: [{ type: 'text', text: `lookback_history: failed (${message}) — try again.` }], details: {} }
+        }
+      },
+    })
+
     // Todo / step progress tracker (update_todos, ADR-255): the model maintains a visible checklist
     // of a multi-step task's steps so the UI shows live progress instead of an opaque tool-call
     // stream. Whole-list-replace each call (simplest for a model to get right). Emits an ephemeral
@@ -1579,11 +1700,21 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     // message — the actual cause of "context fills up in 1-2 messages", not a compaction bug).
     // `noSkills: true` below is pi's OWN unrelated skill-discovery mechanism (kept off for
     // prompt hygiene) — this is TurboLLM's own Skills library.
-    // agentsMd: <repoRoot>/AGENTS.md + ~/.turbollm/agents.md, like OpenCode — d.store.dir() IS
-    // TurboLLM's own data dir (the same one SkillStore above reads from).
-    appendSystemPrompt: buildAppendPrompt(mode, skills, { repoRoot, globalDir: d.store.dir() }, !!d.tools),
+    // agentsMd: <repoRoot>/<candidate> + <TurboLLM data dir>/<candidate>, like OpenCode — d.store.dir()
+    // IS TurboLLM's own data dir (the same one SkillStore above reads from). Candidate lists read
+    // fresh from config here (not passed in from further up) so a Settings change takes effect on
+    // this session's NEXT turn without needing a new session — see persona.ts's own doc comment.
+    appendSystemPrompt: buildAppendPrompt(mode, skills, {
+      repoRoot,
+      globalDir: d.store.dir(),
+      projectCandidates: d.store.snapshot().code.agentsMdProjectCandidates,
+      globalCandidates: d.store.snapshot().code.agentsMdGlobalCandidates,
+    }, !!d.tools),
     // Keep the prompt lean and deterministic — no global skills/prompts/themes discovery.
     noSkills: true,
+    // Disables pi's own native AGENTS.md/CLAUDE.md loader — see the skill sub-session's
+    // identical construction above for the full double-injection writeup.
+    noContextFiles: true,
     noPromptTemplates: true,
     noThemes: true,
   })
@@ -1635,7 +1766,22 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   const unsubscribe = session.subscribe((ev: AgentSessionEvent) => {
     // First real model output means prefill is over — stop the /slots poller now, a cross-check in
     // case a slot's numbers never quite reach n_prompt_tokens (stale/rounding) before decode begins.
-    if (ev.type === 'message_update') stopPrefillPoll()
+    if (ev.type === 'message_update') {
+      stopPrefillPoll()
+      if (roundStartedAt !== undefined && roundFirstTokenAt === undefined) {
+        roundFirstTokenAt = Date.now()
+        if (ttftMs === undefined) ttftMs = roundFirstTokenAt - turnStartedAt
+      }
+    } else if (ev.type === 'message_end' && ev.message.role === 'assistant' && roundStartedAt !== undefined) {
+      // Round closes out — fold this round's prefill/gen split into the turn totals (see the
+      // state declarations above for why this is summed across rounds, not just the last one).
+      const roundEnded = Date.now()
+      const firstTok = roundFirstTokenAt ?? roundEnded
+      promptMsTotal += firstTok - roundStartedAt
+      genMsTotal += roundEnded - firstTok
+      roundStartedAt = undefined
+      roundFirstTokenAt = undefined
+    }
     const frame = codeEventToFrame(ev, turnCounter)
     if (frame) void sink(frame)
   })
@@ -1657,6 +1803,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
 
   d.manager.generationStart()
   params.onSteerable?.(steerHandle)
+  turnStartedAt = Date.now()
   try {
     // Not-streaming prompt: resolves after the whole agentic loop settles (mirrors pi's own
     // print mode), including any steered continuation folded in via steerHandle above.
@@ -1675,9 +1822,10 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
   // Prefer pi's live context-usage estimate; fall back to the aggregate token total.
   const contextUsed = stats.contextUsage?.tokens ?? stats.tokens.total ?? 0
   const contextMax = stats.contextUsage?.contextWindow ?? contextWindow
+  const usage = foldTurnUsage(stats.tokens, { promptMsTotal, genMsTotal, ttftMs, totalMs: Date.now() - turnStartedAt })
   session.dispose()
 
-  return { finalText, contextUsed, contextMax, aborted }
+  return { finalText, contextUsed, contextMax, aborted, ...usage }
 }
 
 export interface CompactCodeParams {
@@ -1776,6 +1924,11 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
     settingsManager: SettingsManager.inMemory(),
     extensionFactories: [{ name: 'turbollm-compact', factory: compactExtension }],
     noSkills: true,
+    // Disables pi's own native AGENTS.md/CLAUDE.md loader — see the skill sub-session's
+    // identical construction above for the full double-injection writeup. Doubly relevant here:
+    // this session's whole purpose is summarizing DB history, so pi's own uncapped
+    // <project_context> injection would be pure noise on top of that.
+    noContextFiles: true,
     noPromptTemplates: true,
     noThemes: true,
   })
@@ -1830,4 +1983,136 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
   })
 
   return { summary: result.summary, upToMessageId, tokensBefore: result.tokensBefore }
+}
+
+export interface LookbackParams {
+  d: Deps
+  convId: string
+  sessionId: string
+  repoRoot: string
+  question: string
+  signal?: AbortSignal
+}
+
+export interface LookbackResult {
+  answer: string
+}
+
+/** `delegate_task`'s sibling for the one thing it can't do: answer a question grounded in
+ *  messages a PRIOR `/compact` already summarized away, which this session's own live context no
+ *  longer carries raw. Today's `/compact` is non-incremental (see compactCodeSession's own doc
+ *  comment) — a second `/compact` re-summarizes everything again, so "the pre-compaction range"
+ *  here just means "every message up to and including the CURRENT compactionUpToMessageId
+ *  cursor" — that already covers any number of stacked prior compactions, since compaction never
+ *  deletes DB rows, only moves the cursor (resolveEffectiveHistory).
+ *
+ *  Same isolation principle as delegate_task/runSkillSubSession: a dedicated, TOOL-LESS pi
+ *  session seeded with the raw pre-compaction messages, prompted with the model's own question,
+ *  and only the final answer text returned — the raw history itself never re-enters the parent
+ *  session's own context, so this doesn't defeat the point of having compacted in the first
+ *  place. */
+export async function lookbackPreCompactionHistory(params: LookbackParams): Promise<LookbackResult> {
+  const { d, convId, sessionId, repoRoot, question, signal } = params
+  const run = d.db.getAgentRun(sessionId)
+  if (!run?.compactionUpToMessageId) throw new Error('nothing_compacted')
+
+  const ms = d.manager.status()
+  if (ms.state !== 'running' || !ms.model) throw new Error('model_not_loaded')
+  const target = d.manager.target()
+  if (!target) throw new Error('model_not_loaded')
+  const engineKind = d.registry.active()?.kind ?? ''
+  const modelId = engineModelAlias(engineKind) ?? ms.model.key
+  const contextWindow = ms.model.ctx > 0 ? ms.model.ctx : 8192
+
+  // Everything up to and including the cut, from the FULL (never-deactivated-by-compaction) DB
+  // history — compaction only ever moves this cursor, it never deletes rows, so this is genuinely
+  // the raw original text regardless of how many compactions have happened since.
+  const all = d.db.getConversation(convId, true)?.messages ?? []
+  const cutIdx = all.findIndex((m) => m.id === run.compactionUpToMessageId)
+  const preCompaction = cutIdx === -1 ? all : all.slice(0, cutIdx + 1)
+  if (preCompaction.length === 0) throw new Error('nothing_compacted')
+
+  const authStorage = AuthStorage.inMemory()
+  const modelRegistry = ModelRegistry.inMemory(authStorage)
+  modelRegistry.registerProvider('local', {
+    baseUrl: `${target}/v1`,
+    apiKey: 'agent-key',
+    authHeader: true,
+    api: 'openai-completions',
+    models: [{
+      id: modelId,
+      name: ms.model.name || 'Local Model',
+      reasoning: false,
+      input: ['text'],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow,
+      maxTokens: 8192,
+      compat: { supportsDeveloperRole: false, thinkingFormat: 'qwen-chat-template' },
+    }],
+  })
+  const model = modelRegistry.find('local', modelId)
+  if (!model) throw new Error('Failed to register local model with pi.')
+
+  const sessionManager = SessionManager.inMemory(repoRoot)
+  const entryTrack: { piId: string; msgIndex: number }[] = []
+  seedPriorHistory(sessionManager, preCompaction, modelId, (piId, msgIndex) => entryTrack.push({ piId, msgIndex }))
+  if (entryTrack.length === 0) throw new Error('nothing_compacted')
+
+  // Same stale-ceiling strip as compactCodeSession's own before_provider_request hook.
+  const lookbackExtension = (pi: ExtensionAPI): void => {
+    pi.on('before_provider_request', async (event) => {
+      const payload = { ...(event.payload as Record<string, unknown>) }
+      delete payload.max_tokens
+      delete payload.max_completion_tokens
+      return payload
+    })
+  }
+  const lookbackAgentDir = join(d.store.dir(), 'pi-agent')
+  const lookbackResourceLoader = new DefaultResourceLoader({
+    cwd: repoRoot,
+    agentDir: lookbackAgentDir,
+    settingsManager: SettingsManager.inMemory(),
+    extensionFactories: [{ name: 'turbollm-lookback', factory: lookbackExtension }],
+    noSkills: true,
+    // Disables pi's own native AGENTS.md/CLAUDE.md loader — see the skill sub-session's
+    // identical construction above for the full double-injection writeup.
+    noContextFiles: true,
+    noPromptTemplates: true,
+    noThemes: true,
+  })
+  await lookbackResourceLoader.reload()
+
+  const { session } = await createAgentSession({
+    cwd: repoRoot,
+    agentDir: lookbackAgentDir,
+    model,
+    authStorage,
+    modelRegistry,
+    sessionManager,
+    settingsManager: SettingsManager.inMemory(),
+    resourceLoader: lookbackResourceLoader,
+    tools: [], // read-only Q&A over already-seeded history — no tool needs to run, none should.
+  })
+
+  const onAbort = () => { void session.abort() }
+  if (signal?.aborted) onAbort()
+  else signal?.addEventListener('abort', onAbort, { once: true })
+  // Reuses delegate_task's own bound — same "isolated, read-only sub-session" risk shape.
+  const timer = setTimeout(() => void session.abort(), DELEGATE_SUBAGENT_TIMEOUT_MS)
+
+  try {
+    await session.prompt(
+      'Answer the following question using ONLY the conversation history above, which is from ' +
+      'earlier in this same coding session, before it was compacted/summarized away. Be concise ' +
+      'and specific — quote or reference exactly what was said/decided if relevant. If the history ' +
+      'does not actually answer the question, say so plainly rather than guessing.\n\n' +
+      `Question: ${question}`,
+    )
+  } finally {
+    clearTimeout(timer)
+    signal?.removeEventListener('abort', onAbort)
+  }
+  const answer = session.getLastAssistantText()?.trim() || '(no answer produced)'
+  session.dispose()
+  return { answer }
 }

--- a/turbollm/src/code/persona.ts
+++ b/turbollm/src/code/persona.ts
@@ -8,6 +8,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Skill } from '../agents/skills'
+import { isContainedFromRoot } from './containment'
 
 export type CodeMode = 'auto' | 'plan' | 'ask'
 
@@ -34,13 +35,34 @@ const MAX_SKILL_INSTRUCTIONS_CHARS = 20_000
 // the ~157K-token full-instructions bug this replaced either way.
 const MAX_SKILL_CATALOG_CHARS = 16_000
 
+// Same safety-cap style as the two skill budgets above, applied to a single AGENTS.md-style
+// file — this repo's own CLAUDE.md is ~8.7K chars, so 20K gives real headroom without being
+// unbounded. A user-configured candidate PATH (config.code.agentsMd*Candidates, config.ts) makes
+// this genuinely reachable now, where the old hardcoded 'AGENTS.md'/'agents.md' literals never
+// pointed anywhere pathological.
+const MAX_AGENTS_MD_CHARS = 20_000
+// Bounds the configured candidate list itself, so a pathological config can't turn every turn
+// into dozens of stat() calls per side.
+const MAX_AGENTS_MD_CANDIDATES = 8
+
+// Built-in fallback candidate lists — used whenever a caller doesn't pass its own (existing call
+// sites/tests all rely on this). Solves the common "this repo uses CLAUDE.md, not AGENTS.md" case
+// (this very repo included) with zero configuration: CLAUDE.md is already a candidate. First
+// EXISTING match wins per side — not a merge/concatenation — mirroring "CLAUDE.md instead of
+// AGENTS.md," not "CLAUDE.md as well as." Includes both AGENTS.md/agents.md casings on each side
+// (not just the historical per-side casing) so a case-sensitive filesystem (Linux, case-sensitive
+// APFS) doesn't silently drop a file Windows/default-macOS would have picked up.
+export const DEFAULT_AGENTS_MD_PROJECT_CANDIDATES = ['AGENTS.md', 'agents.md', 'CLAUDE.md']
+export const DEFAULT_AGENTS_MD_GLOBAL_CANDIDATES = ['agents.md', 'AGENTS.md', 'CLAUDE.md']
+
 /** Short product persona framing. */
 export function basePersona(): string {
   return [
     'You are TurboLLM Code, a coding agent running fully locally on the user\'s own machine.',
     'You are working inside a single project directory. Keep changes tightly scoped to the task,',
     'prefer the smallest correct edit, and explain what you changed and why in your final reply.',
-    'You cannot access anything outside the project directory — file tools are confined to it.',
+    'You may read files anywhere on the machine (e.g. a sibling repo or shared library) if it',
+    'helps the task, but edits and new files are confined to this project directory.',
   ].join(' ')
 }
 
@@ -215,53 +237,93 @@ export function skillCatalogBlock(skills: Skill[]): string {
   return header + lines.join('\n') + footer
 }
 
-/** Reads one AGENTS.md-style file, trimmed. Missing file, permission error, or a path that
- *  isn't a plain file are all treated the same way — silently absent, not a failure. This
- *  block is optional standing context (like OpenCode's AGENTS.md convention), never something
- *  that should block a turn from running just because a file is unreadable. */
+/** Reads one AGENTS.md-style file, trimmed and capped at MAX_AGENTS_MD_CHARS. Missing file,
+ *  permission error, or a path that isn't a plain file are all treated the same way — silently
+ *  absent, not a failure. This block is optional standing context (like OpenCode's AGENTS.md
+ *  convention), never something that should block a turn from running just because a file is
+ *  unreadable. */
 function readAgentsFile(path: string): string | null {
   try {
     const text = readFileSync(path, 'utf8').trim()
-    return text || null
+    if (!text) return null
+    return text.length > MAX_AGENTS_MD_CHARS ? text.slice(0, MAX_AGENTS_MD_CHARS) : text
   } catch {
     return null
   }
 }
 
-/** Whether a project (`<repoRoot>/AGENTS.md`) and/or global (`<globalDir>/agents.md`) AGENTS.md
- *  file is actually present — for the loaded-resources header (ADR-262), which needs a boolean per
- *  file, not the injected prompt text `agentsMdBlock` returns. Uses the exact same lookup +
- *  whitespace-only-counts-as-absent rule as `agentsMdBlock`, so "present here" always matches
- *  "actually injected into the prompt." Cheap (two small reads); safe to call per session-detail
- *  request. */
-export function agentsMdPresence(repoRoot: string, globalDir: string): { project: boolean; global: boolean } {
+/** Tries each candidate filename against `root`, IN ORDER — the first candidate that is
+ *  containment-checked in-bounds AND resolves to a readable, non-whitespace file wins; the rest
+ *  are never even read. First-existing-wins, not a merge of every match (see the default lists'
+ *  own comment for why). A candidate that isn't relative or escapes `root` (absolute path, `..`
+ *  traversal, a symlink escape) is skipped exactly like a missing file — silent, never throws —
+ *  since this is the one thing that turns a previously hardcoded-safe read into a
+ *  user-configurable one; `isContainedFromRoot` is the same primitive every real tool call
+ *  (read/edit/write/grep/find/ls) is already checked against. */
+function resolveAgentsFile(root: string, candidates: string[]): { name: string; text: string } | null {
+  for (const entry of candidates.slice(0, MAX_AGENTS_MD_CANDIDATES)) {
+    if (!isContainedFromRoot(entry, root)) continue
+    const text = readAgentsFile(join(root, entry))
+    if (text !== null) return { name: entry, text }
+  }
+  return null
+}
+
+/** Whether a project and/or global AGENTS.md-style file is actually present — for the
+ *  loaded-resources header (ADR-262), which needs a boolean per side, not the injected prompt
+ *  text `agentsMdBlock` returns. Uses the exact same resolution + whitespace-only-counts-as-absent
+ *  rule as `agentsMdBlock`, so "shown loaded" always matches "actually injected into the prompt."
+ *  Cheap; safe to call per session-detail request. Candidate lists default to the built-ins so
+ *  every existing call site keeps working unchanged. Deliberately still {project, global} booleans
+ *  only, NOT the resolved filename — showing which candidate actually matched is a real header UX
+ *  improvement but touches ADR-262's shipped surface across several files, so it needs its own
+ *  vetting pass rather than riding along with this change. */
+export function agentsMdPresence(
+  repoRoot: string,
+  globalDir: string,
+  projectCandidates: string[] = DEFAULT_AGENTS_MD_PROJECT_CANDIDATES,
+  globalCandidates: string[] = DEFAULT_AGENTS_MD_GLOBAL_CANDIDATES,
+): { project: boolean; global: boolean } {
   return {
-    project: readAgentsFile(join(repoRoot, 'AGENTS.md')) !== null,
-    global: readAgentsFile(join(globalDir, 'agents.md')) !== null,
+    project: resolveAgentsFile(repoRoot, projectCandidates) !== null,
+    global: resolveAgentsFile(globalDir, globalCandidates) !== null,
   }
 }
 
-/** `<repoRoot>/AGENTS.md` (project-level, the user's own repo) and `<globalDir>/agents.md`
- *  (global — TurboLLM's own data dir, e.g. `~/.turbollm/agents.md`), like OpenCode's AGENTS.md
- *  convention: standing project/user instructions picked up automatically, no per-session setup.
- *  Global comes first (broader, user-wide defaults), then project (more specific, overrides in
- *  spirit if they conflict — same "more specific wins" reading order the rest of this file's
- *  guidance already follows: persona → mode → edit rules → skills → these). Neither file is
- *  required to exist; this returns '' when there's nothing to add. */
-export function agentsMdBlock(repoRoot: string, globalDir: string): string {
-  const global = readAgentsFile(join(globalDir, 'agents.md'))
-  const project = readAgentsFile(join(repoRoot, 'AGENTS.md'))
+/** Project-level (`<repoRoot>/<first matching candidate>`) and global (`<globalDir>/<first
+ *  matching candidate>`) standing instructions, like OpenCode's AGENTS.md convention — picked up
+ *  automatically, no per-session setup. Global comes first (broader, user-wide defaults), then
+ *  project (more specific, overrides in spirit if they conflict — same "more specific wins"
+ *  reading order the rest of this file's guidance already follows: persona → mode → edit rules →
+ *  skills → these). Neither side is required to exist; this returns '' when nothing resolves.
+ *  Candidate lists default to the built-ins so every existing call site keeps working unchanged. */
+export function agentsMdBlock(
+  repoRoot: string,
+  globalDir: string,
+  projectCandidates: string[] = DEFAULT_AGENTS_MD_PROJECT_CANDIDATES,
+  globalCandidates: string[] = DEFAULT_AGENTS_MD_GLOBAL_CANDIDATES,
+): string {
+  const global = resolveAgentsFile(globalDir, globalCandidates)
+  const project = resolveAgentsFile(repoRoot, projectCandidates)
   const parts: string[] = []
-  if (global) parts.push(`## Global instructions (~/.turbollm/agents.md)\n\n${global}`)
-  if (project) parts.push(`## Project instructions (AGENTS.md)\n\n${project}`)
+  if (global) parts.push(`## Global instructions (~/.turbollm/${global.name})\n\n${global.text}`)
+  if (project) parts.push(`## Project instructions (${project.name})\n\n${project.text}`)
   if (parts.length === 0) return ''
   return 'The user has provided the following standing instructions for this project — follow them:\n\n' + parts.join('\n\n---\n\n')
 }
 
 /** The full append-prompt block for a session, in order. `skills` defaults to empty and
  *  `agentsMd` defaults to omitted so every existing call site (and test) that doesn't pass them
- *  keeps today's exact output. */
-export function buildAppendPrompt(mode: CodeMode, skills: Skill[] = [], agentsMd?: { repoRoot: string; globalDir: string }, hasWebTools = false): string[] {
+ *  keeps today's exact output. `agentsMd.projectCandidates`/`globalCandidates` default to the
+ *  built-in lists (DEFAULT_AGENTS_MD_*_CANDIDATES) when omitted — a caller that resolves them
+ *  from config (code-session.ts) should read `d.store.snapshot().code` fresh at call time, not
+ *  cache them, so a changed setting takes effect on the session's next turn. */
+export function buildAppendPrompt(
+  mode: CodeMode,
+  skills: Skill[] = [],
+  agentsMd?: { repoRoot: string; globalDir: string; projectCandidates?: string[]; globalCandidates?: string[] },
+  hasWebTools = false,
+): string[] {
   const blocks = [basePersona(), modeGuidance(mode)]
   // Read-only plan mode has no edit tool, so the edit/LSP guidance is irrelevant there — install_lsp
   // is still registered in plan mode, but pre-warming a server with nothing to attach diagnostics
@@ -279,7 +341,12 @@ export function buildAppendPrompt(mode: CodeMode, skills: Skill[] = [], agentsMd
   const catalog = skillCatalogBlock(skills)
   if (catalog) blocks.push(catalog)
   if (agentsMd) {
-    const agents = agentsMdBlock(agentsMd.repoRoot, agentsMd.globalDir)
+    const agents = agentsMdBlock(
+      agentsMd.repoRoot,
+      agentsMd.globalDir,
+      agentsMd.projectCandidates ?? DEFAULT_AGENTS_MD_PROJECT_CANDIDATES,
+      agentsMd.globalCandidates ?? DEFAULT_AGENTS_MD_GLOBAL_CANDIDATES,
+    )
     if (agents) blocks.push(agents)
   }
   return blocks

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -99,12 +99,13 @@ export interface Daemon {
   /** Release 3: background extraction of durable facts from the user's own chat messages,
    *  injected into future new conversations. Off by default — unlike autoGenerateTitles,
    *  this builds a persistent cross-conversation profile of the user, so it's opt-in
-   *  (same trust-surface posture as lanBind), not default-on. Two-layer gate, same shape as
-   *  Code: `experimental.memory` (below) is the master "is this feature unlocked at all"
+   *  (same trust-surface posture as lanBind), not default-on. Two-layer gate:
+   *  `experimental.memory` (below) is the master "is this feature unlocked at all"
    *  switch — MemorySection's own UI in Settings → General only renders when it's on, and
    *  extraction only runs when BOTH it and this field are true (chat-routes.ts). This field is
-   *  the finer opt-in WITHIN that (do you actually want facts remembered), same relationship
-   *  Code's own mode/tool settings have to `experimental.code` unlocking the workspace itself. */
+   *  the finer opt-in WITHIN that (do you actually want facts remembered). Code used to follow
+   *  this same two-layer shape via `experimental.code` — removed when Code graduated out of
+   *  experimental status and became available to everyone by default (ADR-280). */
   autoMemoryEnabled: boolean
   /** Experimental features (2026-07-14, preparing for wider distribution): still-in-progress
    *  capabilities gated behind an explicit opt-in toggle in Settings → Experimental, off by
@@ -118,9 +119,6 @@ export interface ExperimentalFeatures {
    *  section reappears in its ORIGINAL location in General — this does NOT relocate Memory's
    *  settings into the Experimental tab, only gates whether they're reachable at all. */
   memory: boolean
-  /** Gates the entire Code workspace (both the UI entry point and /api/v1/code/* itself —
-   *  see auth.ts's requireExperimentalCode). */
-  code: boolean
   /** Gates the Cloud Launch / RunPod deploy-link surface (ADR-153's cloudDeploy config,
    *  previously only reachable via the internal-only TURBOLLM_FEATURES=cloud-deploy env var,
    *  features.ts — this is now the primary, user-facing way to turn it on). */
@@ -495,7 +493,7 @@ export function defaultConfig(): Config {
       theme: 'system',
       autoGenerateTitles: true,
       autoMemoryEnabled: false,
-      experimental: { memory: false, code: false, cloudDeploy: false },
+      experimental: { memory: false, cloudDeploy: false },
     },
     telemetry: { level: 'unset', machineId: '' },
     apiKeys: [],
@@ -854,15 +852,18 @@ function normalize(c: Config): void {
   const cd = (c.cloudDeploy ?? {}) as Partial<CloudDeployConfig>
   c.cloudDeploy = { runpodTemplateId: typeof cd.runpodTemplateId === 'string' ? cd.runpodTemplateId.trim() : '' }
   // Experimental feature flags (2026-07-14): absent in pre-this-decision configs → default
-  // false for code/cloudDeploy, same conservative posture as lanBind. `memory` is the one
+  // false for cloudDeploy, same conservative posture as lanBind. `memory` is the one
   // exception: a config that ALREADY had autoMemoryEnabled=true (the user had genuinely opted
   // in before this gate existed) migrates to memory=true too, so the section they were already
   // using doesn't silently vanish from Settings → General the moment they upgrade — a config
   // that never turned it on gets memory=false, the same conservative default as everything else.
+  // `code` was removed from this shape entirely (ADR-280) when Code graduated out of
+  // experimental status — an old config's stale `experimental.code` value (if any survives in
+  // an on-disk config.json from before this change) is simply dropped here, not migrated,
+  // since there's no longer a field for it to migrate into.
   const ex = (c.daemon.experimental ?? {}) as Partial<ExperimentalFeatures>
   c.daemon.experimental = {
     memory: ex.memory === true || c.daemon.autoMemoryEnabled === true,
-    code: ex.code === true,
     cloudDeploy: ex.cloudDeploy === true,
   }
   // Telemetry level (spec 09 §3): the UI exposes 'off' | 'anon' | 'full'. Migrate

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -247,6 +247,23 @@ export interface ComfyUI {
 export interface BuildConfig {
   toolchainDirs: string[]
 }
+/** Standing-context filename candidates for Code's AGENTS.md-style injection
+ *  (persona.ts's agentsMdBlock) — tried in order per side, first EXISTING match wins. Global-
+ *  only for now (applies to every repo alike, not a per-repo setting — see decision-log for the
+ *  rationale): solves the common "this repo uses CLAUDE.md, not AGENTS.md" case with zero
+ *  configuration, since the shipped defaults already include CLAUDE.md. Entries must be
+ *  RELATIVE (validate() below rejects an absolute one with a clean 400) — persona.ts still
+ *  containment-checks each one again at read time regardless, since config.json is hand-editable
+ *  and route-level validation alone can't be trusted as the only gate. */
+export interface CodeConfig {
+  /** Tried against each repo's own root. Defaults mirror persona.ts's own
+   *  DEFAULT_AGENTS_MD_PROJECT_CANDIDATES (duplicated as a literal, not imported — config.ts
+   *  stays dependency-free of feature modules by design; update both if this ever changes). */
+  agentsMdProjectCandidates: string[]
+  /** Tried against the global TurboLLM data dir (~/.turbollm). Mirrors persona.ts's
+   *  DEFAULT_AGENTS_MD_GLOBAL_CANDIDATES. */
+  agentsMdGlobalCandidates: string[]
+}
 /** Cloud Launch deploy-link settings (ADR-153, RunPod recipe). RunPod is the only
  *  provider for now — a user who has published their own RunPod Template (following
  *  deploy/runpod/README.md) pastes its ID here; the Developer screen's "Deploy on
@@ -382,6 +399,8 @@ export interface Config {
   builtinAgentOverrides: Record<string, BuiltinAgentOverride>
   /** Compile-from-source settings (ADR-089/100): toolchain dirs prepended to PATH. */
   build: BuildConfig
+  /** Code's AGENTS.md-style standing-context candidate lists. */
+  code: CodeConfig
   /** Cloud Launch deploy-link settings (ADR-153). */
   cloudDeploy: CloudDeployConfig
   devModel?: DevModel
@@ -501,6 +520,7 @@ export function defaultConfig(): Config {
     customAgents: [],
     builtinAgentOverrides: {},
     build: { toolchainDirs: [] },
+    code: { agentsMdProjectCandidates: ['AGENTS.md', 'agents.md', 'CLAUDE.md'], agentsMdGlobalCandidates: ['agents.md', 'AGENTS.md', 'CLAUDE.md'] },
     cloudDeploy: { runpodTemplateId: '' },
   }
 }
@@ -818,6 +838,18 @@ function normalize(c: Config): void {
       ? bd.toolchainDirs.filter((p): p is string => typeof p === 'string' && p.trim() !== '').map((p) => p.trim())
       : [],
   }
+  // AGENTS.md candidate lists: absent/empty in pre-this-decision configs → the real defaults
+  // (NOT []), so a fresh/upgraded config resolves standing context exactly like the old hardcoded
+  // 'AGENTS.md'/'agents.md' literals did, plus CLAUDE.md. The validator enforces relative paths.
+  const cc = (c.code ?? {}) as Partial<CodeConfig>
+  const cleanCandidates = (v: unknown, fallback: string[]): string[] => {
+    const filtered = Array.isArray(v) ? v.filter((p): p is string => typeof p === 'string' && p.trim() !== '').map((p) => p.trim()) : []
+    return filtered.length > 0 ? filtered : fallback
+  }
+  c.code = {
+    agentsMdProjectCandidates: cleanCandidates(cc.agentsMdProjectCandidates, ['AGENTS.md', 'agents.md', 'CLAUDE.md']),
+    agentsMdGlobalCandidates: cleanCandidates(cc.agentsMdGlobalCandidates, ['agents.md', 'AGENTS.md', 'CLAUDE.md']),
+  }
   // Cloud Launch deploy-link settings (ADR-153): absent in pre-ADR-153 configs → ''.
   const cd = (c.cloudDeploy ?? {}) as Partial<CloudDeployConfig>
   c.cloudDeploy = { runpodTemplateId: typeof cd.runpodTemplateId === 'string' ? cd.runpodTemplateId.trim() : '' }
@@ -888,6 +920,18 @@ function validate(c: Config): void {
   // matter the daemon's cwd when it spawns git/cmake.
   for (const dir of c.build.toolchainDirs) {
     if (!isAbsolutePath(dir)) throw new ValueError('build.toolchainDirs', 'toolchain directories must be absolute paths')
+  }
+  // AGENTS.md candidates: the OPPOSITE constraint from toolchainDirs — must be RELATIVE (resolved
+  // against a repo root / the global data dir, never an absolute host path), and capped short so a
+  // pathological config can't turn every turn into dozens of stat() calls. This is a clean-400
+  // convenience, not the real security boundary — persona.ts containment-checks each entry again
+  // at read time regardless, since this config is hand-editable and bypasses this route entirely.
+  const MAX_AGENTS_MD_CANDIDATES = 8
+  for (const [field, list] of [['code.agentsMdProjectCandidates', c.code.agentsMdProjectCandidates], ['code.agentsMdGlobalCandidates', c.code.agentsMdGlobalCandidates]] as const) {
+    if (list.length > MAX_AGENTS_MD_CANDIDATES) throw new ValueError(field, `at most ${MAX_AGENTS_MD_CANDIDATES} candidates`)
+    for (const entry of list) {
+      if (isAbsolutePath(entry)) throw new ValueError(field, 'candidates must be relative filenames/paths, not absolute')
+    }
   }
   // Agents (spec 13 §2.1): enforce the schema invariants so a bad config can't widen
   // an agent's filesystem scope or break the run manager's lookups.

--- a/turbollm/src/mcp-server.test.ts
+++ b/turbollm/src/mcp-server.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { delegateCodeTask, handleMcpRequest, DELEGATE_TOOL_NAME } from './mcp-server'
+
+const BASE = 'http://127.0.0.1:6996'
+
+/** Builds a fake fetch that answers by URL suffix + method, in the exact call order a real
+ *  delegateCodeTask run makes them: POST /sessions → POST /sessions/:id/messages → GET /sessions/:id (polled). */
+function fakeFetch(handlers: Array<(url: string, init?: RequestInit) => Response | Promise<Response>>): typeof fetch {
+  let i = 0
+  return (async (url: string, init?: RequestInit) => {
+    const h = handlers[Math.min(i, handlers.length - 1)]
+    i++
+    return h(url, init)
+  }) as typeof fetch
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+test('delegateCodeTask: happy path returns the last assistant message once running=false', async () => {
+  const f = fakeFetch([
+    () => json({ sessionId: 'sess-1' }, 201),
+    () => json({ ok: true, queued: false }, 202),
+    () => json({
+      running: false,
+      conversation: { messages: [
+        { role: 'user', content: 'do the thing' },
+        { role: 'assistant', content: 'done, here is the result' },
+      ] },
+    }),
+  ])
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'do the thing', timeoutSeconds: 10 }, f)
+  assert.equal(result.ok, true)
+  assert.equal(result.text, 'done, here is the result')
+})
+
+test('delegateCodeTask: polls past running=true frames before returning', async () => {
+  let pollCount = 0
+  const f = fakeFetch([
+    () => json({ sessionId: 'sess-2' }, 201),
+    () => json({ ok: true, queued: false }, 202),
+    () => {
+      pollCount++
+      if (pollCount < 3) return json({ running: true, conversation: { messages: [] } })
+      return json({ running: false, conversation: { messages: [{ role: 'assistant', content: 'finished after polling' }] } })
+    },
+  ])
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'x', timeoutSeconds: 30 }, f)
+  assert.equal(result.ok, true)
+  assert.equal(result.text, 'finished after polling')
+  assert.ok(pollCount >= 3)
+})
+
+test('delegateCodeTask: daemon unreachable returns a clear, non-throwing error', async () => {
+  const f = (async () => { throw new Error('ECONNREFUSED') }) as typeof fetch
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'x' }, f)
+  assert.equal(result.ok, false)
+  assert.match(result.text, /Is it running/)
+  assert.match(result.text, /npx turbollm/)
+})
+
+test('delegateCodeTask: session-create rejection (e.g. missing repoRoot) surfaces the daemon\'s own error message', async () => {
+  const f = fakeFetch([() => json({ error: { code: 'invalid_input', message: 'repoRoot is required.' } }, 400)])
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'x' }, f)
+  assert.equal(result.ok, false)
+  assert.match(result.text, /repoRoot is required/)
+})
+
+test('delegateCodeTask: 409 model_not_loaded from POST /messages surfaces cleanly, not a raw HTTP status', async () => {
+  const f = fakeFetch([
+    () => json({ sessionId: 'sess-3' }, 201),
+    () => json({ error: { code: 'model_not_loaded', message: 'Load a model first.' } }, 409),
+  ])
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'x' }, f)
+  assert.equal(result.ok, false)
+  assert.match(result.text, /Load a model first/)
+})
+
+test('delegateCodeTask: empty repoRoot or task fails fast without any network call', async () => {
+  let called = false
+  const f = (async () => { called = true; return json({}) }) as typeof fetch
+  const r1 = await delegateCodeTask(BASE, { repoRoot: '  ', task: 'x' }, f)
+  const r2 = await delegateCodeTask(BASE, { repoRoot: '/repo', task: '  ' }, f)
+  assert.equal(r1.ok, false)
+  assert.equal(r2.ok, false)
+  assert.equal(called, false)
+})
+
+test('delegateCodeTask: gives up after the deadline with a message that names the session id', async () => {
+  const f = fakeFetch([
+    () => json({ sessionId: 'sess-stuck' }, 201),
+    () => json({ ok: true, queued: false }, 202),
+    () => json({ running: true, conversation: { messages: [] } }), // never finishes
+  ])
+  // timeoutSeconds floors at 10s in the implementation; the poll interval (1.5s) still fires
+  // a few times inside that window, exercising the real timeout path without a slow test.
+  const start = Date.now()
+  const result = await delegateCodeTask(BASE, { repoRoot: '/repo', task: 'x', timeoutSeconds: 1 }, f)
+  assert.equal(result.ok, false)
+  assert.match(result.text, /Timed out/)
+  assert.match(result.text, /sess-stuck/)
+  assert.ok(Date.now() - start < 15_000) // sanity: didn't hang way past the floor
+})
+
+// ── JSON-RPC dispatch ─────────────────────────────────────────────────────────
+
+test('handleMcpRequest: initialize returns protocol version and serverInfo', async () => {
+  const res = await handleMcpRequest({ jsonrpc: '2.0', id: 1, method: 'initialize' }, BASE, '1.2.3')
+  assert.ok(res)
+  assert.equal((res!.result as { serverInfo: { version: string } }).serverInfo.version, '1.2.3')
+})
+
+test('handleMcpRequest: tools/list advertises exactly the delegate tool', async () => {
+  const res = await handleMcpRequest({ jsonrpc: '2.0', id: 2, method: 'tools/list' }, BASE, '1.0.0')
+  const tools = (res!.result as { tools: Array<{ name: string }> }).tools
+  assert.equal(tools.length, 1)
+  assert.equal(tools[0].name, DELEGATE_TOOL_NAME)
+})
+
+test('handleMcpRequest: a notification (no id) returns null — nothing written to stdout', async () => {
+  const res = await handleMcpRequest({ jsonrpc: '2.0', method: 'notifications/initialized' }, BASE, '1.0.0')
+  assert.equal(res, null)
+})
+
+test('handleMcpRequest: tools/call with an unknown tool name returns a JSON-RPC error, not a throw', async () => {
+  const res = await handleMcpRequest(
+    { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'nope', arguments: {} } },
+    BASE, '1.0.0',
+  )
+  assert.ok(res!.error)
+  assert.match(res!.error!.message, /Unknown tool/)
+})
+
+test('handleMcpRequest: tools/call missing required arguments returns a JSON-RPC error', async () => {
+  const res = await handleMcpRequest(
+    { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: DELEGATE_TOOL_NAME, arguments: { task: 'x' } } },
+    BASE, '1.0.0',
+  )
+  assert.ok(res!.error)
+  assert.match(res!.error!.message, /repoRoot/)
+})
+
+test('handleMcpRequest: tools/call success wraps delegateCodeTask\'s result as MCP content, isError=false on success', async () => {
+  const f = fakeFetch([
+    () => json({ sessionId: 'sess-4' }, 201),
+    () => json({ ok: true, queued: false }, 202),
+    () => json({ running: false, conversation: { messages: [{ role: 'assistant', content: 'all done' }] } }),
+  ])
+  const res = await handleMcpRequest(
+    { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: DELEGATE_TOOL_NAME, arguments: { repoRoot: '/repo', task: 'x' } } },
+    BASE, '1.0.0', f,
+  )
+  const result = res!.result as { content: Array<{ type: string; text: string }>; isError: boolean }
+  assert.equal(result.isError, false)
+  assert.equal(result.content[0].text, 'all done')
+})
+
+test('handleMcpRequest: tools/call failure (e.g. daemon down) sets isError=true rather than a JSON-RPC error', async () => {
+  const f = (async () => { throw new Error('down') }) as typeof fetch
+  const res = await handleMcpRequest(
+    { jsonrpc: '2.0', id: 6, method: 'tools/call', params: { name: DELEGATE_TOOL_NAME, arguments: { repoRoot: '/repo', task: 'x' } } },
+    BASE, '1.0.0', f,
+  )
+  const result = res!.result as { isError: boolean }
+  assert.equal(result.isError, true)
+})
+
+test('handleMcpRequest: unknown method returns a JSON-RPC error', async () => {
+  const res = await handleMcpRequest({ jsonrpc: '2.0', id: 7, method: 'bogus/method' }, BASE, '1.0.0')
+  assert.ok(res!.error)
+  assert.match(res!.error!.message, /Unknown method/)
+})

--- a/turbollm/src/mcp-server.ts
+++ b/turbollm/src/mcp-server.ts
@@ -26,7 +26,10 @@ export const DELEGATE_TOOL_NAME = 'delegate_code_task'
 export const DELEGATE_TOOL_SCHEMA = {
   name: DELEGATE_TOOL_NAME,
   description:
-    'Delegate a coding task to TurboLLM\'s local Code agent (real bash/edit/write tool execution against a repo), running on whatever model is already loaded in a locally-running TurboLLM daemon. Blocks until the task finishes and returns the agent\'s final message. Requires a TurboLLM daemon already running with a model loaded — start one with `npx turbollm` first if this fails.',
+    'Delegate a coding task to TurboLLM\'s local Code agent (real bash/edit/write tool execution against a repo), running on whatever model is already loaded in a locally-running TurboLLM daemon. ' +
+    'Prefer this over doing the task yourself when the task is well-scoped and mechanical — bulk/repetitive edits, boilerplate, small self-contained fixes, simple lookups or summarization over a repo — rather than requiring deep multi-file reasoning or architectural judgment; ' +
+    'or when the user explicitly asks to use the local model / offload work to save cloud-model usage. Use mode: \'ask\' for read-only investigation (no file changes) and \'auto\' (the default) when the task should actually edit files. ' +
+    'Blocks until the task finishes and returns the agent\'s final message. Requires a TurboLLM daemon already running with a model loaded — start one with `npx turbollm` first if this fails. If the call fails because no daemon is reachable, do not retry; fall back to doing the task yourself and mention that TurboLLM wasn\'t running.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/turbollm/src/mcp-server.ts
+++ b/turbollm/src/mcp-server.ts
@@ -1,0 +1,228 @@
+// `turbollm mcp-server` (TODO.md item 4, ADR-275): exposes Code as an MCP tool so OTHER
+// agentic CLIs (Claude Code, Gemini CLI, etc.) can delegate a well-scoped task to a local
+// model. This is a thin BRIDGE, not a second daemon: it talks to an ALREADY-RUNNING TurboLLM
+// daemon over its existing HTTP API (loopback only — auth.ts's LOOPBACK carve-out already
+// permits unauthenticated 127.0.0.1 calls, same trust boundary the web UI itself uses) and
+// never touches ConfigStore/Manager/model-loading directly. It does not start a daemon or
+// load a model on the caller's behalf — a host spawns this per-connection, so it must stay a
+// fast-starting, side-effect-free process; auto-starting a whole daemon from here would be a
+// surprising, hard-to-reason-about side effect for a stdio tool call.
+//
+// Scope decisions (resolving TODO.md item 4's "not designed" list):
+//   - Synchronous-with-result, not fire-and-forget: MCP tool calls are a request/response
+//     protocol with no standard mid-call progress channel a generic host is guaranteed to
+//     render, so the simplest correct contract is "block until done, return the final text".
+//   - A fresh scratch Code session per call, not attaching to an existing one: the caller has
+//     no session id to pass, and reusing/continuing a session would need a second tool (list
+//     sessions, resume by id) that's out of scope for a first pass.
+//   - Packaging: reuses the ALREADY-PUBLISHED `turbollm` package (`npx turbollm mcp-server`)
+//     instead of a new npm package or a CLI-specific plugin manifest — the manifest/extension
+//     wrapper for a specific host (Claude Code plugin, Gemini CLI extension) is a thin config
+//     file pointing at this same command and can be added later without touching this module.
+import { setTimeout as delay } from 'node:timers/promises'
+
+export const DELEGATE_TOOL_NAME = 'delegate_code_task'
+
+export const DELEGATE_TOOL_SCHEMA = {
+  name: DELEGATE_TOOL_NAME,
+  description:
+    'Delegate a coding task to TurboLLM\'s local Code agent (real bash/edit/write tool execution against a repo), running on whatever model is already loaded in a locally-running TurboLLM daemon. Blocks until the task finishes and returns the agent\'s final message. Requires a TurboLLM daemon already running with a model loaded — start one with `npx turbollm` first if this fails.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      repoRoot: { type: 'string', description: 'Absolute path to the repository/directory the task should run against.' },
+      task: { type: 'string', description: 'The task to perform, in natural language.' },
+      mode: { type: 'string', enum: ['auto', 'plan', 'ask'], description: 'Permission mode for the run. Defaults to auto (full read/write/bash access, contained to repoRoot).' },
+      modelKey: { type: 'string', description: 'Optional — use a specific model key instead of whatever is currently loaded.' },
+      timeoutSeconds: { type: 'number', description: 'Give up waiting after this many seconds (default 1800 = 30 minutes).' },
+    },
+    required: ['repoRoot', 'task'],
+  },
+} as const
+
+const DEFAULT_TIMEOUT_SECONDS = 1800
+const POLL_INTERVAL_MS = 1500
+const HTTP_TIMEOUT_MS = 10_000
+
+export interface DelegateParams {
+  repoRoot: string
+  task: string
+  mode?: string
+  modelKey?: string
+  timeoutSeconds?: number
+}
+
+export interface DelegateResult {
+  ok: boolean
+  text: string
+}
+
+/** Extracts `{error:{message}}` from a code-routes.ts-shaped error body; falls back to the raw
+ *  text (truncated) when the body isn't that shape, so a non-JSON error (proxy, crash page)
+ *  still surfaces something readable instead of throwing during error formatting itself. */
+async function describeHttpError(res: Response): Promise<string> {
+  const raw = await res.text().catch(() => '')
+  try {
+    const parsed = JSON.parse(raw) as { error?: { message?: string } }
+    if (parsed.error?.message) return parsed.error.message
+  } catch { /* not JSON — fall through to raw */ }
+  return raw.slice(0, 500) || `HTTP ${res.status}`
+}
+
+/** Runs one Code task to completion against a running daemon and returns its final message.
+ *  `fetchImpl` is injectable for tests; production always uses the real global fetch. */
+export async function delegateCodeTask(
+  baseUrl: string,
+  params: DelegateParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DelegateResult> {
+  const repoRoot = params.repoRoot.trim()
+  const task = params.task.trim()
+  if (!repoRoot) return { ok: false, text: 'repoRoot is required.' }
+  if (!task) return { ok: false, text: 'task is required.' }
+
+  const timeoutMs = Math.max(10, params.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000
+  const deadline = Date.now() + timeoutMs
+
+  let createRes: Response
+  try {
+    createRes = await fetchImpl(`${baseUrl}/api/v1/code/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoRoot, task, mode: params.mode ?? 'auto', modelKey: params.modelKey }),
+      signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+    })
+  } catch (e) {
+    return {
+      ok: false,
+      text: `Could not reach the TurboLLM daemon at ${baseUrl}. Is it running? Start one with \`npx turbollm\`. (${e instanceof Error ? e.message : e})`,
+    }
+  }
+  if (!createRes.ok) return { ok: false, text: `TurboLLM rejected the task: ${await describeHttpError(createRes)}` }
+  const { sessionId } = await createRes.json() as { sessionId: string }
+
+  const startRes = await fetchImpl(`${baseUrl}/api/v1/code/sessions/${sessionId}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}', // no content/promptOverride → runs the seeded task from session creation
+    signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+  })
+  if (!startRes.ok) return { ok: false, text: `TurboLLM could not start the run: ${await describeHttpError(startRes)}` }
+
+  // Poll the persisted session rather than the SSE stream: this bridge has no UI to show live
+  // progress TO, so "block until running:false, read back the transcript" is simpler and just
+  // as correct as consuming the stream for a wait-for-result tool.
+  while (Date.now() < deadline) {
+    await delay(POLL_INTERVAL_MS)
+    let detailRes: Response
+    try {
+      detailRes = await fetchImpl(`${baseUrl}/api/v1/code/sessions/${sessionId}`, { signal: AbortSignal.timeout(HTTP_TIMEOUT_MS) })
+    } catch {
+      continue // transient — keep polling until the deadline
+    }
+    if (!detailRes.ok) continue
+    const detail = await detailRes.json() as {
+      running?: boolean
+      conversation?: { messages?: Array<{ role: string; content: string }> }
+    }
+    if (detail.running) continue
+    const messages = detail.conversation?.messages ?? []
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant')
+    return { ok: true, text: lastAssistant?.content?.trim() || '(Code agent finished with no final message — check the TurboLLM UI for details.)' }
+  }
+  return {
+    ok: false,
+    text: `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the Code agent. Session ${sessionId} may still be running — check the TurboLLM UI.`,
+  }
+}
+
+// ── stdio JSON-RPC MCP server ────────────────────────────────────────────────
+// Mirrors the wire format `tools/mcp-client.ts` already speaks as a CLIENT (this project has
+// no MCP SDK dependency in either direction — hand-rolling stays consistent and adds zero deps).
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  id?: string | number
+  method: string
+  params?: unknown
+}
+
+function isString(v: unknown): v is string {
+  return typeof v === 'string'
+}
+
+/** Builds the JSON-RPC response for one already-parsed request. Exported separately from the
+ *  stdio plumbing so the dispatch logic (the part with actual bugs to have) is unit-testable
+ *  without spinning up real stdin/stdout streams. */
+export async function handleMcpRequest(
+  req: JsonRpcRequest,
+  baseUrl: string,
+  version: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ jsonrpc: '2.0'; id: string | number; result?: unknown; error?: { code: number; message: string } } | null> {
+  if (req.id === undefined) return null // a notification (e.g. notifications/initialized) — nothing to reply to
+  try {
+    switch (req.method) {
+      case 'initialize':
+        return {
+          jsonrpc: '2.0', id: req.id,
+          result: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'turbollm', version } },
+        }
+      case 'tools/list':
+        return { jsonrpc: '2.0', id: req.id, result: { tools: [DELEGATE_TOOL_SCHEMA] } }
+      case 'tools/call': {
+        const p = (req.params ?? {}) as { name?: string; arguments?: Record<string, unknown> }
+        if (p.name !== DELEGATE_TOOL_NAME) throw new Error(`Unknown tool: ${p.name}`)
+        const args = p.arguments ?? {}
+        if (!isString(args.repoRoot) || !args.repoRoot.trim()) throw new Error('repoRoot is required')
+        if (!isString(args.task) || !args.task.trim()) throw new Error('task is required')
+        const result = await delegateCodeTask(baseUrl, {
+          repoRoot: args.repoRoot,
+          task: args.task,
+          mode: isString(args.mode) ? args.mode : undefined,
+          modelKey: isString(args.modelKey) ? args.modelKey : undefined,
+          timeoutSeconds: typeof args.timeoutSeconds === 'number' ? args.timeoutSeconds : undefined,
+        }, fetchImpl)
+        return { jsonrpc: '2.0', id: req.id, result: { content: [{ type: 'text', text: result.text }], isError: !result.ok } }
+      }
+      default:
+        throw new Error(`Unknown method: ${req.method}`)
+    }
+  } catch (e) {
+    return { jsonrpc: '2.0', id: req.id, error: { code: -32000, message: e instanceof Error ? e.message : String(e) } }
+  }
+}
+
+/** Runs the stdio MCP server loop until stdin closes (the host disconnected). */
+export function runMcpServer(baseUrl: string, version: string): Promise<void> {
+  return new Promise((resolveServer) => {
+    process.stdin.setEncoding('utf8')
+    let buf = ''
+
+    const onData = (chunk: string) => {
+      buf += chunk
+      const lines = buf.split('\n')
+      buf = lines.pop() ?? ''
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        void handleLine(trimmed)
+      }
+    }
+
+    async function handleLine(line: string): Promise<void> {
+      let req: JsonRpcRequest
+      try {
+        req = JSON.parse(line) as JsonRpcRequest
+      } catch {
+        return // malformed frame — drop rather than crash the bridge over one bad line
+      }
+      const res = await handleMcpRequest(req, baseUrl, version)
+      if (res) process.stdout.write(JSON.stringify(res) + '\n')
+    }
+
+    process.stdin.on('data', onData)
+    process.stdin.on('end', () => resolveServer())
+    process.stdin.on('close', () => resolveServer())
+  })
+}

--- a/turbollm/src/mcp-server.ts
+++ b/turbollm/src/mcp-server.ts
@@ -36,7 +36,6 @@ export const DELEGATE_TOOL_SCHEMA = {
       repoRoot: { type: 'string', description: 'Absolute path to the repository/directory the task should run against.' },
       task: { type: 'string', description: 'The task to perform, in natural language.' },
       mode: { type: 'string', enum: ['auto', 'plan', 'ask'], description: 'Permission mode for the run. Defaults to auto (full read/write/bash access, contained to repoRoot).' },
-      modelKey: { type: 'string', description: 'Optional — use a specific model key instead of whatever is currently loaded.' },
       timeoutSeconds: { type: 'number', description: 'Give up waiting after this many seconds (default 1800 = 30 minutes).' },
     },
     required: ['repoRoot', 'task'],
@@ -47,11 +46,20 @@ const DEFAULT_TIMEOUT_SECONDS = 1800
 const POLL_INTERVAL_MS = 1500
 const HTTP_TIMEOUT_MS = 10_000
 
+// No `modelKey` param, deliberately (found and removed in the v1.9.0 pre-release review): a Code
+// session's `modelKey` (POST /api/v1/code/sessions) is stored purely as a display LABEL on the
+// conversation row — nothing in runCodeSession/code-run-manager reads it to actually load or
+// switch models, the turn always runs against whatever's currently loaded (code-session.ts's
+// d.manager.status()). The old schema documented it as "use a specific model key instead of
+// whatever is currently loaded," which was simply false, and — since this MCP tool exposes no way
+// to ever list/see that label back — there was no way for a caller to even notice the promise
+// wasn't kept. Real model-pinning (load the requested model before running the turn) would be a
+// genuine feature needing its own careful pass through this project's model-loading subsystem, not
+// a quick add-on here.
 export interface DelegateParams {
   repoRoot: string
   task: string
   mode?: string
-  modelKey?: string
   timeoutSeconds?: number
 }
 
@@ -92,7 +100,7 @@ export async function delegateCodeTask(
     createRes = await fetchImpl(`${baseUrl}/api/v1/code/sessions`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ repoRoot, task, mode: params.mode ?? 'auto', modelKey: params.modelKey }),
+      body: JSON.stringify({ repoRoot, task, mode: params.mode ?? 'auto' }),
       signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
     })
   } catch (e) {
@@ -183,7 +191,6 @@ export async function handleMcpRequest(
           repoRoot: args.repoRoot,
           task: args.task,
           mode: isString(args.mode) ? args.mode : undefined,
-          modelKey: isString(args.modelKey) ? args.modelKey : undefined,
           timeoutSeconds: typeof args.timeoutSeconds === 'number' ? args.timeoutSeconds : undefined,
         }, fetchImpl)
         return { jsonrpc: '2.0', id: req.id, result: { content: [{ type: 'text', text: result.text }], isError: !result.ok } }

--- a/turbollm/src/server.ts
+++ b/turbollm/src/server.ts
@@ -11,7 +11,7 @@ import { registerAgentRoutes } from './agents/agent-routes'
 import { registerCodeRoutes } from './code/code-routes'
 import type { Deps } from './deps'
 import { registerGateway } from './gateway/gateway'
-import { lanAuth, codeAuth, requireExperimentalCode } from './auth'
+import { lanAuth, codeAuth } from './auth'
 
 // Reuse TCP connections for all engine and HF fetch calls. Without this, Node
 // opens a new connection per request — ~5–20 ms of extra latency every Claude
@@ -60,10 +60,6 @@ export function createApp(d: Deps): Hono {
   // LAN auth gate (spec 06 §5): no-op while loopback-only (lanBind=false); once
   // LAN-exposed, requires a valid API key for non-loopback /api/* and /v1/* calls.
   app.use('*', lanAuth(d))
-  // Experimental-feature gate (2026-07-14): checked BEFORE codeAuth below — cheaper (no
-  // credential parsing) and more fundamental (no point authenticating access to a feature
-  // that's simply off). See auth.ts's requireExperimentalCode doc comment.
-  app.use('/api/v1/code/*', requireExperimentalCode(d))
   // Code-specific gate (independent of requireApiKey — see auth.ts's codeAuth doc comment):
   // Code always needs a key from a non-host device, even when the rest of the app is open.
   app.use('/api/v1/code/*', codeAuth(d))

--- a/turbollm/web/src/App.tsx
+++ b/turbollm/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import {
   Navigate,
   Route,
@@ -9,7 +9,7 @@ import { TooltipProvider } from './components/ui/tooltip'
 import { Shell } from './components/Shell'
 import { UnreachableOverlay } from './components/UnreachableOverlay'
 import { AuthGate } from './components/AuthGate'
-import { useStatus, useSettings } from './lib/queries'
+import { useStatus } from './lib/queries'
 import { ApiError, setAuthToken } from './lib/api'
 import { subscribeCodeAuthNeeded, isCodeAuthNeeded } from './lib/auth-signal'
 
@@ -40,19 +40,6 @@ function ScreenFallback() {
   )
 }
 
-/** Route-level gate for Code (2026-07-14, Settings → Experimental) — the authoritative check;
- *  ConversationSidebar.tsx hiding the Chat|Code pill is a UX nicety, not the real gate, since a
- *  direct navigation or stale bookmark bypasses hidden UI entirely. Redirects to Chat when the
- *  flag is off. Shows the same loading fallback the route-chunk Suspense uses while the setting
- *  is still being fetched, rather than redirecting prematurely on a fast first paint before the
- *  real value is known — a false "disabled" flash would bounce a user with the flag ON right
- *  back out of Code before the settings query resolves. */
-function RequireCodeEnabled({ children }: { children: ReactNode }) {
-  const { query } = useSettings()
-  if (query.isLoading) return <ScreenFallback />
-  if (!query.data?.experimental?.code) return <Navigate to="/workspace/chat" replace />
-  return <>{children}</>
-}
 
 export function App() {
   const statusQ = useStatus()
@@ -101,10 +88,10 @@ export function App() {
             <Route path="/workspace" element={<Navigate to="/workspace/chat" replace />} />
             <Route path="/workspace/chat" element={<WorkspaceScreen />} />
             <Route path="/workspace/chat/:convId" element={<WorkspaceScreen />} />
-            {/* Code — Workspace's second mode, not a separate nav item. Gated behind the
-                experimental flag (Settings → Experimental) — see RequireCodeEnabled above. */}
-            <Route path="/workspace/code" element={<RequireCodeEnabled><CodeHomeScreen /></RequireCodeEnabled>} />
-            <Route path="/workspace/code/:sessionId" element={<RequireCodeEnabled><CodeSessionScreen /></RequireCodeEnabled>} />
+            {/* Code — Workspace's second mode, not a separate nav item. Generally available
+                (ADR-280) — no longer gated behind an experimental-feature flag. */}
+            <Route path="/workspace/code" element={<CodeHomeScreen />} />
+            <Route path="/workspace/code/:sessionId" element={<CodeSessionScreen />} />
             {/* Back-compat: the old Workspace → Agent tab is gone; land on Chat instead. */}
             <Route path="/workspace/agent" element={<Navigate to="/workspace/chat" replace />} />
             <Route path="/workspace/agent/:convId" element={<Navigate to="/workspace/chat" replace />} />

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -722,11 +722,14 @@ export function getTelemetryPreview(level: TelemetryLevel): Promise<TelemetryPre
 }
 
 /** LAN network info (spec 08 §2): expose state, the reachable LAN URL, and whether
- *  an API key exists (required for non-local access). */
+ *  an API key exists (required for non-local access). `requireApiKey` + `isHost` mirror the
+ *  backend's /api/v1/keys host gate so the UI can honestly reflect the same rule. */
 export type NetworkInfo = {
   lanBind: boolean
   lanUrl: string
   hasApiKey: boolean
+  requireApiKey: boolean
+  isHost: boolean
 }
 
 export function getNetworkInfo(): Promise<NetworkInfo> {

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -597,8 +597,9 @@ export type DaemonSettings = {
    *  published themselves — not a secret, just an id, echoed back as-is. */
   cloudDeploy: { runpodTemplateId: string }
   /** Experimental feature flags (2026-07-14, Settings → Experimental). Off by default for
-   *  new/distributed installs. */
-  experimental: { memory: boolean; code: boolean; cloudDeploy: boolean }
+   *  new/distributed installs. Code used to be one of these — removed when it graduated to
+   *  generally available (ADR-280). */
+  experimental: { memory: boolean; cloudDeploy: boolean }
 }
 
 /** Tool-call approval gate policy (mirrors turbollm/src/tools/tool-policy.ts). */

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -583,6 +583,9 @@ export type DaemonSettings = {
   /** Build environment (ADR-100): folders prepended to PATH for compile-from-source so a
    *  conda-env / custom-path CUDA Toolkit + compiler are found. Not secret — echoed back. */
   build: { toolchainDirs: string[] }
+  /** Code's AGENTS.md-style standing-context candidate lists (config.ts's CodeConfig) — tried
+   *  in order per side, first EXISTING file wins. Not secret — echoed back. */
+  code: { agentsMdProjectCandidates: string[]; agentsMdGlobalCandidates: string[] }
   /** Tool-call approval gate (F-025): per-tool default policy. Missing tools default
    *  to 'ask'. Keyed by tool name (e.g. 'run_code', 'mcp__server__tool'). */
   toolPolicies: Record<string, ToolPolicy>
@@ -607,11 +610,14 @@ export type SearchProvider = 'tavily' | 'kagi' | 'searxng'
  *  `hfToken` (spec 10 §4) that sets/clears the stored Hugging Face token. `comfyui`
  *  is patchable per-field (only `enabled` is set here; `gatePath` is owned by the
  *  install endpoints). */
-export type DaemonSettingsPatch = Partial<Omit<DaemonSettings, 'comfyui' | 'tavilyKeySet' | 'search' | 'mcp' | 'experimental'>> & {
+export type DaemonSettingsPatch = Partial<Omit<DaemonSettings, 'comfyui' | 'tavilyKeySet' | 'search' | 'mcp' | 'experimental' | 'code'>> & {
   comfyui?: Partial<ComfyUiSettings>
   /** Patchable per-field — the backend applies each key independently (api/routes.ts), so a
    *  patch touching only one flag must not be forced to also supply the other. */
   experimental?: Partial<DaemonSettings['experimental']>
+  /** Patchable per-field, same reason as `experimental` — routes.ts applies each candidate list
+   *  independently. */
+  code?: Partial<DaemonSettings['code']>
   hfToken?: string
   /** Write-only: set or clear the Tavily API key (legacy alias for `search.tavilyApiKey`). */
   tavilyApiKey?: string

--- a/turbollm/web/src/lib/brand-icons.ts
+++ b/turbollm/web/src/lib/brand-icons.ts
@@ -8,7 +8,7 @@ import {
   siHubspot, siMixpanel, siGoogle,
   siPostgresql, siGit, siPuppeteer, siGoogledrive, siBrave,
   siDocker, siRedis, siMongodb, siObsidian, siYoutube, siRss,
-  siKubernetes, siMysql, siKagi, siSearxng,
+  siKubernetes, siMysql, siKagi, siSearxng, siUpstash,
 } from 'simple-icons'
 
 export type BrandIcon = { path: string; hex: string }
@@ -46,4 +46,5 @@ export const BRAND_ICONS: Record<string, BrandIcon> = {
   mysql:      { path: siMysql.path,      hex: siMysql.hex },
   kagi:       { path: siKagi.path,       hex: siKagi.hex },
   searxng:    { path: siSearxng.path,    hex: siSearxng.hex },
+  upstash:    { path: siUpstash.path,    hex: siUpstash.hex },
 }

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -174,6 +174,16 @@ export const CLOUD_MCPS: CloudEntry[] = [
     url: 'https://mcp.mixpanel.com/mcp',
     keyNote: 'Create a service account at mixpanel.com → Settings → Service Accounts, then run: echo -n "username:secret" | base64 — and paste "Basic <that-base64>" here (include the word Basic).',
   },
+  {
+    id: 'firecrawl',
+    name: 'Firecrawl',
+    cat: 'Automation',
+    desc: 'Scrape, crawl, and search the live web into clean, LLM-ready pages.',
+    auth: 'key',
+    color: '#fa5d19',
+    url: 'https://mcp.firecrawl.dev/v2/mcp',
+    keyNote: 'Get an API key at firecrawl.dev → API Keys. A keyless tier works for basic scrape/search, but crawl/extract/agent tools and higher limits need a key.',
+  },
 ]
 
 export const LOCAL_MCPS: LocalEntry[] = [
@@ -373,6 +383,17 @@ export const LOCAL_MCPS: LocalEntry[] = [
       { key: 'COMFYUI_URL', desc: 'ComfyUI server URL (default: http://127.0.0.1:8188)', required: false },
       { key: 'CIVITAI_API_TOKEN', desc: 'For downloading models from CivitAI', required: false },
       { key: 'HUGGINGFACE_TOKEN', desc: 'For downloading models from Hugging Face', required: false },
+    ],
+  },
+  {
+    id: 'context7',
+    name: 'Context7',
+    cat: 'AI',
+    desc: 'Up-to-date, version-specific docs and code examples for any library.',
+    cmd: 'npx -y @upstash/context7-mcp',
+    iconSlug: 'upstash',
+    envs: [
+      { key: 'CONTEXT7_API_KEY', desc: 'Optional — from context7.com/dashboard for higher rate limits', required: false },
     ],
   },
 ]

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -37,7 +37,7 @@ const TURBOLLM_KNOWLEDGE =
   '- **Switching to a different conversation never cancels a reply that\'s still generating** — it keeps going in the background and saves when done. The sidebar shows a spinning indicator on any conversation generating in the background, and a dot on one that just finished while you were elsewhere (clears once you open it).\n' +
   '- **Thinking budget**: a graduated slider (not just on/off) — cap reasoning to a specific token count, disable it entirely, or leave it unlimited. Same control in Code.\n\n' +
 
-  '**Code** (Workspace → Code tab, next to Chat; opt-in via Settings → Experimental, off by default — the whole tab is hidden until enabled) — a local coding agent on the same loaded model, working in a real project directory. Nothing leaves the machine.\n' +
+  '**Code** (Workspace → Code tab, next to Chat — on by default for everyone, no setup needed) — a local coding agent on the same loaded model, working in a real project directory. Nothing leaves the machine.\n' +
   '- Point it at a repo folder (optional isolated git worktree so the real checkout stays untouched), describe a task, pick a mode (plan-only / ask-before-mutating / auto plan-and-edit) — it reads, edits files, runs shell commands, and reports a real diff.\n' +
   '- **Persistent sessions**: archive/filter past runs, revert to any earlier message (with optional real file-edit reversal), attach files as context, transcript copy. A "Coding activity" dashboard (sessions, tasks shipped, files touched, diff shipped, streaks) is built from real history.\n' +
   '- **Real LSP integration** for TypeScript/JavaScript and Python — detects the language, installs the language server if needed, uses it for edits.\n' +
@@ -67,9 +67,11 @@ const TURBOLLM_KNOWLEDGE =
   '- **Engine updates**: honest check vs GitHub releases/latest; rollback-safe (probe new build before swap, old build kept until success).\n' +
   '- Per-engine auto-update policy: Off / Notify / Auto (default Notify).\n\n' +
 
-  '**Developer** — connect an outside app or CLI to this server.\n' +
-  '- **Connection panel**: the server URL and your API key(s) in one place.\n' +
-  '- **One-command CLI setup cards**: `turbollm launch claude|opencode|kilo|openclaw|hermes` for each supported coding CLI, plus a collapsed reference for the public `/v1/*` API.\n\n' +
+  '**Developer** — connect an outside app or CLI to this server, or expose Code to one.\n' +
+  '- **Connection panel**: the server URL (shows your LAN address when sharing is on, not just localhost) and your API key(s) in one place.\n' +
+  '- **One-command CLI setup cards**: `turbollm launch claude|opencode|kilo|openclaw|hermes` for each supported coding CLI, plus a collapsed reference for the public `/v1/*` API.\n' +
+  '- **TurboLLM MCP section**: setup for `turbollm mcp-server`, a stdio MCP server exposing Code as a `delegate_code_task` tool any MCP-compatible tool can call (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, etc.) — the reverse direction from the rest of this screen.\n' +
+  '- **Key management is host-only while the LAN is open and unauthenticated** (LAN sharing on, "Require an API key" off in Settings → Network): viewing/creating/revoking keys and the connect-setup snippets (which embed a live key) are locked to this machine until a key is required, with an explanatory message instead of just silently missing.\n\n' +
 
   '**Agents** — background agent runs (v1.5.0+).\n' +
   '- Detached conversations that run without the UI open.\n' +
@@ -94,7 +96,7 @@ const TURBOLLM_KNOWLEDGE =
   '- **Models & loading**: idle timeout (auto-stop after N minutes), default context length, Gateway (auto model-swap + Keep-N pool, 1–4 models), model folders, Hugging Face token, and an **Advanced** collapsible for expert knobs — default GPU layers, VRAM headroom (300 MB–2 GB, default 1 GB, or drag to 0 to opt into MoE auto-tune\'s "VRAM-spill" search — see Auto-Tune below), and image/response token caps.\n' +
   '- **Tools & safety**: per-tool Ask/Allow/Deny defaults for every tool the model can call (web_search, fetch_url, run_code, MCP tools), plus an **Auto-allow all** master toggle (default off) that skips the approval prompt for anything set to Ask — a tool explicitly set to Deny still stays blocked either way.\n' +
   '- **Network & sharing**: LAN exposure (bind to 0.0.0.0 vs loopback-only), port, require-API-key auth, and ComfyUI integration (URL, Reverse GPU gate, update banner).\n' +
-  '- **Experimental**: still-in-progress features, off by default — a single on/off row each for **Memory** (silently extracts durable facts from chat using the loaded model; its own settings stay in General, unlocked once this is on), **Code** (the Workspace → Code tab; disabling this removes the tab entirely, not just its content), and **Cloud Launch/RunPod** (earliest-stage of the three — turning it on doesn\'t yet unlock a built UI).\n' +
+  '- **Experimental**: still-in-progress features, off by default — a single on/off row each for **Memory** (silently extracts durable facts from chat using the loaded model; its own settings stay in General, unlocked once this is on) and **Cloud Launch/RunPod** (turning it on doesn\'t yet unlock a built UI). Code used to be a third row here — it\'s generally available now, no toggle needed.\n' +
   '- **System**: hardware panel, telemetry (Off / Anonymous / Full), About (current version, update-available chip, copy install command).\n\n' +
 
   '## Agents (formerly "Personas")\n\n' +

--- a/turbollm/web/src/screens/DeveloperScreen.test.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.test.tsx
@@ -1,8 +1,10 @@
-// Covers the two Developer-pane fixes: (1) Server URL shows the LAN-reachable address once LAN
-// sharing is on, not just window.location.origin (which still reads 127.0.0.1/localhost even
-// when OTHER devices reach the daemon over the LAN); (2) API key management is hidden — with an
-// explanatory message, not just silently missing — for a non-host viewer while the LAN is open
-// and unauthenticated (requireApiKey off). The real security boundary is server-side
+// Covers the three Developer-pane fixes: (1) Server URL shows the LAN-reachable address once
+// LAN sharing is on, not just window.location.origin (which still reads 127.0.0.1/localhost even
+// when OTHER devices reach the daemon over the LAN); (2) the API-keys list + create form is
+// hidden — with an explanatory message, not just silently missing — for a non-host viewer while
+// the LAN is open and unauthenticated (requireApiKey off); (3) same lock for the "Connect an
+// app" setup snippets, which embed a live API key and — unlike the keys list — fetch
+// automatically on page load with no click required. The real security boundary is server-side
 // (keys-network.test.ts); this only verifies the UI honestly reflects that same state.
 import { render, screen } from '@testing-library/react'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
@@ -10,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { NetworkInfo } from '../lib/api'
 
 let networkInfo: NetworkInfo | undefined
+const getConnectSpy = vi.fn(() => Promise.resolve({ cli: 'claude-code', title: '', steps: [{ label: 'bash', snippet: 'ANTHROPIC_AUTH_TOKEN="tllm-secret-value" claude', lang: 'bash' }] }))
 
 vi.mock('../lib/queries', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../lib/queries')>()
@@ -26,7 +29,7 @@ vi.mock('../lib/queries', async (importOriginal) => {
 
 vi.mock('../lib/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../lib/api')>()
-  return { ...actual, getConnect: () => Promise.resolve({ cli: 'claude-code', title: '', steps: [] }) }
+  return { ...actual, getConnect: (...args: unknown[]) => getConnectSpy(...(args as [])) }
 })
 
 function renderScreen() {
@@ -64,7 +67,7 @@ describe('DeveloperScreen — API key management gating', () => {
     networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: true }
     await renderScreen()
     expect(screen.getByPlaceholderText('Key name (e.g. claude-code)')).toBeInTheDocument()
-    expect(screen.queryByText(/only available from this machine/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/API key management is only available/i)).not.toBeInTheDocument()
   })
 
   it('shows the key list + create form once requireApiKey is on, even for a non-host viewer', async () => {
@@ -77,13 +80,39 @@ describe('DeveloperScreen — API key management gating', () => {
     networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: false }
     await renderScreen()
     expect(screen.queryByPlaceholderText('Key name (e.g. claude-code)')).not.toBeInTheDocument()
-    expect(screen.getByText(/only available from this machine/i)).toBeInTheDocument()
+    expect(screen.getByText(/API key management is only available/i)).toBeInTheDocument()
   })
 
   it('fails CLOSED (locked) while network info is still loading, rather than flashing the form', async () => {
     networkInfo = undefined
     await renderScreen()
     expect(screen.queryByPlaceholderText('Key name (e.g. claude-code)')).not.toBeInTheDocument()
-    expect(screen.getByText(/only available from this machine/i)).toBeInTheDocument()
+    expect(screen.getByText(/API key management is only available/i)).toBeInTheDocument()
+  })
+})
+
+describe('DeveloperScreen — Connect-an-app setup snippet gating', () => {
+  beforeEach(() => { networkInfo = undefined; getConnectSpy.mockClear() })
+
+  it('fetches and shows the live-key setup snippet on the host machine, even with LAN open and no auth yet', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    await screen.findByText(/tllm-secret-value/)
+    expect(getConnectSpy).toHaveBeenCalled()
+  })
+
+  it('does NOT fetch the setup snippet for a non-host viewer while the LAN is open and unauthenticated — no key is minted', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: false }
+    await renderScreen()
+    await screen.findByText(/Setup snippets include a live API key/i)
+    expect(screen.queryByText(/tllm-secret-value/)).not.toBeInTheDocument()
+    expect(getConnectSpy).not.toHaveBeenCalled()
+  })
+
+  it('fetches the setup snippet again once requireApiKey is on, even for a non-host viewer', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: true, requireApiKey: true, isHost: false }
+    await renderScreen()
+    await screen.findByText(/tllm-secret-value/)
+    expect(getConnectSpy).toHaveBeenCalled()
   })
 })

--- a/turbollm/web/src/screens/DeveloperScreen.test.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.test.tsx
@@ -1,0 +1,89 @@
+// Covers the two Developer-pane fixes: (1) Server URL shows the LAN-reachable address once LAN
+// sharing is on, not just window.location.origin (which still reads 127.0.0.1/localhost even
+// when OTHER devices reach the daemon over the LAN); (2) API key management is hidden — with an
+// explanatory message, not just silently missing — for a non-host viewer while the LAN is open
+// and unauthenticated (requireApiKey off). The real security boundary is server-side
+// (keys-network.test.ts); this only verifies the UI honestly reflects that same state.
+import { render, screen } from '@testing-library/react'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NetworkInfo } from '../lib/api'
+
+let networkInfo: NetworkInfo | undefined
+
+vi.mock('../lib/queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/queries')>()
+  return {
+    ...actual,
+    useApiKeys: () => ({
+      query: { data: { keys: [] } },
+      create: { mutate: vi.fn(), isPending: false },
+      revoke: { mutate: vi.fn(), isPending: false },
+    }),
+    useNetworkInfo: () => ({ data: networkInfo }),
+  }
+})
+
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>()
+  return { ...actual, getConnect: () => Promise.resolve({ cli: 'claude-code', title: '', steps: [] }) }
+})
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return import('./DeveloperScreen').then(({ DeveloperScreen }) =>
+    render(
+      <QueryClientProvider client={qc}>
+        <DeveloperScreen />
+      </QueryClientProvider>,
+    ),
+  )
+}
+
+describe('DeveloperScreen — Server URL', () => {
+  beforeEach(() => { networkInfo = undefined })
+
+  it('shows window.location.origin when LAN sharing is off', async () => {
+    networkInfo = { lanBind: false, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    expect(screen.getByText(window.location.origin)).toBeInTheDocument()
+  })
+
+  it('shows the LAN-reachable URL, not window.location.origin, when LAN sharing is on', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    expect(screen.getByText('http://192.168.1.5:6996')).toBeInTheDocument()
+    expect(screen.queryByText(window.location.origin)).not.toBeInTheDocument()
+  })
+})
+
+describe('DeveloperScreen — API key management gating', () => {
+  beforeEach(() => { networkInfo = undefined })
+
+  it('shows the key list + create form on the host machine, even with LAN open and no auth yet', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    expect(screen.getByPlaceholderText('Key name (e.g. claude-code)')).toBeInTheDocument()
+    expect(screen.queryByText(/only available from this machine/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the key list + create form once requireApiKey is on, even for a non-host viewer', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: true, requireApiKey: true, isHost: false }
+    await renderScreen()
+    expect(screen.getByPlaceholderText('Key name (e.g. claude-code)')).toBeInTheDocument()
+  })
+
+  it('hides the key list + create form for a non-host viewer while the LAN is open and unauthenticated', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: false }
+    await renderScreen()
+    expect(screen.queryByPlaceholderText('Key name (e.g. claude-code)')).not.toBeInTheDocument()
+    expect(screen.getByText(/only available from this machine/i)).toBeInTheDocument()
+  })
+
+  it('fails CLOSED (locked) while network info is still loading, rather than flashing the form', async () => {
+    networkInfo = undefined
+    await renderScreen()
+    expect(screen.queryByPlaceholderText('Key name (e.g. claude-code)')).not.toBeInTheDocument()
+    expect(screen.getByText(/only available from this machine/i)).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/screens/DeveloperScreen.test.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.test.tsx
@@ -116,3 +116,34 @@ describe('DeveloperScreen — Connect-an-app setup snippet gating', () => {
     expect(getConnectSpy).toHaveBeenCalled()
   })
 })
+
+describe('DeveloperScreen — TurboLLM MCP section', () => {
+  beforeEach(() => { networkInfo = undefined })
+
+  it('shows the generic MCP host config and the Claude Code one-liner', async () => {
+    networkInfo = { lanBind: false, lanUrl: '', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    expect(screen.getByText('TurboLLM MCP')).toBeInTheDocument()
+    expect(screen.getByText(/"command": "npx"/)).toBeInTheDocument()
+    expect(screen.getByText(/"args": \[/)).toBeInTheDocument()
+    expect(screen.getByText('claude mcp add turbollm -- npx turbollm mcp-server')).toBeInTheDocument()
+  })
+
+  it('lists the delegate_code_task parameters', async () => {
+    networkInfo = { lanBind: false, lanUrl: '', hasApiKey: false, requireApiKey: false, isHost: true }
+    await renderScreen()
+    expect(screen.getByText('delegate_code_task parameters')).toBeInTheDocument()
+    for (const name of ['repoRoot', 'task', 'mode', 'modelKey', 'timeoutSeconds']) {
+      expect(screen.getByText(name)).toBeInTheDocument()
+    }
+  })
+
+  it('is NOT gated behind the host-only key lock — it embeds no secret, unlike the sections above', async () => {
+    networkInfo = { lanBind: true, lanUrl: 'http://192.168.1.5:6996', hasApiKey: false, requireApiKey: false, isHost: false }
+    await renderScreen()
+    // Both sections above ARE locked in this exact state (see the other describe blocks) —
+    // this section must render fully regardless, since it has nothing sensitive to protect.
+    expect(screen.getByText('TurboLLM MCP')).toBeInTheDocument()
+    expect(screen.getByText(/"command": "npx"/)).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/screens/DeveloperScreen.test.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.test.tsx
@@ -133,7 +133,7 @@ describe('DeveloperScreen — TurboLLM MCP section', () => {
     networkInfo = { lanBind: false, lanUrl: '', hasApiKey: false, requireApiKey: false, isHost: true }
     await renderScreen()
     expect(screen.getByText('delegate_code_task parameters')).toBeInTheDocument()
-    for (const name of ['repoRoot', 'task', 'mode', 'modelKey', 'timeoutSeconds']) {
+    for (const name of ['repoRoot', 'task', 'mode', 'timeoutSeconds']) {
       expect(screen.getByText(name)).toBeInTheDocument()
     }
   })

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -7,11 +7,24 @@ import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
 import { useApiKeys, useNetworkInfo } from '../lib/queries'
-import { ApiError, getConnect, type ConnectStep } from '../lib/api'
+import { ApiError, getConnect, type ConnectStep, type NetworkInfo } from '../lib/api'
 import { toast } from '../components/ui/sonner'
 import { cn } from '../lib/utils'
 
 const BASE = window.location.origin
+
+/** Host-only while the LAN is open and unauthenticated (lanBind on, requireApiKey off): in that
+ *  state the backend accepts key material from ANY device with no credential at all (spec 06 §5's
+ *  "opted into open LAN access") — a non-host viewer could otherwise list/create keys directly, OR
+ *  (the connect-setup snippets) get a live key just by loading the page. Mirrors the server-
+ *  enforced gate `keysHostGate` in routes.ts (both /api/v1/keys and /api/v1/connect/:cli) — this
+ *  hides the UI to match, it isn't the actual security boundary. `net` undefined (still loading)
+ *  fails CLOSED so nothing containing key material flashes visible before the real state is known.
+ *  ONE shared definition so the two call sites (API keys list, connect-setup snippets) can't drift
+ *  out of sync with each other or with the backend rule. */
+function isKeysLocked(net: NetworkInfo | undefined): boolean {
+  return net ? !net.isHost && !net.requireApiKey : true
+}
 
 // Only the endpoints an external app actually builds against (OpenAI + Anthropic
 // compatible). The daemon's own internal /api/v1/* management endpoints are not
@@ -64,15 +77,7 @@ function ConnectionPanel() {
   // dashboard locally even though LAN sharing is on for OTHER devices — show the actually
   // LAN-reachable URL in that case, since that's the address an external app needs.
   const serverUrl = net?.lanBind && net.lanUrl ? net.lanUrl : BASE
-
-  // Host-only while the LAN is open and unauthenticated (lanBind on, requireApiKey off):
-  // in that state the backend itself accepts key management from ANY device with no
-  // credential (spec 06 §5's "opted into open LAN access"), so a non-host viewer here could
-  // otherwise list key names or mint itself a durable key with zero credential. Mirrors the
-  // server-enforced gate on /api/v1/keys (routes.ts) — this hides the UI to match, it isn't
-  // the actual security boundary. `net` undefined (still loading) fails CLOSED (locked) so
-  // the form never flashes visible then disappears once the real state arrives.
-  const keysLocked = net ? !net.isHost && !net.requireApiKey : true
+  const keysLocked = isKeysLocked(net)
 
   const handleCreate = () => {
     const name = newName.trim()
@@ -185,8 +190,14 @@ function ConnectionPanel() {
 // ── Connect an app ────────────────────────────────────────────────────────────
 
 function ConnectSection() {
+  const { data: net } = useNetworkInfo()
   const [selected, setSelected] = useState<string>(CLI_LIST[0].id)
   const cli = CLI_LIST.find((c) => c.id === selected) ?? CLI_LIST[0]
+  // Setup snippets embed a live API key when the daemon is LAN-exposed (routes.ts's
+  // GET /api/v1/connect/:cli mints one on every call) — same lock as the API-keys list above,
+  // and just as necessary here: unlike that list, this fires automatically the moment the
+  // page loads (no click needed) for whichever CLI is selected by default.
+  const keysLocked = isKeysLocked(net)
 
   return (
     <section>
@@ -201,7 +212,17 @@ function ConnectSection() {
         ))}
       </div>
 
-      <SetupPanel key={cli.id} cli={cli} />
+      {keysLocked ? (
+        <div className="mt-3 flex items-start gap-2 rounded-xl border border-border bg-panel p-4 text-[13px] text-faint">
+          <Lock size={14} className="mt-0.5 shrink-0" />
+          <span>
+            Setup snippets include a live API key, so they're only available from this machine
+            until "Require an API key" is turned on for LAN access (Settings → Network).
+          </span>
+        </div>
+      ) : (
+        <SetupPanel key={cli.id} cli={cli} />
+      )}
     </section>
   )
 }

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { LucideIcon } from 'lucide-react'
-import { Bot, ChevronRight, Code2, Globe, Key, Loader2, Plug, Plus, Sparkles, Terminal, Trash2, Wrench } from 'lucide-react'
+import { Bot, ChevronRight, Code2, Globe, Key, Loader2, Lock, Plug, Plus, Sparkles, Terminal, Trash2, Wrench } from 'lucide-react'
 import { CopyButton } from '../components/ui/copy-button'
 import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
-import { useApiKeys } from '../lib/queries'
+import { useApiKeys, useNetworkInfo } from '../lib/queries'
 import { ApiError, getConnect, type ConnectStep } from '../lib/api'
 import { toast } from '../components/ui/sonner'
 import { cn } from '../lib/utils'
@@ -55,9 +55,24 @@ export function DeveloperScreen() {
 
 function ConnectionPanel() {
   const { query, create, revoke } = useApiKeys()
+  const { data: net } = useNetworkInfo()
   const [newName, setNewName] = useState('')
   const [justCreated, setJustCreated] = useState<string | null>(null)
   const keys = query.data?.keys ?? []
+
+  // window.location.origin alone still reads 127.0.0.1/localhost when you're viewing the
+  // dashboard locally even though LAN sharing is on for OTHER devices — show the actually
+  // LAN-reachable URL in that case, since that's the address an external app needs.
+  const serverUrl = net?.lanBind && net.lanUrl ? net.lanUrl : BASE
+
+  // Host-only while the LAN is open and unauthenticated (lanBind on, requireApiKey off):
+  // in that state the backend itself accepts key management from ANY device with no
+  // credential (spec 06 §5's "opted into open LAN access"), so a non-host viewer here could
+  // otherwise list key names or mint itself a durable key with zero credential. Mirrors the
+  // server-enforced gate on /api/v1/keys (routes.ts) — this hides the UI to match, it isn't
+  // the actual security boundary. `net` undefined (still loading) fails CLOSED (locked) so
+  // the form never flashes visible then disappears once the real state arrives.
+  const keysLocked = net ? !net.isHost && !net.requireApiKey : true
 
   const handleCreate = () => {
     const name = newName.trim()
@@ -81,13 +96,14 @@ function ConnectionPanel() {
         <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Connection</h2>
       </div>
 
-      {/* Server URL — whatever address you're reaching TurboLLM at. */}
+      {/* Server URL — whatever address you're reaching TurboLLM at, or the LAN-reachable
+          address when sharing is on (the address an external app actually needs). */}
       <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-bg px-3 py-2.5">
         <div className="min-w-0">
           <div className="text-[11px] text-muted">Server URL</div>
-          <code className="font-mono text-[13px] text-ink">{BASE}</code>
+          <code className="font-mono text-[13px] text-ink">{serverUrl}</code>
         </div>
-        <CopyButton text={BASE} />
+        <CopyButton text={serverUrl} />
       </div>
 
       {/* API keys — needed for access from another device (or when a key is required). */}
@@ -96,59 +112,71 @@ function ConnectionPanel() {
           <Key size={13} /> API keys
         </div>
 
-        {justCreated && (
-          <div
-            className="mb-3 rounded-md border p-3"
-            style={{ borderColor: 'var(--ok)', background: 'color-mix(in srgb, var(--ok) 8%, transparent)' }}
-          >
-            <p className="mb-1.5 text-[12px] font-medium" style={{ color: 'var(--ok)' }}>
-              Key created — copy it now, it won't be shown again.
-            </p>
-            <div className="flex items-center gap-2 rounded border border-border bg-bg px-2 py-1.5">
-              <code className="min-w-0 flex-1 break-all font-mono text-[12px] text-ink">{justCreated}</code>
-              <CopyButton text={justCreated} />
-            </div>
+        {keysLocked ? (
+          <div className="flex items-start gap-2 rounded-md border border-border bg-bg px-3 py-2.5 text-[13px] text-faint">
+            <Lock size={14} className="mt-0.5 shrink-0" />
+            <span>
+              API key management is only available from this machine until "Require an API key"
+              is turned on for LAN access (Settings → Network).
+            </span>
           </div>
-        )}
-
-        {keys.length === 0 && !justCreated && (
-          <p className="mb-3 text-[13px] text-faint">No API keys yet. Create one to connect from another device or an external app.</p>
-        )}
-
-        {keys.length > 0 && (
-          <div className="mb-3 divide-y divide-border rounded-md border border-border">
-            {keys.map((k) => (
-              <div key={k.id} className="flex items-center justify-between px-3 py-2.5">
-                <div>
-                  <span className="text-[13px] font-medium text-ink">{k.name}</span>
-                  <span className="ml-2 font-mono text-[11px] text-faint">{k.prefix}…</span>
+        ) : (
+          <>
+            {justCreated && (
+              <div
+                className="mb-3 rounded-md border p-3"
+                style={{ borderColor: 'var(--ok)', background: 'color-mix(in srgb, var(--ok) 8%, transparent)' }}
+              >
+                <p className="mb-1.5 text-[12px] font-medium" style={{ color: 'var(--ok)' }}>
+                  Key created — copy it now, it won't be shown again.
+                </p>
+                <div className="flex items-center gap-2 rounded border border-border bg-bg px-2 py-1.5">
+                  <code className="min-w-0 flex-1 break-all font-mono text-[12px] text-ink">{justCreated}</code>
+                  <CopyButton text={justCreated} />
                 </div>
-                <button
-                  type="button"
-                  onClick={() => handleRevoke(k.id, k.prefix)}
-                  className="rounded p-1 text-faint transition-colors hover:text-err"
-                  title="Revoke key"
-                >
-                  <Trash2 size={14} />
-                </button>
               </div>
-            ))}
-          </div>
-        )}
+            )}
 
-        <div className="flex gap-2">
-          <input
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="Key name (e.g. claude-code)"
-            className="flex-1 rounded-md border border-border bg-bg px-2.5 py-1.5 text-[13px] text-ink outline-none placeholder:text-faint focus:border-[color:var(--accent)]"
-            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-          />
-          <Button size="sm" onClick={handleCreate} disabled={!newName.trim() || create.isPending}>
-            <Plus size={13} />
-            {create.isPending ? 'Creating…' : 'New key'}
-          </Button>
-        </div>
+            {keys.length === 0 && !justCreated && (
+              <p className="mb-3 text-[13px] text-faint">No API keys yet. Create one to connect from another device or an external app.</p>
+            )}
+
+            {keys.length > 0 && (
+              <div className="mb-3 divide-y divide-border rounded-md border border-border">
+                {keys.map((k) => (
+                  <div key={k.id} className="flex items-center justify-between px-3 py-2.5">
+                    <div>
+                      <span className="text-[13px] font-medium text-ink">{k.name}</span>
+                      <span className="ml-2 font-mono text-[11px] text-faint">{k.prefix}…</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRevoke(k.id, k.prefix)}
+                      className="rounded p-1 text-faint transition-colors hover:text-err"
+                      title="Revoke key"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="Key name (e.g. claude-code)"
+                className="flex-1 rounded-md border border-border bg-bg px-2.5 py-1.5 text-[13px] text-ink outline-none placeholder:text-faint focus:border-[color:var(--accent)]"
+                onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              />
+              <Button size="sm" onClick={handleCreate} disabled={!newName.trim() || create.isPending}>
+                <Plus size={13} />
+                {create.isPending ? 'Creating…' : 'New key'}
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </section>
   )

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -43,7 +43,6 @@ const MCP_PARAMS = [
   { name: 'repoRoot', required: true, desc: 'Absolute path to the repo the task should run against.' },
   { name: 'task', required: true, desc: 'What to do, in plain language.' },
   { name: 'mode', required: false, desc: 'auto / plan / ask — defaults to auto.' },
-  { name: 'modelKey', required: false, desc: 'Pin a specific model instead of whatever is currently loaded.' },
   { name: 'timeoutSeconds', required: false, desc: 'Give up waiting after this long — defaults to 1800 (30 min).' },
 ] as const
 

--- a/turbollm/web/src/screens/DeveloperScreen.tsx
+++ b/turbollm/web/src/screens/DeveloperScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { LucideIcon } from 'lucide-react'
-import { Bot, ChevronRight, Code2, Globe, Key, Loader2, Lock, Plug, Plus, Sparkles, Terminal, Trash2, Wrench } from 'lucide-react'
+import { Bot, ChevronRight, Code2, Globe, Key, Loader2, Lock, Plug, Plus, Sparkles, Terminal, Trash2, Workflow, Wrench } from 'lucide-react'
 import { CopyButton } from '../components/ui/copy-button'
 import { ScreenHeader } from '../components/common'
 import { Button } from '../components/ui/button'
@@ -36,6 +36,17 @@ const PUBLIC_APIS = [
   { method: 'GET', path: '/v1/models', desc: 'Models list' },
 ] as const
 
+// `delegate_code_task`'s params (turbollm/src/mcp-server.ts's DELEGATE_TOOL_SCHEMA) — kept as
+// display copy here, not fetched from the daemon: this is documentation, not live state, and
+// the tool schema itself is only reachable over the MCP stdio protocol, not a plain HTTP route.
+const MCP_PARAMS = [
+  { name: 'repoRoot', required: true, desc: 'Absolute path to the repo the task should run against.' },
+  { name: 'task', required: true, desc: 'What to do, in plain language.' },
+  { name: 'mode', required: false, desc: 'auto / plan / ask — defaults to auto.' },
+  { name: 'modelKey', required: false, desc: 'Pin a specific model instead of whatever is currently loaded.' },
+  { name: 'timeoutSeconds', required: false, desc: 'Give up waiting after this long — defaults to 1800 (30 min).' },
+] as const
+
 type Cli = { id: string; name: string; hint: string; icon: LucideIcon }
 const CLI_LIST: Cli[] = [
   { id: 'claude-code', name: 'Claude Code', hint: 'turbollm launch claude', icon: Sparkles },
@@ -58,6 +69,7 @@ export function DeveloperScreen() {
       <div className="flex flex-col gap-6">
         <ConnectionPanel />
         <ConnectSection />
+        <McpSection />
         <ApiReferenceSection />
       </div>
     </div>
@@ -283,6 +295,78 @@ function SnippetBlock({ step }: { step: ConnectStep }) {
         <CopyButton text={step.snippet} className="absolute right-2 top-2" />
       </div>
     </div>
+  )
+}
+
+// ── TurboLLM MCP (delegate_code_task) ──────────────────────────────────────────
+// The REVERSE direction from everything above: instead of an outside app calling TurboLLM's
+// chat-completions API, this lets any MCP-compatible tool hand TurboLLM's own Code agent a task
+// to run. No secret material in this section (the config is a static command, and the bridge only
+// ever talks to the daemon over loopback) — unlike the API keys / connect-setup snippets above,
+// nothing here needs host-only gating.
+const MCP_CONFIG_SNIPPET: ConnectStep = {
+  label: 'Any MCP host (Claude Desktop, Cursor, Windsurf, Cline, etc.) — paste into its MCP settings',
+  lang: 'json',
+  snippet: JSON.stringify(
+    { mcpServers: { turbollm: { command: 'npx', args: ['turbollm', 'mcp-server'] } } },
+    null,
+    2,
+  ),
+}
+const MCP_CLAUDE_CODE_SNIPPET: ConnectStep = {
+  label: 'Claude Code',
+  lang: 'bash',
+  snippet: 'claude mcp add turbollm -- npx turbollm mcp-server',
+}
+
+function McpSection() {
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <div className="mb-1 flex items-center gap-2">
+        <Workflow size={15} className="text-accent" />
+        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">TurboLLM MCP</h2>
+      </div>
+      <p className="mb-3 text-[13px] text-muted">
+        Let ANY MCP-compatible tool — not just Claude Code — delegate real coding tasks to
+        TurboLLM's local Code agent (bash/edit/write, containment, permission modes), running on
+        whatever model is loaded in this daemon.
+      </p>
+
+      <div className="mb-3 rounded-md border border-border bg-bg p-3">
+        <div className="mb-1.5 text-[12px] font-medium text-ink">What it does</div>
+        <ul className="list-disc space-y-1 pl-4 text-[13px] text-muted">
+          <li>Exposes one tool, <code className="font-mono text-[12px] text-ink">delegate_code_task</code>, over MCP's standard stdio transport.</li>
+          <li>Hand it a repo path and a task in plain language — it runs a full Code session (reads, edits, runs shell commands) and returns the agent's final result.</li>
+          <li>Runs on whatever model is already loaded here — nothing extra to configure on TurboLLM's side.</li>
+        </ul>
+      </div>
+
+      <div className="mb-3 flex flex-col gap-2.5">
+        <SnippetBlock step={MCP_CONFIG_SNIPPET} />
+        <SnippetBlock step={MCP_CLAUDE_CODE_SNIPPET} />
+      </div>
+
+      <div className="rounded-md border border-border bg-bg p-3">
+        <div className="mb-1.5 text-[12px] font-medium text-ink">delegate_code_task parameters</div>
+        <div className="divide-y divide-border">
+          {MCP_PARAMS.map((p) => (
+            <div key={p.name} className="flex items-start gap-3 py-1.5 first:pt-0 last:pb-0">
+              <code className="w-28 shrink-0 font-mono text-[12px] text-ink">
+                {p.name}
+                {!p.required && <span className="text-faint">?</span>}
+              </code>
+              <span className="text-[13px] text-muted">{p.desc}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-3 text-[11px] text-faint">
+        Requires a model already loaded in this daemon. The bridge only talks to the daemon over
+        loopback, so it has to run on this same machine — a remote MCP host can't point it at a
+        daemon on a different computer.
+      </p>
+    </section>
   )
 }
 

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -22,6 +22,7 @@ import {
 import { CopyButton } from '../components/ui/copy-button'
 import { ModelDirs } from './models/ModelDirs'
 import { ToolPermissionsSection } from './settings/ToolPermissionsSection'
+import { CodeContextSection } from './settings/CodeContextSection'
 import { MemorySection } from './settings/MemorySection'
 import { ExperimentalSection } from './settings/ExperimentalSection'
 
@@ -611,6 +612,9 @@ export function SettingsScreen() {
             <>
               {/* Tool permissions — moved here from Developer. */}
               <ToolPermissionsSection />
+
+              {/* Code's AGENTS.md-style standing-context candidate lists. */}
+              <CodeContextSection />
             </>
           )}
 

--- a/turbollm/web/src/screens/chat/ConversationSidebar.test.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.test.tsx
@@ -5,16 +5,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { ConversationSidebar } from './ConversationSidebar'
 import type { CodeSession } from '../../lib/code-types'
 
-// Code mode is gated behind Settings → Experimental (ConversationSidebar.tsx:299) — force it on
-// so the sidebar actually renders CodeSessionsList instead of the chat folder/conversation list.
-vi.mock('../../lib/api', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../lib/api')>()
-  return {
-    ...actual,
-    getSettings: vi.fn(async () => ({ experimental: { code: true } }) as ReturnType<typeof actual.getSettings> extends Promise<infer T> ? T : never),
-  }
-})
-
 const RUNNING_SESSION: CodeSession = {
   id: 's-running',
   convId: 'c-running',

--- a/turbollm/web/src/screens/chat/ConversationSidebar.tsx
+++ b/turbollm/web/src/screens/chat/ConversationSidebar.tsx
@@ -29,7 +29,6 @@ import { Skeleton } from '../../components/ui/skeleton'
 import { useArchiveCodeSession, useCodeSessionRename, useCodeSessions, useDeleteCodeSession } from '../../lib/code-queries'
 import type { CodeSession, CodeSessionFilter, SessionStatus } from '../../lib/code-types'
 import { ApiError } from '../../lib/api'
-import { useSettings } from '../../lib/queries'
 
 /** localStorage key for the client-only "confirm before deleting a conversation"
  *  preference (mirrors SettingsScreen). Default ON when unset. */
@@ -298,11 +297,6 @@ export function ConversationSidebar({
   // never both at once. Route is the single source of truth for which is active
   // (kept in sync with the Chat|Code pill in CodeHomeScreen's own header).
   const isCodeMode = pathname.startsWith('/workspace/code')
-  // Code is an experimental feature (2026-07-14, Settings → Experimental), off by default —
-  // hides the Code pill entirely rather than showing it disabled/locked (founder's chosen
-  // behavior). If the flag is off WHILE already viewing Code (turned off mid-session), the
-  // pill just won't render on the next paint — App.tsx's route guard handles navigating away.
-  const codeExperimentalEnabled = useSettings().query.data?.experimental?.code ?? false
   // Switching modes restores whatever conversation/session was last open in the OTHER
   // mode, instead of always resetting to that mode's list/launchpad root.
   const lastChatConvId = readLastChatConvId()
@@ -490,10 +484,7 @@ export function ConversationSidebar({
       {/* Mode switch (Chat|Code) — mirrors the pill in CodeHomeScreen's own header,
           kept in sync via the route (isCodeMode above). Lets the user flip modes
           from the sidebar itself, not just the main content header. This replaced
-          the old single-purpose "Code · preview" footer link. Hidden entirely (not just the
-          Code side) when Code is experimentally disabled — a two-way switcher with only one
-          reachable option is pointless UI; the sidebar just shows plain Chat content instead. */}
-      {codeExperimentalEnabled && (
+          the old single-purpose "Code · preview" footer link. */}
       <div className="px-3 pt-3">
         <div className="flex overflow-hidden rounded-lg border border-border" role="group" aria-label="Workspace mode">
           {isCodeMode ? (
@@ -530,7 +521,6 @@ export function ConversationSidebar({
           )}
         </div>
       </div>
-      )}
 
       <div className="flex items-center gap-2 px-3 pb-3 pt-2">
         {onToggle && (

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -256,6 +256,10 @@ export interface CodeComposerProps {
    *  follow-up this needs (a `CodeSessionScreen.tsx` change, outside this task's scope). */
   lastPromptTokens?: number
   lastGenTokens?: number
+  /** Same turn's real prefill/generation speed (`MessageStats.promptTps`/`tps`) — rendered
+   *  alongside the token counts above, same undefined-means-omit rule. */
+  lastPromptTps?: number
+  lastGenTps?: number
 
   /** '/' commands this composer variant supports (e.g. compact only applies mid-session, not on
    *  the launchpad's "start a new session" composer — see CodeSessionScreen/CodeHomeScreen for
@@ -281,6 +285,7 @@ export function CodeComposer({
   ctxUsed, ctxMax, live, onStop, sendDisabled,
   onAddContext, contextFiles, onRemoveContextFile, hintText, statusText, slashCommands = [],
   thinkingBudget, onThinkingBudgetChange, onImagesChange, lastPromptTokens, lastGenTokens,
+  lastPromptTps, lastGenTps,
 }: CodeComposerProps) {
   const ModeIcon = MODE_ICONS[mode.id]
 
@@ -900,13 +905,12 @@ export function CodeComposer({
               launchpad's own repo-picker row already shows both (repoPath's folder name in the
               trigger, `repo.branchLabel` as a chip), so repeating them here would duplicate that
               row specifically.
-            - Tokens ↑/↓ (`lastPromptTokens`/`lastGenTokens`) are real backend-tracked data
-              (`MessageStats.promptTokens`/`genTokens`, chat-types.ts) — NOT fabricated, NOT an
-              estimate — but nothing feeds these props yet (no per-turn stats are threaded into
-              this component today); they simply render nothing until a caller (CodeSessionScreen.tsx,
-              outside this composer-only task's scope) starts passing real numbers. Left as a ready
-              receiving end rather than omitted outright, so wiring it later is a small follow-up
-              rather than new composer-side plumbing.
+            - Tokens ↑/↓ and t/s (`lastPromptTokens`/`lastGenTokens`/`lastPromptTps`/`lastGenTps`)
+              are real backend-tracked data (`MessageStats`, chat-types.ts) — NOT fabricated, NOT
+              an estimate — fed from `CodeSessionScreen.tsx`'s `lastRealStats`, itself sourced
+              from `code-session.ts`'s `foldTurnUsage` (summed across every agentic round of the
+              turn, mirroring Chat's own engine-agnostic timing fallback). Still `undefined` (no
+              segment rendered) whenever the engine returns no usable usage at all.
           Keybinds are now genuinely PERMANENT (no more hiding while `textareaDisabled`) — each
           clause instead governs its own accuracy: "Enter to send" only claims true when the
           textarea can actually be typed into; "Esc to stop" only appears once a run is actually
@@ -925,8 +929,12 @@ export function CodeComposer({
             </span>
           )}
           {lastPromptTokens !== undefined && lastGenTokens !== undefined && (
-            <span title={`Last turn: ${lastPromptTokens.toLocaleString()} prompt, ${lastGenTokens.toLocaleString()} generated`}>
+            <span title={`Last turn: ${lastPromptTokens.toLocaleString()} prompt` +
+              (lastPromptTps !== undefined ? ` (${lastPromptTps.toFixed(0)} tok/s prefill)` : '') +
+              `, ${lastGenTokens.toLocaleString()} generated` +
+              (lastGenTps !== undefined ? ` (${lastGenTps.toFixed(1)} tok/s)` : '')}>
               &uarr;{fmtCompactTokens(lastPromptTokens)} &darr;{fmtCompactTokens(lastGenTokens)}
+              {lastGenTps !== undefined && ` · ${lastGenTps.toFixed(1)} t/s`}
             </span>
           )}
         </span>

--- a/turbollm/web/src/screens/code/CodeSessionScreen.test.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.test.tsx
@@ -1,0 +1,262 @@
+// Closes the test-coverage gap TODO.md flagged for CodeSessionScreen.tsx: "the toast-on-send and
+// reconnect-seeding logic there aren't unit-testable as-is." Renders the REAL screen (real hooks,
+// real send()/effects) with the heavy child components stubbed out and the API/SSE layers mocked
+// — same "mock at the API boundary, keep the screen's own logic real" discipline as
+// CodeGitDialog.test.tsx, extended with a controllable fake CodeSessionClient since that class
+// owns its own fetch-based streaming internally.
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '../../lib/api'
+import type { CodeSessionDetail } from '../../lib/code-api'
+
+// jsdom's environment doesn't wire up a working localStorage (authHeaders() reads it on every
+// call) — same gap CodeComposer.test.tsx/CodeGitDialog.test.tsx/code-api.test.ts already work around.
+beforeEach(() => {
+  const store = new Map<string, string>()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => { store.set(k, v) },
+    removeItem: (k: string) => { store.delete(k) },
+    clear: () => store.clear(),
+  })
+})
+
+// ── controllable fake CodeSessionClient ──────────────────────────────────────────────
+// The real class owns a fetch-based SSE loop internally with no injectable transport at this
+// boundary; replacing the whole module is simpler and more robust than trying to mock fetch/
+// ReadableStream. Captures the handlers passed to the constructor so a test can manually fire
+// onTurnDone/onLostConnection/etc., and exposes connect/abort as spies.
+const connectSpy = vi.fn()
+const abortSpy = vi.fn()
+let fakeIsActive = false
+
+vi.mock('../../lib/code-session-client', () => ({
+  CodeSessionClient: class {
+    constructor(_sessionId: string, _handlers: Record<string, (...args: unknown[]) => unknown>) {}
+    get isActive() { return fakeIsActive }
+    connect = connectSpy
+    abort = abortSpy
+  },
+}))
+
+// ── code-api.ts — mock only the calls this screen's own logic makes ─────────────────
+const getCodeSessionMock = vi.fn()
+const startCodeRunMock = vi.fn()
+const stopCodeSessionMock = vi.fn()
+
+vi.mock('../../lib/code-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/code-api')>()
+  return {
+    ...actual, // keeps steerOutcomeMessage etc. real — pure formatters, no reason to fake them
+    getCodeSession: (...args: unknown[]) => getCodeSessionMock(...args),
+    startCodeRun: (...args: unknown[]) => startCodeRunMock(...args),
+    stopCodeSession: (...args: unknown[]) => stopCodeSessionMock(...args),
+  }
+})
+
+// ── lib/queries.ts (useStatus/useModels/useModelActions) — this screen only reads status ──
+vi.mock('../../lib/queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/queries')>()
+  return {
+    ...actual,
+    useStatus: () => ({ data: { engine: { state: 'running' } } }),
+    useModels: () => ({ data: { models: [] } }),
+    useModelActions: () => ({
+      load: { mutate: vi.fn(), isPending: false },
+      eject: { mutate: vi.fn(), isPending: false },
+    }),
+  }
+})
+
+vi.mock('../../lib/agent-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/agent-api')>()
+  return { ...actual, fetchSkills: () => Promise.resolve([]) }
+})
+
+vi.mock('../../lib/useIsDesktop', () => ({ useIsDesktop: () => true }))
+
+// ── heavy child components — stubbed to keep this test scoped to the SCREEN's own logic ──
+vi.mock('../chat/ConversationSidebar', () => ({ ConversationSidebar: () => null }))
+vi.mock('./CodeResourcesHeader', () => ({ CodeResourcesHeader: () => null }))
+vi.mock('./CodeGitDialog', () => ({ CodeGitDialog: () => null }))
+vi.mock('../models/ModelDetailDialog', () => ({ ModelDetailDialog: () => null }))
+vi.mock('../engines/FsBrowser', () => ({ FsBrowser: () => null }))
+vi.mock('../chat/ToolApprovalBar', () => ({ ToolApprovalBar: () => null }))
+vi.mock('./CodeTranscript', () => ({
+  CodeTranscript: () => null,
+  CodeTranscriptSkeleton: () => null,
+  TodoChecklist: () => null,
+}))
+// A minimal, interactive stand-in for the real composer — exposes exactly the two triggers these
+// tests need (a plain send and a steer send) without depending on its own internal state machine.
+vi.mock('./CodeComposer', () => ({
+  CodeComposer: (props: { value: string; onValueChange: (v: string) => void; onSubmit: (kind?: 'followUp' | 'steer') => void }) => (
+    <div>
+      <textarea aria-label="composer" value={props.value} onChange={(e) => props.onValueChange(e.target.value)} />
+      <button onClick={() => props.onSubmit()}>Send</button>
+      <button onClick={() => props.onSubmit('steer')}>Steer</button>
+    </div>
+  ),
+}))
+
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+vi.mock('../../components/ui/sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+async function importScreen() {
+  // Imported dynamically, after the mocks above are registered (vi.mock calls are hoisted by
+  // vitest regardless of import order, but this keeps the file's own reading order honest).
+  const mod = await import('./CodeSessionScreen')
+  return mod.CodeSessionScreen
+}
+
+function detail(overrides: Partial<CodeSessionDetail> = {}): CodeSessionDetail {
+  return {
+    session: {
+      id: 'sess-1', convId: 'conv-1', title: 'Fix the bug', status: 'review',
+      branch: 'main', when: 'now', add: 0, del: 0, mode: 'auto',
+      createdAt: new Date().toISOString(), repoRoot: '/repo',
+    },
+    conversation: {
+      id: 'conv-1', title: 'Fix the bug', systemPrompt: '', modelKey: 'model-a', sampling: {},
+      expertMode: false,
+      messages: [
+        { id: 'm1', convId: 'conv-1', seq: 1, role: 'user', content: 'fix the bug', reasoning: '', attachments: [], textAttachments: [], toolCalls: [], stats: {}, createdAt: new Date().toISOString(), variantGroup: null, isActive: true },
+        { id: 'm2', convId: 'conv-1', seq: 2, role: 'assistant', content: 'done', reasoning: '', attachments: [], textAttachments: [], toolCalls: [], stats: {}, createdAt: new Date().toISOString(), variantGroup: null, isActive: true },
+      ],
+    },
+    doc: null,
+    running: false,
+    queued: [],
+    ...overrides,
+  } as unknown as CodeSessionDetail
+}
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/workspace/code/sess-1']}>
+        <Routes>
+          <Route path="/workspace/code/:sessionId" element={<ScreenUnderTest />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+// Lazily resolved so the module-level mocks above are guaranteed registered first.
+let ScreenComp: React.ComponentType | null = null
+function ScreenUnderTest() {
+  if (!ScreenComp) throw new Error('ScreenUnderTest used before importScreen() resolved')
+  const S = ScreenComp
+  return <S />
+}
+
+describe('CodeSessionScreen — reconnect-on-load seeding', () => {
+  beforeEach(async () => {
+    connectSpy.mockClear()
+    abortSpy.mockClear()
+    fakeIsActive = false
+    getCodeSessionMock.mockReset()
+    ScreenComp = await importScreen()
+  })
+
+  it('a session opened while a run is live in the daemon calls client.connect() to attach, instead of assuming nothing is in flight', async () => {
+    getCodeSessionMock.mockResolvedValue(detail({ running: true }))
+    renderScreen()
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled())
+  })
+
+  it('does NOT call connect() when nothing is running in the daemon', async () => {
+    getCodeSessionMock.mockResolvedValue(detail({ running: false }))
+    renderScreen()
+    await waitFor(() => expect(getCodeSessionMock).toHaveBeenCalled())
+    expect(connectSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call connect() again if the client already reports itself active (no duplicate stream)', async () => {
+    fakeIsActive = true
+    getCodeSessionMock.mockResolvedValue(detail({ running: true }))
+    renderScreen()
+    await waitFor(() => expect(getCodeSessionMock).toHaveBeenCalled())
+    expect(connectSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('CodeSessionScreen — toast-on-send', () => {
+  beforeEach(async () => {
+    connectSpy.mockClear()
+    toastSuccess.mockClear()
+    toastError.mockClear()
+    getCodeSessionMock.mockReset()
+    startCodeRunMock.mockReset()
+    getCodeSessionMock.mockResolvedValue(detail({ running: false }))
+    ScreenComp = await importScreen()
+  })
+
+  it('a successful steer send shows a success toast built from the real outcome (steered: true)', async () => {
+    startCodeRunMock.mockResolvedValue({ steered: true })
+    const user = userEvent.setup()
+    renderScreen()
+    await screen.findByLabelText('composer')
+    await user.type(screen.getByLabelText('composer'), 'redirect the current turn')
+    await user.click(screen.getByRole('button', { name: 'Steer' }))
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled())
+    expect(toastSuccess.mock.calls[0][0]).toMatch(/redirect|steer/i)
+  })
+
+  it('a steer send that could not actually interject (queued instead) shows the honest outcome, not a false "redirected" claim', async () => {
+    startCodeRunMock.mockResolvedValue({ steered: false })
+    const user = userEvent.setup()
+    renderScreen()
+    await screen.findByLabelText('composer')
+    await user.type(screen.getByLabelText('composer'), 'redirect the current turn')
+    await user.click(screen.getByRole('button', { name: 'Steer' }))
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled())
+    expect(toastSuccess.mock.calls[0][0]).not.toMatch(/redirect/i)
+  })
+
+  it('a plain follow-up send shows NO toast on success — its queued card is the only feedback', async () => {
+    startCodeRunMock.mockResolvedValue({ steered: false })
+    const user = userEvent.setup()
+    renderScreen()
+    await screen.findByLabelText('composer')
+    await user.type(screen.getByLabelText('composer'), 'a normal follow-up')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(startCodeRunMock).toHaveBeenCalled())
+    expect(toastSuccess).not.toHaveBeenCalled()
+  })
+
+  it('a failed send shows an error toast and restores the typed text rather than losing it', async () => {
+    startCodeRunMock.mockRejectedValue(new ApiError('internal', 'Could not send.', 500))
+    const user = userEvent.setup()
+    renderScreen()
+    await screen.findByLabelText('composer')
+    await user.type(screen.getByLabelText('composer'), 'this should survive the failure')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    expect(screen.getByLabelText('composer')).toHaveValue('this should survive the failure')
+  })
+
+  it('a successful send re-connects the stream (clientRef.current?.connect()) so the client picks up the newly-started/queued turn', async () => {
+    startCodeRunMock.mockResolvedValue({ steered: false })
+    const user = userEvent.setup()
+    renderScreen()
+    await screen.findByLabelText('composer')
+    connectSpy.mockClear() // clear the reconnect-on-load call this same render already made
+    await user.type(screen.getByLabelText('composer'), 'go')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(connectSpy).toHaveBeenCalled())
+  })
+})

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -829,6 +829,10 @@ export function CodeSessionScreen() {
             onModelSettings={(key) => setSettingsKey(key)}
             ctxUsed={ctxUsed}
             ctxMax={ctxMax}
+            lastPromptTokens={lastRealStats?.promptTokens}
+            lastGenTokens={lastRealStats?.genTokens}
+            lastPromptTps={lastRealStats?.promptTps}
+            lastGenTps={lastRealStats?.tps}
             live={!!live}
             onStop={() => void handleStop()}
             sendDisabled={!input.trim() || manualCompacting}

--- a/turbollm/web/src/screens/code/CodeTranscript.tsx
+++ b/turbollm/web/src/screens/code/CodeTranscript.tsx
@@ -92,6 +92,30 @@ function toolIcon(name: string) {
   return Terminal
 }
 
+// Mirrors the backend's MUTATING_TOOLS (code-session.ts) — edit/write/bash are the tools that
+// can change the filesystem; read/grep/find/ls never do. bash carries no path argument (the
+// backend's own comment: "containment can't confine it, the mode system is its only guard"), so
+// this is a conservative "may write" signal applied to EVERY bash call, never sniffed from the
+// command string itself — a heuristic that labels a destructive command "read" would actively
+// mislead, which is worse than no label at all.
+const MUTATING_TOOLS = new Set(['edit', 'write', 'bash'])
+
+function isMutating(name: string): boolean {
+  return MUTATING_TOOLS.has(name)
+}
+
+/** Hover tooltip explaining what a tool call actually does, read/write-explicit. `label` is the
+ *  same path/command string the line itself already shows. */
+function toolTooltip(name: string, label: string): string {
+  if (EDIT_TOOLS.has(name)) return `Modifies ${label}`
+  if (WRITE_TOOLS.has(name)) return `Creates or overwrites ${label}`
+  if (BASH_TOOLS.has(name)) return 'Runs a shell command — may read or write anywhere'
+  if (READ_TOOLS.has(name)) return `Reads ${label}`
+  if (SEARCH_TOOLS.has(name)) return `Searches for ${label}`
+  if (name === 'ls') return `Lists ${label}`
+  return friendlyName(name)
+}
+
 /** A file-taking tool's `path` arg, for the flat line's label — falls back to the
  *  friendly tool name when there's no path (bash, or an odd/legacy call shape).
  *  invoke_skill has neither a path nor a command, just a skillId, so without this it would
@@ -226,6 +250,7 @@ function CodeOutputPanel({ text, streaming }: { text: string; streaming?: boolea
 function CodeToolLine({ call }: { call: NormalizedCall }) {
   const Icon = toolIcon(call.name)
   const label = toolLabel(call.name, call.args)
+  const mutating = isMutating(call.name)
   const hasDiff = !!call.diff?.trim()
   // Live cumulative output while the tool is still running (bash) — shown before the terminal
   // `result` exists (Phase 2). Once the real result lands it takes over.
@@ -248,9 +273,14 @@ function CodeToolLine({ call }: { call: NormalizedCall }) {
         type="button"
         onClick={() => hasOutput && setExpanded((e) => !e)}
         disabled={!hasOutput}
+        title={toolTooltip(call.name, label)}
         className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-panel-2 disabled:cursor-default disabled:hover:bg-transparent"
       >
-        <Icon size={13} className="shrink-0 text-muted" />
+        <Icon
+          size={13}
+          className={cn('shrink-0', !mutating && 'text-muted')}
+          style={mutating ? { color: 'var(--warn)' } : undefined}
+        />
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{label}</span>
         {stats && (stats.add > 0 || stats.del > 0) && (
           <span className="shrink-0 font-mono text-[11px] tabular-nums">
@@ -337,10 +367,13 @@ function CodeToolGroup({ lead, calls }: { lead: string; calls: NormalizedCall[] 
       <button
         type="button"
         onClick={() => setExpanded((e) => !e)}
+        title="Runs shell commands — may read or write anywhere"
         className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left transition-colors hover:bg-panel-2"
       >
         <ChevronRight size={13} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
-        <Terminal size={13} className="shrink-0 text-muted" />
+        {/* Every member of a group is a bash call (groupToolCalls/bashLeadWord) — same
+            unconditional warn tint as a single CodeToolLine's bash icon. */}
+        <Terminal size={13} className="shrink-0" style={{ color: 'var(--warn)' }} />
         <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-ink">{calls.length} {lead} commands</span>
         <StatusIcon status={status} />
       </button>

--- a/turbollm/web/src/screens/settings/CodeContextSection.tsx
+++ b/turbollm/web/src/screens/settings/CodeContextSection.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import { ChevronRight, FileText, Plus, X } from 'lucide-react'
+import { useSettings } from '../../lib/queries'
+import { ApiError } from '../../lib/api'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../../components/ui/collapsible'
+import { toast } from '../../components/ui/sonner'
+import { cn } from '../../lib/utils'
+
+/** One editable ORDERED candidate-filename list, mirroring BuildGuideDialog's toolchain-dirs
+ *  list editor (draft-until-saved, one input row per entry). `candidates` is the saved value;
+ *  `draft` (null when not being edited) shadows it locally so typing doesn't fire a save per
+ *  keystroke. First candidate that actually exists on disk wins at read time (persona.ts's
+ *  resolveAgentsFile) — order matters, which is why this is a list of rows, not an unordered
+ *  chip set. */
+function CandidateList({ label, hint, placeholder, candidates, saving, onSave }: {
+  label: string
+  hint: string
+  placeholder: string
+  candidates: string[]
+  saving: boolean
+  onSave: (next: string[]) => void
+}) {
+  const [draft, setDraft] = useState<string[] | null>(null)
+  const rows = draft ?? candidates
+  const cleaned = rows.map((r) => r.trim()).filter(Boolean)
+  const dirty = draft !== null && JSON.stringify(cleaned) !== JSON.stringify(candidates)
+
+  const save = () => {
+    onSave(cleaned)
+    setDraft(null)
+  }
+
+  return (
+    <div>
+      <div className="text-[13px] font-medium text-ink">{label}</div>
+      <p className="mb-2 mt-0.5 text-[11px] text-faint">{hint}</p>
+      <div className="flex flex-col gap-1.5">
+        {rows.map((entry, i) => (
+          <div key={i} className="flex items-center gap-1.5">
+            <span className="w-4 shrink-0 text-right font-mono text-[11px] text-faint">{i + 1}</span>
+            <input
+              value={entry}
+              onChange={(e) => {
+                const next = [...rows]
+                next[i] = e.target.value
+                setDraft(next)
+              }}
+              placeholder={placeholder}
+              className="min-w-0 flex-1 rounded-md border border-border bg-panel-2 px-2 py-1 font-mono text-[12px] text-ink outline-none focus:border-accent"
+            />
+            <button
+              type="button"
+              onClick={() => setDraft(rows.filter((_, j) => j !== i))}
+              className="shrink-0 rounded-md p-1 text-faint hover:text-ink"
+              aria-label={`Remove candidate ${i + 1}`}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        ))}
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => setDraft([...rows, ''])}
+            className="inline-flex items-center gap-1 text-[12px] text-muted hover:text-ink"
+          >
+            <Plus size={13} /> Add candidate
+          </button>
+          {dirty && (
+            <button
+              type="button"
+              onClick={save}
+              disabled={saving}
+              className="rounded-md bg-accent px-2.5 py-1 text-[12px] font-medium text-on-accent hover:bg-accent-hover disabled:opacity-50"
+            >
+              Save
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Which file(s) Code reads as standing project/user instructions (persona.ts's AGENTS.md-style
+ *  injection, like OpenCode's AGENTS.md convention) — configurable instead of the old hardcoded
+ *  exactly-AGENTS.md/exactly-agents.md. Each list below is tried IN ORDER; the FIRST existing,
+ *  readable file wins — not a merge of every match (a repo with "CLAUDE.md instead of AGENTS.md"
+ *  should get just CLAUDE.md's content, not both concatenated). Global-only for now: one shared
+ *  pair of lists applies to every repo/session alike, not a per-project override — the built-in
+ *  defaults already solve the common case (a repo using CLAUDE.md as its convention) with zero
+ *  configuration, since CLAUDE.md is already a candidate on both sides. */
+export function CodeContextSection() {
+  const [open, setOpen] = useState(false)
+  const { query: settingsQ, save } = useSettings()
+  // Optional-chained one level deeper than the type strictly requires: a daemon still running an
+  // older build (e.g. this exact dev-server-against-a-stale-production-daemon setup) won't have
+  // `code` in its /api/v1/settings response yet, and this section should degrade to empty lists
+  // rather than crash the whole Settings screen.
+  const project = settingsQ.data?.code?.agentsMdProjectCandidates ?? []
+  const global = settingsQ.data?.code?.agentsMdGlobalCandidates ?? []
+
+  const onError = (e: unknown) => toast.error(e instanceof ApiError ? e.message : 'Could not update standing-context files.')
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-border bg-panel p-4">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+        <ChevronRight size={14} className={cn('shrink-0 text-faint transition-transform', open && 'rotate-90')} />
+        <FileText size={15} className="text-accent" />
+        <h2 className="text-[13px] font-semibold uppercase tracking-wide text-faint">Standing context (Code)</h2>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <p className="mb-4 mt-3 text-[12px] text-muted">
+          Code automatically reads one standing-instructions file per project (from the repo root) and one
+          global file (from TurboLLM&apos;s own data dir) into every session, the same way OpenCode&apos;s
+          AGENTS.md convention works. Each list below is tried in order — the first file that actually
+          exists wins.
+        </p>
+        <div className="flex flex-col gap-5">
+          <CandidateList
+            label="Project file (repo root)"
+            hint="Tried against the root of whichever repo a Code session is running in."
+            placeholder="AGENTS.md"
+            candidates={project}
+            saving={save.isPending}
+            onSave={(next) => save.mutate({ code: { agentsMdProjectCandidates: next } }, { onError })}
+          />
+          <CandidateList
+            label="Global file"
+            hint="Tried against TurboLLM's own data directory (~/.turbollm) — applies to every session."
+            placeholder="agents.md"
+            candidates={global}
+            saving={save.isPending}
+            onSave={(next) => save.mutate({ code: { agentsMdGlobalCandidates: next } }, { onError })}
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/turbollm/web/src/screens/settings/ExperimentalSection.tsx
+++ b/turbollm/web/src/screens/settings/ExperimentalSection.tsx
@@ -1,4 +1,4 @@
-import { FlaskConical, SquareTerminal, Rocket, Brain } from 'lucide-react'
+import { FlaskConical, Rocket, Brain } from 'lucide-react'
 import { useSettings } from '../../lib/queries'
 import { ApiError } from '../../lib/api'
 import { Badge } from '../../components/ui/badge'
@@ -39,18 +39,20 @@ function FeatureRow({
 
 /** Experimental features (2026-07-14, preparing for wider distribution): still-in-progress
  *  capabilities, off by default for new/distributed installs, turned on individually here.
- *  ALL THREE are simple master on/off rows in this ONE list — Memory's own richer settings
+ *  Both are simple master on/off rows in this ONE list — Memory's own richer settings
  *  (the "remember facts about you" toggle + facts list) stay in their ORIGINAL location,
  *  Settings → General's MemorySection, and only render there when this row is checked. This is
  *  a correction of an earlier version that moved MemorySection's whole UI into this tab — the
  *  founder was explicit that Memory's settings belong where they've always been, gated on
- *  visibility (and, on the backend, on actually running) by this checkbox alone, not relocated. */
+ *  visibility (and, on the backend, on actually running) by this checkbox alone, not relocated.
+ *  Code used to be a third row here — removed when it graduated to generally available
+ *  (ADR-280), rather than staying an opt-in toggle. */
 export function ExperimentalSection() {
   const { query: settingsQ, save } = useSettings()
-  const experimental = settingsQ.data?.experimental ?? { memory: false, code: false, cloudDeploy: false }
+  const experimental = settingsQ.data?.experimental ?? { memory: false, cloudDeploy: false }
   const busy = save.isPending
 
-  const setFlag = (key: 'memory' | 'code' | 'cloudDeploy', value: boolean) => {
+  const setFlag = (key: 'memory' | 'cloudDeploy', value: boolean) => {
     save.mutate(
       { experimental: { [key]: value } },
       { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not update experimental setting.') },
@@ -74,14 +76,6 @@ export function ExperimentalSection() {
         description="Silently remembers durable facts from your chats. Its settings live in General — this only controls whether that section is unlocked and actually runs."
         checked={experimental.memory}
         onChange={(v) => setFlag('memory', v)}
-        disabled={busy}
-      />
-      <FeatureRow
-        icon={SquareTerminal}
-        title="Code"
-        description="A local coding agent that reads, edits, and runs commands in a real project directory. Disabling this removes the Code entry point entirely."
-        checked={experimental.code}
-        onChange={(v) => setFlag('code', v)}
         disabled={busy}
       />
       <FeatureRow


### PR DESCRIPTION
## Summary

- **Code graduates out of experimental status.** The entire `experimental.code` gate is removed (not just defaulted on) — config field, backend enforcement middleware, frontend route guard, and the Settings → Experimental toggle row are all gone. Available to everyone by default.
- **`turbollm mcp-server`** — exposes Code as a `delegate_code_task` MCP tool so other agentic CLIs (not just Claude Code) can delegate real coding tasks to a local model. A thin bridge to an already-running daemon, not a second daemon.
- **New "TurboLLM MCP" section in the Developer pane**, documenting the above with a generic MCP-host config snippet, a Claude Code one-liner, and the tool's parameters.
- **Two real security fixes in the Developer pane:** the API-keys list/create form and the connect-setup snippets (which embed a live API key and fetch automatically on page load) are now host-gated while the LAN is open and unauthenticated — closes a real self-escalation path.
- **Server URL now shows the LAN-reachable address** when sharing is on, instead of `window.location.origin` (which still reads `127.0.0.1` even when other devices reach the daemon over the LAN).
- Several Code fixes: auto-compaction abort-on-near-overflow (plus a related pre-existing bug), a second `/revert` now supersedes instead of hard-blocking, `delegate_code_task`'s tool description now carries delegation guidance for calling agents.

## Release prep still to come on this branch
Version bump, CHANGELOG, README/persona sync per `docs/RELEASE.md` Step 4 — not yet done as of this PR's opening.

## Test plan
- [x] Backend suite green (1230/1233, 3 pre-existing skips)
- [x] Frontend suite green (186/186)
- [x] Clean typecheck both sides
- [x] Live-verified on a real running daemon: MCP stdio handshake, Developer-pane security fixes, steer() live-interject
- [ ] Opus code-reviewer pass (next step)