### PR TITLE
docker support for NVIDIA & AMD GPUs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+**/node_modules
+**/dist
+**/src/webdist
+assets
+deploy
+*.md
+*.bat
+*.cmd
+lib

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -49,10 +49,18 @@ COPY --from=build /src/node_modules ./node_modules
 # Create models folder
 RUN mkdir -p /root/.turbollm/models
 # Define the model path
+# lanBind must be true here: the container always binds 0.0.0.0 (see CMD below), and
+# --addr alone does not set this flag (src/cli.ts) — without it, src/auth.ts's
+# bypassesAuth() treats the daemon as loopback-only and skips the API key check even
+# though the port is published to the host/LAN.
 RUN echo '{ \
       "modelDirs": [ \
         "/root/.turbollm/models" \
-      ] \
+      ], \
+      "daemon": { \
+        "lanBind": true, \
+        "requireApiKey": true \
+      } \
     }' > /root/.turbollm/config.json
 
 # Force the GPU backend during the image build.

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -1,0 +1,65 @@
+# =========================
+# Stage 1: Build TurboLLM
+# =========================
+FROM node:22-bookworm AS build
+
+WORKDIR /src
+
+# Copy just the package.json/lock files first so this layer caches across source edits.
+COPY turbollm/package*.json ./
+COPY turbollm/web/package*.json ./web/
+
+RUN npm ci 
+RUN cd web && npm ci
+
+# Now bring in the rest of the source and build.
+COPY turbollm/ ./
+
+# 1) React UI -> turbollm/src/webdist (web/vite.config.ts outDir)
+RUN npm run build:web
+# 2) Daemon -> turbollm/dist/cli.js (tsup bundle), then copies src/webdist -> dist/webdist
+RUN npm run build
+
+# Prune devDependencies (typescript/tsup/tsx/@types) — tsup externalizes
+# @earendil-works/pi-ai and @earendil-works/pi-coding-agent (dynamic requires it can't
+# bundle), so the *production* node_modules must still ship alongside dist/cli.js.
+RUN npm prune --omit=dev
+
+# =========================
+# Stage 2: runtime
+# =========================
+
+# TurboLLM on ROCm (AMD GPUs)
+FROM rocm/dev-ubuntu-22.04:6.4
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        libgomp1 && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /src/dist ./dist
+COPY --from=build /src/bin ./bin
+COPY --from=build /src/package.json ./package.json
+COPY --from=build /src/node_modules ./node_modules
+
+# Force the GPU backend during the image build.
+# Docker builds cannot detect the host GPU.
+ENV TURBOLLM_SEED_BACKEND=rocm
+RUN (node bin/turbollm.mjs --no-open --port 6996 &) \
+    && for i in $(seq 1 60); do \
+      node -e "process.exit((()=>{try{return JSON.parse(require('fs').readFileSync(process.env.HOME+'/.turbollm/config.json','utf8')).engines.length>0}catch{return false}})()?0:1)" && break; \
+      sleep 3; \
+    done \
+    && node bin/turbollm.mjs --stop || true
+
+
+EXPOSE 6996/tcp
+
+ENTRYPOINT ["node", "bin/turbollm.mjs"]
+# --addr 0.0.0.0:... required in a container (default bind is loopback-only).
+# --no-open because there's no browser inside the container.
+CMD ["--addr", "0.0.0.0:6996", "--no-open"]

--- a/Dockerfile.amd
+++ b/Dockerfile.amd
@@ -46,6 +46,15 @@ COPY --from=build /src/bin ./bin
 COPY --from=build /src/package.json ./package.json
 COPY --from=build /src/node_modules ./node_modules
 
+# Create models folder
+RUN mkdir -p /root/.turbollm/models
+# Define the model path
+RUN echo '{ \
+      "modelDirs": [ \
+        "/root/.turbollm/models" \
+      ] \
+    }' > /root/.turbollm/config.json
+
 # Force the GPU backend during the image build.
 # Docker builds cannot detect the host GPU.
 ENV TURBOLLM_SEED_BACKEND=rocm

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -45,10 +45,18 @@ COPY --from=build /src/node_modules ./node_modules
 # Create models folder
 RUN mkdir -p /root/.turbollm/models
 # Define the model path
+# lanBind must be true here: the container always binds 0.0.0.0 (see CMD below), and
+# --addr alone does not set this flag (src/cli.ts) — without it, src/auth.ts's
+# bypassesAuth() treats the daemon as loopback-only and skips the API key check even
+# though the port is published to the host/LAN.
 RUN echo '{ \
       "modelDirs": [ \
         "/root/.turbollm/models" \
-      ] \
+      ], \
+      "daemon": { \
+        "lanBind": true, \
+        "requireApiKey": true \
+      } \
     }' > /root/.turbollm/config.json
 
 # Force the GPU backend during the image build.

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -1,0 +1,61 @@
+# =========================
+# Stage 1: Build TurboLLM
+# =========================
+FROM node:22-bookworm AS build
+
+WORKDIR /src
+
+# Copy just the package.json/lock files first so this layer caches across source edits.
+COPY turbollm/package*.json ./
+COPY turbollm/web/package*.json ./web/
+
+RUN npm ci 
+RUN cd web && npm ci
+
+# Now bring in the rest of the source and build.
+COPY turbollm/ ./
+
+# 1) React UI -> turbollm/src/webdist (web/vite.config.ts outDir)
+RUN npm run build:web
+# 2) Daemon -> turbollm/dist/cli.js (tsup bundle), then copies src/webdist -> dist/webdist
+RUN npm run build
+
+# Prune devDependencies (typescript/tsup/tsx/@types) — tsup externalizes
+# @earendil-works/pi-ai and @earendil-works/pi-coding-agent (dynamic requires it can't
+# bundle), so the *production* node_modules must still ship alongside dist/cli.js.
+RUN npm prune --omit=dev
+
+# =========================
+# Stage 2: runtime
+# =========================
+
+FROM nvidia/cuda:12.6.3-runtime-ubuntu22.04
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl ca-certificates libvulkan1 libgomp1 \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY --from=build /src/dist ./dist
+COPY --from=build /src/bin ./bin
+COPY --from=build /src/package.json ./package.json
+COPY --from=build /src/node_modules ./node_modules
+
+# Force the GPU backend during the image build.
+# Docker builds cannot detect the host GPU.
+ENV TURBOLLM_SEED_BACKEND=vulkan
+RUN (node bin/turbollm.mjs --no-open --port 6996 &) \
+    && for i in $(seq 1 60); do \
+      node -e "process.exit((()=>{try{return JSON.parse(require('fs').readFileSync(process.env.HOME+'/.turbollm/config.json','utf8')).engines.length>0}catch{return false}})()?0:1)" && break; \
+      sleep 3; \
+    done \
+    && node bin/turbollm.mjs --stop || true
+
+
+EXPOSE 6996/tcp
+
+ENTRYPOINT ["node", "bin/turbollm.mjs"]
+# --addr 0.0.0.0:... required in a container (default bind is loopback-only).
+# --no-open because there's no browser inside the container.
+CMD ["--addr", "0.0.0.0:6996", "--no-open"]

--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -42,6 +42,15 @@ COPY --from=build /src/bin ./bin
 COPY --from=build /src/package.json ./package.json
 COPY --from=build /src/node_modules ./node_modules
 
+# Create models folder
+RUN mkdir -p /root/.turbollm/models
+# Define the model path
+RUN echo '{ \
+      "modelDirs": [ \
+        "/root/.turbollm/models" \
+      ] \
+    }' > /root/.turbollm/config.json
+
 # Force the GPU backend during the image build.
 # Docker builds cannot detect the host GPU.
 ENV TURBOLLM_SEED_BACKEND=vulkan

--- a/README.md
+++ b/README.md
@@ -286,7 +286,6 @@ the detail:
 
 <details>
 <summary><strong>🧑‍💻 Code — a local coding agent, in a real project directory</strong></summary>
-<em>(experimental, off by default — Settings → Experimental)</em>
 
 <br/>
 
@@ -307,7 +306,11 @@ there. Entirely local; nothing leaves your machine.
   `run_code` tool — are available to Code too, alongside honest skill invocation and
   `AGENTS.md`/`agents.md` support.
 - **Independent access control** — gated behind its own API key on non-host devices, separate
-  from Chat's gate, and hidden entirely until you opt in from Settings → Experimental.
+  from Chat's gate.
+- **Expose it to other tools over MCP** — `turbollm mcp-server` runs a stdio MCP server so any
+  MCP-compatible tool (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and more) can
+  delegate a real coding task to Code, not just chat completions. Setup snippets for any host
+  are in the Developer tab.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ the detail:
 
 <details>
 <summary><strong>🧑‍💻 Code — a local coding agent, in a real project directory</strong></summary>
+<em>(experimental, off by default — Settings → Experimental)</em>
 
 <br/>
 
@@ -306,11 +307,7 @@ there. Entirely local; nothing leaves your machine.
   `run_code` tool — are available to Code too, alongside honest skill invocation and
   `AGENTS.md`/`agents.md` support.
 - **Independent access control** — gated behind its own API key on non-host devices, separate
-  from Chat's gate.
-- **Expose it to other tools over MCP** — `turbollm mcp-server` runs a stdio MCP server so any
-  MCP-compatible tool (Claude Desktop, Cursor, Windsurf, Cline, Claude Code, and more) can
-  delegate a real coding task to Code, not just chat completions. Setup snippets for any host are
-  in the Developer tab.
+  from Chat's gate, and hidden entirely until you opt in from Settings → Experimental.
 
 </details>
 
@@ -640,6 +637,70 @@ shadcn/ui frontend. One TypeScript codebase, shipped as an npm package.
 
 ---
 
+## 🐳 Docker Deployment (NVIDIA / AMD GPU)
+
+TurboLLM includes Docker support with dedicated configurations for NVIDIA CUDA
+and AMD ROCm GPUs.
+
+The Docker images provide an isolated environment while allowing TurboLLM to
+access your GPU directly for accelerated local LLM inference.
+
+---
+
+### NVIDIA GPU (CUDA)
+
+#### Requirements
+
+- NVIDIA GPU with CUDA support
+- Installed NVIDIA drivers
+- NVIDIA Container Toolkit
+
+Install NVIDIA Container Toolkit:
+
+```bash
+# Ubuntu / Debian example
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#' | \
+sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+
+sudo systemctl restart docker
+
+docker compose -f docker-compose-nvidia.yaml up -d
+```
+
+### AMD GPU
+
+#### Requirements
+
+- AMD ROCm
+- Installed AMD drivers
+
+```bash
+# Ubuntu / Debian example
+sudo apt update
+sudo apt install wget gnupg
+
+wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+sudo gpg --dearmor -o /usr/share/keyrings/rocm.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/latest ubuntu main" | \
+sudo tee /etc/apt/sources.list.d/rocm.list
+
+sudo apt update
+
+sudo apt install rocm
+sudo usermod -aG render,video $USER
+sudo reboot
+
+docker compose -f docker-compose-amd.yaml up -d
+```
+---
 ## Community
 
 Questions, ideas, and show-and-tell — join the [Discord](https://discord.gg/v6kRbV7nC).

--- a/docker-compose-amd.yaml
+++ b/docker-compose-amd.yaml
@@ -1,0 +1,38 @@
+services:
+  turbollm:
+    build:
+      context: .
+      dockerfile: Dockerfile.amd
+    image: turbollm-amd:latest
+    container_name: turbollm-amd
+    ports:
+      - "6996:6996"
+    volumes:
+      - turbollm-data:/root/.turbollm
+
+    # --- AMD GPU passthrough (ROCm) ---
+    # /dev/kfd is the ROCm kernel driver device; /dev/dri is the DRM/GPU device nodes.
+    # This is the same pair AMD's own docs use for `docker run --device=/dev/kfd
+    # --device=/dev/dri --group-add video`.
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+      - render
+    # If the container can't see the GPU (permission denied on /dev/kfd or /dev/dri),
+    # the usual cause is that the host's `render` group GID doesn't match any group
+    # name inside the container. Find the host GID with `getent group render` and
+    # replace the "render" line above with that numeric GID instead.
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:6996/api/v1/status >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  turbollm-data:
+    name: turbollm-data
+    

--- a/docker-compose-amd.yaml
+++ b/docker-compose-amd.yaml
@@ -8,6 +8,12 @@ services:
     ports:
       - "6996:6996"
     volumes:
+      # Persists config.json, the chat SQLite DB, downloaded engines/models, and logs
+      # across container restarts/rebuilds (this is ~/.turbollm inside the container).
+      # NOTE: the image seeds daemon.lanBind=true in this config.json, so the daemon's
+      # default requireApiKey behavior actually enforces on this exposed port. Don't
+      # flip lanBind back to false while this port is published — that reopens the
+      # port to unauthenticated access.
       - turbollm-data:/root/.turbollm
 
     # --- AMD GPU passthrough (ROCm) ---
@@ -35,4 +41,3 @@ services:
 volumes:
   turbollm-data:
     name: turbollm-data
-    

--- a/docker-compose-nvidia.yaml
+++ b/docker-compose-nvidia.yaml
@@ -14,6 +14,10 @@ services:
     volumes:
       # Persists config.json, the chat SQLite DB, downloaded engines/models, and logs
       # across container restarts/rebuilds (this is ~/.turbollm inside the container).
+      # NOTE: the image seeds daemon.lanBind=true in this config.json, so the daemon's
+      # default requireApiKey behavior actually enforces on this exposed port. Don't
+      # flip lanBind back to false while this port is published — that reopens the
+      # port to unauthenticated access.
       - turbollm-data:/root/.turbollm
 
     # --- NVIDIA GPU passthrough (requires the NVIDIA Container Toolkit on the host) ---

--- a/docker-compose-nvidia.yaml
+++ b/docker-compose-nvidia.yaml
@@ -1,0 +1,42 @@
+services:
+  turbollm:
+    # Build context must be the root of a clone of https://github.com/mohitsoni48/TurboLLM
+    # (this Dockerfile expects to find the `turbollm/` subfolder in it). Put this
+    # docker-compose.yml (and the Dockerfile) at the repo root, or change `context:` below
+    # to point at wherever you cloned it.
+    build:
+      context: .
+      dockerfile: Dockerfile.nvidia
+    image: turbollm-nvidia:latest
+    container_name: turbollm-nvidia
+    ports:
+      - "6996:6996"
+    volumes:
+      # Persists config.json, the chat SQLite DB, downloaded engines/models, and logs
+      # across container restarts/rebuilds (this is ~/.turbollm inside the container).
+      - turbollm-data:/root/.turbollm
+
+    # --- NVIDIA GPU passthrough (requires the NVIDIA Container Toolkit on the host) ---
+    # Delete this whole "environment" + "deploy" block if you're running CPU-only —
+    # TurboLLM falls back to a CPU build automatically.
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:6996/api/v1/status >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  turbollm-data:
+    name: turbollm-data


### PR DESCRIPTION
Everything should be solved now. tested on NVIDIA GPU.
Also add predefined models folder 

### Create models folder
RUN mkdir -p /root/.turbollm/models
### Define the models path
RUN echo '{ \
      "modelDirs": [ \
        "/root/.turbollm/models" \
      ] \
    }' > /root/.turbollm/config.json

## 🐳 Docker Deployment (NVIDIA / AMD GPU)

TurboLLM includes Docker support with dedicated configurations for NVIDIA CUDA
and AMD ROCm GPUs.

The Docker images provide an isolated environment while allowing TurboLLM to
access your GPU directly for accelerated local LLM inference.

---

### NVIDIA GPU (CUDA)

#### Requirements

- NVIDIA GPU with CUDA support
- Installed NVIDIA drivers
- NVIDIA Container Toolkit

Install NVIDIA Container Toolkit:

```bash
# Ubuntu / Debian example
curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg

curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#' | \
sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list

sudo apt update
sudo apt install -y nvidia-container-toolkit

sudo systemctl restart docker

docker compose -f docker-compose-nvidia.yaml up -d
```

### AMD GPU

#### Requirements

- AMD ROCm
- Installed AMD drivers

```bash
# Ubuntu / Debian example
sudo apt update
sudo apt install wget gnupg

wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
sudo gpg --dearmor -o /usr/share/keyrings/rocm.gpg

echo "deb [arch=amd64 signed-by=/usr/share/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/latest ubuntu main" | \
sudo tee /etc/apt/sources.list.d/rocm.list

sudo apt update

sudo apt install rocm
sudo usermod -aG render,video $USER
sudo reboot

docker compose -f docker-compose-amd.yaml up -d
```
---