### PR TITLE
chore(release): v1.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,12 @@ actually sending it. Change your level any time from **Settings → Privacy & te
 - **Off** — sends only that one-time choice, nothing else, ever.
 - **Anonymous usage + benchmarks** — which features you use, your hardware, model names, and
   measured speed. Never prompts, files, paths, or keys.
-- **Usage + benchmarks + crash reports** (default) — adds error fingerprints (never your content).
+- **Usage + benchmarks + crash reports** (default) — adds error fingerprints (never your content),
+  the resolved model config behind a load or benchmark (context length, quantization, GPU
+  offload — never anything that could identify a specific file), which coding tool is connected to
+  the local API (e.g. Claude Code, opencode — never which files, projects, or prompts it sends),
+  daily volume counts (chats, messages per chat, API requests — never their content), and which
+  screens and buttons you use (never their content or your cursor position).
 
 You can preview the exact payload before anything is sent, and inspect a running log of every
 event this machine has *actually* transmitted, from the same Settings section. For scripted or

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,29 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.10.3] - 2026-08-06
+
+### Changed
+- If you've opted into the "Full" telemetry level, it now also reports which screens/buttons you
+  interact with (click-level, no content — e.g. "Engines screen, install button") and which
+  external coding-tool client is connecting to your local API (e.g. Claude Code, Cursor), on top
+  of the model/feature usage it already reported. The "Anonymous" and "Off" levels are unaffected.
+  Settings → Privacy → "Preview what we send" always shows the exact current payload for your
+  level, and the README documents the full breakdown.
+- Cleared 13 of 15 known dependency security advisories via routine updates (2 remain, both
+  blocked on upstream releases not yet available).
+
+### Fixed
+- "Rename" and "Re-probe" are back for custom (git-built) engines on the Engines screen. A
+  screen redesign several releases back had silently dropped these buttons from view even though
+  renaming/re-probing kept working correctly underneath — they're now wired into the engine card
+  again.
+
+### Discord
+- Fixed: "Rename" and "Re-probe" for your own custom-built engines, which had quietly stopped showing up a while back — they're back on the Engines screen.
+- Cleared 13 known security advisories in our dependencies under the hood — nothing for you to do.
+- If you've opted into full telemetry: it now also reports which screens/buttons you use and which coding-tool client connects to your API (Claude Code, Cursor, etc.), so we can see what's actually getting used. Totally optional — check exactly what's sent anytime in Settings → Privacy.
+
 ## [1.10.2] - 2026-08-05
 
 ### Added

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",


### PR DESCRIPTION
## Summary

Release v1.10.3 (patch). Bundles ~90 commits merged to `main` since v1.10.2 (each already its own reviewed/verified PR — see decision-log ADR-332 through ADR-336): the telemetry event-taxonomy redesign (spec 23/24), the full Phase 6 `ui_action` click-coverage instrumentation backlog, plus two unrelated fixes.

User-facing:
- **Fixed:** "Rename" + "Re-probe" restored for custom (git-built) engines on the Engines screen — a regression live since the v1.0.0 catalog redesign.
- **Changed:** the opt-in "Full" telemetry level now also reports UI screen/button interactions and connected coding-tool client identity (mandatory privacy-copy disclosure shipped alongside it, per spec 23 §6a).
- **Changed:** cleared 13 of 15 npm audit advisories (2 remain, blocked upstream).

Internal-only (no user-visible change): telemetry registry/validator rewrite, CI schema-drift gate, Worker quarantine safety net, harness identification.

## Release-prep gate (this PR)

- Opus `code-reviewer` review over the full `v1.10.2..main` diff returned content-free 3x in a row (known relay failure mode) — fell back to a manual review per RELEASE.md's documented fallback: read the core telemetry consent-gating (`emit.ts`), ingest/quarantine handler (`ingest.ts`), schema/validator (`schema.ts`, `core/validate.ts`), the harness classifier, the EngineRow restore diff, and spot-checked the `ui_action` instrumentation pattern (type-safe via closed enums end to end). No blocking issues found.
- `npm run typecheck` clean; full backend suite 2330/2334 passing (4 skipped, 0 failing).
- `turbollm/CHANGELOG.md` [1.10.3] added; root `README.md` mirror re-synced (was stale since the privacy-copy commit).
- Persona `TURBOLLM_KNOWLEDGE`: no change needed (existing Engines/Privacy sections already describe at the right altitude).

## Test plan
- [x] `npm run typecheck` (turbollm/) — clean
- [x] `npm test` (turbollm/) — 2330/2334 passing, 0 failing
- [ ] User sign-off on release notes/Discord draft (RELEASE.md Step 6, pending)