### PR TITLE
fix(tools): run_code worker's sibling import breaks on Linux CI

### DIFF
--- a/turbollm/src/tools/run-code-worker.ts
+++ b/turbollm/src/tools/run-code-worker.ts
@@ -5,7 +5,21 @@
 // back. No other logic belongs here — anything more would be one more thing to keep off the
 // caller's realm.
 import { parentPort, workerData } from 'node:worker_threads'
-import { runCodeInSandbox } from './run-code-sandbox.js'
+
+// A plain `import './run-code-sandbox.js'` relies on tsx's loader remapping that `.js` specifier
+// to the sibling `.ts` source in dev/test — but a freshly spawned worker_threads Worker doesn't
+// reliably inherit that loader hook for its OWN nested imports (confirmed live: this failed with
+// "Cannot find module '.../run-code-sandbox.js'" on Linux CI while passing on Windows dev, even
+// though this very file — also raw `.ts` — loaded fine as the worker's entry point either way).
+// Fixed the same way builtin.ts already resolves THIS file's own path (see WORKER_PATH there):
+// compute the sibling module's real extension from this file's own `import.meta.url` (`.ts` under
+// tsx, `.js` once built — see tsup.config.ts, where run-code-sandbox is its own build entry for
+// exactly this) and dynamically import an absolute same-directory URL, so resolution never depends
+// on any loader hook being active in this thread — only on a real file existing next to this one,
+// which is true in both dev and the built package.
+const SANDBOX_EXT = import.meta.url.endsWith('.ts') ? '.ts' : '.js'
+const SANDBOX_URL = new URL(`./run-code-sandbox${SANDBOX_EXT}`, import.meta.url)
+const { runCodeInSandbox } = await import(SANDBOX_URL.href)
 
 if (!parentPort) {
   throw new Error('run-code-worker.ts must be run as a worker_threads Worker, not imported directly.')

--- a/turbollm/tsup.config.ts
+++ b/turbollm/tsup.config.ts
@@ -4,11 +4,21 @@ export default defineConfig({
   // run-code-worker is a second, independent entry point (not imported/bundled into cli.js) —
   // execRunCode in builtin.ts spawns it as a real node:worker_threads Worker at runtime, which
   // needs an actual file on disk beside the built cli.js, not something inlined into that bundle.
+  // run-code-sandbox is a THIRD, equally independent entry for the same reason: run-code-worker.ts
+  // dynamically imports it via a computed same-directory URL (see run-code-worker.ts) instead of a
+  // static import, so it also needs to exist as a real file rather than get inlined — a spawned
+  // worker_threads Worker doesn't reliably inherit tsx's loader hook for sibling-module resolution
+  // (confirmed: fails on Linux, works on Windows), so the fix is to never depend on that hook at
+  // all and target a real file directly, in both dev/tsx and the built package alike.
   // Object form (not an array) so tsup names the output by these keys FLAT in dist/ — an array
   // entry preserves each file's src/-relative subdirectory (dist/tools/run-code-worker.js),
-  // which would land one directory deeper than cli.js and break builtin.ts's same-directory
-  // `new URL('./run-code-worker.js', import.meta.url)` resolution at runtime.
-  entry: { cli: 'src/cli.ts', 'run-code-worker': 'src/tools/run-code-worker.ts' },
+  // which would land one directory deeper than cli.js and break builtin.ts's/run-code-worker.ts's
+  // same-directory `new URL('./run-code-worker.js', import.meta.url)`-style resolution at runtime.
+  entry: {
+    cli: 'src/cli.ts',
+    'run-code-worker': 'src/tools/run-code-worker.ts',
+    'run-code-sandbox': 'src/tools/run-code-sandbox.ts',
+  },
   format: ['esm'],
   clean: true,
   target: 'node22',


### PR DESCRIPTION
## Summary
CI has been red on \`main\` since \`6973b29\` (before this session's release work) — \`run-code-worker.ts\`'s \`./run-code-sandbox.js\` import relies on tsx's loader remapping it to the sibling \`.ts\` file, which a freshly spawned \`worker_threads.Worker\` doesn't reliably inherit for its own nested imports on Linux (confirmed: fails on CI, passes on Windows dev).

Zero production impact — confirmed via \`tsup.config.ts\`: the static import was being inlined into the built \`run-code-worker.js\` at publish time, so real npm users never had a separate file to fail to find. This is a test-harness-only interaction between tsx and worker_threads, but it means CI currently can't verify the security-critical \`run_code\` sandbox tests on Linux at all — worth fixing properly rather than skipping.

## Fix
- \`run-code-worker.ts\`: replaced the static \`./run-code-sandbox.js\` import with a dynamic import against a computed same-directory URL (\`.ts\` under tsx, \`.js\` once built) — the exact same pattern \`builtin.ts\` already uses to resolve the worker's own path (\`WORKER_PATH\`). Resolution no longer depends on any loader hook being active in the worker thread, only on a real file existing next to this one.
- \`tsup.config.ts\`: \`run-code-sandbox\` is now its own build entry, so that real file actually exists in the published package (previously only inlined via the static import).

## Verification
- [x] Windows: tsx dev/test suite 26/26 (\`run_code\`/\`SECURITY\` tests) and 1575/1575 (full backend)
- [x] Built \`dist/run-code-worker.js\` spawned as a real \`Worker\` against \`dist/run-code-sandbox.js\`, standalone, no tsx involved — executes and returns correctly (the actual runtime path a published package takes)
- [ ] **Linux CI is the real verification for the platform this was actually broken on** — watching this PR's CI run