### PR TITLE
fix(code): a session whose folder is gone now says so, instead of "error code: 267"

### DIFF
--- a/turbollm/src/code/worktree-wiring.test.ts
+++ b/turbollm/src/code/worktree-wiring.test.ts
@@ -87,8 +87,21 @@ test('the PTY cwd uses agentCwd too — both agents must see the same tree', () 
   const terminal = readFileSync(join(HERE, '..', 'terminal', 'terminal-routes.ts'), 'utf8')
   const create = terminal.split('\n').find((l) => l.includes('m.create('))
   assert.ok(create, 'terminal creation call must still exist')
+
+  // Accept the value either inline or via a local assigned from agentCwd — an earlier version of
+  // this test matched the literal `agentCwd(run)` on the m.create line and failed the moment the
+  // call was legitimately refactored to hoist the value into a `cwd` variable (needed so the route
+  // can check the directory still exists before spawning). Resolving one level of indirection
+  // keeps the guard honest about what it actually cares about — where the directory COMES FROM —
+  // without breaking on a rename.
+  const firstArg = /m\.create\(\s*([A-Za-z0-9_.()]+)/.exec(create)?.[1] ?? ''
+  const derivedFromAgentCwd =
+    firstArg === 'agentCwd(run)' ||
+    new RegExp(`const\\s+${firstArg}\\s*=\\s*agentCwd\\(run\\)`).test(terminal)
+
   assert.ok(
-    create.includes('agentCwd(run)'),
-    `the CLI must open in the same tree the in-app agent edits, got:\n  ${create.trim()}`,
+    derivedFromAgentCwd,
+    `the CLI must open in the same tree the in-app agent edits — first argument to m.create() is ` +
+      `${JSON.stringify(firstArg)}, which is not agentCwd(run) nor assigned from it:\n  ${create.trim()}`,
   )
 })

--- a/turbollm/src/code/worktree.test.ts
+++ b/turbollm/src/code/worktree.test.ts
@@ -308,3 +308,52 @@ test('sanitizeBranchName: a long name is capped without ending in a separator', 
   assert.ok(out.length <= 80)
   assert.ok(!/[-./]$/.test(out), `must not end in a separator, got ${JSON.stringify(out)}`)
 })
+
+// ── a directory that is already gone is SUCCESS, not failure ─────────────────────────────────
+// Founder-reported: deleting a session whose folder no longer existed returned
+// `worktreeNote: "spawn git ENOENT"` — git cannot even start when its cwd is missing. The delete
+// itself had succeeded, but the raw Node error on the response made it look like it had failed.
+// Nothing to remove is nothing to report.
+test('removeSessionWorktree: a worktree that no longer exists is a clean success', async () => {
+  const root = await makeRepo()
+  try {
+    const r = await createSessionWorktree({ repoRoot: root, branch: 'feature' })
+    assert.ok(r.ok)
+    if (!r.ok) return
+    // Someone removed it by hand, or deleted the folder.
+    rmSync(r.path, { recursive: true, force: true })
+
+    const removed = await removeSessionWorktree(root, r.path)
+    assert.equal(removed.ok, true, `expected success, got ${JSON.stringify(removed)}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('removeSessionWorktree: a base repo that no longer exists is also a clean success', async () => {
+  // The whole project moved or was deleted, or its drive is unplugged. There is nothing to clean
+  // and no way to run git — reporting `spawn git ENOENT` to the user helps nobody.
+  const root = await makeRepo()
+  const worktreePath = join(root, WORKTREES_SUBDIR, 'feature')
+  rmSync(root, { recursive: true, force: true })
+  const removed = await removeSessionWorktree(root, worktreePath)
+  assert.equal(removed.ok, true, `expected success, got ${JSON.stringify(removed)}`)
+})
+
+test('removeSessionWorktree: a DIRTY worktree is still refused — the guard did not weaken that', () => {
+  // Guarding on existence must not turn the "never destroy uncommitted work" rule into a no-op.
+  return (async () => {
+    const root = await makeRepo()
+    try {
+      const r = await createSessionWorktree({ repoRoot: root, branch: 'feature' })
+      assert.ok(r.ok)
+      if (!r.ok) return
+      writeFileSync(join(r.path, 'README.md'), 'unmerged work\n')
+      const removed = await removeSessionWorktree(root, r.path)
+      assert.equal(removed.ok, false)
+      if (!removed.ok) assert.equal(removed.code, 'dirty')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })()
+})

--- a/turbollm/src/code/worktree.ts
+++ b/turbollm/src/code/worktree.ts
@@ -19,6 +19,7 @@
 //     `.turbollm/` is untracked, so it is not part of any branch, so a checkout of that branch
 //     never materialises it. Verified empirically, not reasoned about.
 import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { appendFile, readFile, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
@@ -224,6 +225,13 @@ export type WorktreeRemoval =
  * Committed work is safe regardless: removing a worktree does not delete its branch (verified).
  */
 export async function removeSessionWorktree(repoRoot: string, worktreePath: string): Promise<WorktreeRemoval> {
+  // Nothing to remove is SUCCESS, not failure. Either directory can legitimately be gone by the
+  // time a session is deleted — the worktree removed with `git worktree remove` by hand, the whole
+  // project moved or deleted, an external drive unplugged. Reporting that as an error produced a
+  // raw `spawn git ENOENT` on the delete response (git cannot even start when its cwd is missing),
+  // which told the user nothing and made a perfectly successful delete look like it had failed.
+  if (!existsSync(worktreePath) || !existsSync(repoRoot)) return { ok: true }
+
   const r = await runGit(repoRoot, ['worktree', 'remove', worktreePath], 60_000)
   if (r.ok) return { ok: true }
 

--- a/turbollm/src/terminal/terminal-routes.ts
+++ b/turbollm/src/terminal/terminal-routes.ts
@@ -20,6 +20,7 @@
 
 import type { Context, Hono } from 'hono'
 import type { Deps } from '../deps'
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { isLocalUpgrade, verifyKeyValue } from '../auth'
 import { sessionAuth } from '../code/session-auth'
@@ -238,6 +239,27 @@ export function registerTerminalRoutes(app: Hono, d: Deps): void {
       return err(c, 400, 'invalid_input', 'This session uses the built-in chat UI, not a terminal agent.')
     }
 
+    // The directory has to still exist, or node-pty's CreateProcess fails with a raw
+    // "Cannot create process, error code: 267" (ERROR_DIRECTORY) that says nothing about WHICH
+    // folder is missing or why — founder-reported. Genuinely reachable: the project can be moved,
+    // renamed or deleted, an external drive unplugged, or (now that worktrees exist) the session's
+    // worktree removed by hand with `git worktree remove`. Checked here rather than inside
+    // PTYSession so the answer is an actionable HTTP error instead of a spawn failure.
+    const cwd = agentCwd(run)
+    if (!existsSync(cwd)) {
+      const isWorktree = !!run.worktreePath && cwd === run.worktreePath
+      return err(
+        c, 400, 'cwd_missing',
+        isWorktree
+          ? `This session's worktree is gone: ${cwd}. It was probably removed outside TurboLLM ` +
+            `(\`git worktree remove\`, or deleting the folder). The session's branch and any commits ` +
+            `on it are unaffected — delete this session and start a new one on the same repo.`
+          : `This session's folder no longer exists: ${cwd}. It may have been moved, renamed or ` +
+            `deleted, or it lives on a drive that isn't connected. Reconnect or restore it, or ` +
+            `delete this session.`,
+      )
+    }
+
     // The caller (TerminalView) fits xterm.js BEFORE calling this, so the PTY is spawned at
     // its real size from the very first byte the launch command writes — never a hardcoded
     // default later corrected by a follow-up resize. A resize that arrives after a TUI's very
@@ -309,7 +331,7 @@ export function registerTerminalRoutes(app: Hono, d: Deps): void {
       // The session's worktree when it has one, else the repo itself (ADR-316) — the CLI must
       // open in the same tree the in-app agent edits, or the two halves of one session would
       // be looking at different checkouts.
-      const terminalId = m.create(agentCwd(run), run.id, cols, rows, launchCommand)
+      const terminalId = m.create(cwd, run.id, cols, rows, launchCommand)
       if (!run.terminalLaunchedOnce) d.db.updateAgentRun(run.id, { terminalLaunchedOnce: true })
       return c.json({ terminalId }, 201)
     } catch (e) {


### PR DESCRIPTION
Founder-reported: opening a Code session failed with

```
Could not create terminal session: Cannot create process, error code: 267
```

`267` is Windows `ERROR_DIRECTORY` — what `CreateProcess` returns when its cwd doesn't exist. Nothing said which directory was missing or why, and the session then appeared undeletable.

## Two separate defects

**1. The terminal route handed node-pty a directory without checking it exists.** Genuinely reachable: the project can be moved, renamed or deleted, an external drive unplugged, or — now that worktrees exist — the session's worktree removed by hand with `git worktree remove`. Now returns an actionable 400 naming the folder, and states plainly that the branch and any commits on it are unaffected.

**2. `removeSessionWorktree` treated an already-absent directory as a failure.** git can't even start when its cwd is missing, so deleting such a session returned `worktreeNote: "spawn git ENOENT"` on an otherwise *successful* delete — a raw Node error that told the user nothing and made a delete that had worked look like it hadn't. Nothing to remove is success.

## Verified live against the daemon

```
before:  Cannot create process, error code: 267
after :  HTTP 400 cwd_missing — "This session's worktree is gone: <path>. It was probably
         removed outside TurboLLM (`git worktree remove`, or deleting the folder). The
         session's branch and any commits on it are unaffected…"

delete:  {"ok":true}          (was: {"ok":true,"worktreeNote":"spawn git ENOENT"})
```

## Note on the guard

The existence check deliberately does **not** weaken the "never destroy uncommitted work" rule — a dirty worktree that still exists is refused exactly as before, with a test pinning it.

`worktree-wiring.test.ts` failed on this change for the right reason and the wrong assertion: it matched the literal `agentCwd(run)` on the `m.create` line, which moved into a local when the route needed to check the directory first. It now resolves one level of indirection, and I re-verified it still fails when the PTY is pointed back at `run.repoRoot`.

1664 tests pass.

## How this arose

The sessions that triggered it were **mine** — leftovers from my own end-to-end worktree testing, pointing at throwaway repos I'd since deleted. I've removed those two rows from the founder's database; no session now points at a missing directory. But the underlying gap was real and worth fixing on its own.