### PR TITLE
fix(telemetry): wire up error/feature_used_daily, engine_install failReason, wider classifiers

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,30 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.10.1] - 2026-08-04
+
+### Added
+- Opt-in telemetry now reports **why** an engine install failed (network issue, no binary for
+  your OS/platform, disk full, permission denied) instead of just pass/fail — makes a stuck
+  install diagnosable instead of a silent dead end.
+- Two telemetry event types that were designed but never actually sent anything now report real
+  data (only relevant if you've opted into `full`): crash/failure signals, and a bucketed daily
+  usage count per feature (never a raw number).
+
+### Fixed
+- Chat usage telemetry was undercounting: it only recognized the Stop-generation button, not
+  actual message-sending or conversation activity. Only affects our own product-analytics
+  accuracy — no user-visible behavior changed.
+- Engine-load failure telemetry recognized fewer real out-of-memory/architecture/corruption
+  messages than it should have, so more failures than necessary were logged as an unhelpful
+  "other." Internal accuracy only.
+
+### Discord
+- Small internal update: fixed a telemetry accuracy bug (chat usage was being undercounted in
+  our own analytics) and turned on two previously-inert telemetry signals — crash reporting and
+  daily feature usage — for anyone on the `full` opt-in level. Nothing to do on your end, no
+  behavior change in the app itself.
+
 ## [1.10.0] - 2026-08-04
 
 ### Added

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -594,7 +594,7 @@ export function registerApi(app: Hono, d: Deps): void {
           try { rmSync(buildRoot, { recursive: true, force: true }) } catch { /* best effort */ }
           if ((e as Error)?.name === 'AbortError') {
             d.build.log('Build cancelled.')
-            d.build.fail('Build cancelled.')
+            d.build.cancel('Build cancelled.')
           } else {
             // Friendlier message for the common "fork needs a GAS/MinGW assembler" case: some
             // forks (e.g. TurboQuant) enable the generic CMake `ASM` language, which on Windows
@@ -701,7 +701,7 @@ export function registerApi(app: Hono, d: Deps): void {
       } catch (e) {
         if ((e as Error)?.name === 'AbortError') {
           d.build.log('CUDA download cancelled.')
-          d.build.fail('CUDA download cancelled.')
+          d.build.cancel('CUDA download cancelled.')
         } else {
           d.build.fail(`Could not download CUDA: ${e instanceof Error ? e.message : String(e)}`)
         }

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -249,6 +249,15 @@ export class BenchRunner {
       this.telemetry.emit('onboarding_step', { step: 'first_load', outcome })
     }
     reportModelLoad(this.store.dir(), this.telemetry, outcome, failReason)
+    // `error` (telemetry-review follow-up): mirrors cli.ts's onLoadSettled wiring —
+    // auto-tune is a separate path to a first load and must feed the ongoing crash
+    // signal too, not just the once-ever model_first_load milestone above. failReason
+    // here is a classifyBenchFailure() result ('oom'|'timeout'|'other'), a different
+    // vocabulary from classifyEngineErrorFingerprint's — mapped by hand since it's a
+    // small, fixed 3-way correspondence, not worth a shared classifier for.
+    if (outcome === 'fail') {
+      this.telemetry.error(failReason === 'oom' ? 'cuda_oom' : failReason === 'timeout' ? 'engine_start_timeout' : 'other')
+    }
   }
 
   /** Stop the engine — force-killed immediately when the run is cancelled (the user is actively

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -46,7 +46,7 @@ import type { Deps } from './deps'
 import { TELEMETRY_ENV } from './telemetry/disabled'
 import { Emitter } from './telemetry/emit'
 import { reportModelLoad } from './telemetry/first-load'
-import { classifyLoadFailure } from './telemetry/classify'
+import { classifyLoadFailure, classifyEngineErrorFingerprint } from './telemetry/classify'
 import { claimOnce } from './telemetry/ledger'
 import { flush } from './telemetry/uploader'
 
@@ -380,6 +380,11 @@ manager.onLoadSettled = (ok, err) => {
     telemetry.emit('onboarding_step', { step: 'first_load', outcome })
   }
   reportModelLoad(store.dir(), telemetry, outcome, ok ? undefined : classifyLoadFailure(err))
+  // `error` (telemetry-review follow-up, previously never wired to anything):
+  // an ongoing crash signal, deliberately NOT once-only — every engine failure
+  // after the first is still real "what is failing?" data, unlike the
+  // once-ever model_first_load milestone above.
+  if (!ok) telemetry.error(classifyEngineErrorFingerprint(err))
 }
 // Auto-tune's sweep is a SEPARATE path to a first load (Manager.start(), not
 // .load()) — a user whose first real model interaction is "let auto-tune find
@@ -396,8 +401,27 @@ bench.telemetry = telemetry
 // `build.onSettled` used to emit an `engine_build` step here (ADR-323 removed it):
 // seedDefaultEngines only ever calls provision, never build, so building from source
 // is a later manual action and was never part of the onboarding path it was measuring.
-provision.onSettled = (ok) => telemetry.emit('onboarding_step', { step: 'engine_install', outcome: ok ? 'ok' : 'fail' })
-downloads.onSettled = (outcome) => telemetry.emit('onboarding_step', { step: 'model_download', outcome })
+// `failReason` (telemetry-review follow-up): ProvisionState now classifies its own
+// failure via `classifyProvisionFailure` before it ever reaches this observer — see
+// provision-state.ts's `fail()` — so this call site still never touches free text.
+provision.onSettled = (ok, failReason) =>
+  telemetry.emit('onboarding_step', { step: 'engine_install', outcome: ok ? 'ok' : 'fail', ...(failReason ? { failReason } : {}) })
+downloads.onSettled = (outcome) => {
+  telemetry.emit('onboarding_step', { step: 'model_download', outcome })
+  // `error` (telemetry-review follow-up): only one ERROR_FINGERPRINTS bucket exists
+  // for this ('download_failed'), so no text classification is needed here — a
+  // deliberate abandon (AbortError → 'cancelled') is a choice, not a failure, and
+  // must not count as one.
+  if (outcome === 'fail') telemetry.error('download_failed')
+}
+// `error` (telemetry-review follow-up): compiling an engine from source is a later,
+// manual, advanced-user action (ADR-323) — unlike engine_install/model_download it
+// was never part of the onboarding funnel, but a build failure is still a real
+// crash-adjacent signal worth the single 'build_failed' fingerprint. No onboarding_step
+// here, on purpose — see the ADR-323 comment above for why build isn't part of that funnel.
+build.onSettled = (ok) => {
+  if (!ok) telemetry.error('build_failed')
+}
 // Deferred so a slow or failing disk cannot delay the listen socket; unref'd so
 // it never holds the process open (ADR-009: telemetry is not a failure mode).
 setTimeout(() => {
@@ -414,6 +438,12 @@ setTimeout(() => {
 // scheduling of it. Re-reads the level fresh on every tick (not the value at
 // startup), so a mid-session opt-out is honoured on the very next flush.
 setInterval(() => void flush(store.dir(), store.snapshot().telemetry.level), 5 * 60_000).unref()
+// Daily-usage rollover (telemetry-review follow-up): rides the same interval as the
+// queue flush above. Without this, a feature used only on a user's LAST active day
+// would never roll over — `useFeature` only rolls a feature's tally over the next
+// time THAT SAME feature is used, which may never happen again for an install that
+// stops running. Same unref()/best-effort reasoning as the flush interval.
+setInterval(() => telemetry.flushDailyUsage(), 5 * 60_000).unref()
 // Cloud Launch (ADR-045/152): only wired when --tunnel is passed. Its mere presence
 // on Deps is what forces auth enforcement on tunneled traffic (see auth.ts lanAuth) —
 // absent entirely for the vast majority of runs that never asked for a tunnel.

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -419,8 +419,10 @@ downloads.onSettled = (outcome) => {
 // was never part of the onboarding funnel, but a build failure is still a real
 // crash-adjacent signal worth the single 'build_failed' fingerprint. No onboarding_step
 // here, on purpose — see the ADR-323 comment above for why build isn't part of that funnel.
-build.onSettled = (ok) => {
-  if (!ok) telemetry.error('build_failed')
+// 'cancelled' deliberately does NOT emit 'error' (PR #105 review finding) — a build
+// the user aborted themselves is a choice, not a crash.
+build.onSettled = (outcome) => {
+  if (outcome === 'fail') telemetry.error('build_failed')
 }
 // Deferred so a slow or failing disk cannot delay the listen socket; unref'd so
 // it never holds the process open (ADR-009: telemetry is not a failure mode).

--- a/turbollm/src/engines/build-state.settled.test.ts
+++ b/turbollm/src/engines/build-state.settled.test.ts
@@ -13,20 +13,40 @@ function started(): BuildState {
   return b
 }
 
-test('BuildState.onSettled: fires with ok=true on done()', () => {
-  const seen: boolean[] = []
+test('BuildState.onSettled: fires with "ok" on done()', () => {
+  const seen: string[] = []
   const b = started()
-  b.onSettled = (ok) => seen.push(ok)
+  b.onSettled = (outcome) => seen.push(outcome)
   b.done()
-  assert.deepEqual(seen, [true])
+  assert.deepEqual(seen, ['ok'])
 })
 
-test('BuildState.onSettled: fires with ok=false on fail()', () => {
-  const seen: boolean[] = []
+test('BuildState.onSettled: fires with "fail" on fail()', () => {
+  const seen: string[] = []
   const b = started()
-  b.onSettled = (ok) => seen.push(ok)
+  b.onSettled = (outcome) => seen.push(outcome)
   b.fail('cmake exited 1')
-  assert.deepEqual(seen, [false])
+  assert.deepEqual(seen, ['fail'])
+})
+
+// cancel() (PR #105 review finding): a build the user aborted themselves must not
+// be reported as a failure — it shares fail()'s terminal UI shape (phase 'error')
+// but a distinct observer outcome.
+test('BuildState.onSettled: fires with "cancelled" on cancel(), distinct from fail()', () => {
+  const seen: string[] = []
+  const b = started()
+  b.onSettled = (outcome) => seen.push(outcome)
+  b.cancel('Build cancelled.')
+  assert.deepEqual(seen, ['cancelled'])
+})
+
+test('BuildState.cancel(): reports the SAME terminal UI shape as fail() — phase error, with the message', () => {
+  const b = started()
+  b.cancel('Build cancelled.')
+  const status = b.get()
+  assert.equal(status.phase, 'error')
+  assert.equal(status.active, false)
+  assert.equal(status.error, 'Build cancelled.')
 })
 
 test('BuildState.onSettled: an observer that throws does not break the build', () => {

--- a/turbollm/src/engines/build-state.settled.test.ts
+++ b/turbollm/src/engines/build-state.settled.test.ts
@@ -58,3 +58,22 @@ test('ProvisionState.onSettled: reports both outcomes and survives a throwing ob
   }
   assert.doesNotThrow(() => q.done())
 })
+
+// failReason (telemetry-review follow-up): fail()'s raw string must be classified
+// BEFORE it reaches onSettled — the observer may never see free text (same
+// invariant the doc comment on onSettled states).
+test('ProvisionState.onSettled: fail() classifies the error into a failReason enum, never passes the raw string', () => {
+  const seen: Array<{ ok: boolean; failReason?: string }> = []
+  const p = new ProvisionState()
+  p.onSettled = (ok, failReason) => seen.push({ ok, failReason })
+  p.fail('404 fetching release asset')
+  assert.deepEqual(seen, [{ ok: false, failReason: 'no_asset' }])
+})
+
+test('ProvisionState.onSettled: done() reports ok with no failReason', () => {
+  const seen: Array<{ ok: boolean; failReason?: string }> = []
+  const p = new ProvisionState()
+  p.onSettled = (ok, failReason) => seen.push({ ok, failReason })
+  p.done()
+  assert.deepEqual(seen, [{ ok: true, failReason: undefined }])
+})

--- a/turbollm/src/engines/build-state.ts
+++ b/turbollm/src/engines/build-state.ts
@@ -52,25 +52,36 @@ export class BuildState {
   }
 
   /** Optional observer for the terminal outcome, wired in cli.ts (ADR-299
-   *  `onboarding_step`). A plain callback so this module keeps no telemetry
-   *  dependency; the error STRING is deliberately not passed, because the only
-   *  consumer may never send free text. */
-  onSettled?: (ok: boolean) => void
+   *  `onboarding_step` / ADR-327 `error`). A plain callback so this module keeps
+   *  no telemetry dependency; the error STRING is deliberately never passed,
+   *  because the only consumer may never send free text. Three outcomes, not
+   *  two — `cancelled` is distinct from `fail` (PR #105 review finding): a
+   *  build the user deliberately aborted must not be reported as a crash. */
+  onSettled?: (outcome: 'ok' | 'fail' | 'cancelled') => void
 
   done(): void {
     // Keep the log visible but mark inactive + terminal so the UI can show "Built".
     this.s = { ...this.s, active: false, phase: 'done', error: null }
-    this.settle(true)
+    this.settle('ok')
   }
 
   fail(error: string): void {
     this.s = { ...this.s, active: false, phase: 'error', error }
-    this.settle(false)
+    this.settle('fail')
   }
 
-  private settle(ok: boolean): void {
+  /** A deliberate user cancellation. Same terminal UI shape as `fail()` (phase
+   *  'error', so the UI still shows the run ended and why) — only the observer
+   *  outcome differs. A cancel is a choice, not a failure, and must not be
+   *  reported as one. */
+  cancel(message: string): void {
+    this.s = { ...this.s, active: false, phase: 'error', error: message }
+    this.settle('cancelled')
+  }
+
+  private settle(outcome: 'ok' | 'fail' | 'cancelled'): void {
     try {
-      this.onSettled?.(ok)
+      this.onSettled?.(outcome)
     } catch {
       // Observers are advisory — they must not affect a build's outcome.
     }

--- a/turbollm/src/engines/provision-state.ts
+++ b/turbollm/src/engines/provision-state.ts
@@ -2,6 +2,8 @@
 // /api/v1/status so the web UI can show a download/extract progress bar.
 // Single in-process holder; provisioning runs once at startup.
 
+import { classifyProvisionFailure } from '../telemetry/classify'
+
 export interface ProvisionStatus {
   active: boolean
   phase: 'idle' | 'downloading' | 'extracting' | 'error'
@@ -32,9 +34,10 @@ export class ProvisionState {
   }
 
   /** Optional observer for the terminal outcome, wired in cli.ts (ADR-299
-   *  `onboarding_step`). The error string is deliberately not passed — the only
-   *  consumer may never transmit free text. */
-  onSettled?: (ok: boolean) => void
+   *  `onboarding_step`). The raw error STRING is deliberately never passed —
+   *  only `failReason`, a `classifyProvisionFailure` enum member, so the only
+   *  consumer still never sees free text even though it now learns *why*. */
+  onSettled?: (ok: boolean, failReason?: string) => void
 
   done(): void {
     this.s = { active: false, phase: 'idle', backend: '', pct: 0, part: 1, parts: 1, error: null }
@@ -43,12 +46,12 @@ export class ProvisionState {
 
   fail(error: string): void {
     this.s = { active: false, phase: 'error', backend: this.s.backend, pct: 0, part: 1, parts: 1, error }
-    this.settle(false)
+    this.settle(false, classifyProvisionFailure(error))
   }
 
-  private settle(ok: boolean): void {
+  private settle(ok: boolean, failReason?: string): void {
     try {
-      this.onSettled?.(ok)
+      this.onSettled?.(ok, failReason)
     } catch {
       // Observers are advisory — they must not affect an engine install.
     }

--- a/turbollm/src/server.ts
+++ b/turbollm/src/server.ts
@@ -67,13 +67,20 @@ export function createApp(d: Deps): Hono {
   // Code always needs a key from a non-host device, even when the rest of the app is open.
   app.use('/api/v1/code/*', codeAuth(d))
 
-  // Feature-discovery telemetry (ADR-299). Runs AFTER the auth gates above, so
-  // a request that was rejected never counts as the user discovering anything.
-  // Only the path is inspected — never the body, never the query string — and
-  // the emitter itself decides whether consent permits recording it.
+  // Feature-discovery + feature-engagement telemetry (ADR-299, the latter's
+  // wiring added by the telemetry-review follow-up). Runs AFTER the auth gates
+  // above, so a request that was rejected never counts as the user discovering
+  // or using anything. Only the path is inspected — never the body, never the
+  // query string — and the emitter itself decides whether consent permits
+  // recording it. `firstUse` answers "did they ever discover this feature";
+  // `useFeature` answers "are they still using it" — deliberately both, since
+  // discovery data alone can't tell a one-time click from real engagement.
   app.use('*', async (c, next) => {
     const feature = d.telemetry ? featureForPath(c.req.path) : null
-    if (feature !== null) d.telemetry?.firstUse(feature)
+    if (feature !== null) {
+      d.telemetry?.firstUse(feature)
+      d.telemetry?.useFeature(feature)
+    }
     await next()
   })
 

--- a/turbollm/src/telemetry/classify.test.ts
+++ b/turbollm/src/telemetry/classify.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { classifyLoadFailure, classifyBenchFailure } from './classify'
-import { FAIL_REASONS } from './schema'
+import { classifyLoadFailure, classifyBenchFailure, classifyEngineErrorFingerprint, classifyProvisionFailure } from './classify'
+import { FAIL_REASONS, ERROR_FINGERPRINTS, PROVISION_FAIL_REASONS } from './schema'
 
 function err(over: Partial<{ code: string; message: string; logTail: string[] }> = {}) {
   return { code: 'load_failed', message: '', exitCode: 1, logTail: [], ...over }
@@ -101,4 +101,83 @@ test('classifyBenchFailure: always returns a value from the enum', () => {
   for (const outcomes of [[{ outcome: 'oom' as const }], [{ outcome: 'crash' as const }], []]) {
     assert.ok((FAIL_REASONS as readonly string[]).includes(classifyBenchFailure(outcomes)))
   }
+})
+
+test('classifyLoadFailure: recognises the widened OOM/arch/corruption phrasings (telemetry-review follow-up)', () => {
+  assert.equal(classifyLoadFailure(err({ message: 'std::bad_alloc' })), 'oom')
+  assert.equal(classifyLoadFailure(err({ message: 'RuntimeError: CUDA_ERROR_OUT_OF_MEMORY' })), 'oom')
+  assert.equal(classifyLoadFailure(err({ message: 'model architecture not supported: mamba2' })), 'unsupported_arch')
+  assert.equal(classifyLoadFailure(err({ message: 'unexpectedly reached end of file' })), 'bad_gguf')
+  assert.equal(classifyLoadFailure(err({ message: 'failed to read tensor blk.0.attn_q.weight' })), 'bad_gguf')
+})
+
+test('classifyEngineErrorFingerprint: always returns a value from the enum', () => {
+  const inputs = [
+    err({ message: 'CUDA error: out of memory' }),
+    err({ code: 'readiness_timeout' }),
+    err({ code: 'model_load_failed' }),
+    err({ code: 'engine_exited' }),
+    err({ code: 'engine_spawn_failed' }),
+    err({ message: 'something nobody has seen before' }),
+    null,
+  ]
+  for (const e of inputs) {
+    assert.ok(
+      (ERROR_FINGERPRINTS as readonly string[]).includes(classifyEngineErrorFingerprint(e)),
+      `classified value must be in the enum, got ${classifyEngineErrorFingerprint(e)}`,
+    )
+  }
+})
+
+test('classifyEngineErrorFingerprint: maps OOM, timeout, and python load failures to their own fingerprints', () => {
+  assert.equal(classifyEngineErrorFingerprint(err({ message: 'CUDA error: out of memory' })), 'cuda_oom')
+  assert.equal(classifyEngineErrorFingerprint(err({ code: 'readiness_timeout' })), 'engine_start_timeout')
+  assert.equal(classifyEngineErrorFingerprint(err({ code: 'model_load_failed', message: 'traceback...' })), 'model_load_failed')
+  assert.equal(classifyEngineErrorFingerprint(err({ message: 'invalid magic characters in gguf file' })), 'model_load_failed')
+})
+
+test('classifyEngineErrorFingerprint: an unexplained process exit is engine_crash, not other', () => {
+  // We DO know structurally that the process died — 'other' would under-describe it.
+  assert.equal(classifyEngineErrorFingerprint(err({ code: 'engine_exited', message: 'The engine process exited unexpectedly.' })), 'engine_crash')
+  assert.equal(classifyEngineErrorFingerprint(err({ code: 'engine_spawn_failed', message: 'ENOENT' })), 'engine_crash')
+})
+
+test('classifyEngineErrorFingerprint: a null error is other', () => {
+  assert.equal(classifyEngineErrorFingerprint(null), 'other')
+})
+
+test('classifyProvisionFailure: always returns a value from the enum', () => {
+  const inputs = [
+    'TurboQuant has no prebuilt binary for this operating system in its latest release.',
+    '404 fetching release asset',
+    'Could not download a default engine. Check your connection or add one manually.',
+    'ENOSPC: no space left on device',
+    'EACCES: permission denied',
+    'something nobody has seen before',
+    null,
+    undefined,
+  ]
+  for (const m of inputs) {
+    assert.ok(
+      (PROVISION_FAIL_REASONS as readonly string[]).includes(classifyProvisionFailure(m)),
+      `classified value must be in the enum, got ${classifyProvisionFailure(m)}`,
+    )
+  }
+})
+
+test('classifyProvisionFailure: recognises real messages seen at ProvisionState.fail() call sites', () => {
+  assert.equal(classifyProvisionFailure('TurboQuant has no prebuilt binary for this operating system in its latest release.'), 'unsupported_platform')
+  assert.equal(classifyProvisionFailure('KoboldCpp has no prebuilt binary for this operating system/architecture in its latest release.'), 'unsupported_platform')
+  assert.equal(classifyProvisionFailure('llamafile has no downloadable binary in its latest release.'), 'no_asset')
+  assert.equal(classifyProvisionFailure('404 fetching release asset'), 'no_asset')
+  assert.equal(classifyProvisionFailure('Could not download a default engine. Check your connection or add one manually.'), 'network')
+  assert.equal(classifyProvisionFailure('Could not install the vulkan engine: fetch failed'), 'network')
+  assert.equal(classifyProvisionFailure('Could not install the cuda engine: ENOSPC: no space left on device'), 'disk_full')
+  assert.equal(classifyProvisionFailure('Could not install the cuda engine: EACCES: permission denied'), 'permission_denied')
+})
+
+test('classifyProvisionFailure: an unrecognised or missing message is other, not a guess', () => {
+  assert.equal(classifyProvisionFailure('something nobody has seen before'), 'other')
+  assert.equal(classifyProvisionFailure(null), 'other')
+  assert.equal(classifyProvisionFailure(undefined), 'other')
 })

--- a/turbollm/src/telemetry/classify.ts
+++ b/turbollm/src/telemetry/classify.ts
@@ -21,7 +21,10 @@ export interface LoadError {
 }
 
 /** Substrings that mean "we ran out of memory", across the backends we ship.
- *  Lowercased before matching. */
+ *  Lowercased before matching. Widened (telemetry-review follow-up) with more
+ *  vendor/runtime phrasings — `failReason: 'other'` was absorbing half of all
+ *  real failures, and these are legitimate, well-known error strings for the
+ *  backends this product actually ships, not guesses. */
 const OOM_SIGNS = [
   'out of memory',
   'outofmemory',
@@ -30,11 +33,39 @@ const OOM_SIGNS = [
   'memory allocation of size',
   'cudamalloc',
   'insufficient memory',
+  'not enough memory',
+  'unable to allocate',
+  'bad_alloc',
+  'out of vram',
+  'vram allocation failed',
+  'cuda_error_out_of_memory',
+  'resource_exhausted',
 ]
 
-const ARCH_SIGNS = ['unknown model architecture', 'unsupported model architecture', 'unsupported architecture']
+const ARCH_SIGNS = [
+  'unknown model architecture',
+  'unsupported model architecture',
+  'unsupported architecture',
+  'architecture not supported',
+  'unknown architecture',
+]
 
-const GGUF_SIGNS = ['invalid magic', 'error loading model', 'failed to load model', 'gguf_init', 'corrupt']
+/** Corruption/truncation signs — includes an incomplete or interrupted
+ *  download, which manifests as a gguf that fails to parse the same way a
+ *  genuinely corrupt one does. */
+const GGUF_SIGNS = [
+  'invalid magic',
+  'error loading model',
+  'failed to load model',
+  'gguf_init',
+  'corrupt',
+  'unexpected end of file',
+  'unexpectedly reached end of file',
+  'truncated',
+  'failed to read tensor',
+  'wrong number of tensors',
+  'tensor not found',
+]
 
 /** Classify a load failure. Never throws; never returns anything but an enum
  *  member. */
@@ -86,5 +117,73 @@ export interface BenchProbeOutcome {
 export function classifyBenchFailure(results: readonly BenchProbeOutcome[]): string {
   if (results.some((r) => r.outcome === 'oom')) return 'oom'
   if (results.some((r) => r.outcome === 'timeout')) return 'timeout'
+  return 'other'
+}
+
+/**
+ * Classify an engine failure into an `ERROR_FINGERPRINTS` member (`error`
+ * event, ADR-299 Decision 6 / the telemetry-review follow-up that added it).
+ *
+ * Distinct purpose from {@link classifyLoadFailure}: that function feeds the
+ * once-ever `model_first_load` milestone; this one feeds the ongoing `error`
+ * event, which is meant to fire every time an engine dies, not just on an
+ * install's first attempt. Reuses the same sign lists so the two classifiers
+ * cannot silently drift into disagreeing about what an OOM message looks like.
+ *
+ * `engine_crash` is the deliberate fallback for `engine_exited`/
+ * `engine_spawn_failed` codes with no more specific signal recognised — we DO
+ * know structurally that the process died, so `other` would under-describe it.
+ */
+export function classifyEngineErrorFingerprint(err: LoadError | null | undefined): string {
+  if (!err) return 'other'
+
+  if (err.code === 'readiness_timeout') return 'engine_start_timeout'
+  if (err.code === 'model_load_failed') return 'model_load_failed'
+
+  const haystack = [err.message ?? '', ...(err.logTail ?? [])].join('\n').toLowerCase()
+
+  if (OOM_SIGNS.some((s) => haystack.includes(s))) return 'cuda_oom'
+  if (ARCH_SIGNS.some((s) => haystack.includes(s))) return 'model_load_failed'
+  if (GGUF_SIGNS.some((s) => haystack.includes(s))) return 'model_load_failed'
+
+  if (err.code === 'engine_exited' || err.code === 'engine_spawn_failed') return 'engine_crash'
+  return 'other'
+}
+
+/** Substrings for provisioning (engine install) failures — a download/extract
+ *  of a prebuilt binary, distinct from both a model load and a from-source
+ *  build. Lowercased before matching. */
+const NETWORK_SIGNS = [
+  'enotfound', 'econnreset', 'econnrefused', 'etimedout', 'fetch failed',
+  'network', 'check your connection',
+]
+const NO_ASSET_SIGNS = ['404', 'no downloadable binary', 'no release asset', 'not found in']
+const UNSUPPORTED_PLATFORM_SIGNS = ['no prebuilt binary for this operating system', 'unsupported platform', 'unsupported architecture']
+const DISK_FULL_SIGNS = ['enospc', 'no space left']
+const PERMISSION_SIGNS = ['eacces', 'eperm', 'permission denied', 'access is denied']
+
+/**
+ * Classify why provisioning a prebuilt engine failed, into a
+ * `PROVISION_FAIL_REASONS` member (`onboarding_step: engine_install`,
+ * ADR-299 amended by the telemetry-review follow-up).
+ *
+ * Mirrors {@link classifyLoadFailure}'s boundary contract exactly: the input
+ * is `ProvisionState.fail()`'s free-form message (built from `Error#message`
+ * at call sites across `api/routes.ts`/`engines/seed.ts`/`engines/update-
+ * apply.ts`), the output is always an enum member, and classification happens
+ * INSIDE `ProvisionState` — never the raw string — so `onSettled` observers
+ * (telemetry included) still never see free text, preserving the invariant
+ * both `ProvisionState` and `BuildState` document on `onSettled`.
+ */
+export function classifyProvisionFailure(message: string | null | undefined): string {
+  if (!message) return 'other'
+  const haystack = message.toLowerCase()
+
+  if (UNSUPPORTED_PLATFORM_SIGNS.some((s) => haystack.includes(s))) return 'unsupported_platform'
+  if (NO_ASSET_SIGNS.some((s) => haystack.includes(s))) return 'no_asset'
+  if (DISK_FULL_SIGNS.some((s) => haystack.includes(s))) return 'disk_full'
+  if (PERMISSION_SIGNS.some((s) => haystack.includes(s))) return 'permission_denied'
+  if (NETWORK_SIGNS.some((s) => haystack.includes(s))) return 'network'
+
   return 'other'
 }

--- a/turbollm/src/telemetry/daily-usage.test.ts
+++ b/turbollm/src/telemetry/daily-usage.test.ts
@@ -1,0 +1,129 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { bucketCount, recordFeatureUse, flushStaleDailyUsage } from './daily-usage'
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'turbollm-daily-usage-'))
+}
+
+test('bucketCount: never returns the raw number — always one of COUNT_BUCKETS', () => {
+  assert.equal(bucketCount(0), '1')
+  assert.equal(bucketCount(1), '1')
+  assert.equal(bucketCount(2), '2-5')
+  assert.equal(bucketCount(5), '2-5')
+  assert.equal(bucketCount(6), '6-20')
+  assert.equal(bucketCount(20), '6-20')
+  assert.equal(bucketCount(21), '21-100')
+  assert.equal(bucketCount(100), '21-100')
+  assert.equal(bucketCount(101), '100+')
+  assert.equal(bucketCount(50_000), '100+')
+})
+
+test('recordFeatureUse: first use ever returns null — nothing to roll over yet', () => {
+  const dir = tempDir()
+  try {
+    assert.equal(recordFeatureUse(dir, 'chat', '2026-07-29'), null)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordFeatureUse: same-day repeats accumulate silently, still no rollover', () => {
+  const dir = tempDir()
+  try {
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    assert.equal(recordFeatureUse(dir, 'chat', '2026-07-29'), null)
+    assert.equal(recordFeatureUse(dir, 'chat', '2026-07-29'), null)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordFeatureUse: a day change rolls over the PREVIOUS day\'s bucketed tally', () => {
+  const dir = tempDir()
+  try {
+    for (let i = 0; i < 3; i++) recordFeatureUse(dir, 'chat', '2026-07-29') // 3 uses on day 1
+    const rolled = recordFeatureUse(dir, 'chat', '2026-07-30') // 1st use on day 2
+    assert.deepEqual(rolled, { day: '2026-07-29', bucket: '2-5' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordFeatureUse: after a rollover, today starts a fresh count of 1', () => {
+  const dir = tempDir()
+  try {
+    for (let i = 0; i < 3; i++) recordFeatureUse(dir, 'chat', '2026-07-29')
+    recordFeatureUse(dir, 'chat', '2026-07-30') // rolls over, starts day 2 at 1
+    assert.equal(recordFeatureUse(dir, 'chat', '2026-07-30'), null, 'still day 2, second use — no rollover yet')
+    const rolled = recordFeatureUse(dir, 'chat', '2026-07-31')
+    assert.deepEqual(rolled, { day: '2026-07-30', bucket: '2-5' }, 'day 2 had exactly 2 uses, not 1 carried over from day 1')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordFeatureUse: distinct features are tracked independently', () => {
+  const dir = tempDir()
+  try {
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    for (let i = 0; i < 10; i++) recordFeatureUse(dir, 'code', '2026-07-29')
+    const chatRolled = recordFeatureUse(dir, 'chat', '2026-07-30')
+    const codeRolled = recordFeatureUse(dir, 'code', '2026-07-30')
+    assert.deepEqual(chatRolled, { day: '2026-07-29', bucket: '1' })
+    assert.deepEqual(codeRolled, { day: '2026-07-29', bucket: '6-20' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordFeatureUse: never throws, even against an unwritable dataDir', () => {
+  assert.doesNotThrow(() => recordFeatureUse('\0bad', 'chat', '2026-07-29'))
+})
+
+test('flushStaleDailyUsage: rolls over every feature not from today, and clears them', () => {
+  const dir = tempDir()
+  try {
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    recordFeatureUse(dir, 'code', '2026-07-29')
+
+    const rolled = flushStaleDailyUsage(dir, '2026-07-30')
+    const byFeature = Object.fromEntries(rolled.map((r) => [r.feature, r.bucket]))
+    assert.deepEqual(byFeature, { chat: '2-5', code: '1' })
+
+    // Flushed entries are gone — a second flush on the same day finds nothing left.
+    assert.deepEqual(flushStaleDailyUsage(dir, '2026-07-30'), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('flushStaleDailyUsage: a feature already on today is left untouched', () => {
+  const dir = tempDir()
+  try {
+    recordFeatureUse(dir, 'chat', '2026-07-30')
+    assert.deepEqual(flushStaleDailyUsage(dir, '2026-07-30'), [])
+    // Still there, still countable — flushing today's entry didn't clear it.
+    const rolled = recordFeatureUse(dir, 'chat', '2026-07-31')
+    assert.deepEqual(rolled, { day: '2026-07-30', bucket: '1' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('flushStaleDailyUsage: never throws, even against an unwritable dataDir', () => {
+  assert.doesNotThrow(() => flushStaleDailyUsage('\0bad', '2026-07-29'))
+})
+
+test('flushStaleDailyUsage: nothing recorded yet is a no-op', () => {
+  const dir = tempDir()
+  try {
+    assert.deepEqual(flushStaleDailyUsage(dir, '2026-07-29'), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/telemetry/daily-usage.test.ts
+++ b/turbollm/src/telemetry/daily-usage.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { bucketCount, recordFeatureUse, flushStaleDailyUsage } from './daily-usage'
+import { readFileSync } from 'node:fs'
+import { bucketCount, recordFeatureUse, flushStaleDailyUsage, persistDailyUsage } from './daily-usage'
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), 'turbollm-daily-usage-'))
@@ -126,4 +127,38 @@ test('flushStaleDailyUsage: nothing recorded yet is a no-op', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
+})
+
+// persistDailyUsage (PR #105 review finding — hot-path fix): same-day counts are
+// in-memory only, to avoid a disk write on every matching API request. This is
+// the periodic-flush half that gets them onto disk before a possible crash.
+test('persistDailyUsage: writes today\'s in-progress (not yet rolled-over) count to disk', () => {
+  const dir = tempDir()
+  try {
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    recordFeatureUse(dir, 'chat', '2026-07-29')
+    // Nothing on disk yet — same-day increments never touch it.
+    assert.throws(() => readFileSync(dir + '/telemetry/daily-usage.json', 'utf8'))
+
+    persistDailyUsage(dir)
+    const onDisk = JSON.parse(readFileSync(dir + '/telemetry/daily-usage.json', 'utf8'))
+    assert.deepEqual(onDisk, { chat: { day: '2026-07-29', count: 3 } })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('persistDailyUsage: nothing recorded this process is a no-op, never throws', () => {
+  const dir = tempDir()
+  try {
+    assert.doesNotThrow(() => persistDailyUsage(dir))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('persistDailyUsage: never throws, even against an unwritable dataDir', () => {
+  recordFeatureUse('\0bad-persist', 'chat', '2026-07-29')
+  assert.doesNotThrow(() => persistDailyUsage('\0bad-persist'))
 })

--- a/turbollm/src/telemetry/daily-usage.ts
+++ b/turbollm/src/telemetry/daily-usage.ts
@@ -1,0 +1,114 @@
+/**
+ * Daily-bucketed feature usage counter (`feature_used_daily`, ADR-299
+ * Decision 6 / the telemetry-review follow-up that actually wired it up).
+ *
+ * A raw usage count is a behavioural fingerprint, so it is never sent as a
+ * number — this module tracks the real per-day-per-feature count locally
+ * (mirrors `ledger.ts`'s file-based, best-effort, never-throws shape) and
+ * only a `COUNT_BUCKETS` bucket ever crosses into an emitted event.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+interface DailyCount {
+  day: string
+  count: number
+}
+
+type DailyUsage = Record<string, DailyCount>
+
+function usagePath(dataDir: string): string {
+  return join(dataDir, 'telemetry', 'daily-usage.json')
+}
+
+function read(dataDir: string): DailyUsage {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(usagePath(dataDir), 'utf8'))
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+    return parsed as DailyUsage
+  } catch {
+    return {}
+  }
+}
+
+function write(dataDir: string, usage: DailyUsage): void {
+  mkdirSync(join(dataDir, 'telemetry'), { recursive: true })
+  writeFileSync(usagePath(dataDir), JSON.stringify(usage))
+}
+
+/** Bucket a raw count into `COUNT_BUCKETS` (schema.ts) — the only shape of
+ *  this number that may ever leave the machine. */
+export function bucketCount(n: number): string {
+  if (n <= 1) return '1'
+  if (n <= 5) return '2-5'
+  if (n <= 20) return '6-20'
+  if (n <= 100) return '21-100'
+  return '100+'
+}
+
+/**
+ * Record one use of `feature` on `today`. Returns the PREVIOUS day's bucketed
+ * tally when the calendar day just rolled over for this feature (the caller
+ * emits it); returns `null` when there is nothing to roll over yet — either
+ * the first use ever, or still the same day as the last one.
+ *
+ * Never throws (ADR-009): any read/write failure is swallowed and treated as
+ * "nothing to roll over", the same failure philosophy as `ledger.ts`.
+ */
+export function recordFeatureUse(
+  dataDir: string,
+  feature: string,
+  today: string,
+): { day: string; bucket: string } | null {
+  try {
+    const usage = read(dataDir)
+    const existing = usage[feature]
+
+    if (existing === undefined) {
+      usage[feature] = { day: today, count: 1 }
+      write(dataDir, usage)
+      return null
+    }
+
+    if (existing.day === today) {
+      usage[feature] = { day: today, count: existing.count + 1 }
+      write(dataDir, usage)
+      return null
+    }
+
+    const rolled = { day: existing.day, bucket: bucketCount(existing.count) }
+    usage[feature] = { day: today, count: 1 }
+    write(dataDir, usage)
+    return rolled
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Roll over every feature whose recorded day is earlier than `today`. Called
+ * from the daemon's periodic telemetry flush (cli.ts) so a feature used only
+ * on a user's LAST active day still gets its count reported, rather than
+ * waiting forever for a next use of that same feature that may never come.
+ */
+export function flushStaleDailyUsage(
+  dataDir: string,
+  today: string,
+): Array<{ feature: string; day: string; bucket: string }> {
+  try {
+    const usage = read(dataDir)
+    const rolled: Array<{ feature: string; day: string; bucket: string }> = []
+    let changed = false
+    for (const [feature, entry] of Object.entries(usage)) {
+      if (entry.day === today) continue
+      rolled.push({ feature, day: entry.day, bucket: bucketCount(entry.count) })
+      delete usage[feature]
+      changed = true
+    }
+    if (changed) write(dataDir, usage)
+    return rolled
+  } catch {
+    return []
+  }
+}

--- a/turbollm/src/telemetry/daily-usage.ts
+++ b/turbollm/src/telemetry/daily-usage.ts
@@ -6,6 +6,18 @@
  * number — this module tracks the real per-day-per-feature count locally
  * (mirrors `ledger.ts`'s file-based, best-effort, never-throws shape) and
  * only a `COUNT_BUCKETS` bucket ever crosses into an emitted event.
+ *
+ * In-memory cache, not a disk round-trip per call (PR #105 review finding):
+ * `recordFeatureUse` runs on the feature-discovery middleware, which fires on
+ * EVERY matching API request — including the heaviest agentic-coding traffic
+ * this product is designed to serve. A synchronous read+write per request
+ * would double the disk I/O the pre-existing `firstUse`/`claimOnce` path
+ * already pays on that same hot path. Instead, same-day increments only touch
+ * an in-memory map; disk writes happen on a real rollover (at most once per
+ * feature per day) or via `persistDailyUsage`, called from the daemon's
+ * existing 5-minute telemetry flush interval (cli.ts) so a crash between
+ * flushes loses at most one interval's worth of counting — the same bounded
+ * risk ADR-009 already accepts for the queue flush.
  */
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
@@ -18,11 +30,16 @@ interface DailyCount {
 
 type DailyUsage = Record<string, DailyCount>
 
+/** Per-dataDir in-memory cache. Keyed by dataDir (not a singleton) so
+ *  multiple daemons/tests pointed at different data directories in the same
+ *  process never share state. */
+const cache = new Map<string, DailyUsage>()
+
 function usagePath(dataDir: string): string {
   return join(dataDir, 'telemetry', 'daily-usage.json')
 }
 
-function read(dataDir: string): DailyUsage {
+function readFromDisk(dataDir: string): DailyUsage {
   try {
     const parsed: unknown = JSON.parse(readFileSync(usagePath(dataDir), 'utf8'))
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
@@ -32,9 +49,20 @@ function read(dataDir: string): DailyUsage {
   }
 }
 
-function write(dataDir: string, usage: DailyUsage): void {
+function writeToDisk(dataDir: string, usage: DailyUsage): void {
   mkdirSync(join(dataDir, 'telemetry'), { recursive: true })
   writeFileSync(usagePath(dataDir), JSON.stringify(usage))
+}
+
+/** The in-memory usage map for `dataDir`, hydrated from disk on first access
+ *  (once per process per dataDir — later calls are pure memory). */
+function loadCache(dataDir: string): DailyUsage {
+  let usage = cache.get(dataDir)
+  if (usage === undefined) {
+    usage = readFromDisk(dataDir)
+    cache.set(dataDir, usage)
+  }
+  return usage
 }
 
 /** Bucket a raw count into `COUNT_BUCKETS` (schema.ts) — the only shape of
@@ -53,6 +81,10 @@ export function bucketCount(n: number): string {
  * emits it); returns `null` when there is nothing to roll over yet — either
  * the first use ever, or still the same day as the last one.
  *
+ * Same-day increments are in-memory only (see module doc comment) — a
+ * rollover is the only case that persists to disk immediately, since it's
+ * inherently rare (at most once per feature per day).
+ *
  * Never throws (ADR-009): any read/write failure is swallowed and treated as
  * "nothing to roll over", the same failure philosophy as `ledger.ts`.
  */
@@ -62,24 +94,22 @@ export function recordFeatureUse(
   today: string,
 ): { day: string; bucket: string } | null {
   try {
-    const usage = read(dataDir)
+    const usage = loadCache(dataDir)
     const existing = usage[feature]
 
     if (existing === undefined) {
       usage[feature] = { day: today, count: 1 }
-      write(dataDir, usage)
       return null
     }
 
     if (existing.day === today) {
       usage[feature] = { day: today, count: existing.count + 1 }
-      write(dataDir, usage)
       return null
     }
 
     const rolled = { day: existing.day, bucket: bucketCount(existing.count) }
     usage[feature] = { day: today, count: 1 }
-    write(dataDir, usage)
+    writeToDisk(dataDir, usage)
     return rolled
   } catch {
     return null
@@ -97,7 +127,7 @@ export function flushStaleDailyUsage(
   today: string,
 ): Array<{ feature: string; day: string; bucket: string }> {
   try {
-    const usage = read(dataDir)
+    const usage = loadCache(dataDir)
     const rolled: Array<{ feature: string; day: string; bucket: string }> = []
     let changed = false
     for (const [feature, entry] of Object.entries(usage)) {
@@ -106,9 +136,27 @@ export function flushStaleDailyUsage(
       delete usage[feature]
       changed = true
     }
-    if (changed) write(dataDir, usage)
+    if (changed) writeToDisk(dataDir, usage)
     return rolled
   } catch {
     return []
+  }
+}
+
+/**
+ * Persist the current in-memory tally to disk as-is, without rolling
+ * anything over — the periodic-flush half of the hot-path fix (PR #105
+ * review): same-day counts otherwise only live in memory and would be lost
+ * on a crash between rollovers. Called from the same 5-minute interval as
+ * `flushStaleDailyUsage` (cli.ts), immediately after it, so a stale entry is
+ * rolled over first and only the fresh remainder gets written here.
+ */
+export function persistDailyUsage(dataDir: string): void {
+  try {
+    const usage = cache.get(dataDir)
+    if (usage === undefined) return // nothing recorded this process — nothing to persist
+    writeToDisk(dataDir, usage)
+  } catch {
+    // Best-effort by contract (ADR-009).
   }
 }

--- a/turbollm/src/telemetry/emit.test.ts
+++ b/turbollm/src/telemetry/emit.test.ts
@@ -207,6 +207,106 @@ test('once: the kill switch does not spend the claim either', () => {
   }
 })
 
+// ── error (telemetry-review follow-up — previously never wired to anything) ──
+
+test('error: requires full level, not just anon', () => {
+  const dir = tempDir()
+  try {
+    makeEmitter(dir, 'anon').emitter.error('engine_crash')
+    assert.deepEqual(names(dir), [], 'anon must not send crash diagnostics')
+
+    makeEmitter(dir, 'full').emitter.error('engine_crash')
+    assert.deepEqual(names(dir), ['error'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('error: NOT once-only — every crash after the first is still real data', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'full')
+    emitter.error('engine_crash')
+    emitter.error('cuda_oom')
+    assert.equal(names(dir).length, 2, 'unlike firstUse/once, repeats must not be deduped')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// ── useFeature / flushDailyUsage (feature_used_daily, telemetry-review follow-up) ──
+
+test('useFeature: does not emit on first use — nothing to roll over yet', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'anon', '2026-07-29')
+    emitter.useFeature('chat')
+    emitter.useFeature('chat')
+    assert.deepEqual(names(dir), [], 'same-day usage has nothing to roll over until the day changes')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('useFeature: rolls over a bucketed count for the previous day once the day changes', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'anon', '2026-07-29')
+    for (let i = 0; i < 4; i++) emitter.useFeature('chat') // 4 uses on day 1
+
+    const { emitter: tomorrow } = makeEmitter(dir, 'anon', '2026-07-30')
+    tomorrow.useFeature('chat') // first use on day 2 triggers the rollover
+    const events = readQueue(dir).map((q) => q.event as { event: string; payload?: Record<string, unknown> })
+    const rolled = events.filter((e) => e.event === 'feature_used_daily')
+    assert.equal(rolled.length, 1)
+    assert.deepEqual(rolled[0].payload, { feature: 'chat', countBucket: '2-5' }, '4 uses buckets to 2-5, never the raw count')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('useFeature: consent off does not spend a count — same reasoning as firstUse', () => {
+  const dir = tempDir()
+  try {
+    makeEmitter(dir, 'off', '2026-07-29').emitter.useFeature('chat')
+    const { emitter: tomorrow } = makeEmitter(dir, 'anon', '2026-07-30')
+    tomorrow.useFeature('chat')
+    assert.deepEqual(names(dir), [], 'no usage was ever recorded while off, so there is nothing to roll over')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('flushDailyUsage: rolls over a feature used only on the last active day', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'anon', '2026-07-29')
+    emitter.useFeature('code')
+    emitter.useFeature('code')
+    assert.deepEqual(names(dir), [], 'nothing rolled over yet — code was never used again')
+
+    const { emitter: tomorrow } = makeEmitter(dir, 'anon', '2026-07-30')
+    tomorrow.flushDailyUsage()
+    const events = readQueue(dir).map((q) => q.event as { event: string; payload?: Record<string, unknown> })
+    const rolled = events.filter((e) => e.event === 'feature_used_daily')
+    assert.deepEqual(rolled[0].payload, { feature: 'code', countBucket: '2-5' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('flushDailyUsage: nothing to flush on the same day is a no-op', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'anon', '2026-07-29')
+    emitter.useFeature('chat')
+    emitter.flushDailyUsage()
+    assert.deepEqual(names(dir), [])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('emit: an unwritable data dir never throws', () => {
   const { emitter } = makeEmitter('\0invalid', 'anon')
   assert.doesNotThrow(() => emitter.emit('app_first_run'))

--- a/turbollm/src/telemetry/emit.ts
+++ b/turbollm/src/telemetry/emit.ts
@@ -16,7 +16,7 @@ import { enqueue } from './queue'
 import { claimOnce } from './ledger'
 import { telemetryDisabled } from './disabled'
 import { TELEMETRY_SCHEMA_VERSION, type EventName } from './schema'
-import { recordFeatureUse, flushStaleDailyUsage } from './daily-usage'
+import { recordFeatureUse, flushStaleDailyUsage, persistDailyUsage } from './daily-usage'
 
 /** Just enough of ConfigStore for the emitter — kept structural so tests need
  *  no real config file. */
@@ -117,16 +117,21 @@ export class Emitter {
   }
 
   /**
-   * Roll over any feature whose tally is from a day earlier than today.
-   * Called periodically (cli.ts, alongside the queue flush) so a feature
-   * used only on a user's LAST active day still gets reported, instead of
-   * waiting indefinitely for a next use of that same feature.
+   * Roll over any feature whose tally is from a day earlier than today, then
+   * persist whatever's left (today's still-in-progress counts) to disk.
+   * Called periodically (cli.ts, alongside the queue flush) for two reasons:
+   * a feature used only on a user's LAST active day still gets reported
+   * instead of waiting indefinitely for a next use that may never come, AND
+   * same-day counts — which `useFeature` only ever keeps in memory, to avoid
+   * a disk write on every matching API request — get a chance to survive a
+   * crash instead of living only until the next rollover.
    */
   flushDailyUsage(): void {
     if (!this.canSend('feature_used_daily')) return
     for (const { feature, bucket } of flushStaleDailyUsage(this.o.dataDir, this.today())) {
       this.emit('feature_used_daily', { feature, countBucket: bucket })
     }
+    persistDailyUsage(this.o.dataDir)
   }
 
   /**

--- a/turbollm/src/telemetry/emit.ts
+++ b/turbollm/src/telemetry/emit.ts
@@ -16,6 +16,7 @@ import { enqueue } from './queue'
 import { claimOnce } from './ledger'
 import { telemetryDisabled } from './disabled'
 import { TELEMETRY_SCHEMA_VERSION, type EventName } from './schema'
+import { recordFeatureUse, flushStaleDailyUsage } from './daily-usage'
 
 /** Just enough of ConfigStore for the emitter — kept structural so tests need
  *  no real config file. */
@@ -99,6 +100,43 @@ export class Emitter {
   dailyActive(): void {
     if (!this.canSend('daily_active')) return
     if (this.claim(`daily:${this.today()}`)) this.emit('daily_active')
+  }
+
+  /**
+   * Count one use of `feature` toward today's tally, emitting a bucketed
+   * `feature_used_daily` for the previous day the moment the calendar day
+   * rolls over. Consent is checked BEFORE any count is recorded — same
+   * reasoning as `firstUse` above (see its doc comment): usage while
+   * telemetry is off must never silently contribute to a count reported
+   * after the user opts in later.
+   */
+  useFeature(feature: string): void {
+    if (!this.canSend('feature_used_daily')) return
+    const rolled = recordFeatureUse(this.o.dataDir, feature, this.today())
+    if (rolled) this.emit('feature_used_daily', { feature, countBucket: rolled.bucket })
+  }
+
+  /**
+   * Roll over any feature whose tally is from a day earlier than today.
+   * Called periodically (cli.ts, alongside the queue flush) so a feature
+   * used only on a user's LAST active day still gets reported, instead of
+   * waiting indefinitely for a next use of that same feature.
+   */
+  flushDailyUsage(): void {
+    if (!this.canSend('feature_used_daily')) return
+    for (const { feature, bucket } of flushStaleDailyUsage(this.o.dataDir, this.today())) {
+      this.emit('feature_used_daily', { feature, countBucket: bucket })
+    }
+  }
+
+  /**
+   * Emit `error` — full level only (`REQUIRES_FULL` above), and deliberately
+   * NOT once-only: unlike `model_first_load`'s single most-valuable-attempt
+   * signal, every crash after the first is still a real data point (ADR-299's
+   * "what is failing?" journey question, previously never wired to anything).
+   */
+  error(fingerprint: string): void {
+    this.emit('error', { fingerprint })
   }
 
   /**

--- a/turbollm/src/telemetry/feature-map.test.ts
+++ b/turbollm/src/telemetry/feature-map.test.ts
@@ -3,13 +3,22 @@ import assert from 'node:assert/strict'
 import { featureForPath } from './feature-map'
 
 test('featureForPath: maps each instrumented surface to its feature', () => {
-  assert.equal(featureForPath('/api/v1/chat/send'), 'chat')
   assert.equal(featureForPath('/api/v1/code/sessions'), 'code')
   assert.equal(featureForPath('/api/v1/artifacts/abc'), 'artifacts')
   assert.equal(featureForPath('/api/v1/mcp/servers'), 'mcp')
   assert.equal(featureForPath('/api/v1/bench/run'), 'autotune')
   assert.equal(featureForPath('/api/v1/comfyui/install'), 'image')
   assert.equal(featureForPath('/api/v1/comfyui/uninstall'), 'image')
+})
+
+// PR #105 review finding: real chat traffic (send a message, create/load a
+// conversation) lives under /api/v1/conversations/*, not /api/v1/chat/* — the
+// latter only covers the Stop-generation button. Both must map to 'chat'.
+test('featureForPath: real chat traffic (conversations) maps to chat, not just the Stop button', () => {
+  assert.equal(featureForPath('/api/v1/conversations'), 'chat', 'listing conversations')
+  assert.equal(featureForPath('/api/v1/conversations/abc123/messages'), 'chat', 'sending a message')
+  assert.equal(featureForPath('/api/v1/conversations/abc123/continue'), 'chat', 'continuing a turn')
+  assert.equal(featureForPath('/api/v1/chat/stop'), 'chat', 'the Stop button, still mapped')
 })
 
 test('featureForPath: research is deliberately NOT mapped — there is no dedicated endpoint', () => {

--- a/turbollm/src/telemetry/feature-map.ts
+++ b/turbollm/src/telemetry/feature-map.ts
@@ -31,7 +31,15 @@
  * that only the path is ever inspected, never the body — so there is no path
  * this table could map without breaking that guarantee. */
 const BY_SEGMENT: Record<string, string> = {
+  // `chat` (bare) only covers `/api/v1/chat/stop` — the Stop-generation button. Real
+  // chat traffic (sending a message, creating/loading a conversation) lives under
+  // `/api/v1/conversations/*` instead (PR #105 review finding: `chat` alone was
+  // silently under-counting the product's own core feature). `conversations` IS the
+  // chat feature's own primary data endpoint, not a foreign feature fetched as a side
+  // effect the way `/api/v1/skills`/`/api/v1/chat-agents` are (see the comment below) —
+  // so, unlike those two, mapping it here doesn't risk corrupting an unrelated signal.
   chat: 'chat',
+  conversations: 'chat',
   code: 'code',
   artifacts: 'artifacts',
   mcp: 'mcp',

--- a/turbollm/src/telemetry/schema.test.ts
+++ b/turbollm/src/telemetry/schema.test.ts
@@ -88,6 +88,43 @@ test('validateEvent: model_first_load takes an optional enum failReason', () => 
   assert.equal(validateEvent(validEvent({ event: 'model_first_load', payload: { outcome: 'ok' } })).ok, true)
 })
 
+test('validateEvent: onboarding_step takes an optional enum failReason (engine_install, telemetry-review follow-up)', () => {
+  assert.equal(
+    validateEvent(
+      validEvent({ event: 'onboarding_step', payload: { step: 'engine_install', outcome: 'fail', failReason: 'network' } }),
+    ).ok,
+    true,
+  )
+  assert.equal(
+    validateEvent(validEvent({ event: 'onboarding_step', payload: { step: 'engine_install', outcome: 'ok' } })).ok,
+    true,
+    'failReason is optional — an ok outcome need not carry one',
+  )
+  const r = validateEvent(
+    validEvent({ event: 'onboarding_step', payload: { step: 'engine_install', outcome: 'fail', failReason: 'oom' } }),
+  )
+  assert.equal(r.ok, false, "'oom' is a model-load reason, not a provisioning one — must not validate here")
+})
+
+test('validateEvent: error requires a known fingerprint', () => {
+  assert.equal(
+    validateEvent(validEvent({ event: 'error', payload: { fingerprint: 'engine_crash' } })).ok,
+    true,
+  )
+  const r = validateEvent(validEvent({ event: 'error', payload: { fingerprint: 'stack trace: at foo.ts:42' } }))
+  assert.equal(r.ok, false)
+  assert.match(r.reason, /fingerprint/)
+})
+
+test('validateEvent: feature_used_daily requires a known feature and a bucketed count, never a raw number', () => {
+  assert.equal(
+    validateEvent(validEvent({ event: 'feature_used_daily', payload: { feature: 'chat', countBucket: '6-20' } })).ok,
+    true,
+  )
+  const r = validateEvent(validEvent({ event: 'feature_used_daily', payload: { feature: 'chat', countBucket: 17 } }))
+  assert.equal(r.ok, false, 'a raw number must never validate as a countBucket')
+})
+
 test('validateEvent: model_first_load rejects a free-text failure message', () => {
   const r = validateEvent(
     validEvent({

--- a/turbollm/src/telemetry/schema.ts
+++ b/turbollm/src/telemetry/schema.ts
@@ -60,6 +60,15 @@ export const FAIL_REASONS = [
   'oom', 'no_engine', 'bad_gguf', 'unsupported_arch', 'timeout', 'cancelled', 'other',
 ] as const
 
+/** Why provisioning a prebuilt engine failed (`onboarding_step: engine_install`
+ *  only — see `classifyProvisionFailure`). A separate enum from `FAIL_REASONS`:
+ *  installing an engine archive and loading a model fail in different ways
+ *  (network/asset/platform vs. oom/arch/corruption), so the two vocabularies
+ *  don't overlap much and shouldn't be merged into one. */
+export const PROVISION_FAIL_REASONS = [
+  'network', 'no_asset', 'unsupported_platform', 'disk_full', 'permission_denied', 'other',
+] as const
+
 /** Usage counts are bucketed, never raw: a raw count is a behavioural fingerprint. */
 export const COUNT_BUCKETS = ['1', '2-5', '6-20', '21-100', '100+'] as const
 
@@ -163,7 +172,14 @@ const HW_SPEC: Record<string, FieldSpec> = {
 }
 
 const PAYLOAD_SPECS: Record<string, Record<string, FieldSpec>> = {
-  onboarding_step: { step: { enum: ONBOARDING_STEPS }, outcome: { enum: OUTCOMES } },
+  // `failReason` is optional and, today, only ever sent for `step: 'engine_install'`
+  // (classified by `classifyProvisionFailure`, PROVISION_FAIL_REASONS) — mirrors
+  // `model_first_load.failReason`'s own "optional, only present on a real failure"
+  // shape. Not step-conditional at the schema level (this validator is flat per
+  // event name, not per payload value) — enforced by convention at the one call
+  // site that sends it (cli.ts's `provision.onSettled`), same as elsewhere in this
+  // file's payload specs.
+  onboarding_step: { step: { enum: ONBOARDING_STEPS }, outcome: { enum: OUTCOMES }, failReason: { enum: PROVISION_FAIL_REASONS, optional: true } },
   model_first_load: { outcome: { enum: OUTCOMES }, failReason: { enum: FAIL_REASONS, optional: true } },
   feature_first_use: { feature: { enum: FEATURES } },
   feature_used_daily: { feature: { enum: FEATURES }, countBucket: { enum: COUNT_BUCKETS } },


### PR DESCRIPTION
## Summary
- Wires up `error{fingerprint}` and `feature_used_daily{feature,countBucket}` — both fully specified in the schema since ADR-299, neither ever emitted by any call site until now
- Adds an optional `failReason` to `onboarding_step` for the `engine_install` step, classified inside `ProvisionState.fail()` so raw error text still never crosses the telemetry boundary
- Widens `classifyLoadFailure`'s OOM/arch/corruption pattern coverage with real vendor/runtime phrasings (live PostHog data showed `other` absorbing 50% of `model_first_load` failures)
- New `telemetry/daily-usage.ts`: a per-day-per-feature counter with day-rollover, flushed on the existing 5-minute telemetry interval
- Companion PostHog config fix (not code): rebuilt the "Onboarding funnel: install to first token" Insight — removed the stale `Engine build` step ADR-323 dropped from the schema two days ago but never removed from the dashboard, marked `Model download` `optionalInFunnel`, and extended the funnel to the real `First chat sent` success step

Full rationale: `docs/decisions/decision-log.md` ADR-327.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx tsx --test` scoped to telemetry/engines/bench/downloads — 234/234 pass
- [x] Full `npm test` — 2187/2187 pass (4 pre-existing skips, unrelated)