### PR TITLE
fix: auto-tune nCpuMoe=0 silently spilled to system RAM (v1.10.4)

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,18 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.10.4] - 2026-08-06
+
+### Fixed
+- Auto-tune could recommend **zero** CPU offload for a MoE model that clearly needed some — on
+  some engine builds (confirmed on BeeLlama.cpp) this silently spilled the model into system RAM
+  instead of failing loudly, so auto-tune's own "0 experts on CPU" search step could look like it
+  fit when it actually didn't. The offload count is now always passed explicitly to the engine,
+  including zero, closing the ambiguity that let this happen.
+
+### Discord
+- Fixed a real auto-tune bug: it could occasionally recommend zero CPU offload for a MoE model that needed some, which silently tanked performance instead of erroring. Re-run Auto-Tune if a model has felt slower than it should since your last tune.
+
 ## [1.10.3] - 2026-08-06
 
 ### Changed

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -1549,6 +1549,14 @@ export function registerApi(app: Hono, d: Deps): void {
         return err(c, 400, 'invalid_profile_value', 'gpu.tensorParallelSize must be an integer ≥ 1.')
       }
     }
+    // profileToArgs now emits --n-cpu-moe explicitly at every value including 0 (2026-08-06
+    // fix) instead of silently omitting it when falsy — a stored `null`/non-number would
+    // previously just get skipped, but now becomes a literal `--n-cpu-moe null` on the launch
+    // command line. Reject it here at the boundary rather than let it reach the engine. A
+    // genuinely absent key (older client, dense-model-only save) is still allowed through.
+    if (p.nCpuMoe !== undefined && (typeof p.nCpuMoe !== 'number' || !Number.isFinite(p.nCpuMoe) || p.nCpuMoe < 0)) {
+      return err(c, 400, 'invalid_profile_value', 'nCpuMoe must be a non-negative number.')
+    }
     // Per-engine profile (issue #35): save into the slot for the engine the client is
     // editing (?engine=<id>), falling back to the active engine, then the '*' fallback.
     const engineId = c.req.query('engine') || d.registry.active()?.id || '*'

--- a/turbollm/src/models/profile.test.ts
+++ b/turbollm/src/models/profile.test.ts
@@ -52,6 +52,20 @@ test('profileToArgs: emits --n-cpu-moe by default on an MoE model', () => {
   assert.deepEqual(args.slice(args.indexOf('--n-cpu-moe'), args.indexOf('--n-cpu-moe') + 2), ['--n-cpu-moe', '4'])
 })
 
+test('profileToArgs: still emits --n-cpu-moe 0 explicitly, not just omits it (BeeLlama fit-abort regression)', () => {
+  // Omitting --n-cpu-moe at nCpuMoe=0 used to be treated as equivalent to passing 0, since
+  // mainline llama.cpp defaults to zero MoE CPU-offload anyway. But -ngl is ALWAYS emitted
+  // alongside it (see the -ngl block above), and BeeLlama.cpp's fork runs its own implicit
+  // fit-placement pass whenever --n-cpu-moe is absent — which then aborts because -ngl is
+  // already pinned ("n_gpu_layers already set by user to N, abort", live-reproduced 2026-08-06)
+  // and falls through to loading every expert on GPU with no real offload, silently spilling to
+  // system RAM. Auto-tune's own nCpuMoe=0 search candidate hit this exact path. Passing
+  // --n-cpu-moe 0 explicitly (like every other tested value) avoids the ambiguity outright.
+  const p = { ...deriveDefault(moeModel, sys), ngl: 99, nCpuMoe: 0 }
+  const args = profileToArgs(p, moeModel, caps)
+  assert.deepEqual(args.slice(args.indexOf('--n-cpu-moe'), args.indexOf('--n-cpu-moe') + 2), ['--n-cpu-moe', '0'])
+})
+
 test('profileToArgs: nCpuMoeFit omits --n-cpu-moe entirely, regardless of the stale value', () => {
   const p = { ...deriveDefault(moeModel, sys), nCpuMoe: 4, nCpuMoeFit: true }
   const args = profileToArgs(p, moeModel, caps)

--- a/turbollm/src/models/profile.test.ts
+++ b/turbollm/src/models/profile.test.ts
@@ -52,18 +52,40 @@ test('profileToArgs: emits --n-cpu-moe by default on an MoE model', () => {
   assert.deepEqual(args.slice(args.indexOf('--n-cpu-moe'), args.indexOf('--n-cpu-moe') + 2), ['--n-cpu-moe', '4'])
 })
 
-test('profileToArgs: still emits --n-cpu-moe 0 explicitly, not just omits it (BeeLlama fit-abort regression)', () => {
+test('profileToArgs: still emits --n-cpu-moe 0 explicitly when -ngl is also explicit, not just omits it (BeeLlama fit-abort regression)', () => {
   // Omitting --n-cpu-moe at nCpuMoe=0 used to be treated as equivalent to passing 0, since
-  // mainline llama.cpp defaults to zero MoE CPU-offload anyway. But -ngl is ALWAYS emitted
-  // alongside it (see the -ngl block above), and BeeLlama.cpp's fork runs its own implicit
-  // fit-placement pass whenever --n-cpu-moe is absent — which then aborts because -ngl is
-  // already pinned ("n_gpu_layers already set by user to N, abort", live-reproduced 2026-08-06)
-  // and falls through to loading every expert on GPU with no real offload, silently spilling to
-  // system RAM. Auto-tune's own nCpuMoe=0 search candidate hit this exact path. Passing
-  // --n-cpu-moe 0 explicitly (like every other tested value) avoids the ambiguity outright.
+  // mainline llama.cpp defaults to zero MoE CPU-offload anyway. But whenever -ngl is ALSO
+  // explicit (p.ngl > 0, same gate as the -ngl push itself), BeeLlama.cpp's fork runs its own
+  // implicit fit-placement pass whenever --n-cpu-moe is absent — which then aborts because -ngl
+  // is already pinned ("n_gpu_layers already set by user to N, abort", live-reproduced
+  // 2026-08-06) and falls through to loading every expert on GPU with no real offload, silently
+  // spilling to system RAM. Auto-tune's own nCpuMoe=0 search candidate hit this exact path.
+  // Passing --n-cpu-moe 0 explicitly (like every other tested value) avoids the ambiguity
+  // outright.
   const p = { ...deriveDefault(moeModel, sys), ngl: 99, nCpuMoe: 0 }
   const args = profileToArgs(p, moeModel, caps)
   assert.deepEqual(args.slice(args.indexOf('--n-cpu-moe'), args.indexOf('--n-cpu-moe') + 2), ['--n-cpu-moe', '0'])
+})
+
+test('profileToArgs: nCpuMoe=0 stays omitted when ngl=0 too — no -ngl to collide with', () => {
+  // ngl=0 means -ngl itself is never emitted (gated on p.ngl > 0, same as -ngl's own push), so
+  // there's no explicit -ngl on the command line for an absent --n-cpu-moe to collide with. This
+  // is the real shape of a CPU-only box (deriveDefault sets ngl: 0 with no GPU) or a user
+  // manually dragging the still-visible MoE ngl slider to 0 — forcing --n-cpu-moe 0 here would
+  // needlessly suppress a fit pass that runs cleanly on its own.
+  const p = { ...deriveDefault(moeModel, sys), ngl: 0, nCpuMoe: 0 }
+  const args = profileToArgs(p, moeModel, caps)
+  assert.equal(args.includes('--n-cpu-moe'), false)
+})
+
+test('profileToArgs: --n-cpu-moe stays gated by engine capability even at nCpuMoe=0', () => {
+  // The capability gate (has('--n-cpu-moe')) must still win over the new always-explicit-at-0
+  // behavior — an engine whose probed --help genuinely lacks --n-cpu-moe must never receive it,
+  // at any value, same as every other flag in this function.
+  const limited: Capabilities = { kvTypes: [], flags: ['-ngl', '--parallel'] }
+  const p = { ...deriveDefault(moeModel, sys), ngl: 99, nCpuMoe: 0 }
+  const args = profileToArgs(p, moeModel, limited)
+  assert.equal(args.includes('--n-cpu-moe'), false)
 })
 
 test('profileToArgs: nCpuMoeFit omits --n-cpu-moe entirely, regardless of the stale value', () => {

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -578,7 +578,15 @@ export function profileToArgs(
   if (has('--parallel')) a.push('--parallel', String(p.parallel))
   if (p.parallel > 1 && p.kvUnified && has('--kv-unified')) a.push('--kv-unified')
   // nCpuMoeFit: omit --n-cpu-moe so -fit's finer-grained MoE offload strategy decides instead.
-  if (m.moe && !p.nCpuMoeFit && p.nCpuMoe > 0 && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
+  // Outside auto-fit, ALWAYS pass it explicitly, including 0 — found 2026-08-06 from a live
+  // BeeLlama.cpp repro: -ngl is emitted unconditionally above, and omitting --n-cpu-moe (on the
+  // old assumption that "0" and "absent" are equivalent) leaves it ambiguous whether the engine
+  // should auto-fit its own placement or use exactly 0 CPU offload. BeeLlama's fork runs an
+  // implicit fit pass whenever --n-cpu-moe is absent, which then aborts on seeing -ngl already
+  // pinned ("n_gpu_layers already set by user to N, abort") and falls through to loading every
+  // expert on GPU with no real offload — silently spilling to system RAM instead of erroring, so
+  // auto-tune's own nCpuMoe=0 search candidate can look like it fits when it doesn't.
+  if (m.moe && !p.nCpuMoeFit && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
   // Emit a non-default KV cache type only when the engine supports the VALUE, not just
   // the --cache-type-k FLAG: e.g. TurboQuant's turbo2/3/4 must NOT leak into a standard
   // llama.cpp / llamafile engine (which has the flag but rejects the value → launch fails).

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -578,15 +578,19 @@ export function profileToArgs(
   if (has('--parallel')) a.push('--parallel', String(p.parallel))
   if (p.parallel > 1 && p.kvUnified && has('--kv-unified')) a.push('--kv-unified')
   // nCpuMoeFit: omit --n-cpu-moe so -fit's finer-grained MoE offload strategy decides instead.
-  // Outside auto-fit, ALWAYS pass it explicitly, including 0 — found 2026-08-06 from a live
-  // BeeLlama.cpp repro: -ngl is emitted unconditionally above, and omitting --n-cpu-moe (on the
-  // old assumption that "0" and "absent" are equivalent) leaves it ambiguous whether the engine
-  // should auto-fit its own placement or use exactly 0 CPU offload. BeeLlama's fork runs an
-  // implicit fit pass whenever --n-cpu-moe is absent, which then aborts on seeing -ngl already
-  // pinned ("n_gpu_layers already set by user to N, abort") and falls through to loading every
-  // expert on GPU with no real offload — silently spilling to system RAM instead of erroring, so
-  // auto-tune's own nCpuMoe=0 search candidate can look like it fits when it doesn't.
-  if (m.moe && !p.nCpuMoeFit && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
+  // Outside auto-fit, pass it explicitly whenever -ngl is ALSO explicit (p.ngl > 0 — the same
+  // gate as the -ngl push above) — including 0 — found 2026-08-06 from a live BeeLlama.cpp repro:
+  // omitting --n-cpu-moe (on the old assumption that "0" and "absent" are equivalent) while -ngl
+  // is explicit leaves it ambiguous whether the engine should auto-fit its own placement or use
+  // exactly 0 CPU offload. BeeLlama's fork runs an implicit fit pass whenever --n-cpu-moe is
+  // absent, which then aborts on seeing -ngl already pinned ("n_gpu_layers already set by user to
+  // N, abort") and falls through to loading every expert on GPU with no real offload — silently
+  // spilling to system RAM instead of erroring, so auto-tune's own nCpuMoe=0 search candidate can
+  // look like it fits when it doesn't. Gating on p.ngl > 0 (not unconditional) matters: when ngl
+  // is 0 (a CPU-only box, or a user dragging the still-visible MoE ngl slider to 0) there's no
+  // -ngl on the command line to collide with, so forcing --n-cpu-moe 0 there would needlessly
+  // suppress a fit pass that runs cleanly on its own.
+  if (m.moe && !p.nCpuMoeFit && p.ngl > 0 && has('--n-cpu-moe')) a.push('--n-cpu-moe', String(p.nCpuMoe))
   // Emit a non-default KV cache type only when the engine supports the VALUE, not just
   // the --cache-type-k FLAG: e.g. TurboQuant's turbo2/3/4 must NOT leak into a standard
   // llama.cpp / llamafile engine (which has the flag but rejects the value → launch fails).


### PR DESCRIPTION
## Summary
- Auto-tune's own `nCpuMoe=0` search candidate omitted `--n-cpu-moe` entirely (relying on the flag's absence being equivalent to 0), while `-ngl` is always emitted for MoE search candidates outside auto-fit mode. On BeeLlama.cpp this recreated the same `-ngl`-explicit / fit-ambiguous collision ADR-325 fixed for the `nCpuMoeFit` toggle, causing it to silently spill into system RAM instead of hard-OOMing, and auto-tune converged on a broken nCpuMoe=0 recommendation.
- `--n-cpu-moe` is now always emitted explicitly (including `0`) outside `nCpuMoeFit` mode, closing the same ambiguity on every `-fit`-capable engine, not just BeeLlama.
- See ADR-337 (`docs/decisions/decision-log.md`) for the full root-cause trace and live verification data.

## Test plan
- [x] New `profile.test.ts` case: `nCpuMoe: 0` now emits `--n-cpu-moe 0` explicitly
- [x] Full backend suite: 2308/2308 pass (4 skipped, unrelated), `tsc --noEmit` clean
- [x] Live re-verified end to end on the real box (port 6996) for the same model (Qwen3.6-35B-A3B Q6) across all three engines that shared this risk:

| Engine | Auto-tune landed on | Gen t/s | Prefill t/s | VRAM |
|---|---|---|---|---|
| BeeLlama.cpp | nCpuMoe=27 (headroom backoff from 26) | 52.0 | 380 | 15.2 GB |
| TurboQuant | nCpuMoe=30 | 51.7 | 343 | 15.9 GB |
| llama.cpp b10099 (cuda, mainline) | nCpuMoe=28 | 53.2 | 360 | 15.7 GB |

All three converge to the same sane range, zero crashes, zero nCpuMoe=0 candidates chosen.