### PR TITLE
fix(telemetry): onboarding funnel — drop engine_build, add first_chat (v1.9.9)

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,15 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.9.9] - 2026-08-03
+
+### Fixed
+- The onboarding analytics funnel counted "building an engine from source" (an optional, manual,
+  advanced-user action from the Engines screen) as a required setup step, which made it look like
+  almost every install got stuck partway through setup — it didn't. That step is removed from the
+  funnel, and a real "first message sent" step was added so onboarding is measured accurately.
+  Internal analytics only; no visible app behavior changes.
+
 ## [1.9.8] - 2026-08-02
 
 ### Changed

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/chat/chat-routes.test.ts
+++ b/turbollm/src/chat/chat-routes.test.ts
@@ -144,7 +144,7 @@ function queued(dir: string): Record<string, unknown>[] {
 test('reportFirstChat: a completed generation reports first_chat as ok', () => {
   const dir = tempDir()
   try {
-    reportFirstChat(dir, makeEmitter(dir), false)
+    reportFirstChat(dir, makeEmitter(dir), 'ok')
     const events = queued(dir)
 
     assert.equal(events.length, 1)
@@ -158,8 +158,22 @@ test('reportFirstChat: a completed generation reports first_chat as ok', () => {
 test('reportFirstChat: an aborted generation reports cancelled, not fail', () => {
   const dir = tempDir()
   try {
-    reportFirstChat(dir, makeEmitter(dir), true)
+    reportFirstChat(dir, makeEmitter(dir), 'cancelled')
     assert.deepEqual(queued(dir)[0].payload, { step: 'first_chat', outcome: 'cancelled' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: an engine error (early bad-response return, or a thrown mid-stream exception) reports fail', () => {
+  // The two real call sites that pass 'fail': runGeneration's early return on a
+  // non-ok engine response, and its catch block on a non-AbortError exception. A
+  // user whose first-ever attempt hits either must not read as either "ok" (silently
+  // wrong) or "never tried" (silently missing) — see the PR review that caught this.
+  const dir = tempDir()
+  try {
+    reportFirstChat(dir, makeEmitter(dir), 'fail')
+    assert.deepEqual(queued(dir)[0].payload, { step: 'first_chat', outcome: 'fail' })
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -171,9 +185,9 @@ test('reportFirstChat: fires exactly once across many generations, not on every 
   const dir = tempDir()
   try {
     const e = makeEmitter(dir)
-    reportFirstChat(dir, e, false)
-    reportFirstChat(dir, e, false)
-    reportFirstChat(dir, e, true)
+    reportFirstChat(dir, e, 'ok')
+    reportFirstChat(dir, e, 'ok')
+    reportFirstChat(dir, e, 'cancelled')
 
     assert.equal(queued(dir).length, 1, 'first_chat means first, not every')
   } finally {
@@ -185,8 +199,8 @@ test('reportFirstChat: an aborted FIRST chat still claims the once-key', () => {
   const dir = tempDir()
   try {
     const e = makeEmitter(dir)
-    reportFirstChat(dir, e, true)
-    reportFirstChat(dir, e, false)
+    reportFirstChat(dir, e, 'cancelled')
+    reportFirstChat(dir, e, 'ok')
 
     const events = queued(dir)
     assert.equal(events.length, 1, 'the aborted attempt was still the first one')
@@ -196,13 +210,28 @@ test('reportFirstChat: an aborted FIRST chat still claims the once-key', () => {
   }
 })
 
+test('reportFirstChat: a FAILED first chat still claims the once-key', () => {
+  const dir = tempDir()
+  try {
+    const e = makeEmitter(dir)
+    reportFirstChat(dir, e, 'fail')
+    reportFirstChat(dir, e, 'ok')
+
+    const events = queued(dir)
+    assert.equal(events.length, 1, 'the failed attempt was still the first one')
+    assert.deepEqual(events[0].payload, { step: 'first_chat', outcome: 'fail' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('reportFirstChat: consent off queues nothing and does not spend the claim', () => {
   const dir = tempDir()
   try {
-    reportFirstChat(dir, makeEmitter(dir, 'off'), false)
+    reportFirstChat(dir, makeEmitter(dir, 'off'), 'ok')
     assert.equal(queued(dir).length, 0)
 
-    reportFirstChat(dir, makeEmitter(dir, 'anon'), false)
+    reportFirstChat(dir, makeEmitter(dir, 'anon'), 'ok')
     assert.equal(queued(dir).length, 1, 'opting in later must still capture the next chat')
   } finally {
     rmSync(dir, { recursive: true, force: true })
@@ -210,5 +239,5 @@ test('reportFirstChat: consent off queues nothing and does not spend the claim',
 })
 
 test('reportFirstChat: no emitter (telemetry not wired) is a silent no-op', () => {
-  assert.doesNotThrow(() => reportFirstChat(tempDir(), undefined, false))
+  assert.doesNotThrow(() => reportFirstChat(tempDir(), undefined, 'ok'))
 })

--- a/turbollm/src/chat/chat-routes.test.ts
+++ b/turbollm/src/chat/chat-routes.test.ts
@@ -6,8 +6,13 @@
 // pass with tool_choice:'none' and use that result as the final reply.
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { stripThinkingBlocks, needsExtraPass } from './think-utils.js'
-import { recentTitleTurns } from './chat-routes.js'
+import { recentTitleTurns, reportFirstChat } from './chat-routes.js'
+import { Emitter } from '../telemetry/emit.js'
+import { readQueue } from '../telemetry/queue.js'
 
 // ── stripThinkingBlocks ───────────────────────────────────────────────────────
 
@@ -112,4 +117,98 @@ test('recentTitleTurns: a system message is excluded even when mixed in with rea
 
 test('recentTitleTurns: empty input yields empty output, no throw', () => {
   assert.deepEqual(recentTitleTurns([]), [])
+})
+
+// ── reportFirstChat (onboarding_step: first_chat, ADR-323) ────────────────────
+// Scaffolding mirrors telemetry/first-load.test.ts: a real temp data dir so the
+// once-only ledger is exercised for real, and a real Emitter over a stub config.
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'turbollm-firstchat-'))
+}
+
+function makeEmitter(dir: string, level = 'anon'): Emitter {
+  const cfg = { telemetry: { level, machineId: '44444444-4444-4444-4444-444444444444' } }
+  return new Emitter({
+    dataDir: dir,
+    store: { snapshot: () => cfg, update: (fn: (c: typeof cfg) => void) => fn(cfg) } as never,
+    version: '1.9.9',
+    os: 'win32/x64',
+  })
+}
+
+function queued(dir: string): Record<string, unknown>[] {
+  return readQueue(dir).map((q) => q.event)
+}
+
+test('reportFirstChat: a completed generation reports first_chat as ok', () => {
+  const dir = tempDir()
+  try {
+    reportFirstChat(dir, makeEmitter(dir), false)
+    const events = queued(dir)
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0].event, 'onboarding_step')
+    assert.deepEqual(events[0].payload, { step: 'first_chat', outcome: 'ok' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: an aborted generation reports cancelled, not fail', () => {
+  const dir = tempDir()
+  try {
+    reportFirstChat(dir, makeEmitter(dir), true)
+    assert.deepEqual(queued(dir)[0].payload, { step: 'first_chat', outcome: 'cancelled' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: fires exactly once across many generations, not on every reply', () => {
+  // This runs at the end of EVERY generation — without the ledger claim an active
+  // user's ordinary chatting would emit a "setup" event forever.
+  const dir = tempDir()
+  try {
+    const e = makeEmitter(dir)
+    reportFirstChat(dir, e, false)
+    reportFirstChat(dir, e, false)
+    reportFirstChat(dir, e, true)
+
+    assert.equal(queued(dir).length, 1, 'first_chat means first, not every')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: an aborted FIRST chat still claims the once-key', () => {
+  const dir = tempDir()
+  try {
+    const e = makeEmitter(dir)
+    reportFirstChat(dir, e, true)
+    reportFirstChat(dir, e, false)
+
+    const events = queued(dir)
+    assert.equal(events.length, 1, 'the aborted attempt was still the first one')
+    assert.deepEqual(events[0].payload, { step: 'first_chat', outcome: 'cancelled' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: consent off queues nothing and does not spend the claim', () => {
+  const dir = tempDir()
+  try {
+    reportFirstChat(dir, makeEmitter(dir, 'off'), false)
+    assert.equal(queued(dir).length, 0)
+
+    reportFirstChat(dir, makeEmitter(dir, 'anon'), false)
+    assert.equal(queued(dir).length, 1, 'opting in later must still capture the next chat')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('reportFirstChat: no emitter (telemetry not wired) is a silent no-op', () => {
+  assert.doesNotThrow(() => reportFirstChat(tempDir(), undefined, false))
 })

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -689,21 +689,25 @@ interface GenerationCtx {
  *
  * Once-only for the same reason `first_load` is: this fires on EVERY generation, and
  * without the ledger claim an active user's ordinary chatting would emit a "setup"
- * event forever. An aborted first reply reports 'cancelled' but still claims the key —
- * a user who stops their very first generation did reach chat, and is a different
- * signal from one who never got there (the same distinction downloads already draw).
+ * event forever. A first reply that FAILS or is cancelled still claims the key —
+ * matching `reportModelLoad`'s "first outcome, whatever it is" semantics — because a
+ * user whose first attempt breaks or is abandoned still reached chat, and conflating
+ * that with "never tried" would hide exactly the drop-off this event exists to find.
+ * Classification is the caller's job (same division of labour as reportModelLoad):
+ * runGeneration has both an early engine-error return and a later thrown-error catch,
+ * and only the caller can tell those apart from a real success.
  *
  * Extracted rather than inlined so the claim-once behaviour is testable without
  * standing up a whole streaming generation. Never throws: `claimOnce` and
  * `Emitter.emit` are both non-throwing by contract (ADR-009).
  */
-export function reportFirstChat(dataDir: string, emitter: Emitter | undefined, aborted: boolean): void {
+export function reportFirstChat(dataDir: string, emitter: Emitter | undefined, outcome: 'ok' | 'fail' | 'cancelled'): void {
   if (!emitter) return
   // Consent is checked before the claim is spent, so chatting while telemetry is off
   // does not silently burn the one chance to record this (see Emitter.canSend).
   if (!emitter.canSend('onboarding_step')) return
   if (!claimOnce(dataDir, 'once:onboarding_step:first_chat')) return
-  emitter.emit('onboarding_step', { step: 'first_chat', outcome: aborted ? 'cancelled' : 'ok' })
+  emitter.emit('onboarding_step', { step: 'first_chat', outcome })
 }
 
 async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx): Promise<void> {
@@ -819,6 +823,11 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
   let finalUsage: { prompt_tokens?: number; completion_tokens?: number; prompt_tokens_details?: { cached_tokens?: number } } = {}
   let finalTimings: Record<string, number> = {}
   let aborted = false
+  // Distinct from `aborted`: a thrown, non-AbortError exception mid-stream (e.g. the
+  // engine process died) is neither a success nor a user-initiated cancellation.
+  // `aborted` alone can't tell the two apart (both leave AbortError-only checks
+  // false/true respectively), and first_chat needs the real three-way split.
+  let engineFailed = false
   let liveOut = 0
 
   d.manager.generationStart()
@@ -915,6 +924,11 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
 
       if (!res.ok || !res.body) {
         await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_error', message: `Engine returned ${res.status}` }) })
+        // This return skips the normal end-of-generation code below (including
+        // reportFirstChat's usual call site) entirely — without this, a user whose
+        // very first chat attempt hits a bad engine response would never claim the
+        // once-only key at all, indistinguishable from "never tried."
+        reportFirstChat(d.store.dir(), d.telemetry, 'fail')
         return
       }
 
@@ -1294,6 +1308,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
     const isAbort = (e as Error)?.name === 'AbortError'
     aborted = isAbort
     if (!isAbort) {
+      engineFailed = true
       await stream.writeSSE({ event: 'error', data: JSON.stringify({ code: 'engine_stopped', message: (e as Error).message }) })
     }
   } finally {
@@ -1369,7 +1384,7 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
   // onboarding_step (ADR-323): the last step of the funnel. Emitted here, at the point the
   // reply is actually persisted, because that — not a model load — is the moment onboarding
   // has genuinely succeeded.
-  reportFirstChat(d.store.dir(), d.telemetry, aborted)
+  reportFirstChat(d.store.dir(), d.telemetry, aborted ? 'cancelled' : engineFailed ? 'fail' : 'ok')
 
   try {
     d.manager.recordCompletion({

--- a/turbollm/src/chat/chat-routes.ts
+++ b/turbollm/src/chat/chat-routes.ts
@@ -18,6 +18,8 @@ import { buildSaveSkillTool } from '../agents/agent-tools'
 import { SkillStore } from '../agents/skills'
 import { saveSkillFromConversation } from '../agents/skill-jobs'
 import { extractMemoryFacts } from './memory'
+import { claimOnce } from '../telemetry/ledger'
+import type { Emitter } from '../telemetry/emit'
 
 // Track in-flight abort controllers per conversation id.
 const inflight = new Map<string, AbortController>()
@@ -682,6 +684,28 @@ interface GenerationCtx {
  * tags, executes tool calls and loops (up to MAX_TOOL_ITER rounds), persists the final
  * message + stats, and fires auto-title. Shared by the messages and continue endpoints.
  */
+/**
+ * `onboarding_step: first_chat` (ADR-323) — the funnel's real success criterion.
+ *
+ * Once-only for the same reason `first_load` is: this fires on EVERY generation, and
+ * without the ledger claim an active user's ordinary chatting would emit a "setup"
+ * event forever. An aborted first reply reports 'cancelled' but still claims the key —
+ * a user who stops their very first generation did reach chat, and is a different
+ * signal from one who never got there (the same distinction downloads already draw).
+ *
+ * Extracted rather than inlined so the claim-once behaviour is testable without
+ * standing up a whole streaming generation. Never throws: `claimOnce` and
+ * `Emitter.emit` are both non-throwing by contract (ADR-009).
+ */
+export function reportFirstChat(dataDir: string, emitter: Emitter | undefined, aborted: boolean): void {
+  if (!emitter) return
+  // Consent is checked before the claim is spent, so chatting while telemetry is off
+  // does not silently burn the one chance to record this (see Emitter.canSend).
+  if (!emitter.canSend('onboarding_step')) return
+  if (!claimOnce(dataDir, 'once:onboarding_step:first_chat')) return
+  emitter.emit('onboarding_step', { step: 'first_chat', outcome: aborted ? 'cancelled' : 'ok' })
+}
+
 async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx): Promise<void> {
   const { db } = d
   const { convId, conv, assistantMsg, ms, target, ac, thinkingBudget } = ctx
@@ -1342,6 +1366,10 @@ async function runGeneration(d: Deps, stream: StreamHandle, ctx: GenerationCtx):
 
   db.updateMessage(assistantMsg.id, { content: fullContent, reasoning: fullReasoning, toolCalls: allToolCalls, stats, researchMeta })
   db.touchConversation(convId)
+  // onboarding_step (ADR-323): the last step of the funnel. Emitted here, at the point the
+  // reply is actually persisted, because that — not a model load — is the moment onboarding
+  // has genuinely succeeded.
+  reportFirstChat(d.store.dir(), d.telemetry, aborted)
 
   try {
     d.manager.recordCompletion({

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -337,7 +337,8 @@ telemetry.dailyActive()
 // which fire load() without awaiting and so cannot see the outcome.
 manager.onLoadSettled = (ok, err) => {
   const outcome = ok ? 'ok' : 'fail'
-  // onboarding_step (ADR-299): the 4th and last setup step — ONBOARDING_STEPS (schema.ts)
+  // onboarding_step (ADR-299): the 3rd setup step (ADR-323 made first_chat the last) —
+  // ONBOARDING_STEPS (schema.ts)
   // defined it from the start, but nothing ever emitted it, so this step of the funnel was
   // structurally stuck at 0% no matter how far real users actually got (found 2026-08-01
   // auditing the funnel against real data; the comment below only ever wired "three setup
@@ -361,12 +362,14 @@ manager.onLoadSettled = (ok, err) => {
 // search probes are individually expected to fail sometimes and must not be
 // hooked the same way as a real load without corrupting the signal.
 bench.telemetry = telemetry
-// onboarding_step (ADR-299): where setup breaks. All four setup steps report both
-// outcomes (first_load wired above, next to model_first_load — once-only, unlike
-// the other three); downloads additionally distinguish 'cancelled', because a
-// user who abandons a download deliberately is not the same signal as one whose
-// download broke, and conflating them reads a choice as a product defect.
-build.onSettled = (ok) => telemetry.emit('onboarding_step', { step: 'engine_build', outcome: ok ? 'ok' : 'fail' })
+// onboarding_step (ADR-299): where setup breaks. The remaining two setup steps are
+// wired here (first_load above, next to model_first_load — once-only, unlike these;
+// first_chat in chat-routes.ts); downloads additionally distinguish 'cancelled',
+// because a user who abandons a download deliberately is not the same signal as one
+// whose download broke, and conflating them reads a choice as a product defect.
+// `build.onSettled` used to emit an `engine_build` step here (ADR-323 removed it):
+// seedDefaultEngines only ever calls provision, never build, so building from source
+// is a later manual action and was never part of the onboarding path it was measuring.
 provision.onSettled = (ok) => telemetry.emit('onboarding_step', { step: 'engine_install', outcome: ok ? 'ok' : 'fail' })
 downloads.onSettled = (outcome) => telemetry.emit('onboarding_step', { step: 'model_download', outcome })
 // Deferred so a slow or failing disk cannot delay the listen socket; unref'd so

--- a/turbollm/src/telemetry/schema.test.ts
+++ b/turbollm/src/telemetry/schema.test.ts
@@ -62,15 +62,14 @@ test('validateEvent: onboarding_step requires a known step and outcome', () => {
   assert.match(r.reason, /outcome/)
 })
 
-test('validateEvent: first_chat is a valid onboarding step, and can be cancelled', () => {
-  assert.equal(
-    validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'first_chat', outcome: 'ok' } })).ok,
-    true,
-  )
-  assert.equal(
-    validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'first_chat', outcome: 'cancelled' } })).ok,
-    true,
-  )
+test('validateEvent: first_chat is a valid onboarding step, and reports ok/fail/cancelled', () => {
+  for (const outcome of ['ok', 'fail', 'cancelled']) {
+    assert.equal(
+      validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'first_chat', outcome } })).ok,
+      true,
+      `first_chat should accept outcome '${outcome}'`,
+    )
+  }
 })
 
 test('validateEvent: engine_build is no longer an onboarding step (ADR-323)', () => {

--- a/turbollm/src/telemetry/schema.test.ts
+++ b/turbollm/src/telemetry/schema.test.ts
@@ -62,6 +62,25 @@ test('validateEvent: onboarding_step requires a known step and outcome', () => {
   assert.match(r.reason, /outcome/)
 })
 
+test('validateEvent: first_chat is a valid onboarding step, and can be cancelled', () => {
+  assert.equal(
+    validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'first_chat', outcome: 'ok' } })).ok,
+    true,
+  )
+  assert.equal(
+    validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'first_chat', outcome: 'cancelled' } })).ok,
+    true,
+  )
+})
+
+test('validateEvent: engine_build is no longer an onboarding step (ADR-323)', () => {
+  // Removed because seedDefaultEngines only ever provisions a prebuilt binary — the
+  // step measured a manual advanced-user action, so it read as near-total drop-off.
+  const r = validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'engine_build', outcome: 'ok' } }))
+  assert.equal(r.ok, false)
+  assert.match(r.reason, /step/)
+})
+
 test('validateEvent: model_first_load takes an optional enum failReason', () => {
   assert.equal(
     validateEvent(validEvent({ event: 'model_first_load', payload: { outcome: 'fail', failReason: 'oom' } })).ok,

--- a/turbollm/src/telemetry/schema.ts
+++ b/turbollm/src/telemetry/schema.ts
@@ -42,8 +42,14 @@ export const FEATURES = [
   'chat', 'code', 'research', 'artifacts', 'mcp', 'agents', 'autotune', 'skills', 'image',
 ] as const
 
-/** Steps in the install → first-token journey (ADR-299 Decision 6). */
-export const ONBOARDING_STEPS = ['engine_install', 'engine_build', 'model_download', 'first_load'] as const
+/** Steps in the install → first-chat journey (ADR-299 Decision 6, amended by
+ *  ADR-323). `engine_build` was on this list originally but is not on the
+ *  automatic path at all: `seedDefaultEngines` only ever provisions a prebuilt
+ *  binary, and building from source is a later, manual, advanced-user action —
+ *  so the step read as near-total drop-off for the entire install base rather
+ *  than as a real signal. `first_chat` replaces it as the last step, because
+ *  "the model loaded" is one step short of the actual success criterion. */
+export const ONBOARDING_STEPS = ['engine_install', 'model_download', 'first_load', 'first_chat'] as const
 
 /** How a step or a load ended. */
 export const OUTCOMES = ['ok', 'fail', 'cancelled'] as const


### PR DESCRIPTION
## Summary
- `engine_build` sat in `ONBOARDING_STEPS` as a funnel gate, but `seedDefaultEngines` (the automatic first-run path) only ever calls `ProvisionState` — building from source is a separate, manual, advanced-user action. Real PostHog data: `engine_install` had 82 attempts over 14 days vs `engine_build`'s 12, so the step read as near-total drop-off for a gate almost no real install was ever meant to reach.
- Dropped `engine_build` from the funnel; added `first_chat` as the real last step (fires once a reply is actually persisted, not just when the model finishes loading).
- `model_download` unchanged — it's honestly conditional (skipped when models already exist at the configured path); making the PostHog *Insight* non-strict on it is a dashboard follow-up, not a code change.

See ADR-323 (`docs/decisions/decision-log.md`, docs repo) for full rationale and the real funnel numbers that motivated this.

## Test plan
- [x] `npx tsx --test` — full turbollm suite: 1669 tests, 1666 pass, 3 skipped, 0 failed
- [x] `npm run typecheck` + `tsup` build — clean
- [x] New `reportFirstChat` tests cover: ok/cancelled outcomes, once-only across many generations, an aborted first chat still claims the once-key, consent-off doesn't spend the claim, no-emitter no-op
- [x] `schema.test.ts` updated: `first_chat` valid, `engine_build` now rejected as an onboarding step