### PR TITLE
feat(telemetry): privacy copy update -- mandatory pre-ship condition (spec 23 §6a)

### DIFF
--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -597,7 +597,12 @@ actually sending it. Change your level any time from **Settings → Privacy & te
 - **Off** — sends only that one-time choice, nothing else, ever.
 - **Anonymous usage + benchmarks** — which features you use, your hardware, model names, and
   measured speed. Never prompts, files, paths, or keys.
-- **Usage + benchmarks + crash reports** (default) — adds error fingerprints (never your content).
+- **Usage + benchmarks + crash reports** (default) — adds error fingerprints (never your content),
+  the resolved model config behind a load or benchmark (context length, quantization, GPU
+  offload — never anything that could identify a specific file), which coding tool is connected to
+  the local API (e.g. Claude Code, opencode — never which files, projects, or prompts it sends),
+  daily volume counts (chats, messages per chat, API requests — never their content), and which
+  screens and buttons you use (never their content or your cursor position).
 
 You can preview the exact payload before anything is sent, and inspect a running log of every
 event this machine has *actually* transmitted, from the same Settings section. For scripted or

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -2417,21 +2417,65 @@ function telemetryPreview(level: string, version: string) {
   }
   const events: unknown[] = [benchEvent]
   if (level === 'full') {
+    // Representative, not exhaustive (this preview has always been "illustrative only" —
+    // see this function's own history) — but these four are the categories spec 23 §6a's
+    // privacy audit found undisclosed by the OLD wording (interaction-level UI tracking,
+    // connected third-party tool identity, and the resolved load config), so they are the
+    // ones that must appear here, not a token one-of-each across all 16 registered events.
     events.push({
-      schema: 1,
-      event: 'crash_report',
+      schema: TELEMETRY_SCHEMA_VERSION,
+      event: 'error',
       ts: new Date().toISOString(),
       machineId: '00000000-0000-0000-0000-000000000000',
       app: { version, os: sys.os },
-      hw,
-      // Error fingerprint only — exit code + first matching error line, never full logs.
-      payload: { engineExitCode: 1, errorFingerprint: 'CUDA error: out of memory' },
+      // Error fingerprint only — a closed enum member, never the raw message or a log line.
+      payload: { fingerprint: 'cuda_oom' },
+    })
+    events.push({
+      schema: TELEMETRY_SCHEMA_VERSION,
+      event: 'model_load',
+      ts: new Date().toISOString(),
+      machineId: '00000000-0000-0000-0000-000000000000',
+      app: { version, os: sys.os },
+      payload: {
+        outcome: 'ok',
+        trigger: 'manual',
+        model: { name: 'Qwen3.6-35B', quant: 'Q4_K_M', arch: 'qwen3moe', sizeBytes: 21_000_000_000, moe: true, nativeCtx: 262144 },
+        engine: { kind: 'llama-server', isCustom: false },
+        params: {
+          ctx: 32768, ngl: 99, nglFit: true, nCpuMoe: 0, nCpuMoeFit: false, kvTypeK: 'q8_0', kvTypeV: 'q8_0',
+          kvUnified: true, kvOffload: true, flashAttn: 'auto', parallel: 1, threads: 8, threadsBatch: 8,
+          cacheReuse: 256, speculative: 'off', contextOverflow: 'shift', nKeep: 0, ropeScalingType: 'none',
+          useJinja: true, hasGrammar: false, hasExtraArgs: false, multiGpu: false, gpuCount: 1,
+        },
+        fit: { estimatedVramMb: 15800 },
+      },
+    })
+    events.push({
+      schema: TELEMETRY_SCHEMA_VERSION,
+      event: 'harness_first_seen',
+      ts: new Date().toISOString(),
+      machineId: '00000000-0000-0000-0000-000000000000',
+      app: { version, os: sys.os },
+      // Which connected coding tool (e.g. Claude Code, opencode) is talking to the gateway —
+      // never which files, projects, or prompts it sent.
+      payload: { harness: 'claude_code', protocol: 'anthropic' },
+    })
+    events.push({
+      schema: TELEMETRY_SCHEMA_VERSION,
+      event: 'ui_action',
+      ts: new Date().toISOString(),
+      machineId: '00000000-0000-0000-0000-000000000000',
+      app: { version, os: sys.os },
+      // Which screen + button, from a fixed closed enum — never a click's surrounding
+      // content, coordinates, or timing.
+      payload: { screen: 'engines', action: 'install_engine' },
     })
   }
   const note =
     level === 'anon'
       ? 'Anonymized hardware + benchmark speed only. No prompts, paths, identifiers, or keys.'
-      : 'Anonymous benchmarks plus crash/error fingerprints. Still no prompts, paths, or content.'
+      : 'Adds error fingerprints, the resolved config behind a benchmark, which connected coding tool (if any) is talking to the gateway, and which screens/buttons you use. Still no prompts, paths, files, or content.'
   return { level, sends: true, note, payload: events }
 }
 

--- a/turbollm/src/api/telemetry-routes.test.ts
+++ b/turbollm/src/api/telemetry-routes.test.ts
@@ -89,6 +89,24 @@ test('POST /api/v1/telemetry/regenerate-id: replaces the machine id', async () =
   }
 })
 
+test('GET /api/v1/telemetry/preview?level=full: renders the categories spec 23 §6a found undisclosed (interaction tracking, connected-tool identity, resolved load config)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'turbollm-routes-'))
+  try {
+    const { app } = fakeApp(dir, { level: 'full', machineId: '11111111-1111-1111-1111-111111111111' })
+    const res = await app.request('/api/v1/telemetry/preview?level=full')
+    const bodyJson = (await res.json()) as { note: string; payload: Array<{ event: string }> }
+
+    const names = bodyJson.payload.map((e) => e.event)
+    assert.ok(names.includes('error'), 'the old "crash_report" name never existed as a real event')
+    assert.ok(names.includes('model_load'), 'the resolved config behind a benchmark must be shown')
+    assert.ok(names.includes('harness_first_seen'), 'connected coding-tool identity must be shown')
+    assert.ok(names.includes('ui_action'), 'interaction-level click tracking must be shown')
+    assert.doesNotMatch(bodyJson.note, /crash\/error fingerprints\. Still no prompts, paths, or content\.$/, 'the note text must mention the new categories too, not just the old two')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 // ── POST /api/v1/telemetry/ui (spec 23 §3.8, Phase 6) ───────────────────────
 
 test('POST /api/v1/telemetry/ui: a valid screen/action reaches the queue as ui_action, and always 202s', async () => {

--- a/turbollm/src/telemetry/emit.test.ts
+++ b/turbollm/src/telemetry/emit.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import { readQueue } from './queue'
 import { TELEMETRY_ENV } from './disabled'
 import { Emitter } from './emit'
+import { EVENT_NAMES } from './schema'
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), 'turbollm-emit-'))
@@ -60,6 +61,26 @@ test('emit: queues nothing when consent is off', () => {
   }
 })
 
+test('canSend: off is absolutely silent — every registered event, not just the ones with a dedicated off-test (spec 23 §6a mandatory condition)', () => {
+  const dir = tempDir()
+  try {
+    const { emitter } = makeEmitter(dir, 'off')
+    // Iterates EVENT_NAMES (derived from REGISTRY) rather than a hand-picked list, so a
+    // future event added to the registry is covered automatically — the exact kind of
+    // hand-maintained-parallel-list drift this whole redesign exists to eliminate.
+    // consent_choice is the one deliberate exception: its Off ping is sent through a
+    // separate bespoke path (consent.ts) that never calls canSend at all, by design
+    // (it is the one thing an opted-out machine still sends) — canSend rejecting it
+    // here too is consistent, not a gap, since nothing in this product ever routes
+    // consent_choice through Emitter.emit/canSend either way.
+    for (const name of EVENT_NAMES) {
+      assert.equal(emitter.canSend(name), false, `${name} must never be sendable while consent is off`)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('emit: queues nothing when consent is unset — undecided is not consent', () => {
   const dir = tempDir()
   try {
@@ -79,6 +100,22 @@ test('emit: the kill switch beats stored consent', () => {
     const { emitter } = makeEmitter(dir, 'full')
     emitter.emit('app_first_run')
     assert.deepEqual(names(dir), [])
+  } finally {
+    if (prev === undefined) delete process.env[TELEMETRY_ENV]
+    else process.env[TELEMETRY_ENV] = prev
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('canSend: --no-telemetry / TURBOLLM_TELEMETRY=off is a hard kill switch for every registered event, even at full consent (spec 23 SS6a)', () => {
+  const dir = tempDir()
+  const prev = process.env[TELEMETRY_ENV]
+  process.env[TELEMETRY_ENV] = 'off'
+  try {
+    const { emitter } = makeEmitter(dir, 'full')
+    for (const name of EVENT_NAMES) {
+      assert.equal(emitter.canSend(name), false, `${name} must never be sendable under the kill switch, even at full consent`)
+    }
   } finally {
     if (prev === undefined) delete process.env[TELEMETRY_ENV]
     else process.env[TELEMETRY_ENV] = prev

--- a/turbollm/src/telemetry/log.test.ts
+++ b/turbollm/src/telemetry/log.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { recordSent, readSentLog, MAX_LOGGED } from './log'
+import { recordSent, readSentLog, MAX_LOGGED, MAX_LOGGED_UI } from './log'
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), 'turbollm-log-'))
@@ -71,4 +71,73 @@ test('readSentLog: a missing or corrupt log reads as empty, never throws', () =>
 
 test('recordSent: an unwritable dir never throws', () => {
   assert.doesNotThrow(() => recordSent('\0bad', [evt()]))
+})
+
+// ── ui_action / ui_daily partitioned bucket (spec 23 §6a mandatory condition) ──
+// High-volume click events get their own bounded bucket so they can never evict a
+// rare, more sensitive entry (error, model_load, ...) from the general log.
+
+test('recordSent: a flood of ui_action entries does not evict a rare general event', () => {
+  const dir = tempDir()
+  try {
+    recordSent(dir, [evt('error')])
+    for (let i = 0; i < MAX_LOGGED_UI + 50; i++) recordSent(dir, [evt('ui_action')])
+
+    const log = readSentLog(dir)
+    assert.ok(
+      log.some((e) => (e.event as { event: string }).event === 'error'),
+      'the one rare event must survive a flood of high-volume ui_action entries',
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordSent: ui_action and ui_daily are each bounded independently of the general log', () => {
+  const dir = tempDir()
+  try {
+    for (let i = 0; i < MAX_LOGGED + 20; i++) recordSent(dir, [evt('app_first_run')])
+    for (let i = 0; i < MAX_LOGGED_UI + 20; i++) recordSent(dir, [evt('ui_action')])
+
+    const log = readSentLog(dir)
+    const general = log.filter((e) => (e.event as { event: string }).event === 'app_first_run')
+    const ui = log.filter((e) => (e.event as { event: string }).event === 'ui_action')
+    assert.equal(general.length, MAX_LOGGED)
+    assert.equal(ui.length, MAX_LOGGED_UI)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('recordSent: a mixed batch splits general and ui_action entries into their own buckets', () => {
+  const dir = tempDir()
+  try {
+    recordSent(dir, [evt('model_load'), evt('ui_action'), evt('ui_daily')])
+    const log = readSentLog(dir)
+    assert.equal(log.length, 3)
+    assert.deepEqual(
+      log.map((e) => (e.event as { event: string }).event).sort(),
+      ['model_load', 'ui_action', 'ui_daily'],
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('readSentLog: merges both buckets, newest first, across the whole log', () => {
+  const dir = tempDir()
+  try {
+    recordSent(dir, [evt('app_first_run')])
+    recordSent(dir, [evt('ui_action')])
+    // A real clock tick between the two buckets' writes above is not guaranteed at
+    // millisecond resolution, so only this last one — recorded well after both —
+    // is asserted as strictly first; the other two may tie and sort either way.
+    recordSent(dir, [evt('daily_active')])
+
+    const names = readSentLog(dir).map((e) => (e.event as { event: string }).event)
+    assert.equal(names[0], 'daily_active', 'the most recent entry across both buckets sorts first')
+    assert.deepEqual(names.slice(1).sort(), ['app_first_run', 'ui_action'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })

--- a/turbollm/src/telemetry/log.ts
+++ b/turbollm/src/telemetry/log.ts
@@ -10,43 +10,83 @@
  * Because of that, entries are stored **verbatim**. Summarising or redacting
  * them here would defeat the whole point: a log that shows a cleaned-up version
  * of the payload proves nothing about the payload.
+ *
+ * Partitioned into two bounded files (spec 23 §6a, mandatory pre-ship
+ * condition): `ui_action`/`ui_daily` can fire many times in a single session
+ * (every click), and a single flat `MAX_LOGGED`-sized ring would let a few
+ * minutes of clicking evict every rare, more sensitive entry (`error`,
+ * `model_load`, `consent_choice`-adjacent events) — silently gutting the one
+ * promise ("inspect what actually left this machine") that makes every other
+ * privacy claim checkable. Each bucket gets its own cap; `readSentLog` merges
+ * and re-sorts them for display so callers see one "newest first" list either
+ * way.
  */
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 
-/** How many transmissions to retain. Enough to inspect a long session; small
- *  enough to stay a trivial file. */
+/** How many transmissions to retain per bucket. Enough to inspect a long
+ *  session; small enough to stay a trivial file. */
 export const MAX_LOGGED = 200
+export const MAX_LOGGED_UI = 200
+
+/** High-volume, per-click events get their own bucket so they can never evict
+ *  a rare event from the general one. */
+const UI_EVENTS = new Set(['ui_action', 'ui_daily'])
 
 export interface SentEntry {
   sentAt: string
   event: Record<string, unknown>
 }
 
-function logPath(dataDir: string): string {
+function generalLogPath(dataDir: string): string {
   return join(dataDir, 'telemetry', 'sent.json')
 }
 
-/** Read the log, newest first. Never throws. */
-export function readSentLog(dataDir: string): SentEntry[] {
+function uiLogPath(dataDir: string): string {
+  return join(dataDir, 'telemetry', 'sent-ui.json')
+}
+
+function readBucket(path: string): SentEntry[] {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(logPath(dataDir), 'utf8'))
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'))
     return Array.isArray(parsed) ? (parsed as SentEntry[]) : []
   } catch {
     return []
   }
 }
 
-/** Append a transmitted batch as individual entries. Never throws. */
+function writeBucket(dataDir: string, path: string, entries: SentEntry[]): void {
+  mkdirSync(join(dataDir, 'telemetry'), { recursive: true })
+  writeFileSync(path, JSON.stringify(entries))
+}
+
+/** Read the full log (both buckets merged), newest first. Never throws. */
+export function readSentLog(dataDir: string): SentEntry[] {
+  const merged = [...readBucket(generalLogPath(dataDir)), ...readBucket(uiLogPath(dataDir))]
+  return merged.sort((a, b) => (a.sentAt < b.sentAt ? 1 : a.sentAt > b.sentAt ? -1 : 0))
+}
+
+/** Append a transmitted batch as individual entries, routing `ui_action`/
+ *  `ui_daily` into their own bounded bucket. Never throws. */
 export function recordSent(dataDir: string, events: unknown[]): void {
   try {
     const sentAt = new Date().toISOString()
-    const fresh = events.map((event) => ({ sentAt, event: event as Record<string, unknown> })).reverse()
-    const next = [...fresh, ...readSentLog(dataDir)].slice(0, MAX_LOGGED)
+    const general: unknown[] = []
+    const ui: unknown[] = []
+    for (const event of events) {
+      const name = (event as { event?: unknown } | null)?.event
+      ;(typeof name === 'string' && UI_EVENTS.has(name) ? ui : general).push(event)
+    }
 
-    mkdirSync(join(dataDir, 'telemetry'), { recursive: true })
-    writeFileSync(logPath(dataDir), JSON.stringify(next))
+    if (general.length > 0) {
+      const fresh = general.map((event) => ({ sentAt, event: event as Record<string, unknown> })).reverse()
+      writeBucket(dataDir, generalLogPath(dataDir), [...fresh, ...readBucket(generalLogPath(dataDir))].slice(0, MAX_LOGGED))
+    }
+    if (ui.length > 0) {
+      const fresh = ui.map((event) => ({ sentAt, event: event as Record<string, unknown> })).reverse()
+      writeBucket(dataDir, uiLogPath(dataDir), [...fresh, ...readBucket(uiLogPath(dataDir))].slice(0, MAX_LOGGED_UI))
+    }
   } catch {
     // Best-effort: failing to log must not fail the send.
   }


### PR DESCRIPTION
## What

Stacked on Phase 7 (`feat/telemetry-phase7-delete-onboarding-step`). Closes spec 23 §6a's
mandatory pre-ship conditions, which apply once `ui_action` (Phase 6) and `harness` (Phase 5)
exist as real, shipping events.

> **Update README.md and docs/site-build/pages/docs/privacy.html first, in the same release.**
> Add interaction-level analytics and connected-tool identification to the level descriptions.

## README.md + site privacy page

Rewrote the "Usage + benchmarks + crash reports" level's description to name what it actually
sends now: resolved model config (ctx/quant/GPU offload), connected coding-tool identity, daily
volume counts (chats/messages/API calls), and UI screen/button usage. The `anon` level's
description was already accurate and untouched — everything newly disclosed is `consent:'full'`
only, verified against each event's own schema declaration, not asserted.

`docs/site-build/pages/docs/privacy.html` had a larger, **pre-existing** problem unrelated to this
session's phases: its lead paragraph claimed *"nothing about how you use it is measured"* and its
network-touchpoints list omitted telemetry uploads entirely — both false today (telemetry defaults
ON). Added a full Telemetry section mirroring README's per-level breakdown, plus telemetry as an
explicit 4th network-touchpoint category. Rebuilt via `build.mjs` and verified locally.
**Not deployed live** (`wrangler pages deploy`) — that publish step is left to you.

## The other three mandatory conditions from spec 23 §6a

- **`telemetry/log.ts`**: partitioned the submission log into two bounded buckets (general +
  `ui_action`/`ui_daily`) instead of one flat `MAX_LOGGED=200` ring. Without this, a few minutes of
  clicking could evict every rare, more-sensitive entry (`error`, `model_load`,
  `consent_choice`-adjacent events) from the one log that lets a user check every other privacy
  claim against reality.
- **`emit.test.ts`**: two new exhaustive regression tests iterating `EVENT_NAMES` (not a
  hand-picked subset) proving `off` and the `--no-telemetry`/`TURBOLLM_TELEMETRY=off` kill switch
  both block *every* registered event, not just the ones with their own dedicated test — covers
  any future event automatically.
- **`routes.ts`'s `telemetryPreview()`**: fixed a real bug — the `'crash_report'` event name shown
  there never existed (the real event is `'error'`) — and added representative examples for the
  three genuinely new disclosure categories (`model_load`'s resolved config, `harness_first_seen`,
  `ui_action`). Deliberately *not* rewritten into a fully generic per-event example generator —
  this preview has always been "illustrative, not exhaustive" by design; the fix targets exactly
  what the audit flagged, not a larger unrelated rebuild.

## Verification

- Full backend suite: **2297/2297 passing** (54 new/changed tests across `log.test.ts`,
  `emit.test.ts`, `telemetry-routes.test.ts`).
- Typecheck clean.
- Site rebuild verified locally (`build.mjs`, no errors) — not yet deployed.

## Test plan

- [x] `npm test` — backend suite green
- [x] `npm run typecheck` — clean
- [x] `node build.mjs` (docs/site-build) — regenerates cleanly, spot-checked output
- [ ] `wrangler pages deploy` — **not done**, left as an explicit publish step for you