### PR TITLE
release: v1.10.2 — generic engine-capability discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@
 # TurboLLM daemon (Node/TS) build outputs
 /turbollm/dist/
 /turbollm/src/webdist/
+# `npx tsx --test` resolving an unset TMPDIR to the literal string "undefined" (Windows dev box)
+/turbollm/undefined/
 
 # Local dev/preview config (machine-specific engine/model paths) + runtime
 /turbollm/dev-config.json

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,18 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.10.2] - 2026-08-05
+
+### Added
+- KV-cache quantization types are now discovered automatically from each engine's own `--help`
+  output, instead of being hardcoded for one specific fork. Concretely: BeeLlama.cpp's KVarN cache
+  types (`kvarn2`…`kvarn8`) now show up correctly in the KV cache type dropdown and work when
+  loading a model — and any future fork's custom KV-cache types will too, without needing an app
+  update.
+
+### Discord
+- KV-cache types now show up automatically for any engine fork instead of only one — if you use BeeLlama.cpp or another fork with custom KV-cache quant types, they'll now appear in the KV cache type dropdown out of the box.
+
 ## [1.10.1] - 2026-08-04
 
 ### Added

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -32,11 +32,13 @@ export interface FlagInfo {
 export interface Capabilities {
   kvTypes: string[]
   flags: string[]
-  /** One entry per probed flag, capturing its inferred argument shape (drives the generic
-   *  "Advanced parameters" UI, spec 22). Optional: absent for engine kinds that never go
-   *  through probe.ts's --help scrape (mlx/rapid-mlx/vllm/sglang, which register with a
-   *  hand-written `{ kvTypes: [], flags: [] }` literal — see api/routes.ts) and for engines
-   *  registered by a daemon predating this field (backfilled by the next reprobe — see
+  /** One entry per probed flag, capturing its inferred argument shape. Reserved for a generic
+   *  "Advanced parameters" UI (spec 22) — built, then removed after live testing found it
+   *  overwhelming for a real engine's ~300 probed flags (v1.10.2); no current consumer renders
+   *  this, but it still backs `kvTypes`'s generic derivation. Optional: absent for engine kinds
+   *  that never go through probe.ts's --help scrape (mlx/rapid-mlx/vllm/sglang, which register
+   *  with a hand-written `{ kvTypes: [], flags: [] }` literal — see api/routes.ts) and for
+   *  engines registered by a daemon predating this field (backfilled by the next reprobe — see
    *  registry.ts's isStaleCapabilities). Treat undefined as "nothing to show yet", never an
    *  error. */
   flagInfo?: FlagInfo[]

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -23,9 +23,23 @@ export const VRAM_HEADROOM_DEFAULT_MB = 1024
  *  before. The Settings slider snaps straight from {@link VRAM_HEADROOM_MIN_MB} to this value. */
 export const VRAM_HEADROOM_SPILL_MB = 0
 
+export interface FlagInfo {
+  name: string
+  kind: 'enum' | 'boolean' | 'valued'
+  enumValues?: string[]
+}
+
 export interface Capabilities {
   kvTypes: string[]
   flags: string[]
+  /** One entry per probed flag, capturing its inferred argument shape (drives the generic
+   *  "Advanced parameters" UI, spec 22). Optional: absent for engine kinds that never go
+   *  through probe.ts's --help scrape (mlx/rapid-mlx/vllm/sglang, which register with a
+   *  hand-written `{ kvTypes: [], flags: [] }` literal — see api/routes.ts) and for engines
+   *  registered by a daemon predating this field (backfilled by the next reprobe — see
+   *  registry.ts's isStaleCapabilities). Treat undefined as "nothing to show yet", never an
+   *  error. */
+  flagInfo?: FlagInfo[]
 }
 /** Per-engine auto-update policy (ADR-085, Phase 6). Default 'notify' (badge the UI;
  *  never auto-apply). 'off' = ignore; 'auto' = apply a found update when the engine is idle. */

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -471,7 +471,7 @@ const ALL: CatalogEngine[] = [
     platforms: ['win32', 'darwin', 'linux'],
     support: 'experimental',
     installEndpoint: '',
-    note: "Upstream publishes prebuilt binaries, but TurboLLM builds from source here. The KVarN cache types (kvarn2...kvarn8, set via --cache-type-k/-v) aren't in the auto-tune sweep yet — use the custom/raw flags field to set them manually.",
+    note: "Upstream publishes prebuilt binaries, but TurboLLM builds from source here. The KVarN cache types (kvarn2...kvarn8, set via --cache-type-k/-v) show up directly in the KV cache type dropdown, but aren't in the auto-tune sweep yet — pick one manually.",
     variants: [
       {
         id: 'beellama-source',

--- a/turbollm/src/engines/probe.test.ts
+++ b/turbollm/src/engines/probe.test.ts
@@ -148,16 +148,53 @@ test('classifyFlag: a flag absent from the help text at all degrades to "valued"
 
 // ---- classifyFlag: C1/C2/I3 regression fixtures (final-review findings) -------------------
 
+// The enum-bearing block must come AFTER the flag under test: classifyFlag only ever scans
+// FORWARD from its own match, so the earlier shape of this fixture (enum block first) could not
+// reproduce the bleed-forward bug at all and passed against the pre-fix code too.
 test('classifyFlag: a flag whose block boundary is a FLUSH-LEFT (column 0) next flag, not indented', () => {
   const help =
-    `--cache-type-k TYPE\n` +
-    `                                        allowed values: f32, f16, bf16\n` +
-    `                                        (default: f16)\n` +
     `--no-host\n` +
-    `                                        disable host header validation\n`
+    `--cache-type-k TYPE\n` +
+    `                                        allowed values: f32, f16, bf16, turbo4\n` +
+    `                                        (default: f16)\n`
   const info = classifyFlag('--no-host', help)
   assert.equal(info.kind, 'boolean')
   assert.equal(info.enumValues, undefined)
+})
+
+test('classifyFlag: a next-flag line indented past 8 columns still terminates the PRECEDING flag\'s block (ik_llama.cpp indents 176 real flag lines at column 9)', () => {
+  const help =
+    `--no-host\n` +
+    `         --cache-type-k TYPE\n` +
+    `                                        allowed values: f32, f16, bf16, turbo4\n`
+  const info = classifyFlag('--no-host', help)
+  assert.equal(info.kind, 'boolean')
+  assert.equal(info.enumValues, undefined)
+})
+
+test('classifyFlag: a multi-alias comma list on one line resolves the REAL trailing placeholder, not "boolean" from the comma after the first alias', () => {
+  const help = `-n,    --predict, --n-predict N        number of tokens to predict (default: -1, -1 = infinity)\n`
+  assert.deepEqual(classifyFlag('--predict', help), { name: '--predict', kind: 'valued' })
+  assert.deepEqual(classifyFlag('--n-predict', help), { name: '--n-predict', kind: 'valued' })
+})
+
+test('classifyFlag: a flag that is a literal PREFIX of an earlier, unrelated sibling flag is not classified from the sibling\'s text', () => {
+  // Real llama.cpp --help is grouped by section, not sorted, so --chat-template-kwargs really
+  // does print before --chat-template.
+  const help =
+    `--chat-template-kwargs STRING          sets additional params for the json template parser\n` +
+    `--chat-template JINJA_TEMPLATE         set custom jinja chat template\n`
+  assert.equal(classifyFlag('--chat-template', help).kind, 'valued')
+})
+
+test('classifyFlag: a flag named inside ANOTHER flag\'s description prose is not mistaken for its own definition', () => {
+  // Real ik_llama.cpp: --in-prefix-bos's description quotes `--in-prefix`, and that mention
+  // appears BEFORE the real --in-prefix definition line.
+  const help =
+    `         --in-prefix-bos          prefix BOS to user inputs, preceding the \`--in-prefix\` string\n` +
+    `         --in-prefix STRING       string to prefix user inputs with (default: empty)\n` +
+    `         --in-suffix STRING       string to suffix after user inputs with (default: empty)\n`
+  assert.equal(classifyFlag('--in-prefix', help).kind, 'valued')
 })
 
 test('classifyFlag: a bracket enum written directly after the flag, no "allowed values:" label', () => {

--- a/turbollm/src/engines/probe.test.ts
+++ b/turbollm/src/engines/probe.test.ts
@@ -1,7 +1,7 @@
 // Capability-flag extraction from --help output (GitHub #43 regression).
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { extractFlags, detectKvTypes } from './probe'
+import { extractFlags, detectKvTypes, parseEnumList, classifyFlag } from './probe'
 
 test('captures a normally-documented flag', () => {
   const help = `--cache-type-k TYPE     KV cache data type for K\n--parallel N            number of parallel sequences\n`
@@ -76,4 +76,72 @@ test('detectKvTypes: -draft/-first/-last sibling flags never confused for the ma
     `--cache-type-k TYPE         KV cache data type for K (default: f16)\n`
   const kvTypes = detectKvTypes(help, true)
   assert.ok(!kvTypes.includes('turbo4'), 'the -draft flag\'s text must not leak turbo4 into the main enum')
+})
+
+test('detectKvTypes: BeeLlama-shaped fork — kvarn2-8 discovered with ZERO BeeLlama-specific code (generic path)', () => {
+  const help =
+    `-ctk,  --cache-type-k TYPE              KV cache data type for K\n` +
+    `                                        allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1,\n` +
+    `                                        kvarn2, kvarn3, kvarn4, kvarn5, kvarn6, kvarn7, kvarn8\n` +
+    `                                        (default: f16)\n` +
+    `-ctv,  --cache-type-v TYPE              KV cache data type for V\n`
+  const kvTypes = detectKvTypes(help, true)
+  for (const t of ['kvarn2', 'kvarn3', 'kvarn4', 'kvarn5', 'kvarn6', 'kvarn7', 'kvarn8']) assert.ok(kvTypes.includes(t), `expected ${t} in ${kvTypes}`)
+  assert.ok(kvTypes.includes('f16')) // base KNOWN_KV set still present
+})
+
+// ---- parseEnumList: generic "allowed values: a, b, c" / "[a|b|c]" extraction --------------
+
+test('parseEnumList: extracts a comma-separated "allowed values:" list, including a wrapped line', () => {
+  const block =
+    `\n                                        allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1,\n` +
+    `                                        kvarn2, kvarn3, kvarn4, kvarn5, kvarn6, kvarn7, kvarn8`
+  const values = parseEnumList(block)
+  assert.deepEqual(values, ['f32', 'f16', 'bf16', 'q8_0', 'q4_0', 'q4_1', 'iq4_nl', 'q5_0', 'q5_1', 'kvarn2', 'kvarn3', 'kvarn4', 'kvarn5', 'kvarn6', 'kvarn7', 'kvarn8'])
+})
+
+test('parseEnumList: extracts a bracket/pipe list when there is no "allowed values:" phrase', () => {
+  assert.deepEqual(parseEnumList('  [none|draft-mtp|nextn]  which speculative mode to use'), ['none', 'draft-mtp', 'nextn'])
+})
+
+test('parseEnumList: a single bracketed word is NOT treated as an enum (needs 2+ values)', () => {
+  assert.deepEqual(parseEnumList('an experimental [beta] flag'), [])
+})
+
+test('parseEnumList: no list of any kind → empty', () => {
+  assert.deepEqual(parseEnumList('KV cache data type for K (default: f16)'), [])
+})
+
+// ---- classifyFlag: generic per-flag kind detection (enum/boolean/valued) -------------------
+
+test('classifyFlag: BeeLlama-shaped --cache-type-k resolves kvarn2-8 via the generic path (no hardcoding)', () => {
+  const help =
+    `-ctk,  --cache-type-k TYPE              KV cache data type for K\n` +
+    `                                        allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1,\n` +
+    `                                        kvarn2, kvarn3, kvarn4, kvarn5, kvarn6, kvarn7, kvarn8\n` +
+    `                                        (default: f16)\n` +
+    `-ctv,  --cache-type-v TYPE              KV cache data type for V\n`
+  const info = classifyFlag('--cache-type-k', help)
+  assert.equal(info.kind, 'enum')
+  assert.ok(info.enumValues?.includes('kvarn2'))
+  assert.ok(info.enumValues?.includes('kvarn8'))
+})
+
+test('classifyFlag: a flag with an ALL-CAPS placeholder and no enum list is "valued"', () => {
+  const help = `--threads N                            number of threads to use during generation\n`
+  assert.deepEqual(classifyFlag('--threads', help), { name: '--threads', kind: 'valued' })
+})
+
+test('classifyFlag: a flag with no placeholder (runs straight into lowercase prose) is "boolean"', () => {
+  const help = `--jinja                                use jinja templating for the chat template\n`
+  assert.deepEqual(classifyFlag('--jinja', help), { name: '--jinja', kind: 'boolean' })
+})
+
+test('classifyFlag: ambiguous text (placeholder present but no real enum) degrades to "valued", never throws', () => {
+  const help = `--some-flag TYPE   an experimental [beta] flag\n`
+  assert.deepEqual(classifyFlag('--some-flag', help), { name: '--some-flag', kind: 'valued' })
+})
+
+test('classifyFlag: a flag absent from the help text at all degrades to "valued", never throws', () => {
+  assert.deepEqual(classifyFlag('--totally-unknown', 'no mention of it anywhere\n'), { name: '--totally-unknown', kind: 'valued' })
 })

--- a/turbollm/src/engines/probe.test.ts
+++ b/turbollm/src/engines/probe.test.ts
@@ -145,3 +145,36 @@ test('classifyFlag: ambiguous text (placeholder present but no real enum) degrad
 test('classifyFlag: a flag absent from the help text at all degrades to "valued", never throws', () => {
   assert.deepEqual(classifyFlag('--totally-unknown', 'no mention of it anywhere\n'), { name: '--totally-unknown', kind: 'valued' })
 })
+
+// ---- classifyFlag: C1/C2/I3 regression fixtures (final-review findings) -------------------
+
+test('classifyFlag: a flag whose block boundary is a FLUSH-LEFT (column 0) next flag, not indented', () => {
+  const help =
+    `--cache-type-k TYPE\n` +
+    `                                        allowed values: f32, f16, bf16\n` +
+    `                                        (default: f16)\n` +
+    `--no-host\n` +
+    `                                        disable host header validation\n`
+  const info = classifyFlag('--no-host', help)
+  assert.equal(info.kind, 'boolean')
+  assert.equal(info.enumValues, undefined)
+})
+
+test('classifyFlag: a bracket enum written directly after the flag, no "allowed values:" label', () => {
+  const help = `--spec-type [none|draft|nextn]         which speculative decoding mode to use\n`
+  const info = classifyFlag('--spec-type', help)
+  assert.equal(info.kind, 'enum')
+  assert.deepEqual(info.enumValues, ['none', 'draft', 'nextn'])
+})
+
+test('classifyFlag: a lowercase/symbolic placeholder that is NOT ALL-CAPS is still classified valued, not boolean', () => {
+  const help = `--rope-scale <0...100>                 RoPE scaling factor\n`
+  const info = classifyFlag('--rope-scale', help)
+  assert.equal(info.kind, 'valued')
+})
+
+test('classifyFlag: a bare boolean flag at true end-of-line (zero trailing spaces before newline) is still boolean', () => {
+  const help = `--no-mmproj\nsome other line\n`
+  const info = classifyFlag('--no-mmproj', help)
+  assert.equal(info.kind, 'boolean')
+})

--- a/turbollm/src/engines/probe.ts
+++ b/turbollm/src/engines/probe.ts
@@ -221,16 +221,40 @@ export function parseEnumList(blockText: string): string[] {
  *  probe. */
 export function classifyFlag(flagName: string, helpText: string): FlagInfo {
   const escaped = flagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  // Boundary widened (C1): a next-flag line can start at ANY indent 0-8 (real llama.cpp prints
-  // many flags flush-left at column 0, not just indented) — was previously indent-only, which let
-  // one flag's enum block bleed into the next flag's classification.
   // Gap-width discrimination (C2): llama.cpp separates a flag from its placeholder by exactly one
   // space, and jumps straight into the description column with 2+ spaces when there's no
   // placeholder at all — that gap width is a much more reliable "does this flag take a value"
   // signal than the placeholder's letter case (real placeholders are often lowercase/symbolic:
   // `<0...100>`, `lo-hi`, `{pca,mean}`). `( *)` (zero-or-more, not one-or-more) so a bare flag at
   // true end-of-line with zero trailing spaces still matches instead of falling through to `!m`.
-  const re = new RegExp(`${escaped}( *)(\\S+)?([\\s\\S]{0,400}?)(?=\\n\\s*\\(default|\\n {0,8}-{1,2}[a-zA-Z]|\\n\\n|$)`, 'i')
+  //
+  // The match is anchored to the start of a flag-DEFINITION line — `(?:^|\n)[ \t]*` plus an
+  // optional run of comma-separated leading aliases — rather than to any occurrence of the flag
+  // name. Three real-output failures make that anchoring load-bearing:
+  //   N1: llama.cpp documents multi-alias flags on one line ("-n,    --predict, --n-predict N").
+  //       The trailing `(?:[ \t]*,[ \t]*ALIAS)*` run consumes the *remaining* aliases so the
+  //       gap/placeholder capture lands on the real trailing placeholder, instead of reading the
+  //       comma right after `--predict` as "nothing follows, must be boolean".
+  //   N2: `(?![-a-zA-Z0-9])` stops the name matching as a literal PREFIX of a longer sibling
+  //       (`--chat-template` inside `--chat-template-kwargs`). Real --help is grouped by section,
+  //       not sorted, so the longer sibling can appear FIRST and leftmost-match-wins would
+  //       otherwise derive the wrong flag's classification.
+  //   prose: a flag is also named inside other flags' description text (ik_llama documents
+  //       `--in-prefix-bos` as "preceding the `--in-prefix` string"). A bare negative lookahead
+  //       does NOT exclude that — a backtick/quote/period passes it — so without the line anchor
+  //       the classifier reads a prose mention as the definition and calls a valued flag boolean.
+  // The block-boundary's next-flag indent is unbounded (`[ \t]*`, not a 0-8 space cap) because
+  // real forks indent flag lines further than 8 columns — ik_llama.cpp has 176 lines at column 9
+  // (N3), and an uncapped indent is still safe: description/prose continuation lines don't start
+  // with `-{1,2}[a-zA-Z]` at any indent.
+  const ALIAS = '-{1,2}[a-zA-Z][a-zA-Z0-9-]*'
+  const re = new RegExp(
+    `(?:^|\\n)[ \\t]*(?:${ALIAS}[ \\t]*,[ \\t]*)*` +
+      `${escaped}(?![-a-zA-Z0-9])(?:[ \\t]*,[ \\t]*${ALIAS})*` +
+      `( *)(\\S+)?([\\s\\S]{0,400}?)` +
+      `(?=\\n\\s*\\(default|\\n[ \\t]*${ALIAS}|\\n\\n|$)`,
+    'i',
+  )
   const m = re.exec(helpText)
   if (!m) return { name: flagName, kind: 'valued' }
   const gap = m[1] ?? ''

--- a/turbollm/src/engines/probe.ts
+++ b/turbollm/src/engines/probe.ts
@@ -221,15 +221,31 @@ export function parseEnumList(blockText: string): string[] {
  *  probe. */
 export function classifyFlag(flagName: string, helpText: string): FlagInfo {
   const escaped = flagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const re = new RegExp(`${escaped}\\s+(\\S+)\\b([\\s\\S]{0,400}?)(?=\\n\\s*\\(default|\\n\\s{2,}-[a-zA-Z]|\\n\\n|$)`, 'i')
+  // Boundary widened (C1): a next-flag line can start at ANY indent 0-8 (real llama.cpp prints
+  // many flags flush-left at column 0, not just indented) — was previously indent-only, which let
+  // one flag's enum block bleed into the next flag's classification.
+  // Gap-width discrimination (C2): llama.cpp separates a flag from its placeholder by exactly one
+  // space, and jumps straight into the description column with 2+ spaces when there's no
+  // placeholder at all — that gap width is a much more reliable "does this flag take a value"
+  // signal than the placeholder's letter case (real placeholders are often lowercase/symbolic:
+  // `<0...100>`, `lo-hi`, `{pca,mean}`). `( *)` (zero-or-more, not one-or-more) so a bare flag at
+  // true end-of-line with zero trailing spaces still matches instead of falling through to `!m`.
+  const re = new RegExp(`${escaped}( *)(\\S+)?([\\s\\S]{0,400}?)(?=\\n\\s*\\(default|\\n {0,8}-{1,2}[a-zA-Z]|\\n\\n|$)`, 'i')
   const m = re.exec(helpText)
   if (!m) return { name: flagName, kind: 'valued' }
-  const placeholder = m[1]
-  const block = m[2] ?? ''
-  const enumValues = parseEnumList(block)
+  const gap = m[1] ?? ''
+  const placeholder = m[2] ?? ''
+  const block = m[3] ?? ''
+  // I3: feed the placeholder token into the enum search too, not just the block — a bracket enum
+  // written directly after the flag (e.g. `--spec-type [none|draft|nextn]  ...`) lands entirely
+  // inside `placeholder` (no internal whitespace for `\S+` to stop at), not `block`.
+  const enumValues = parseEnumList(placeholder + '\n' + block)
   if (enumValues.length > 0) return { name: flagName, kind: 'enum', enumValues }
-  if (/^[A-Z][A-Z0-9_]*$/.test(placeholder)) return { name: flagName, kind: 'valued' }
-  return { name: flagName, kind: 'boolean' }
+  // gap !== 1 (either 0 — bare flag, nothing follows at all — or 2+ — straight into prose, no
+  // placeholder) or no placeholder captured at all → boolean. Only a single-space gap followed by
+  // a real placeholder token is a value-taking flag with no detected enum.
+  if (gap.length !== 1 || !placeholder) return { name: flagName, kind: 'boolean' }
+  return { name: flagName, kind: 'valued' }
 }
 
 function firstNonEmptyLine(s: string): string {

--- a/turbollm/src/engines/probe.ts
+++ b/turbollm/src/engines/probe.ts
@@ -3,10 +3,11 @@
 import { execFile } from 'node:child_process'
 import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
+import type { FlagInfo } from '../config/config'
 
 export interface ProbeResult {
   version: string
-  capabilities: { kvTypes: string[]; flags: string[] }
+  capabilities: { kvTypes: string[]; flags: string[]; flagInfo: FlagInfo[] }
 }
 
 export class ProbeError extends Error {
@@ -100,6 +101,7 @@ export async function probe(bin: string): Promise<ProbeResult> {
 
   const flags = extractFlags(h.out)
   const kvTypes = detectKvTypes(h.out, flags.includes('--cache-type-k'))
+  const flagInfo = flags.map((f) => classifyFlag(f, h.out))
 
   // Capture the accepted `--spec-type` enum values (e.g. `none,draft-mtp,nextn`)
   // as `spec-type:<value>` pseudo-flags. The enum differs by engine — official
@@ -118,7 +120,7 @@ export async function probe(bin: string): Promise<ProbeResult> {
     }
   }
 
-  return { version, capabilities: { kvTypes, flags: [...new Set(flags)].sort() } }
+  return { version, capabilities: { kvTypes, flags: [...new Set(flags)].sort(), flagInfo } }
 }
 
 type BinFormat = 'pe' | 'elf' | 'macho' | 'unknown'
@@ -182,11 +184,52 @@ export function extractFlags(helpText: string): string[] {
  *  turbo2, turbo3, turbo4") and ik_llama.cpp's (no such list near --cache-type-k at all). */
 export function detectKvTypes(helpText: string, hasCacheTypeFlag: boolean): string[] {
   const kvTypes = hasCacheTypeFlag ? [...KNOWN_KV] : ['f16']
-  const kvFlagBlock = /--cache-type-k\s+\S+\b([\s\S]{0,400}?)(?=\n\s*\(default|\n\s{2,}-[a-zA-Z]|\n\n|$)/i.exec(helpText)
-  if (kvFlagBlock) {
-    for (const t of ['turbo2', 'turbo3', 'turbo4']) if (kvFlagBlock[1].includes(t) && !kvTypes.includes(t)) kvTypes.push(t)
+  const cacheTypeK = classifyFlag('--cache-type-k', helpText)
+  if (cacheTypeK.kind === 'enum') {
+    for (const extra of cacheTypeK.enumValues ?? []) if (!kvTypes.includes(extra)) kvTypes.push(extra)
   }
   return kvTypes
+}
+
+/** Parses a comma/pipe-separated list of accepted values out of a flag's own help block.
+ *  Tries llama.cpp's own convention first ("allowed values: a, b, c", which may wrap onto a
+ *  continuation line — see the KV-cache fixtures in probe.test.ts), then falls back to a
+ *  bracket/pipe group (some forks print `[none|draft-mtp|nextn]` instead). Requires 2+ clean
+ *  alphanumeric tokens to count as a real enum — a single bracketed word (e.g. "[beta]") is
+ *  prose, not a value list, and would otherwise false-positive. Returns [] when nothing
+ *  matches; NEVER guesses beyond what's actually printed. */
+export function parseEnumList(blockText: string): string[] {
+  const labeled = /allowed values:\s*([\s\S]+)/i.exec(blockText)
+  const bracketed = /\[([^\]\n]+)\]/.exec(blockText)
+  const raw = labeled?.[1] ?? bracketed?.[1]
+  if (!raw) return []
+  const values = raw
+    .split(/[,|]/)
+    .map((s) => s.trim())
+    .filter((s) => /^[a-z][a-z0-9_-]*$/i.test(s))
+  return values.length >= 2 ? values : []
+}
+
+/** Classifies a probed flag's argument shape from its own --help block: 'enum' (a detected
+ *  value list — drives a dropdown), 'boolean' (no argument — drives a checkbox), or 'valued'
+ *  (takes an argument but no enum was found — drives a free-text input). Reuses the exact
+ *  block-scoping boundary already proven in detectKvTypes (stop at the next flag line, a
+ *  "(default" continuation, or a blank line) so a sibling flag's text — e.g.
+ *  --cache-type-k-draft leaking into --cache-type-k — can't cross-contaminate. Best-effort by
+ *  design (spec 22 §4): --help formatting is inconsistent across forks, so anything ambiguous
+ *  or unparseable degrades to 'valued' — the safe default that never hides a flag or blocks a
+ *  probe. */
+export function classifyFlag(flagName: string, helpText: string): FlagInfo {
+  const escaped = flagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`${escaped}\\s+(\\S+)\\b([\\s\\S]{0,400}?)(?=\\n\\s*\\(default|\\n\\s{2,}-[a-zA-Z]|\\n\\n|$)`, 'i')
+  const m = re.exec(helpText)
+  if (!m) return { name: flagName, kind: 'valued' }
+  const placeholder = m[1]
+  const block = m[2] ?? ''
+  const enumValues = parseEnumList(block)
+  if (enumValues.length > 0) return { name: flagName, kind: 'enum', enumValues }
+  if (/^[A-Z][A-Z0-9_]*$/.test(placeholder)) return { name: flagName, kind: 'valued' }
+  return { name: flagName, kind: 'boolean' }
 }
 
 function firstNonEmptyLine(s: string): string {

--- a/turbollm/src/engines/registry.staleness.test.ts
+++ b/turbollm/src/engines/registry.staleness.test.ts
@@ -6,26 +6,40 @@ import { test } from 'node:test'
 import { isStaleCapabilities } from './registry'
 
 test('flags an engine that still carries the removed draft-max/draft-min flags', () => {
-  assert.equal(isStaleCapabilities(['--mtp-head', '--draft-max', '--draft-min']), true)
+  assert.equal(isStaleCapabilities(['--mtp-head', '--draft-max', '--draft-min'], []), true)
 })
 
 test('flags an engine carrying any one of the removed draft-family flags', () => {
-  assert.equal(isStaleCapabilities(['--draft']), true)
-  assert.equal(isStaleCapabilities(['--draft-n']), true)
-  assert.equal(isStaleCapabilities(['--draft-n-min']), true)
+  assert.equal(isStaleCapabilities(['--draft'], []), true)
+  assert.equal(isStaleCapabilities(['--draft-n'], []), true)
+  assert.equal(isStaleCapabilities(['--draft-n-min'], []), true)
 })
 
 test('flags the pre-existing spec-type-without-enum staleness case', () => {
-  assert.equal(isStaleCapabilities(['--spec-type', '--mtp-head']), true)
+  assert.equal(isStaleCapabilities(['--spec-type', '--mtp-head'], []), true)
 })
 
 test('does not flag a fresh, fully-probed modern engine', () => {
   assert.equal(
-    isStaleCapabilities(['--mtp-head', '--spec-draft-n-max', '--spec-draft-n-min', '--spec-type', 'spec-type:draft-mtp']),
+    isStaleCapabilities(
+      ['--mtp-head', '--spec-draft-n-max', '--spec-draft-n-min', '--spec-type', 'spec-type:draft-mtp'],
+      [{ name: '--mtp-head', kind: 'valued' }],
+    ),
     false,
   )
 })
 
 test('does not flag an engine with no speculative-decoding flags at all', () => {
-  assert.equal(isStaleCapabilities(['--parallel', '--cache-type-k']), false)
+  assert.equal(isStaleCapabilities(['--parallel', '--cache-type-k'], []), false)
+})
+
+test('flags an engine probed before flagInfo existed (undefined), even with otherwise-modern flags', () => {
+  assert.equal(
+    isStaleCapabilities(['--mtp-head', '--spec-draft-n-max', '--spec-draft-n-min', '--spec-type', 'spec-type:draft-mtp'], undefined),
+    true,
+  )
+})
+
+test('does not flag an engine that has flagInfo, even if it is an empty array (genuinely no extra flags)', () => {
+  assert.equal(isStaleCapabilities(['--parallel'], []), false)
 })

--- a/turbollm/src/engines/registry.ts
+++ b/turbollm/src/engines/registry.ts
@@ -2,7 +2,7 @@
 // enforced by the API layer using the Manager's live state.
 import { existsSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
-import { ConfigStore, CustomEngineSource, Engine, UpdatePolicy, ValueError, findEngine } from '../config/config'
+import { ConfigStore, CustomEngineSource, Engine, FlagInfo, UpdatePolicy, ValueError, findEngine } from '../config/config'
 import { probe } from './probe'
 import { normRepoUrl } from './build-runner'
 
@@ -370,7 +370,7 @@ export class Registry {
    *  NextN/MTP gating has the data it needs without a manual re-probe. */
   async ensureProbed(): Promise<void> {
     for (const e of this.list().engines) {
-      if (e.version && !isStaleCapabilities(e.capabilities.flags)) continue
+      if (e.version && !isStaleCapabilities(e.capabilities.flags, e.capabilities.flagInfo)) continue
       try {
         await this.reprobe(e.id)
       } catch {
@@ -397,7 +397,7 @@ export function customSourceKey(s: { sourceRepo?: string; sourceBranch?: string;
  *  "re-probe" by hand. Checked at every startup (ensureProbed) so the fix in probe.ts
  *  actually reaches engines that were added before it existed — installing a new
  *  TurboLLM build alone does NOT retroactively fix already-cached capability data. */
-export function isStaleCapabilities(flags: string[]): boolean {
+export function isStaleCapabilities(flags: string[], flagInfo: FlagInfo[] | undefined): boolean {
   // Case 1 (pre-existing): `--spec-type` was captured but its accepted enum values
   // (`spec-type:<value>`) weren't — an older probe that predates that extraction.
   if (flags.includes('--spec-type') && !flags.some((f) => f.startsWith('spec-type:'))) return true
@@ -410,5 +410,11 @@ export function isStaleCapabilities(flags: string[]): boolean {
   // an idempotent no-op here (the flags stay present either way), so this is safe
   // to check unconditionally.
   if (['--draft-max', '--draft-min', '--draft', '--draft-n', '--draft-n-min'].some((f) => flags.includes(f))) return true
+  // Case 3 (spec 22, ADR-328): a probe from before `flagInfo` existed carries no
+  // structured per-flag metadata at all — reprobe once to backfill it, so the generic
+  // KV-type detection and the Advanced Parameters UI reach already-registered engines
+  // without a manual re-add. `[]` (probed the new way, nothing extra to report) is NOT
+  // stale; only `undefined` (never probed the new way) is.
+  if (flagInfo === undefined) return true
   return false
 }

--- a/turbollm/src/engines/registry.ts
+++ b/turbollm/src/engines/registry.ts
@@ -420,9 +420,10 @@ export function isStaleCapabilities(flags: string[], flagInfo: FlagInfo[] | unde
   if (['--draft-max', '--draft-min', '--draft', '--draft-n', '--draft-n-min'].some((f) => flags.includes(f))) return true
   // Case 3 (spec 22, ADR-328): a probe from before `flagInfo` existed carries no
   // structured per-flag metadata at all — reprobe once to backfill it, so the generic
-  // KV-type detection and the Advanced Parameters UI reach already-registered engines
-  // without a manual re-add. `[]` (probed the new way, nothing extra to report) is NOT
-  // stale; only `undefined` (never probed the new way) is.
+  // KV-type detection (kvTypes) reaches already-registered engines without a manual
+  // re-add. (flagInfo itself is reserved for the Advanced Parameters UI, not currently
+  // rendered — see config.ts's Capabilities.flagInfo doc comment.) `[]` (probed the new
+  // way, nothing extra to report) is NOT stale; only `undefined` (never probed) is.
   if (flagInfo === undefined) return true
   return false
 }

--- a/turbollm/src/engines/registry.ts
+++ b/turbollm/src/engines/registry.ts
@@ -370,6 +370,14 @@ export class Registry {
    *  NextN/MTP gating has the data it needs without a manual re-probe. */
   async ensureProbed(): Promise<void> {
     for (const e of this.list().engines) {
+      // Only 'llama-server'-kind engines go through probe.ts's --help scrape at all
+      // (mlx/rapid-mlx/vllm/sglang register with a hand-written, permanently-flagInfo-less
+      // capabilities literal — see addMlx/addRapidMlx/addVllm/addSglang in api/routes.ts).
+      // Without this guard, Case 3 below would mark those engines stale on every startup and
+      // reprobe() would run --version/--help against a non-llama-server binary (e.g. a Python
+      // venv interpreter for mlx/vllm), which succeeds and silently overwrites that engine's
+      // version/capabilities with garbage instead of failing loudly.
+      if (e.kind !== 'llama-server') continue
       if (e.version && !isStaleCapabilities(e.capabilities.flags, e.capabilities.flagInfo)) continue
       try {
         await this.reprobe(e.id)

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -201,7 +201,7 @@ const TURBOLLM_KNOWLEDGE =
   '**Prism** (Windows / Linux / macOS — GGUF):\n' +
   'llama.cpp fork tuned for 1-2 bit ternary/Bonsai models. Build-from-source only (guided walkthrough) — no one-click install, even though upstream publishes prebuilts.\n\n' +
   '**BeeLlama.cpp** (Windows / Linux / macOS — GGUF):\n' +
-  'llama.cpp fork adding variance-normalized KV-cache quantization (KVarN: `kvarn2`…`kvarn8`, set via `--cache-type-k`/`-v`), a KV precision tail, and adaptive DFlash speculative decoding. Build-from-source only. The KVarN types aren\'t in the auto-tune sweep yet — set them via the custom/raw flags field.\n\n' +
+  'llama.cpp fork adding variance-normalized KV-cache quantization (KVarN: `kvarn2`…`kvarn8`, set via `--cache-type-k`/`-v`), a KV precision tail, and adaptive DFlash speculative decoding. Build-from-source only. The KVarN types show up directly in the KV cache type dropdown (auto-discovered from the build\'s own --help output) but aren\'t in the auto-tune sweep yet — pick one manually.\n\n' +
 
   '## Gateway\n\n' +
   'TurboLLM at `http://localhost:6996` exposes:\n' +

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -204,10 +204,17 @@ export type ComfyRuntime = {
   currentVersion: number
 }
 
+export type FlagInfo = {
+  name: string
+  kind: 'enum' | 'boolean' | 'valued'
+  enumValues?: string[]
+}
+
 /** A registered engine (GET /api/v1/engines, config §3 shape). */
 export type EngineCapabilities = {
   kvTypes: string[]
   flags: string[]
+  flagInfo?: FlagInfo[]
 }
 
 export type Engine = {

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -331,7 +331,7 @@ const ENGINE_META: Record<string, EngineMeta> = {
       'KV precision tail keeps recent tokens exact, cheaply',
       'Adaptive DFlash speculative decoding',
     ],
-    cons: ['Solo maintainer, fast churn (v0.4.0 dropped TurboQuant/TCQ)', 'No install endpoint yet — build from source', 'KVarN types need the raw flags field, not auto-tune yet'],
+    cons: ['Solo maintainer, fast churn (v0.4.0 dropped TurboQuant/TCQ)', 'No install endpoint yet — build from source', 'KVarN types are manual-pick only, not in the auto-tune sweep yet'],
   },
 }
 

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -42,64 +42,6 @@ function loadModeForEngine(engineKind: string | undefined): LoadMode {
   }
 }
 
-/** Flags `profileToArgs` (turbollm/src/models/profile.ts) already hand-models with a dedicated
- *  structured control — must be excluded from the generic "Advanced parameters" section so a
- *  flag never gets two conflicting controls. Keep in sync with profileToArgs; this is the
- *  authoritative list as of spec 22 (ADR-328). Includes `--ctx-size`, the long-form alias of the
- *  `-c` flag the "Context length" slider already emits (profile.ts:549) — routes.ts:2561 treats
- *  `-c`/`--ctx-size` as synonyms elsewhere, and a probed engine that documents the long form would
- *  otherwise surface as a second, independent control for the same setting. Also includes
- *  `--gpu-layers`/`--n-gpu-layers` (long-form aliases of `-ngl`, the "GPU layers" slider,
- *  profile.ts:564) and `--temperature` (long-form alias of `--temp`, the "Temperature" slider,
- *  profile.ts:663) for the same reason — without these, a probed engine documenting the long
- *  form surfaces a duplicate control whose manually-set value silently wins at launch while the
- *  slider shows stale state. */
-const MODELED_FLAGS = new Set([
-  '--split-mode', '--tensor-split', '--main-gpu', '--parallel', '--kv-unified', '--n-cpu-moe',
-  '--cache-type-k', '--cache-type-v', '--flash-attn', '--no-kv-offload', '--threads', '--threads-batch',
-  '--batch-size', '--ubatch-size', '--mmproj', '--no-mmproj-offload', '--image-max-tokens', '--cache-reuse',
-  '--jinja', '--chat-template-file', '--spec-type', '--mtp-head', '--model-draft', '--draft-max',
-  '--spec-draft-n-max', '--draft-min', '--spec-draft-n-min', '--temp', '--top-p', '--top-k', '--min-p',
-  '--repeat-penalty', '--presence-penalty', '--frequency-penalty', '--n-keep', '--rope-scaling',
-  '--rope-freq-base', '--rope-freq-scale', '--embeddings', '--grammar', '--no-mmap', '--ctx-size',
-  '--gpu-layers', '--n-gpu-layers', '--temperature',
-])
-
-/** Flags the daemon sets itself when spawning the engine (turbollm/src/engines/manager.ts) —
- *  must NEVER be offered as a generic user-editable control, since overriding them generically
- *  could break the daemon's ability to manage the process (port collision, wrong bind host,
- *  wrong model path). Confirmed from manager.ts:777's `['-m', opts.modelPath, '--host',
- *  '127.0.0.1', '--port', String(port)]` launch prefix, plus `--metrics`/`--no-webui`/
- *  `--slot-save-path`, which manager.ts:779-783 pushes conditionally a few lines below that
- *  prefix. `--slot-save-path` is the highest-risk of the three: it's a *valued* flag (the KV
- *  prompt-cache persistence path), and since `extraArgs` is appended last, a user setting it via
- *  the generic control here would silently override the daemon's own managed path and break
- *  slot-cache restore with no visible error. `--model` is `-m`'s documented long-form alias
- *  (llama.cpp: `-m, --model FNAME`) — included for the same reason: left out, a user could
- *  silently override which model the running engine actually loads via the generic control. */
-const DAEMON_OWNED_FLAGS = new Set(['-m', '--model', '--host', '--port', '--metrics', '--no-webui', '--slot-save-path'])
-
-/** Reads a flag's current value out of extraArgs: '' for a bare boolean flag present with no
- *  following value, the value string for `--flag value`, or undefined if the flag isn't set. */
-function extraArgValue(extraArgs: string[], flagName: string): string | undefined {
-  const i = extraArgs.indexOf(flagName)
-  if (i === -1) return undefined
-  const next = extraArgs[i + 1]
-  return next !== undefined && !next.startsWith('--') ? next : ''
-}
-
-/** Sets, updates, or removes a flag in extraArgs, preserving every other entry's position.
- *  value === undefined removes the flag entirely; '' sets it as a bare boolean (no argument);
- *  anything else sets `--flag value`. */
-function setExtraArg(extraArgs: string[], flagName: string, value: string | undefined): string[] {
-  const i = extraArgs.indexOf(flagName)
-  const next = i === -1 ? undefined : extraArgs[i + 1]
-  const consumedNext = i !== -1 && next !== undefined && !next.startsWith('--')
-  const without = i === -1 ? extraArgs : [...extraArgs.slice(0, i), ...extraArgs.slice(i + (consumedNext ? 2 : 1))]
-  if (value === undefined) return without
-  return value === '' ? [...without, flagName] : [...without, flagName, value]
-}
-
 export function ModelDetailDialog({
   modelKey,
   onClose,
@@ -164,9 +106,6 @@ export function ModelDetailDialog({
   // (spec 05 §8). MTP is a Gemma-4 feature; NextN is a Qwen3 feature; draft works
   // with any model (separate small draft GGUF).
   const flags = activeEngine?.capabilities.flags ?? []
-  const advancedFlags = (activeEngine?.capabilities.flagInfo ?? []).filter(
-    (f) => !MODELED_FLAGS.has(f.name) && !DAEMON_OWNED_FLAGS.has(f.name),
-  )
   const hasFlag = (f: string) => flags.length === 0 || flags.includes(f)
   // Whether the engine accepts a given `--spec-type` value (probe captures these
   // as `spec-type:<value>`). Official llama.cpp lacks `nextn`; forks may add it.
@@ -616,46 +555,6 @@ export function ModelDetailDialog({
               </Section>
             )}
             </>)}
-
-            {(isLlamaCpp || isVllm) && advancedFlags.length > 0 && draft && (
-              <>
-                <SectionTitle>Advanced parameters</SectionTitle>
-                <Section>
-                  {advancedFlags.map((f) => (
-                    <Row
-                      key={f.name}
-                      label={f.name}
-                      hint={f.kind === 'enum' ? `Detected values: ${(f.enumValues ?? []).join(', ')}` : undefined}
-                    >
-                      {f.kind === 'enum' && (
-                        <Select
-                          value={extraArgValue(draft.extraArgs, f.name) ?? ''}
-                          options={['', ...(f.enumValues ?? [])]}
-                          onChange={(v) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, v === '' ? undefined : v))}
-                        />
-                      )}
-                      {f.kind === 'boolean' && (
-                        <input
-                          type="checkbox"
-                          checked={draft.extraArgs.includes(f.name)}
-                          onChange={(e) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, e.target.checked ? '' : undefined))}
-                          className="h-4 w-4 shrink-0 accent-[var(--accent)]"
-                        />
-                      )}
-                      {f.kind === 'valued' && (
-                        <input
-                          type="text"
-                          value={extraArgValue(draft.extraArgs, f.name) ?? ''}
-                          onChange={(e) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, e.target.value === '' ? undefined : e.target.value))}
-                          placeholder="value"
-                          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-right font-mono text-[12px] text-ink outline-none placeholder:text-faint"
-                        />
-                      )}
-                    </Row>
-                  ))}
-                </Section>
-              </>
-            )}
 
             {(isLlamaCpp || isVllm) && (
               <>

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -42,6 +42,48 @@ function loadModeForEngine(engineKind: string | undefined): LoadMode {
   }
 }
 
+/** Flags `profileToArgs` (turbollm/src/models/profile.ts) already hand-models with a dedicated
+ *  structured control — must be excluded from the generic "Advanced parameters" section so a
+ *  flag never gets two conflicting controls. Keep in sync with profileToArgs; this is the
+ *  authoritative list as of spec 22 (ADR-328). */
+const MODELED_FLAGS = new Set([
+  '--split-mode', '--tensor-split', '--main-gpu', '--parallel', '--kv-unified', '--n-cpu-moe',
+  '--cache-type-k', '--cache-type-v', '--flash-attn', '--no-kv-offload', '--threads', '--threads-batch',
+  '--batch-size', '--ubatch-size', '--mmproj', '--no-mmproj-offload', '--image-max-tokens', '--cache-reuse',
+  '--jinja', '--chat-template-file', '--spec-type', '--mtp-head', '--model-draft', '--draft-max',
+  '--spec-draft-n-max', '--draft-min', '--spec-draft-n-min', '--temp', '--top-p', '--top-k', '--min-p',
+  '--repeat-penalty', '--presence-penalty', '--frequency-penalty', '--n-keep', '--rope-scaling',
+  '--rope-freq-base', '--rope-freq-scale', '--embeddings', '--grammar', '--no-mmap',
+])
+
+/** Flags the daemon sets itself when spawning the engine (turbollm/src/engines/manager.ts) —
+ *  must NEVER be offered as a generic user-editable control, since overriding them generically
+ *  could break the daemon's ability to manage the process (port collision, wrong bind host,
+ *  wrong model path). Confirmed from manager.ts:777's `['-m', opts.modelPath, '--host',
+ *  '127.0.0.1', '--port', String(port)]` launch prefix. */
+const DAEMON_OWNED_FLAGS = new Set(['-m', '--host', '--port'])
+
+/** Reads a flag's current value out of extraArgs: '' for a bare boolean flag present with no
+ *  following value, the value string for `--flag value`, or undefined if the flag isn't set. */
+function extraArgValue(extraArgs: string[], flagName: string): string | undefined {
+  const i = extraArgs.indexOf(flagName)
+  if (i === -1) return undefined
+  const next = extraArgs[i + 1]
+  return next !== undefined && !next.startsWith('--') ? next : ''
+}
+
+/** Sets, updates, or removes a flag in extraArgs, preserving every other entry's position.
+ *  value === undefined removes the flag entirely; '' sets it as a bare boolean (no argument);
+ *  anything else sets `--flag value`. */
+function setExtraArg(extraArgs: string[], flagName: string, value: string | undefined): string[] {
+  const i = extraArgs.indexOf(flagName)
+  const next = i === -1 ? undefined : extraArgs[i + 1]
+  const consumedNext = i !== -1 && next !== undefined && !next.startsWith('--')
+  const without = i === -1 ? extraArgs : [...extraArgs.slice(0, i), ...extraArgs.slice(i + (consumedNext ? 2 : 1))]
+  if (value === undefined) return without
+  return value === '' ? [...without, flagName] : [...without, flagName, value]
+}
+
 export function ModelDetailDialog({
   modelKey,
   onClose,
@@ -106,6 +148,9 @@ export function ModelDetailDialog({
   // (spec 05 §8). MTP is a Gemma-4 feature; NextN is a Qwen3 feature; draft works
   // with any model (separate small draft GGUF).
   const flags = activeEngine?.capabilities.flags ?? []
+  const advancedFlags = (activeEngine?.capabilities.flagInfo ?? []).filter(
+    (f) => !MODELED_FLAGS.has(f.name) && !DAEMON_OWNED_FLAGS.has(f.name),
+  )
   const hasFlag = (f: string) => flags.length === 0 || flags.includes(f)
   // Whether the engine accepts a given `--spec-type` value (probe captures these
   // as `spec-type:<value>`). Official llama.cpp lacks `nextn`; forks may add it.
@@ -555,6 +600,46 @@ export function ModelDetailDialog({
               </Section>
             )}
             </>)}
+
+            {(isLlamaCpp || isVllm) && advancedFlags.length > 0 && draft && (
+              <>
+                <SectionTitle>Advanced parameters</SectionTitle>
+                <Section>
+                  {advancedFlags.map((f) => (
+                    <Row
+                      key={f.name}
+                      label={f.name}
+                      hint={f.kind === 'enum' ? `Detected values: ${(f.enumValues ?? []).join(', ')}` : undefined}
+                    >
+                      {f.kind === 'enum' && (
+                        <Select
+                          value={extraArgValue(draft.extraArgs, f.name) ?? ''}
+                          options={['', ...(f.enumValues ?? [])]}
+                          onChange={(v) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, v === '' ? undefined : v))}
+                        />
+                      )}
+                      {f.kind === 'boolean' && (
+                        <input
+                          type="checkbox"
+                          checked={draft.extraArgs.includes(f.name)}
+                          onChange={(e) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, e.target.checked ? '' : undefined))}
+                          className="h-4 w-4 shrink-0 accent-[var(--accent)]"
+                        />
+                      )}
+                      {f.kind === 'valued' && (
+                        <input
+                          type="text"
+                          value={extraArgValue(draft.extraArgs, f.name) ?? ''}
+                          onChange={(e) => set('extraArgs', setExtraArg(draft.extraArgs, f.name, e.target.value === '' ? undefined : e.target.value))}
+                          placeholder="value"
+                          className="w-32 rounded-md border border-border bg-bg px-2 py-1 text-right font-mono text-[12px] text-ink outline-none placeholder:text-faint"
+                        />
+                      )}
+                    </Row>
+                  ))}
+                </Section>
+              </>
+            )}
 
             {(isLlamaCpp || isVllm) && (
               <>

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -45,7 +45,10 @@ function loadModeForEngine(engineKind: string | undefined): LoadMode {
 /** Flags `profileToArgs` (turbollm/src/models/profile.ts) already hand-models with a dedicated
  *  structured control — must be excluded from the generic "Advanced parameters" section so a
  *  flag never gets two conflicting controls. Keep in sync with profileToArgs; this is the
- *  authoritative list as of spec 22 (ADR-328). */
+ *  authoritative list as of spec 22 (ADR-328). Includes `--ctx-size`, the long-form alias of the
+ *  `-c` flag the "Context length" slider already emits (profile.ts:549) — routes.ts:2561 treats
+ *  `-c`/`--ctx-size` as synonyms elsewhere, and a probed engine that documents the long form would
+ *  otherwise surface as a second, independent control for the same setting. */
 const MODELED_FLAGS = new Set([
   '--split-mode', '--tensor-split', '--main-gpu', '--parallel', '--kv-unified', '--n-cpu-moe',
   '--cache-type-k', '--cache-type-v', '--flash-attn', '--no-kv-offload', '--threads', '--threads-batch',
@@ -53,15 +56,20 @@ const MODELED_FLAGS = new Set([
   '--jinja', '--chat-template-file', '--spec-type', '--mtp-head', '--model-draft', '--draft-max',
   '--spec-draft-n-max', '--draft-min', '--spec-draft-n-min', '--temp', '--top-p', '--top-k', '--min-p',
   '--repeat-penalty', '--presence-penalty', '--frequency-penalty', '--n-keep', '--rope-scaling',
-  '--rope-freq-base', '--rope-freq-scale', '--embeddings', '--grammar', '--no-mmap',
+  '--rope-freq-base', '--rope-freq-scale', '--embeddings', '--grammar', '--no-mmap', '--ctx-size',
 ])
 
 /** Flags the daemon sets itself when spawning the engine (turbollm/src/engines/manager.ts) —
  *  must NEVER be offered as a generic user-editable control, since overriding them generically
  *  could break the daemon's ability to manage the process (port collision, wrong bind host,
  *  wrong model path). Confirmed from manager.ts:777's `['-m', opts.modelPath, '--host',
- *  '127.0.0.1', '--port', String(port)]` launch prefix. */
-const DAEMON_OWNED_FLAGS = new Set(['-m', '--host', '--port'])
+ *  '127.0.0.1', '--port', String(port)]` launch prefix, plus `--metrics`/`--no-webui`/
+ *  `--slot-save-path`, which manager.ts:779-783 pushes conditionally a few lines below that
+ *  prefix. `--slot-save-path` is the highest-risk of the three: it's a *valued* flag (the KV
+ *  prompt-cache persistence path), and since `extraArgs` is appended last, a user setting it via
+ *  the generic control here would silently override the daemon's own managed path and break
+ *  slot-cache restore with no visible error. */
+const DAEMON_OWNED_FLAGS = new Set(['-m', '--host', '--port', '--metrics', '--no-webui', '--slot-save-path'])
 
 /** Reads a flag's current value out of extraArgs: '' for a bare boolean flag present with no
  *  following value, the value string for `--flag value`, or undefined if the flag isn't set. */

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -48,7 +48,12 @@ function loadModeForEngine(engineKind: string | undefined): LoadMode {
  *  authoritative list as of spec 22 (ADR-328). Includes `--ctx-size`, the long-form alias of the
  *  `-c` flag the "Context length" slider already emits (profile.ts:549) — routes.ts:2561 treats
  *  `-c`/`--ctx-size` as synonyms elsewhere, and a probed engine that documents the long form would
- *  otherwise surface as a second, independent control for the same setting. */
+ *  otherwise surface as a second, independent control for the same setting. Also includes
+ *  `--gpu-layers`/`--n-gpu-layers` (long-form aliases of `-ngl`, the "GPU layers" slider,
+ *  profile.ts:564) and `--temperature` (long-form alias of `--temp`, the "Temperature" slider,
+ *  profile.ts:663) for the same reason — without these, a probed engine documenting the long
+ *  form surfaces a duplicate control whose manually-set value silently wins at launch while the
+ *  slider shows stale state. */
 const MODELED_FLAGS = new Set([
   '--split-mode', '--tensor-split', '--main-gpu', '--parallel', '--kv-unified', '--n-cpu-moe',
   '--cache-type-k', '--cache-type-v', '--flash-attn', '--no-kv-offload', '--threads', '--threads-batch',
@@ -57,6 +62,7 @@ const MODELED_FLAGS = new Set([
   '--spec-draft-n-max', '--draft-min', '--spec-draft-n-min', '--temp', '--top-p', '--top-k', '--min-p',
   '--repeat-penalty', '--presence-penalty', '--frequency-penalty', '--n-keep', '--rope-scaling',
   '--rope-freq-base', '--rope-freq-scale', '--embeddings', '--grammar', '--no-mmap', '--ctx-size',
+  '--gpu-layers', '--n-gpu-layers', '--temperature',
 ])
 
 /** Flags the daemon sets itself when spawning the engine (turbollm/src/engines/manager.ts) —
@@ -68,8 +74,10 @@ const MODELED_FLAGS = new Set([
  *  prefix. `--slot-save-path` is the highest-risk of the three: it's a *valued* flag (the KV
  *  prompt-cache persistence path), and since `extraArgs` is appended last, a user setting it via
  *  the generic control here would silently override the daemon's own managed path and break
- *  slot-cache restore with no visible error. */
-const DAEMON_OWNED_FLAGS = new Set(['-m', '--host', '--port', '--metrics', '--no-webui', '--slot-save-path'])
+ *  slot-cache restore with no visible error. `--model` is `-m`'s documented long-form alias
+ *  (llama.cpp: `-m, --model FNAME`) — included for the same reason: left out, a user could
+ *  silently override which model the running engine actually loads via the generic control. */
+const DAEMON_OWNED_FLAGS = new Set(['-m', '--model', '--host', '--port', '--metrics', '--no-webui', '--slot-save-path'])
 
 /** Reads a flag's current value out of extraArgs: '' for a bare boolean flag present with no
  *  following value, the value string for `--flag value`, or undefined if the flag isn't set. */
@@ -653,7 +661,7 @@ export function ModelDetailDialog({
               <>
                 <SectionTitle>Custom flags</SectionTitle>
                 <Section>
-                  <Row label="Extra command-line flags" hint="Appended to the launch command last, so they can override anything above. e.g. --something value">
+                  <Row label="Extra command-line flags" hint="Appended to the launch command last, so they can override anything above. Add the flag and its value as two separate entries — e.g. type --something, press Enter, type value, press Enter.">
                     <div className="w-full" />
                   </Row>
                   <ChipListInput


### PR DESCRIPTION
## Summary
- Replaces probe.ts's hardcoded per-fork KV-cache-type literals (turbo2/3/4) with one generic --help classifier (`classifyFlag`/`parseEnumList`), so any fork's KV-cache types (e.g. BeeLlama.cpp's kvarn2-8) are discovered generically and appear in the existing KV-cache-type dropdown, with zero fork-specific code.
- Adds automatic reprobe-on-startup backfill for engines registered before this field existed, gated to llama-server-kind engines only.
- Backend flagInfo/classifyFlag pipeline is real and live-verified against all 6 real installed engine binaries (including two rounds of regex-correctness fixes found via final whole-branch review, independently re-verified against real binary ground truth).
- A first pass also added a frontend "Advanced Parameters" UI section surfacing every probed-but-unmodeled flag; removed after live user testing showed it was overwhelming (~270+ rows for a real engine) — backend flagInfo generation stays intact and still feeds the existing KV-type dropdown.

Spec: `docs/specs/22-generic-engine-capability-discovery.md` (ADR-328).

## Test plan
- [x] `npm test` — 2213 tests, 0 failures
- [x] `npx tsc --noEmit` clean (backend + web)
- [x] Live-verified against the real daemon: BeeLlama.cpp's kvarn2/3/4/5/6/8 KV-cache types load and generate successfully via the existing dropdown
- [x] Live-verified: already-registered engines backfill flagInfo automatically on daemon restart, no manual re-add