### PR TITLE
fix(ci): regenerate package-lock.json with npm 10 so CI can install it

### DIFF
--- a/turbollm/package-lock.json
+++ b/turbollm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turbollm",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turbollm",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "FSL-1.1-ALv2",
       "dependencies": {
         "@earendil-works/pi-ai": "0.80.6",
@@ -16,7 +16,6 @@
         "@xterm/xterm": "^6.0.0",
         "diff": "^9.0.0",
         "hono": "^4.6.0",
-        "node-pty": "^1.1.0",
         "puppeteer-core": "^23.11.1",
         "typebox": "1.1.38",
         "undici": "^7.0.0",
@@ -35,6 +34,9 @@
       },
       "engines": {
         "node": ">=22.13.0"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -544,6 +546,17 @@
         }
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
       "version": "0.80.6",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
@@ -1047,7 +1060,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1305,7 +1318,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2350,7 +2362,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2906,7 +2917,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2925,7 +2935,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3952,8 +3961,7 @@
       "version": "0.0.1367902",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "9.0.0",
@@ -3995,7 +4003,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4329,7 +4336,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4556,7 +4562,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -4611,6 +4618,7 @@
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
@@ -4711,7 +4719,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5280,7 +5287,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -5796,7 +5802,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
CI has been red since `c38b87f` — every run on the v1.9.1 branch, and now `main`. The failing step is `npm ci`, not typecheck or tests:

```
npm error code EUSAGE
npm error Missing: zod@4.4.3 from lock file
```

**Root cause (reproduced, not inferred).** The lock was regenerated on a dev box running Node 25 / npm 11.6.2. CI pins `node-version: '22'` → npm 10. npm 11 accepts that lock; npm 10 computes a different required tree and finds the nested `@earendil-works/pi-ai/node_modules/zod@4.4.3` entry missing.

- `npx npm@10 ci --dry-run` → reproduces the CI error exactly on the dev box
- `npm ci --dry-run` (npm 11) → passes, which is why it was never caught locally

**Fix.** Regenerated with the npm CI actually uses: `npx npm@10 install --package-lock-only`. Verified against **both** npm 10 and npm 11. `node_modules` untouched.

Node 22 is the declared minimum (`engines: >=22.13`), so the lock must be installable by the npm that ships with it — fixing the lock is correct here rather than raising CI's Node to match the dev box.

The regenerated lock also picks up two things it had drifted on: the package version (still read `1.9.0`) and `node-pty`'s move into `optionalDependencies`, now marked `optional: true`.