### PR TITLE
fix(code): attribute the Claude CLI's own edits to Code launchpad stats

### DIFF
--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -523,7 +523,7 @@ test('streamToAnthropic keeps two tool calls in the same turn apart by their ind
 
 // Fires with an EMPTY array rather than not firing at all: the observer's question is "did a real
 // turn happen on this session", of which the tool calls are only one part — a text-only reply
-// still counts (see recordCodeSessionToolCalls' optimistic 'done' marking).
+// still counts (see observeCodeSessionTurn's optimistic 'done' marking).
 test('streamToAnthropic still fires onToolCalls, with an empty list, for a turn with no tool calls', async () => {
   const upstream = sseStream([
     'data: {"choices":[{"delta":{"content":"No tools needed."}}]}',
@@ -545,6 +545,35 @@ test('streamToAnthropic drops a tool call whose argument fragments never form va
   let calls: { id: string }[] | null = null
   for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_trunc', undefined, undefined, (c) => { calls = c })) { /* drain */ }
   assert.deepEqual((calls as unknown as { id: string }[]).map((t) => t.id), ['toolu_ok'])
+})
+
+// The `if (!failed)` guard, from the observer's side. A stream that ERRORS (engine crash, model
+// evicted, connection cut) delivered only part of the turn, so its client never received the rest
+// of that tool call and never ran it — observing it anyway would credit an edit that provably
+// never happened. Throwing from `pull` rather than `controller.error()` (which resets the queue)
+// makes the already-enqueued, fully-formed call arrive first, so this pins the guard and not
+// merely the absence of data.
+test('streamToAnthropic does NOT fire onToolCalls when the stream fails mid-turn', async () => {
+  const enc = new TextEncoder()
+  const line = 'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_dead","function":{"name":"Edit","arguments":"{\\"file_path\\":\\"/repo/a.ts\\"}"}}]}}]}\n'
+  let sent = false
+  const upstream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!sent) { sent = true; controller.enqueue(enc.encode(line)); return }
+      throw new Error('engine stopped mid-stream')
+    },
+  })
+
+  let fired = false
+  let usageFired = false
+  const events: { event: string; data: string }[] = []
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_dead', () => { usageFired = true }, undefined, () => { fired = true })) {
+    events.push(evt)
+  }
+
+  assert.equal(fired, false, 'a half-received turn must never be observed as a completed one')
+  assert.equal(usageFired, false, 'nor recorded as usage')
+  assert.equal(events.at(-1)?.event, 'error', 'the client is told the engine stopped, in place of message_stop')
 })
 
 // ── streamToAnthropic usage mapping ─────────────────────────────────────────

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -457,6 +457,96 @@ test('streamToAnthropic reports no rates at all when the engine sent none — ne
   assert.equal(u.genTps, undefined)
 })
 
+// ── streamToAnthropic tool-call observation (onToolCalls) ───────────────────
+//
+// The side channel gateway.ts uses to credit a terminal-agent Code session for the edits its CLI
+// makes: the CLI applies them inside its own subprocess and never reports back, so this stream is
+// the only place the daemon ever sees them. The engine splits one call across many deltas sharing
+// a `tool_calls[].index` — `id`/`function.name` only on the first, `function.arguments` in
+// fragments after it — so a call is only whole once the stream ends.
+
+test('streamToAnthropic reassembles a tool call whose arguments arrive across several deltas', async () => {
+  const upstream = sseStream([
+    'data: {"choices":[{"delta":{"content":"Editing that file."}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_01","function":{"name":"Edit","arguments":"{\\"file_path\\":"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"/repo/a.ts\\",\\"old_string\\":\\"let x = 1\\""}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\\"new_string\\":\\"const x = 2\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}',
+    'data: [DONE]',
+  ])
+
+  let calls: { id: string; name: string; input: unknown }[] | null = null
+  const events: { event: string; data: string }[] = []
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_tools', undefined, undefined, (c) => { calls = c })) {
+    events.push(evt)
+  }
+
+  assert.ok(calls, 'onToolCalls must fire')
+  const observed = calls as unknown as { id: string; name: string; input: Record<string, string> }[]
+  assert.equal(observed.length, 1)
+  assert.equal(observed[0].id, 'toolu_01')
+  assert.equal(observed[0].name, 'Edit', 'the name arrives only on the FIRST delta of the run and must survive the later ones')
+  assert.deepEqual(observed[0].input, { file_path: '/repo/a.ts', old_string: 'let x = 1', new_string: 'const x = 2' })
+
+  // Observation only — the client's own stream must be byte-for-byte what it was before: one
+  // tool_use block started with the name, then the raw argument fragments as input_json_delta.
+  const starts = events.filter((e) => e.event === 'content_block_start').map((e) => JSON.parse(e.data) as { content_block: { type: string; name?: string; id?: string } })
+  assert.deepEqual(starts.map((s) => s.content_block.type), ['text', 'tool_use'])
+  assert.equal(starts[1].content_block.name, 'Edit')
+  const partials = events
+    .filter((e) => e.event === 'content_block_delta')
+    .map((e) => JSON.parse(e.data) as { delta: { type: string; partial_json?: string } })
+    .filter((d) => d.delta.type === 'input_json_delta')
+    .map((d) => d.delta.partial_json)
+  assert.equal(partials.length, 3, 'each argument fragment is still forwarded unbuffered as it arrives')
+  assert.equal(partials.join(''), '{"file_path":"/repo/a.ts","old_string":"let x = 1","new_string":"const x = 2"}')
+})
+
+test('streamToAnthropic keeps two tool calls in the same turn apart by their index', async () => {
+  const upstream = sseStream([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_a","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"new.ts\\",\\"content\\":\\"hi\\"}"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"toolu_b","function":{"name":"Bash","arguments":"{\\"command\\":"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\\"ls\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+
+  let calls: { id: string; name: string; input: unknown }[] | null = null
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tools2', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+
+  const observed = calls as unknown as { id: string; name: string; input: Record<string, string> }[]
+  assert.deepEqual(observed.map((t) => [t.id, t.name]), [['toolu_a', 'Write'], ['toolu_b', 'Bash']])
+  assert.deepEqual(observed[0].input, { file_path: '/repo/new.ts', content: 'hi' })
+  assert.deepEqual(observed[1].input, { command: 'ls' })
+})
+
+// Fires with an EMPTY array rather than not firing at all: the observer's question is "did a real
+// turn happen on this session", of which the tool calls are only one part — a text-only reply
+// still counts (see recordCodeSessionToolCalls' optimistic 'done' marking).
+test('streamToAnthropic still fires onToolCalls, with an empty list, for a turn with no tool calls', async () => {
+  const upstream = sseStream([
+    'data: {"choices":[{"delta":{"content":"No tools needed."}}]}',
+    'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":3}}',
+    'data: [DONE]',
+  ])
+  let calls: unknown[] | null = null
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_notools', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+  assert.deepEqual(calls, [])
+})
+
+test('streamToAnthropic drops a tool call whose argument fragments never form valid JSON, keeping the rest', async () => {
+  const upstream = sseStream([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_trunc","function":{"name":"Edit","arguments":"{\\"file_path\\":\\"/repo/a"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"toolu_ok","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/b.ts\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  let calls: { id: string }[] | null = null
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_trunc', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+  assert.deepEqual((calls as unknown as { id: string }[]).map((t) => t.id), ['toolu_ok'])
+})
+
 // ── streamToAnthropic usage mapping ─────────────────────────────────────────
 
 async function cacheReadFromTimings(timingsJson: string): Promise<number> {

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -373,17 +373,33 @@ export type StreamUsage = { inputTokens: number; outputTokens: number; promptTps
  *  gateway stream. Mirrors the manager's LiveGen shape without importing it. */
 export type LiveProgress = { phase: 'prompt' | 'gen'; pct: number; outputTokens: number }
 
+/** One fully-reassembled tool call observed while translating a stream. The engine emits a call
+ *  as a RUN of deltas sharing one `tool_calls[].index` — the first carries `id`/`function.name`,
+ *  every later one only a fragment of `function.arguments` — so neither the name nor the parsed
+ *  input exists at any single point in the loop below; both have to be accumulated across the
+ *  whole run and finalised at the end. The `input_json_delta` chunks the client receives are the
+ *  raw fragments, deliberately forwarded unbuffered so the CLI can render a call as it arrives;
+ *  this type is the side-channel copy for observers that need the WHOLE call (gateway.ts's Code
+ *  session attribution — a terminal-launched CLI applies its edits in its own subprocess and
+ *  never reports back, so the request stream is the only place the daemon ever sees them). */
+export type StreamToolCall = { id: string; name: string; input: unknown }
+
 export async function* streamToAnthropic(
   oaiStream: ReadableStream<Uint8Array>,
   modelName: string,
   msgId: string,
   onUsage?: (u: StreamUsage) => void,
   onLive?: (p: LiveProgress) => void,
+  onToolCalls?: (calls: StreamToolCall[]) => void,
 ): AsyncGenerator<SseEvent> {
   let blockIdx = 0
   let inThinking = false
   let inText = false
   let activeToolIdx = -1
+  // Keyed by the engine's own `tool_calls[].index`, which is what groups a call's deltas
+  // together — NOT by blockIdx (that also advances for thinking/text blocks) and not by id
+  // (absent on every delta after the first).
+  const toolAcc = new Map<number, { id: string; name: string; args: string }>()
   let stopReason = 'end_turn'
   let outputTokens = 0
   let inputTokens = 0
@@ -498,6 +514,19 @@ export async function* streamToAnthropic(
             blockIdx++
           }
           for (const tc of delta.tool_calls) {
+            // Side-channel accumulation, kept strictly ahead of (and independent of) the block
+            // bookkeeping below so it can never perturb a single byte of the client's SSE output.
+            // `id`/`name` are only filled in when still empty: they arrive on the FIRST delta of
+            // a run and would be clobbered back to '' by the `?? ''` fallbacks on later ones.
+            let acc = toolAcc.get(tc.index)
+            if (!acc) {
+              acc = { id: '', name: '', args: '' }
+              toolAcc.set(tc.index, acc)
+            }
+            if (!acc.id && tc.id) acc.id = tc.id
+            if (!acc.name && tc.function?.name) acc.name = tc.function.name
+            if (tc.function?.arguments) acc.args += tc.function.arguments
+
             if (tc.index !== activeToolIdx) {
               if (activeToolIdx >= 0) {
                 yield cbStop(blockIdx)
@@ -564,6 +593,22 @@ export async function* streamToAnthropic(
           genTps: genTps > 0 ? genTps : undefined,
         })
       } catch { /* swallow */ }
+    }
+    // Best-effort observation of the turn's tool calls, finalised only here: an argument buffer
+    // is only valid JSON once its LAST fragment has arrived, so nothing can be parsed mid-loop.
+    // Fires on every completed stream, including one with no tool calls at all (an empty array)
+    // — the observer's job is "a real turn happened", of which the calls are only one part; a
+    // text-only reply must still reach it. A call whose buffer doesn't parse is dropped rather
+    // than thrown on: the client has already received that call verbatim as input_json_delta
+    // chunks and its own turn is unaffected by what an observer could or couldn't make of it.
+    if (onToolCalls) {
+      const calls: StreamToolCall[] = []
+      for (const acc of toolAcc.values()) {
+        try {
+          calls.push({ id: acc.id, name: acc.name, input: JSON.parse(acc.args) })
+        } catch { /* unparseable fragment run — skip this one call, keep the rest */ }
+      }
+      try { onToolCalls(calls) } catch { /* swallow */ }
     }
   }
 }

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -8,7 +8,15 @@ type ABlock =
   | { type: 'text'; text: string }
   | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }
   | { type: 'tool_use'; id: string; name: string; input: unknown }
-  | { type: 'tool_result'; tool_use_id: string; content: string | Array<{ type: string; text?: string }> }
+  // `is_error` is the client's own verdict on whether the call it was asked to make actually
+  // succeeded — set when the tool threw, when its preconditions failed (an `Edit` whose
+  // `old_string` wasn't found or wasn't unique, the single most common local-model tool
+  // failure), or when the user declined it at a permission prompt. Optional and absent on
+  // success, per the Anthropic API. It is not used in translation (OpenAI's `role:'tool'`
+  // message has no equivalent field) — it exists here because it is the ONLY signal the daemon
+  // ever gets about whether a terminal-agent CLI's edit really landed, which gateway.ts's
+  // coding-activity attribution correlates against before crediting anything.
+  | { type: 'tool_result'; tool_use_id: string; is_error?: boolean; content: string | Array<{ type: string; text?: string }> }
 // 'system' is undocumented but real: Claude Code injects hook context (e.g. SessionStart)
 // as a `role:'system'` entry directly into `messages`, not just via the top-level `system`
 // field — mapToOpenAI folds every one of these into a single leading system message (see there).

--- a/turbollm/src/gateway/gateway.code-activity.test.ts
+++ b/turbollm/src/gateway/gateway.code-activity.test.ts
@@ -1,0 +1,262 @@
+// Coding-activity attribution for terminal-agent Code sessions. A session run through the
+// embedded Claude CLI applies its edits inside its own subprocess and never reports back, so
+// nothing ever wrote to the two tables the "Coding activity" dashboard reads (codeStats(): a
+// code conversation's `messages.tool_calls`, and `agent_runs.status`). Result: real work moved
+// none of the Tasks shipped / Files touched / Diff shipped tiles.
+//
+// The gateway is the one component that can see those edits — it is the HTTP intermediary the CLI
+// asks for every token, and it already resolves which session a request belongs to from the
+// session-scoped bearer token (session-auth.ts). These tests pin what it records, on both the
+// streaming and non-streaming /v1/messages branches, and — critically — that a request with no
+// resolved Code session (independent CLI usage, plain chat, the shared static token) still
+// touches none of it.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerGateway } from './gateway'
+import { sessionAuth } from '../code/session-auth'
+import type { Deps } from '../deps'
+import type { ToolCallRecord } from '../chat/db'
+
+const LIBRARY = [{ key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' }]
+
+type DbSpy = {
+  getAgentRunIds: string[]
+  messages: { convId: string; toolCalls: ToolCallRecord[] }[]
+  runUpdates: { id: string; patch: { status?: string; endedAt?: string } }[]
+}
+
+/** Deps stub whose `db` records exactly the three calls this feature makes. `run` null models a
+ *  token that resolves to a session whose run row is gone. */
+function fakeDeps(run: { id: string; convId: string } | null = { id: 'sess-1', convId: 'conv-1' }): { deps: Deps; spy: DbSpy } {
+  const spy: DbSpy = { getAgentRunIds: [], messages: [], runUpdates: [] }
+  const deps = {
+    scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
+    modelRouter: { route: async () => ({ target: 'http://engine.invalid.local:1' }) },
+    store: { snapshot: () => ({ modelDefaults: { maxTokens: 0 }, gateway: { autoSwap: false } }) },
+    manager: {
+      status: () => ({ state: 'running', model: { name: 'Qwen3 8B', key: 'qwen3-8b|Q4|123' } }),
+      target: () => 'http://engine.invalid.local:1',
+      generationStart: () => {},
+      generationEnd: () => {},
+      recordCompletion: () => {},
+      setLiveGen: () => {},
+    },
+    registry: { active: () => ({ kind: 'llama.cpp' }) },
+    db: {
+      recordApiUsage: () => {},
+      getAgentRun: (id: string) => { spy.getAgentRunIds.push(id); return run },
+      addMessage: (convId: string, _role: string, _content: string, extra?: { toolCalls?: ToolCallRecord[] }) => {
+        spy.messages.push({ convId, toolCalls: extra?.toolCalls ?? [] })
+      },
+      updateAgentRun: (id: string, patch: { status?: string; endedAt?: string }) => { spy.runUpdates.push({ id, patch }) },
+    },
+  } as unknown as Deps
+  return { deps, spy }
+}
+
+/** Point the engine fetch at a canned OpenAI-shaped SSE stream, in the same one-chunk-per-line
+ *  shape llama.cpp emits (a tool call's arguments split across deltas). */
+function stubStreamingEngine(lines: string[]): () => void {
+  const original = globalThis.fetch
+  const enc = new TextEncoder()
+  globalThis.fetch = (async () => new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const l of lines) controller.enqueue(enc.encode(l + '\n'))
+        controller.close()
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'text/event-stream' } },
+  )) as typeof fetch
+  return () => { globalThis.fetch = original }
+}
+
+/** Point the engine fetch at a canned non-streaming OpenAI completion. */
+function stubJsonEngine(body: Record<string, unknown>): () => void {
+  const original = globalThis.fetch
+  globalThis.fetch = (async () => new Response(JSON.stringify(body), {
+    status: 200, headers: { 'content-type': 'application/json' },
+  })) as typeof fetch
+  return () => { globalThis.fetch = original }
+}
+
+async function postMessages(app: Hono, token: string, body: Record<string, unknown>): Promise<void> {
+  const res = await app.request('/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ model: 'qwen3-8b|Q4|123', max_tokens: 4096, messages: [], ...body }),
+  })
+  await res.text() // drain: the SSE branch's recording happens as the stream is consumed
+}
+
+const EDIT_STREAM = [
+  'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_01","function":{"name":"Edit","arguments":"{\\"file_path\\":\\"/repo/src/a.ts\\","}}]}}]}',
+  'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"old_string\\":\\"let x = 1\\\\n\\",\\"new_string\\":\\"const x = 2\\\\nconst y = 3\\\\n\\"}"}}]}}]}',
+  'data: {"choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":100,"completion_tokens":20}}',
+  'data: [DONE]',
+]
+
+test('an Edit tool call from a session-scoped CLI is recorded as an edit record with a real unified diff', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubStreamingEngine(EDIT_STREAM)
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  assert.deepEqual(spy.getAgentRunIds, ['sess-1'], 'the run is looked up by the session the token resolves to')
+  assert.equal(spy.messages.length, 1)
+  assert.equal(spy.messages[0].convId, 'conv-1', 'the record lands on the run\'s own conversation — what codeStats() joins on')
+  const [record] = spy.messages[0].toolCalls
+  assert.equal(record.id, 'toolu_01')
+  assert.equal(record.name, 'edit', 'lower-cased to the name codeStats() matches, not Claude Code\'s PascalCase')
+  assert.equal(record.args.path, '/repo/src/a.ts', 'codeStats() reads args.path for filesTouched')
+  // A real unified diff, so countDiffLines() sees one removed and two added lines.
+  assert.ok(record.diff, 'an edit must carry a diff — it is the only thing feeding "Diff shipped"')
+  const changed = record.diff!.split('\n').filter((l) => (l.startsWith('+') || l.startsWith('-')) && !l.startsWith('+++') && !l.startsWith('---'))
+  assert.deepEqual(changed, ['-let x = 1', '+const x = 2', '+const y = 3'])
+})
+
+test('a Write tool call is recorded with no diff — it counts toward files touched only', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_w","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/new.ts\\",\\"content\\":\\"hello\\\\n\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  const [record] = spy.messages[0].toolCalls
+  assert.equal(record.name, 'write')
+  assert.equal(record.args.path, '/repo/new.ts')
+  assert.equal(record.diff, undefined, 'codeStats() only counts diff lines for edits, never writes')
+})
+
+test('a MultiEdit is credited for files touched but carries no fabricated diff', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_m","function":{"name":"MultiEdit","arguments":"{\\"file_path\\":\\"/repo/multi.ts\\",\\"edits\\":[{\\"old_string\\":\\"a\\",\\"new_string\\":\\"b\\"}]}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  const [record] = spy.messages[0].toolCalls
+  assert.equal(record.name, 'edit', 'recorded as an edit so the file still counts toward filesTouched')
+  assert.equal(record.args.path, '/repo/multi.ts')
+  assert.equal(record.diff, undefined, 'fragment pairs cannot be reconstructed into an honest diff — omit rather than invent')
+})
+
+// The optimistic marking (see recordCodeSessionToolCalls): leaving the terminal tab does not quit
+// the CLI (ADR-298), so waiting for a completion signal leaves nearly every real session stuck at
+// 'queued' — and reconcileOnStartup then relabels it 'interrupted' on the next daemon restart.
+test('any observed turn marks the run done, even one that touched no files at all', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_b","function":{"name":"Bash","arguments":"{\\"command\\":\\"npm test\\"}"}}]}}]}',
+    'data: {"choices":[{"delta":{"content":"Tests pass."}}]}',
+    'data: {"choices":[{"finish_reason":"stop"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  assert.equal(spy.messages.length, 0, 'Bash touches no file — nothing to record into messages.tool_calls')
+  assert.equal(spy.runUpdates.length, 1)
+  assert.equal(spy.runUpdates[0].id, 'sess-1')
+  assert.equal(spy.runUpdates[0].patch.status, 'done')
+  assert.ok(spy.runUpdates[0].patch.endedAt, 'endedAt is stamped alongside the status')
+})
+
+test('a text-only reply with no tool calls at all still marks the run done', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"content":"Here is what I found."}}]}',
+    'data: {"choices":[{"finish_reason":"stop"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  assert.equal(spy.messages.length, 0)
+  assert.deepEqual(spy.runUpdates.map((u) => u.patch.status), ['done'])
+})
+
+// The backward-compatibility case that matters most. resolveCodeSession returns null for the
+// shared static token, a manual `turbollm launch`, or any other client — none of them is a Code
+// session and none may have anything written on its behalf.
+test('a request with no resolved Code session touches none of getAgentRun/addMessage/updateAgentRun', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+
+  const restore = stubStreamingEngine(EDIT_STREAM)
+  try { await postMessages(app, 'turbollm-local', { stream: true }) } finally { restore() }
+
+  assert.deepEqual(spy.getAgentRunIds, [], 'the run lookup itself must not happen')
+  assert.equal(spy.messages.length, 0)
+  assert.equal(spy.runUpdates.length, 0)
+})
+
+test('a token resolving to a session whose run row is gone records nothing and does not throw', async () => {
+  const { deps, spy } = fakeDeps(null)
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-missing')
+
+  const restore = stubStreamingEngine(EDIT_STREAM)
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  assert.deepEqual(spy.getAgentRunIds, ['sess-missing'])
+  assert.equal(spy.messages.length, 0)
+  assert.equal(spy.runUpdates.length, 0)
+})
+
+// The non-streaming branch has no per-delta reassembly to do, but must not be the one shape of
+// terminal-agent turn that silently records nothing.
+test('a NON-streaming turn records the same edit record and the same optimistic done marking', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-1')
+
+  const restore = stubJsonEngine({
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        content: '',
+        tool_calls: [{
+          id: 'toolu_ns',
+          type: 'function',
+          function: { name: 'Edit', arguments: JSON.stringify({ file_path: '/repo/ns.ts', old_string: 'old\n', new_string: 'new\n' }) },
+        }],
+      },
+    }],
+    usage: { prompt_tokens: 50, completion_tokens: 10 },
+  })
+  try { await postMessages(app, token, { stream: false }) } finally { restore() }
+
+  assert.equal(spy.messages.length, 1)
+  const [record] = spy.messages[0].toolCalls
+  assert.equal(record.name, 'edit')
+  assert.equal(record.args.path, '/repo/ns.ts')
+  assert.ok(record.diff?.includes('-old'))
+  assert.ok(record.diff?.includes('+new'))
+  assert.deepEqual(spy.runUpdates.map((u) => u.patch.status), ['done'])
+})

--- a/turbollm/src/gateway/gateway.code-activity.test.ts
+++ b/turbollm/src/gateway/gateway.code-activity.test.ts
@@ -10,6 +10,14 @@
 // streaming and non-streaming /v1/messages branches, and — critically — that a request with no
 // resolved Code session (independent CLI usage, plain chat, the shared static token) still
 // touches none of it.
+//
+// Attribution takes TWO requests, and most tests below therefore drive two. The gateway sees a
+// tool call the moment the ENGINE emits it, which is before the CLI has run it and before the
+// user has been asked to permit it — so a call is only stashed as pending there. The request
+// AFTER it replays the conversation carrying that call's `tool_result`, and only that confirms
+// (or, with `is_error`, retires) it. Crediting on sight instead counted files that were never
+// modified and diffs that were declined or that failed and were then retried 2-4 times, which is
+// exactly the two tiles this feature exists to populate.
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { Hono } from 'hono'
@@ -72,6 +80,29 @@ function stubStreamingEngine(lines: string[]): () => void {
   return () => { globalThis.fetch = original }
 }
 
+/** An engine that delivers `lines` and then DIES — the stream errors instead of closing, which
+ *  is what a crashed/OOM-killed llama-server, an evicted model, or a severed connection looks
+ *  like from here. Throwing from `pull` (rather than `controller.error()`, which resets the
+ *  queue) means the already-enqueued lines are still consumed first, so the failure lands
+ *  mid-turn with a fully-formed tool call already seen. */
+function stubDyingStreamingEngine(lines: string[]): () => void {
+  const original = globalThis.fetch
+  const enc = new TextEncoder()
+  globalThis.fetch = (async () => {
+    let i = 0
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (i < lines.length) { controller.enqueue(enc.encode(lines[i++] + '\n')); return }
+          throw new Error('engine stopped mid-stream')
+        },
+      }),
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    )
+  }) as typeof fetch
+  return () => { globalThis.fetch = original }
+}
+
 /** Point the engine fetch at a canned non-streaming OpenAI completion. */
 function stubJsonEngine(body: Record<string, unknown>): () => void {
   const original = globalThis.fetch
@@ -81,13 +112,49 @@ function stubJsonEngine(body: Record<string, unknown>): () => void {
   return () => { globalThis.fetch = original }
 }
 
-async function postMessages(app: Hono, token: string, body: Record<string, unknown>): Promise<void> {
+/** Returns the raw response body so a test can assert the CLI still got a complete answer. */
+async function postMessages(app: Hono, token: string, body: Record<string, unknown>): Promise<string> {
   const res = await app.request('/v1/messages', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({ model: 'qwen3-8b|Q4|123', max_tokens: 4096, messages: [], ...body }),
   })
-  await res.text() // drain: the SSE branch's recording happens as the stream is consumed
+  return await res.text() // drains too: the SSE branch's recording happens as the stream is consumed
+}
+
+const NO_TOOL_STREAM = [
+  'data: {"choices":[{"delta":{"content":"Done."}}]}',
+  'data: {"choices":[{"finish_reason":"stop"}]}',
+  'data: [DONE]',
+]
+
+/** The CLI's NEXT request. An Anthropic-protocol client resends the whole conversation every
+ *  turn, so this is where the previous turn's `tool_result` blocks arrive — the only place the
+ *  daemon ever learns whether an edit it watched the engine ask for actually landed. */
+async function postToolResults(
+  app: Hono,
+  token: string,
+  results: Array<{ id: string; isError?: boolean }>,
+  engineLines: string[] = NO_TOOL_STREAM,
+): Promise<string> {
+  const restore = stubStreamingEngine(engineLines)
+  try {
+    return await postMessages(app, token, {
+      stream: true,
+      messages: [
+        { role: 'user', content: 'edit that file' },
+        {
+          role: 'user',
+          content: results.map((r) => ({
+            type: 'tool_result',
+            tool_use_id: r.id,
+            content: r.isError ? 'String to replace not found in file.' : 'The file has been updated.',
+            ...(r.isError ? { is_error: true } : {}),
+          })),
+        },
+      ],
+    })
+  } finally { restore() }
 }
 
 const EDIT_STREAM = [
@@ -97,7 +164,7 @@ const EDIT_STREAM = [
   'data: [DONE]',
 ]
 
-test('an Edit tool call from a session-scoped CLI is recorded as an edit record with a real unified diff', async () => {
+test('an Edit tool call is credited only once its tool_result confirms the CLI applied it', async () => {
   const { deps, spy } = fakeDeps()
   const app = new Hono()
   registerGateway(app, deps)
@@ -106,7 +173,13 @@ test('an Edit tool call from a session-scoped CLI is recorded as an edit record 
   const restore = stubStreamingEngine(EDIT_STREAM)
   try { await postMessages(app, token, { stream: true }) } finally { restore() }
 
-  assert.deepEqual(spy.getAgentRunIds, ['sess-1'], 'the run is looked up by the session the token resolves to')
+  // The turn the engine ASKED for the edit on proves nothing: at this instant the CLI has not run
+  // it, and the user has not been asked to permit it.
+  assert.equal(spy.messages.length, 0, 'an unconfirmed edit must not be credited')
+
+  await postToolResults(app, token, [{ id: 'toolu_01' }])
+
+  assert.deepEqual([...new Set(spy.getAgentRunIds)], ['sess-1'], 'the run is only ever looked up by the session the token resolves to')
   assert.equal(spy.messages.length, 1)
   assert.equal(spy.messages[0].convId, 'conv-1', 'the record lands on the run\'s own conversation — what codeStats() joins on')
   const [record] = spy.messages[0].toolCalls
@@ -119,11 +192,67 @@ test('an Edit tool call from a session-scoped CLI is recorded as an edit record 
   assert.deepEqual(changed, ['-let x = 1', '+const x = 2', '+const y = 3'])
 })
 
+// The failure this whole pending/confirm split exists for. An `Edit` whose `old_string` isn't
+// found or isn't unique is the single most common local-model tool failure, and a decline at a
+// permission prompt comes back the same shape — both as `is_error: true`. Crediting either one
+// inflates "Files touched" with a file that was never modified and "Diff shipped" with a change
+// that never happened (then again on each retry).
+test('a tool_result marked is_error retires the record without crediting anything', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-err')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_fail","function":{"name":"Edit","arguments":"{\\"file_path\\":\\"/repo/nope.ts\\",\\"old_string\\":\\"a\\",\\"new_string\\":\\"b\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  await postToolResults(app, token, [{ id: 'toolu_fail', isError: true }])
+  assert.equal(spy.messages.length, 0, 'a failed or declined edit is never credited')
+
+  // Retired, not merely skipped: replaying the same history (which every later turn does) must
+  // not resurrect it either.
+  await postToolResults(app, token, [{ id: 'toolu_fail' }])
+  assert.equal(spy.messages.length, 0, 'a retired record can never be revived by a later replay')
+
+  // The run is still marked shipped throughout — that claim is about the session having done real
+  // work, which the turns themselves prove regardless of how any one call turned out.
+  assert.ok(spy.runUpdates.length >= 1)
+  assert.deepEqual([...new Set(spy.runUpdates.map((u) => u.patch.status))], ['done'])
+})
+
+// Every request replays the ENTIRE conversation, so a confirmed call's tool_result keeps arriving
+// for the rest of the session. Counting it each time would multiply both tiles by the number of
+// remaining turns.
+test('a confirmed tool_result replayed on later turns is counted exactly once', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-replay')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_once","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/once.ts\\",\\"content\\":\\"hi\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  await postToolResults(app, token, [{ id: 'toolu_once' }])
+  await postToolResults(app, token, [{ id: 'toolu_once' }])
+  await postToolResults(app, token, [{ id: 'toolu_once' }])
+
+  assert.equal(spy.messages.length, 1, 'the same call must land in messages.tool_calls exactly once')
+  assert.equal(spy.messages[0].toolCalls[0].id, 'toolu_once')
+})
+
 test('a Write tool call is recorded with no diff — it counts toward files touched only', async () => {
   const { deps, spy } = fakeDeps()
   const app = new Hono()
   registerGateway(app, deps)
-  const token = sessionAuth.mint('sess-1')
+  const token = sessionAuth.mint('sess-write')
 
   const restore = stubStreamingEngine([
     'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_w","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/new.ts\\",\\"content\\":\\"hello\\\\n\\"}"}}]}}]}',
@@ -131,6 +260,7 @@ test('a Write tool call is recorded with no diff — it counts toward files touc
     'data: [DONE]',
   ])
   try { await postMessages(app, token, { stream: true }) } finally { restore() }
+  await postToolResults(app, token, [{ id: 'toolu_w' }])
 
   const [record] = spy.messages[0].toolCalls
   assert.equal(record.name, 'write')
@@ -142,7 +272,7 @@ test('a MultiEdit is credited for files touched but carries no fabricated diff',
   const { deps, spy } = fakeDeps()
   const app = new Hono()
   registerGateway(app, deps)
-  const token = sessionAuth.mint('sess-1')
+  const token = sessionAuth.mint('sess-multi')
 
   const restore = stubStreamingEngine([
     'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_m","function":{"name":"MultiEdit","arguments":"{\\"file_path\\":\\"/repo/multi.ts\\",\\"edits\\":[{\\"old_string\\":\\"a\\",\\"new_string\\":\\"b\\"}]}"}}]}}]}',
@@ -150,6 +280,7 @@ test('a MultiEdit is credited for files touched but carries no fabricated diff',
     'data: [DONE]',
   ])
   try { await postMessages(app, token, { stream: true }) } finally { restore() }
+  await postToolResults(app, token, [{ id: 'toolu_m' }])
 
   const [record] = spy.messages[0].toolCalls
   assert.equal(record.name, 'edit', 'recorded as an edit so the file still counts toward filesTouched')
@@ -157,7 +288,62 @@ test('a MultiEdit is credited for files touched but carries no fabricated diff',
   assert.equal(record.diff, undefined, 'fragment pairs cannot be reconstructed into an honest diff — omit rather than invent')
 })
 
-// The optimistic marking (see recordCodeSessionToolCalls): leaving the terminal tab does not quit
+// See MAX_DIFF_INPUT_CHARS: createPatch is synchronous Myers on Node's single thread, so a
+// whole-block rewrite (well within a 32k-token response budget) blocks the entire daemon for
+// hundreds of milliseconds. The record is still made — only the diff is given up.
+test('an oversized Edit still counts toward files touched but skips the daemon-blocking diff', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-big')
+
+  const big = 'x'.repeat(40 * 1024) // 40 KB each side: 80 KB combined, past the 64 KB ceiling
+  const restore = stubJsonEngine({
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        content: '',
+        tool_calls: [{
+          id: 'toolu_big',
+          type: 'function',
+          function: { name: 'Edit', arguments: JSON.stringify({ file_path: '/repo/big.ts', old_string: big, new_string: `${big}y` }) },
+        }],
+      },
+    }],
+  })
+  try { await postMessages(app, token, { stream: false }) } finally { restore() }
+  await postToolResults(app, token, [{ id: 'toolu_big' }])
+
+  const [record] = spy.messages[0].toolCalls
+  assert.equal(record.name, 'edit')
+  assert.equal(record.args.path, '/repo/big.ts', 'filesTouched credit survives — that is the whole point of still recording it')
+  assert.equal(record.diff, undefined, 'the diff is skipped rather than blocking the event loop on it')
+})
+
+// A malformed call must be DROPPED, not coerced: `String(undefined)` would put the literal
+// "undefined" into args.path, which codeStats() would then count as a real file touched.
+test('a file-touching tool call with no usable file_path is dropped, never coerced to "undefined"', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-nopath')
+
+  const restore = stubStreamingEngine([
+    // First: no file_path at all. Second: a non-string one (a model that emitted a number).
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_nopath","function":{"name":"Edit","arguments":"{\\"old_string\\":\\"a\\",\\"new_string\\":\\"b\\"}"}}]}}]}',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"toolu_numpath","function":{"name":"Write","arguments":"{\\"file_path\\":42,\\"content\\":\\"hi\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+  await postToolResults(app, token, [{ id: 'toolu_nopath' }, { id: 'toolu_numpath' }])
+
+  assert.equal(spy.messages.length, 0, 'neither call was ever stashed, so a confirming result finds nothing to credit')
+  // The turn itself still counted — only the unusable records were dropped.
+  assert.deepEqual([...new Set(spy.runUpdates.map((u) => u.patch.status))], ['done'])
+})
+
+// The optimistic marking (see observeCodeSessionTurn): leaving the terminal tab does not quit
 // the CLI (ADR-298), so waiting for a completion signal leaves nearly every real session stuck at
 // 'queued' — and reconcileOnStartup then relabels it 'interrupted' on the next daemon restart.
 test('any observed turn marks the run done, even one that touched no files at all', async () => {
@@ -234,7 +420,7 @@ test('a NON-streaming turn records the same edit record and the same optimistic 
   const { deps, spy } = fakeDeps()
   const app = new Hono()
   registerGateway(app, deps)
-  const token = sessionAuth.mint('sess-1')
+  const token = sessionAuth.mint('sess-ns')
 
   const restore = stubJsonEngine({
     choices: [{
@@ -251,6 +437,7 @@ test('a NON-streaming turn records the same edit record and the same optimistic 
     usage: { prompt_tokens: 50, completion_tokens: 10 },
   })
   try { await postMessages(app, token, { stream: false }) } finally { restore() }
+  await postToolResults(app, token, [{ id: 'toolu_ns' }])
 
   assert.equal(spy.messages.length, 1)
   const [record] = spy.messages[0].toolCalls
@@ -258,5 +445,87 @@ test('a NON-streaming turn records the same edit record and the same optimistic 
   assert.equal(record.args.path, '/repo/ns.ts')
   assert.ok(record.diff?.includes('-old'))
   assert.ok(record.diff?.includes('+new'))
-  assert.deepEqual(spy.runUpdates.map((u) => u.patch.status), ['done'])
+  assert.deepEqual([...new Set(spy.runUpdates.map((u) => u.patch.status))], ['done'])
+})
+
+// streamToAnthropic only fires onToolCalls inside `if (!failed)`. That guard is what stops a
+// half-received turn — the engine crashed, the model was evicted, the connection was cut — from
+// being observed as though it had completed: the client never got the rest of that tool call, so
+// its CLI never ran it, and nothing about it may reach the database.
+test('a stream that dies mid-turn records nothing at all, and leaves nothing to confirm later', async () => {
+  const { deps, spy } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-dead')
+
+  const restore = stubDyingStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_dead","function":{"name":"Edit","arguments":"{\\"file_path\\":\\"/repo/dead.ts\\",\\"old_string\\":\\"a\\",\\"new_string\\":\\"b\\"}"}}]}}]}',
+  ])
+  let body: string
+  try { body = await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  assert.ok(body.includes('"type":"error"'), 'the client is told the engine stopped')
+  assert.deepEqual(spy.getAgentRunIds, [], 'a failed turn is never observed — not even to mark the run done')
+  assert.equal(spy.messages.length, 0)
+  assert.equal(spy.runUpdates.length, 0)
+
+  // Nothing was stashed either, so even a (fabricated) later confirmation credits nothing.
+  await postToolResults(app, token, [{ id: 'toolu_dead' }])
+  assert.equal(spy.messages.length, 0, 'a call from a failed stream can never be credited retroactively')
+})
+
+// Attribution is a side observation of a request whose actual job is to answer the CLI. Every DB
+// call it makes is inside a swallow, so a locked/failing database costs the tiles, never the turn.
+test('a DB failure during attribution still returns the CLI a complete non-streaming message', async () => {
+  const { deps } = fakeDeps()
+  ;(deps.db as unknown as { getAgentRun: () => never }).getAgentRun = () => { throw new Error('database is locked') }
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-dbfail')
+
+  const restore = stubJsonEngine({
+    choices: [{
+      finish_reason: 'tool_calls',
+      message: {
+        content: 'Editing that now.',
+        tool_calls: [{
+          id: 'toolu_dbfail',
+          type: 'function',
+          function: { name: 'Edit', arguments: JSON.stringify({ file_path: '/repo/x.ts', old_string: 'a', new_string: 'b' }) },
+        }],
+      },
+    }],
+    usage: { prompt_tokens: 12, completion_tokens: 5 },
+  })
+  let body: string
+  try { body = await postMessages(app, token, { stream: false }) } finally { restore() }
+
+  const msg = JSON.parse(body) as { type: string; content: Array<{ type: string; name?: string }>; stop_reason: string; usage: { output_tokens: number } }
+  assert.equal(msg.type, 'message')
+  assert.deepEqual(msg.content.map((b) => b.type), ['text', 'tool_use'], 'the engine\'s real answer reaches the client untouched')
+  assert.equal(msg.content[1].name, 'Edit')
+  assert.equal(msg.stop_reason, 'tool_use')
+  assert.equal(msg.usage.output_tokens, 5)
+})
+
+test('a DB failure while committing a confirmed call still returns a complete SSE stream', async () => {
+  const { deps } = fakeDeps()
+  const app = new Hono()
+  registerGateway(app, deps)
+  const token = sessionAuth.mint('sess-dbfail2')
+
+  const restore = stubStreamingEngine([
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"toolu_c","function":{"name":"Write","arguments":"{\\"file_path\\":\\"/repo/c.ts\\",\\"content\\":\\"hi\\"}"}}]}}]}',
+    'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+    'data: [DONE]',
+  ])
+  try { await postMessages(app, token, { stream: true }) } finally { restore() }
+
+  // Fails on the NEXT request, i.e. exactly while the confirm path tries to commit the record.
+  ;(deps.db as unknown as { addMessage: () => never }).addMessage = () => { throw new Error('database is locked') }
+  const body = await postToolResults(app, token, [{ id: 'toolu_c' }])
+
+  assert.ok(body.includes('event: message_start'), 'the stream still opens')
+  assert.ok(body.includes('Done.'), 'the engine\'s text still reaches the client')
+  assert.ok(body.includes('event: message_stop'), 'and it still terminates cleanly')
 })

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -141,6 +141,12 @@ export function registerGateway(app: Hono, d: Deps): void {
     // (including a manually-run `turbollm launch claude`) is completely unaffected.
     const { token: anthropicToken, codeSessionId: anthropicCodeSessionId } = resolveCodeSession(c)
     if (anthropicCodeSessionId) {
+      // Coding-activity attribution, confirm half (see commitConfirmedCodeToolCalls): this
+      // request's own history is what tells the daemon whether the edits it watched the engine
+      // ask for on an earlier turn actually landed. Read here, before the request is touched in
+      // any way, so it happens for every real turn including ones that later fail to route or
+      // never reach the engine at all.
+      commitConfirmedCodeToolCalls(d, anthropicCodeSessionId, req)
       const override = sessionAuth.getThinkingBudgetForToken(anthropicToken)
       if (override !== null) {
         req.thinking = override > 0 ? { type: 'enabled', budget_tokens: override } : undefined
@@ -316,10 +322,10 @@ export function registerGateway(app: Hono, d: Deps): void {
         // so Claude Code traffic shows the same live row as in-app chat.
         (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
         // Coding-activity attribution for terminal-agent sessions — see
-        // recordCodeSessionToolCalls. Nothing to attribute for any other client.
+        // observeCodeSessionTurn. Nothing to attribute for any other client.
         (calls) => {
           if (!anthropicCodeSessionId) return
-          try { recordCodeSessionToolCalls(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
+          try { observeCodeSessionTurn(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
         },
       )
       // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
@@ -348,7 +354,13 @@ export function registerGateway(app: Hono, d: Deps): void {
       // Same coding-activity attribution the streaming branch gets. A non-streaming turn has no
       // per-delta reassembly to do — the engine already hands back whole `arguments` strings —
       // but it must not be the one shape of terminal-agent turn that silently records nothing.
-      if (anthropicCodeSessionId) recordCodeSessionToolCalls(d, anthropicCodeSessionId, openAiToolCalls(oaiRes))
+      // Wrapped like the streaming branch's callback: `openAiToolCalls(oaiRes)` is evaluated as
+      // an ARGUMENT, i.e. before the callee's own try, so its containment has to live out here
+      // — this block has no catch of its own and a throw would reach the client as a bodyless
+      // 500 in place of a perfectly good answer the engine already produced.
+      if (anthropicCodeSessionId) {
+        try { observeCodeSessionTurn(d, anthropicCodeSessionId, openAiToolCalls(oaiRes)) } catch { /* swallow */ }
+      }
       return c.json(mapFromOpenAI(oaiRes, modelName))
     } finally {
       d.manager.generationEnd()
@@ -597,9 +609,51 @@ function openAiToolCalls(oai: Record<string, unknown>): StreamToolCall[] {
   return calls
 }
 
-/** Credit a Code session for a turn its terminal-launched CLI just took, into the SAME two tables
- *  the in-process pi agent writes (`messages.tool_calls` + `agent_runs.status`) — so codeStats()
- *  needs no knowledge that a second kind of agent exists.
+/** Above this combined `old_string.length + new_string.length`, an edit's unified diff is skipped
+ *  and the record kept diff-less. `createPatch` is Myers (O(N × D)) and fully SYNCHRONOUS on
+ *  Node's single thread, so a large enough edit stalls the WHOLE daemon for its duration — the
+ *  UI, engine-card polling, other Code sessions, every other gateway turn. Measured against this
+ *  repo's own `diff@9`: 22 KB of input → 22 ms, 69 KB → 168 ms, 140 KB → 653 ms, degrading
+ *  superlinearly past that. A "rewrite this whole block" Edit of that size fits comfortably
+ *  inside a 32k-token response budget (~4 chars/token), so it is reachable in ordinary use, not
+ *  a crafted input. Skipping costs only the "Diff shipped" contribution — the file still gets
+ *  its filesTouched credit, exactly as MultiEdit already does below. */
+const MAX_DIFF_INPUT_CHARS = 64 * 1024
+
+/** Edit/Write/MultiEdit calls a session's CLI has been TOLD to make but is not yet known to have
+ *  actually made, keyed `codeSessionId -> tool_use id -> record`.
+ *
+ *  Why they can't be credited on sight: the gateway sees a call the instant the ENGINE emits it —
+ *  before the CLI has run it, and before the user has been asked to permit it. Crediting there
+ *  counts files that were never modified and diffs that were declined or that failed outright
+ *  (an `Edit` whose `old_string` isn't found or isn't unique is the single most common local-model
+ *  tool failure, and the model then RETRIES, so the same logical change lands 2-4 times). Those
+ *  are precisely the two tiles this feature exists to populate, so an approximation there is worse
+ *  than nothing. The in-process pi path has never had this problem — it only records a
+ *  ToolCallRecord on a `tool_call` event whose status is already 'done'/'error'
+ *  (code-run-manager.ts) — and this path is deliberately built to match it.
+ *
+ *  The outcome IS observable, just one turn later: an Anthropic-protocol client resends the whole
+ *  conversation every request, so the request AFTER a tool_use carries that call's `tool_result`
+ *  block (with `is_error` when it failed or was declined). commitConfirmedCodeToolCalls below
+ *  reads it and commits only what really happened.
+ *
+ *  Pure in-memory and deliberately so, mirroring session-auth.ts: this is ephemeral state tied to
+ *  a live CLI subprocess whose worst-case loss is one turn of tile credit, and a daemon restart
+ *  has already killed the PTY that produced it. */
+const pendingCodeToolCalls = new Map<string, Map<string, ToolCallRecord>>()
+
+/** Ceiling on one session's un-confirmed records. In normal operation a turn's calls are all
+ *  resolved by the very next request, so this map holds a handful of entries at a time; the cap
+ *  only matters for calls whose result never arrives at all (the CLI is killed mid-turn, the
+ *  user abandons a permission prompt), which would otherwise sit here until the daemon restarts.
+ *  Oldest-first eviction, which is also age order — a record still unconfirmed after hundreds of
+ *  later calls is never going to be. */
+const MAX_PENDING_PER_SESSION = 256
+
+/** Observe a turn a Code session's terminal-launched CLI just took: stash its file-touching tool
+ *  calls as PENDING (see pendingCodeToolCalls — they are committed only once a later request
+ *  confirms the CLI really applied them) and mark the run shipped.
  *
  *  Why this lives in the gateway at all: a terminal session's CLI executes its own edits inside
  *  its own subprocess and never reports them back, so nothing downstream of it can see them. The
@@ -615,51 +669,114 @@ function openAiToolCalls(oai: Record<string, unknown>): StreamToolCall[] {
  *
  *  Wholly best-effort: any failure here is swallowed, because this is a side observation of a
  *  request whose actual job is to answer the CLI. */
-function recordCodeSessionToolCalls(d: Deps, codeSessionId: string, calls: StreamToolCall[]): void {
+function observeCodeSessionTurn(d: Deps, codeSessionId: string, calls: StreamToolCall[]): void {
   try {
     const run = d.db.getAgentRun(codeSessionId)
     if (!run) return
 
-    const records: ToolCallRecord[] = []
+    let pending = pendingCodeToolCalls.get(codeSessionId)
     for (const call of calls) {
       const name = call.name.toLowerCase()
       if (!CODE_ACTIVITY_TOOLS.has(name)) continue
+      // Without an id there is no `tool_result` to ever match this against, so it could only be
+      // credited unconditionally — the exact thing the pending/confirm split exists to prevent.
+      // A real client always sends one; the protocol needs it to address the result back.
+      if (!call.id) continue
       // `input` came off the wire as JSON — narrow every field rather than trusting the shape.
       const input = (call.input ?? {}) as Record<string, unknown>
       const path = typeof input.file_path === 'string' ? input.file_path : ''
       if (!path) continue
+      let record: ToolCallRecord
       if (name === 'write') {
         // No diff: codeStats() counts diff lines for 'edit' only, and a whole-file write has no
         // meaningful before-state here anyway. It still lands in filesTouched, which is the
         // entirety of what a write contributes on the pi path too.
-        records.push({ id: call.id, name: 'write', args: { path } })
+        record = { id: call.id, name: 'write', args: { path } }
       } else if (name === 'edit') {
         const oldString = typeof input.old_string === 'string' ? input.old_string : ''
         const newString = typeof input.new_string === 'string' ? input.new_string : ''
-        records.push({ id: call.id, name: 'edit', args: { path }, diff: createPatch(path, oldString, newString) })
+        record = oldString.length + newString.length > MAX_DIFF_INPUT_CHARS
+          ? { id: call.id, name: 'edit', args: { path } } // see MAX_DIFF_INPUT_CHARS
+          : { id: call.id, name: 'edit', args: { path }, diff: createPatch(path, oldString, newString) }
       } else {
         // MultiEdit carries N independent {old_string,new_string} FRAGMENT pairs and no file
         // content, so there is no honest way to reconstruct one unified diff from it — the
         // fragments' line positions relative to each other are unknown. Recorded as an edit for
         // filesTouched credit with the diff deliberately omitted: an omitted number is a gap in
         // "Diff shipped", a fabricated one is a wrong number nobody can tell is wrong.
-        records.push({ id: call.id, name: 'edit', args: { path } })
+        record = { id: call.id, name: 'edit', args: { path } }
       }
+      if (!pending) {
+        pending = new Map<string, ToolCallRecord>()
+        pendingCodeToolCalls.set(codeSessionId, pending)
+      }
+      pending.set(call.id, record)
     }
-    if (records.length > 0) d.db.addMessage(run.convId, 'assistant', '', { toolCalls: records })
+    while (pending && pending.size > MAX_PENDING_PER_SESSION) {
+      const oldest = pending.keys().next().value
+      if (oldest === undefined) break
+      pending.delete(oldest)
+    }
 
     // Optimistic, and deliberately so: observing ANY real turn on this session — even a
     // text-only reply or a pure Bash/Read turn — is what marks it shipped. The alternative is
     // waiting for a completion signal that in practice never arrives, because leaving the
     // terminal tab does not quit the CLI (ADR-298), so the overwhelming majority of real
     // sessions would stay 'queued' forever and never count toward "Tasks shipped". A run that
-    // is genuinely still going simply gets marked again on its next turn.
+    // is genuinely still going simply gets marked again on its next turn. Unlike the tool-call
+    // records above this needs no confirmation: the claim it makes is "this session did real
+    // work", which the turn itself already proves regardless of how any one call turned out.
     //
     // It also removes a second, quieter wrong: CodeRunManager.reconcileOnStartup force-marks
     // every code run still 'queued'/'running' at daemon startup as 'interrupted'. A terminal
     // session that never left 'queued' was being labelled interrupted on the next restart no
     // matter how much work it had actually done.
     d.db.updateAgentRun(run.id, { status: 'done', endedAt: new Date().toISOString() })
+  } catch { /* swallow — attribution is best-effort and must never affect the CLI's response */ }
+}
+
+/** Commit the pending records this INCOMING request proves the CLI actually applied, into the
+ *  same table the in-process pi agent writes (`messages.tool_calls`) — so codeStats() still needs
+ *  no knowledge that a second kind of agent exists.
+ *
+ *  An Anthropic-protocol client resends the entire conversation every turn, so a `tool_use` the
+ *  gateway stashed on turn N reappears here as a `tool_result` block carrying its verdict. A
+ *  result with `is_error: true` — the tool threw, its preconditions failed, or the user declined
+ *  it at a permission prompt — retires the pending record WITHOUT crediting it; anything else
+ *  commits it. Either way it leaves the pending map, so the same call can never be counted twice
+ *  no matter how many later requests replay the same history.
+ *
+ *  Runs on every request for a resolved Code session, ahead of anything that touches the engine,
+ *  and returns immediately when the session has nothing pending (the overwhelmingly common case
+ *  — no scan of a large conversation happens for a client that isn't mid-edit). Best-effort like
+ *  the rest of this feature: it must never affect the CLI's own response. */
+function commitConfirmedCodeToolCalls(d: Deps, codeSessionId: string, req: AnthropicRequest): void {
+  try {
+    const pending = pendingCodeToolCalls.get(codeSessionId)
+    if (!pending || pending.size === 0) return
+
+    const confirmed: ToolCallRecord[] = []
+    for (const msg of req.messages ?? []) {
+      const raw = msg.content
+      // Array.isArray rather than anthropic.ts's `typeof raw === 'string'` test: this runs before
+      // the request has been validated at all, and one malformed message must cost at most its own
+      // blocks, not throw out of the loop and strand the whole session's pending set.
+      if (!Array.isArray(raw)) continue
+      for (const block of raw) {
+        if (block.type !== 'tool_result') continue
+        const record = pending.get(block.tool_use_id)
+        if (!record) continue
+        pending.delete(block.tool_use_id)
+        if (block.is_error !== true) confirmed.push(record)
+      }
+    }
+    if (confirmed.length === 0) return
+
+    // Looked up only now, not on entry: a request that confirms nothing must cost this session
+    // no DB work at all, and a run row that has since disappeared simply drops the credit.
+    const run = d.db.getAgentRun(codeSessionId)
+    if (!run) return
+    d.db.addMessage(run.convId, 'assistant', '', { toolCalls: confirmed })
   } catch { /* swallow — attribution is best-effort and must never affect the CLI's response */ }
 }
 

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -3,12 +3,14 @@ import { randomUUID } from 'node:crypto'
 import type { Context, Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
+import { createPatch } from 'diff'
 import type { Deps } from '../deps'
+import type { ToolCallRecord } from '../chat/db'
 import { clampMaxTokens } from '../config/config'
 import { engineModelAlias } from '../engines/compat'
 import { presentedKey } from '../auth'
 import { sessionAuth } from '../code/session-auth'
-import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, type AnthropicRequest } from './anthropic'
+import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, type AnthropicRequest, type StreamToolCall } from './anthropic'
 import { applyAgentGuidance } from './agent-guidance'
 import {
   extractSearchQuery,
@@ -313,6 +315,12 @@ export function registerGateway(app: Hono, d: Deps): void {
         // Live per-request progress for the engine card (prefill % + token count),
         // so Claude Code traffic shows the same live row as in-app chat.
         (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
+        // Coding-activity attribution for terminal-agent sessions — see
+        // recordCodeSessionToolCalls. Nothing to attribute for any other client.
+        (calls) => {
+          if (!anthropicCodeSessionId) return
+          try { recordCodeSessionToolCalls(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
+        },
       )
       // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
       // Raw ReadableStream does not — chunks buffer until the response completes,
@@ -337,6 +345,10 @@ export function registerGateway(app: Hono, d: Deps): void {
       const oaiRes = (await res.json()) as Record<string, unknown>
       // session stats (B4) + durable #71 record, fail-safe
       recordOpenAiUsage(d, oaiRes, 'anthropic', req.model ?? null, anthropicCodeSessionId, Date.now() - requestStart)
+      // Same coding-activity attribution the streaming branch gets. A non-streaming turn has no
+      // per-delta reassembly to do — the engine already hands back whole `arguments` strings —
+      // but it must not be the one shape of terminal-agent turn that silently records nothing.
+      if (anthropicCodeSessionId) recordCodeSessionToolCalls(d, anthropicCodeSessionId, openAiToolCalls(oaiRes))
       return c.json(mapFromOpenAI(oaiRes, modelName))
     } finally {
       d.manager.generationEnd()
@@ -559,6 +571,96 @@ export function registerGateway(app: Hono, d: Deps): void {
     chatGateRelease?.()
     return new Response(res.body, { status: res.status, headers: res.headers })
   })
+}
+
+// ── Coding-activity attribution for terminal-agent sessions ─────────────────
+
+/** The only tool names that feed the Code launchpad's filesTouched/diff tiles. Claude Code sends
+ *  them PascalCase (`Edit`/`Write`/`MultiEdit`, confirmed against a real transcript), so matching
+ *  is case-insensitive; every other tool it has (Bash, Read, Grep, WebFetch, …) is deliberately
+ *  ignored, exactly as on the in-process pi path, where only edit/write records carry a path. */
+const CODE_ACTIVITY_TOOLS = new Set(['edit', 'write', 'multiedit'])
+
+/** Reassembled tool calls off a NON-streaming OpenAI completion — the flat counterpart to
+ *  streamToAnthropic's per-delta accumulation, for the same observer. An unparseable
+ *  `arguments` string drops that one call rather than the whole turn's worth. */
+function openAiToolCalls(oai: Record<string, unknown>): StreamToolCall[] {
+  const raw = (oai.choices as Array<{ message?: { tool_calls?: Array<{ id?: string; function?: { name?: string; arguments?: string } }> } }> | undefined)
+    ?.[0]?.message?.tool_calls
+  if (!Array.isArray(raw)) return []
+  const calls: StreamToolCall[] = []
+  for (const tc of raw) {
+    try {
+      calls.push({ id: tc.id ?? '', name: tc.function?.name ?? '', input: JSON.parse(tc.function?.arguments ?? '') })
+    } catch { /* skip this one call */ }
+  }
+  return calls
+}
+
+/** Credit a Code session for a turn its terminal-launched CLI just took, into the SAME two tables
+ *  the in-process pi agent writes (`messages.tool_calls` + `agent_runs.status`) — so codeStats()
+ *  needs no knowledge that a second kind of agent exists.
+ *
+ *  Why this lives in the gateway at all: a terminal session's CLI executes its own edits inside
+ *  its own subprocess and never reports them back, so nothing downstream of it can see them. The
+ *  gateway is the one component that does — it is the HTTP intermediary the CLI asks for every
+ *  token — and it already knows which session a request belongs to from the session-scoped bearer
+ *  token (resolveCodeSession). Without this, a terminal session moved none of the "Coding
+ *  activity" tiles no matter how much real work it did.
+ *
+ *  Two paths were considered and rejected before this one: the CLI's process-exit event (leaving
+ *  the terminal tab is Ctrl+D, which does NOT quit the CLI — see TerminalView.tsx and ADR-298 —
+ *  so it almost never fires in real use), and parsing Claude Code's own private on-disk JSONL
+ *  transcript (undocumented, third-party, single-agent-only, and outside our data directory).
+ *
+ *  Wholly best-effort: any failure here is swallowed, because this is a side observation of a
+ *  request whose actual job is to answer the CLI. */
+function recordCodeSessionToolCalls(d: Deps, codeSessionId: string, calls: StreamToolCall[]): void {
+  try {
+    const run = d.db.getAgentRun(codeSessionId)
+    if (!run) return
+
+    const records: ToolCallRecord[] = []
+    for (const call of calls) {
+      const name = call.name.toLowerCase()
+      if (!CODE_ACTIVITY_TOOLS.has(name)) continue
+      // `input` came off the wire as JSON — narrow every field rather than trusting the shape.
+      const input = (call.input ?? {}) as Record<string, unknown>
+      const path = typeof input.file_path === 'string' ? input.file_path : ''
+      if (!path) continue
+      if (name === 'write') {
+        // No diff: codeStats() counts diff lines for 'edit' only, and a whole-file write has no
+        // meaningful before-state here anyway. It still lands in filesTouched, which is the
+        // entirety of what a write contributes on the pi path too.
+        records.push({ id: call.id, name: 'write', args: { path } })
+      } else if (name === 'edit') {
+        const oldString = typeof input.old_string === 'string' ? input.old_string : ''
+        const newString = typeof input.new_string === 'string' ? input.new_string : ''
+        records.push({ id: call.id, name: 'edit', args: { path }, diff: createPatch(path, oldString, newString) })
+      } else {
+        // MultiEdit carries N independent {old_string,new_string} FRAGMENT pairs and no file
+        // content, so there is no honest way to reconstruct one unified diff from it — the
+        // fragments' line positions relative to each other are unknown. Recorded as an edit for
+        // filesTouched credit with the diff deliberately omitted: an omitted number is a gap in
+        // "Diff shipped", a fabricated one is a wrong number nobody can tell is wrong.
+        records.push({ id: call.id, name: 'edit', args: { path } })
+      }
+    }
+    if (records.length > 0) d.db.addMessage(run.convId, 'assistant', '', { toolCalls: records })
+
+    // Optimistic, and deliberately so: observing ANY real turn on this session — even a
+    // text-only reply or a pure Bash/Read turn — is what marks it shipped. The alternative is
+    // waiting for a completion signal that in practice never arrives, because leaving the
+    // terminal tab does not quit the CLI (ADR-298), so the overwhelming majority of real
+    // sessions would stay 'queued' forever and never count toward "Tasks shipped". A run that
+    // is genuinely still going simply gets marked again on its next turn.
+    //
+    // It also removes a second, quieter wrong: CodeRunManager.reconcileOnStartup force-marks
+    // every code run still 'queued'/'running' at daemon startup as 'interrupted'. A terminal
+    // session that never left 'queued' was being labelled interrupted on the next restart no
+    // matter how much work it had actually done.
+    d.db.updateAgentRun(run.id, { status: 'done', endedAt: new Date().toISOString() })
+  } catch { /* swallow — attribution is best-effort and must never affect the CLI's response */ }
 }
 
 // ── session-stats recording helpers (B4) ────────────────────────────────────

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -806,9 +806,13 @@ export function CodeSessionScreen() {
               onEjectModel={handleEject}
               onModelSettings={(key) => setSettingsKey(key)}
               // NOT the shared `ctxUsed` above — that one reads the last PERSISTED assistant
-              // message's stats, and a terminal-agent session never writes one: the CLI talks to
-              // the gateway directly, so nothing of its conversation lands in the code session's
-              // message store. The ring and footer were therefore showing whichever stale value
+              // message's stats, and a terminal-agent session never writes one carrying stats:
+              // the CLI talks to the gateway directly, so none of its conversational turns land
+              // in the code session's message store. (The gateway does write ONE narrow kind of
+              // message on its behalf — a stats-less record of the Edit/Write/MultiEdit calls it
+              // has confirmed the CLI applied, purely so the "Coding activity" tiles can count
+              // them; see gateway.ts's commitConfirmedCodeToolCalls. No text, no reasoning, and
+              // nothing this ring could read.) The ring and footer were therefore showing whichever stale value
               // happened to be sitting in this session's very first (pre-terminal) turn, frozen
               // forever. Measured live on 2026-07-29 against the founder's own `claude` session:
               // persisted message said 30,645 tokens / 15% (written two days earlier, and the


### PR DESCRIPTION
## Summary
- A terminal-agent Code session's CLI applies its edits inside its own subprocess and never reports back, so `codeStats()` (Sessions / Tasks shipped / Files touched / Diff shipped on the Code launchpad) stayed blind to it no matter how much real work happened.
- The gateway already sees every one of those turns as HTTP traffic and already knows which Code session a request belongs to (`session-auth.ts`) — it just wasn't recording anything from it.
- `streamToAnthropic()` now reassembles the tool calls it was already parsing to translate for the client, and the gateway writes `Edit`/`Write`/`MultiEdit` calls into the same `messages.tool_calls` + `agent_runs.status` the in-process agent already uses — `codeStats()` itself needed no changes.
- Status is marked optimistically on any observed turn rather than waiting for the CLI to exit, since leaving the terminal tab doesn't quit it and that signal essentially never fires in real use.
- See ADR-318 in `docs/decisions/decision-log.md` (local-only docs repo) for the full root cause and the two rejected approaches (CLI exit hook, parsing Claude Code's private transcript file).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full backend + web-unit suite: 1679 tests, 1676 pass, 0 fail, 3 pre-existing unrelated skips
- [x] 14 new tests in `gateway/gateway.code-activity.test.ts` (Edit/Write/MultiEdit shaping, optimistic done-marking, missing-run and no-session backward-compat, streaming + non-streaming)
- [x] 4 new `streamToAnthropic` tests in `anthropic.test.ts` (multi-delta reassembly, concurrent tool calls kept apart by index, empty-array firing, unparseable-fragment call dropped)
- [x] Live-verified against the real daemon: a real Write + Edit through the actual `claude` CLI in a Code session moved Sessions/Tasks shipped/Files touched/Diff shipped by exactly the expected amounts, with a correct persisted unified diff (`hello` → `hello world`), then cleaned up back to baseline