### PR TITLE
fix: terminal ctx/auto-compact, gateway keep-alive pings, Workspace nav+sidebar memory (v1.10.5)

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -25,6 +25,44 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 _Nothing yet._
 
+## [1.10.5] - 2026-08-07
+
+### Fixed
+- **Terminal-agent (`turbollm launch claude`) context meter could flicker between full and
+  empty**, and **auto-compact could fail to fire at all** for a local model. Parallel Task-tool
+  sub-agent calls share the same session as the main conversation turn, and the smaller sub-agent
+  request could momentarily overwrite the Context ring with a much smaller number even though the
+  real conversation hadn't shrunk — the ring now always reflects the session's largest request,
+  not just the most recent one. Separately, the CLI now gets the real loaded model's context
+  window passed explicitly, so it compacts against your actual local context instead of assuming
+  a generic ~200K.
+- **A multi-line first message could silently never reach the `claude` CLI** in a fresh Code
+  session — since the composer's own hint text says "Shift+Enter for newline," a multi-line task
+  description is the normal case, and it was being dropped instead of seeded, leaving the terminal
+  open with no indication anything was wrong. Line breaks are now folded into the seeded command
+  instead of disqualifying the whole message.
+- **Local-model requests could show Claude Code's "Waiting for API response, retrying in `<n>`
+  minutes" banner even though the model was actively working** — during a slow prefill on a large
+  or uncached prompt, and while queued behind another request on a single-slot engine (e.g. a
+  Task-tool sub-agent fan-out). The gateway now sends periodic keep-alive signals the whole time a
+  request is waiting on the engine, so Claude Code's own idle-connection watchdog no longer
+  mistakes real local-model work for a stalled connection.
+- **The Workspace nav item always opened a brand-new chat**, even if you had a specific Code
+  session or Routines panel open — navigating away (e.g. to Usage) and back now returns to exactly
+  where you left off, for the current session.
+- **The Workspace sidebar's collapsed/expanded state reset every time you switched screens** —
+  collapsing it in a Code session and navigating elsewhere would re-expand it. It now stays exactly
+  as you left it for the rest of the session.
+
+### Discord
+- Fixed a couple of real annoyances: the terminal-agent context meter could flicker or fail to
+  auto-compact, a multi-line first message could silently vanish instead of starting your session,
+  and Claude Code could show a false "Waiting for API response" banner while your local model was
+  still genuinely working (including while queued behind another request).
+- The Workspace nav item now remembers exactly where you were — the Code session or Routines panel
+  you had open — instead of always landing on a new chat, and the sidebar's collapsed/expanded
+  state now sticks for the rest of your session.
+
 ## [1.10.4] - 2026-08-06
 
 ### Fixed

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/chat/db.apiusage-session.test.ts
+++ b/turbollm/src/chat/db.apiusage-session.test.ts
@@ -104,14 +104,49 @@ test('getLastApiUsageForSession: null tps when no duration was recorded (e.g. An
   }
 })
 
-test('getLastApiUsageForSession: only ever returns the MOST RECENT row for that session', () => {
+test('getLastApiUsageForSession: a later, larger row wins over an earlier, smaller one', () => {
   const root = makeTmpRoot()
   const db = new ConversationStore(root)
   try {
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 100, genTokens: 10, codeSessionId: 'sess-3', durationMs: 1000 })
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 200, genTokens: 20, codeSessionId: 'sess-3', durationMs: 1000 })
     const usage = db.getLastApiUsageForSession('sess-3')
-    assert.equal(usage!.promptTokens, 200, 'must be the second (later) row, not the first')
+    assert.equal(usage!.promptTokens, 200, 'must be the second (later, larger) row, not the first')
+  } finally {
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('getLastApiUsageForSession: a smaller row recorded AFTER a larger one does not override it (ctx-fill flicker fix)', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    // Shaped like a real terminal-agent session: the main conversation's own turn (large,
+    // ever-growing prompt) followed by a parallel Task-tool sub-agent call the CLI spawned for a
+    // small, isolated sub-task — both share the SAME code_session_id (resolveCodeSession keys
+    // purely off the CLI's one ANTHROPIC_AUTH_TOKEN), and the sub-agent's own request happens to
+    // finish and get recorded second. Before this fix, "most recent row wins" made the Context
+    // ring flicker down to the sub-agent's tiny prompt size every time this ordering occurred,
+    // even though the real conversation never shrank.
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 98259, genTokens: 400, codeSessionId: 'sess-3b', durationMs: 5000 })
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 1200, genTokens: 30, codeSessionId: 'sess-3b', durationMs: 500 })
+    const usage = db.getLastApiUsageForSession('sess-3b')
+    assert.equal(usage!.promptTokens, 98259, 'the real, larger main-turn prompt must win over the later, smaller sub-agent call')
+  } finally {
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('getLastApiUsageForSession: ties on prompt_tokens break toward the more recent row', () => {
+  const root = makeTmpRoot()
+  const db = new ConversationStore(root)
+  try {
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 500, genTokens: 10, codeSessionId: 'sess-3c', durationMs: 1000, promptTps: 111 })
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 500, genTokens: 20, codeSessionId: 'sess-3c', durationMs: 1000, promptTps: 222 })
+    const usage = db.getLastApiUsageForSession('sess-3c')
+    assert.equal(usage!.promptTps, 222, 'the more recent of two equal-sized rows must win')
   } finally {
     db.close()
     rmSync(root, { recursive: true, force: true })

--- a/turbollm/src/chat/db.apiusage-session.test.ts
+++ b/turbollm/src/chat/db.apiusage-session.test.ts
@@ -104,13 +104,14 @@ test('getLastApiUsageForSession: null tps when no duration was recorded (e.g. An
   }
 })
 
-test('getLastApiUsageForSession: a later, larger row wins over an earlier, smaller one', () => {
+test('getLastApiUsageForSession: a later, larger row wins as both ctxUsed and the last-turn stats', () => {
   const root = makeTmpRoot()
   const db = new ConversationStore(root)
   try {
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 100, genTokens: 10, codeSessionId: 'sess-3', durationMs: 1000 })
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 200, genTokens: 20, codeSessionId: 'sess-3', durationMs: 1000 })
     const usage = db.getLastApiUsageForSession('sess-3')
+    assert.equal(usage!.ctxUsed, 200, 'the ring must reflect the larger row')
     assert.equal(usage!.promptTokens, 200, 'must be the second (later, larger) row, not the first')
   } finally {
     db.close()
@@ -118,7 +119,7 @@ test('getLastApiUsageForSession: a later, larger row wins over an earlier, small
   }
 })
 
-test('getLastApiUsageForSession: a smaller row recorded AFTER a larger one does not override it (ctx-fill flicker fix)', () => {
+test('getLastApiUsageForSession: ctxUsed (ring) and last-turn stats are two different rows when a smaller request lands after a bigger one (ctx-fill flicker fix, review-caught follow-up)', () => {
   const root = makeTmpRoot()
   const db = new ConversationStore(root)
   try {
@@ -126,26 +127,34 @@ test('getLastApiUsageForSession: a smaller row recorded AFTER a larger one does 
     // ever-growing prompt) followed by a parallel Task-tool sub-agent call the CLI spawned for a
     // small, isolated sub-task — both share the SAME code_session_id (resolveCodeSession keys
     // purely off the CLI's one ANTHROPIC_AUTH_TOKEN), and the sub-agent's own request happens to
-    // finish and get recorded second. Before this fix, "most recent row wins" made the Context
-    // ring flicker down to the sub-agent's tiny prompt size every time this ordering occurred,
-    // even though the real conversation never shrank.
-    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 98259, genTokens: 400, codeSessionId: 'sess-3b', durationMs: 5000 })
-    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 1200, genTokens: 30, codeSessionId: 'sess-3b', durationMs: 500 })
+    // finish and get recorded second. Before the original fix, "most recent row wins" made the
+    // Context ring flicker down to the sub-agent's tiny prompt size every time this ordering
+    // occurred, even though the real conversation never shrank. That fix then shipped a second
+    // bug (caught in review before tagging): it made EVERY field — including genTokens/tps, which
+    // describe the actual last turn, not the session high-water mark — pin to the bigger row too,
+    // so the sub-agent's own real stats never showed and, after a `/clear`, would freeze forever.
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 98259, genTokens: 400, codeSessionId: 'sess-3b', durationMs: 5000, promptTps: 5000, genTps: 50 })
+    db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 1200, genTokens: 30, codeSessionId: 'sess-3b', durationMs: 500, promptTps: 3000, genTps: 60 })
     const usage = db.getLastApiUsageForSession('sess-3b')
-    assert.equal(usage!.promptTokens, 98259, 'the real, larger main-turn prompt must win over the later, smaller sub-agent call')
+    assert.equal(usage!.ctxUsed, 98259, 'the ring must keep the real, larger main-turn prompt, not drop to the later sub-agent call')
+    assert.equal(usage!.promptTokens, 1200, 'the last-turn stat must be the ACTUAL last request, the sub-agent call')
+    assert.equal(usage!.genTokens, 30, 'same — must not borrow the earlier, bigger turn\'s gen count')
+    assert.equal(usage!.promptTps, 3000)
+    assert.equal(usage!.genTps, 60)
   } finally {
     db.close()
     rmSync(root, { recursive: true, force: true })
   }
 })
 
-test('getLastApiUsageForSession: ties on prompt_tokens break toward the more recent row', () => {
+test('getLastApiUsageForSession: ties on prompt_tokens still resolve the last-turn stats to the more recent row', () => {
   const root = makeTmpRoot()
   const db = new ConversationStore(root)
   try {
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 500, genTokens: 10, codeSessionId: 'sess-3c', durationMs: 1000, promptTps: 111 })
     db.recordApiUsage({ source: 'anthropic', modelKey: 'm1', promptTokens: 500, genTokens: 20, codeSessionId: 'sess-3c', durationMs: 1000, promptTps: 222 })
     const usage = db.getLastApiUsageForSession('sess-3c')
+    assert.equal(usage!.ctxUsed, 500)
     assert.equal(usage!.promptTps, 222, 'the more recent of two equal-sized rows must win')
   } finally {
     db.close()

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -1135,6 +1135,17 @@ export class ConversationStore {
       if (!this.hasColumn('api_usage', 'harness')) this.db.exec(`ALTER TABLE api_usage ADD COLUMN harness TEXT;`)
       this.db.exec(`PRAGMA user_version = 43;`)
     }
+    // v44 (founder-reported: a terminal-agent session's ctx-fill ring jumped between full and
+    // empty within the same session): getLastApiUsageForSession now picks the row with the
+    // MAX prompt_tokens for the session instead of literally the most-recently-inserted one —
+    // see that method's own doc comment for the full root cause (Task-tool sub-agent requests
+    // share the main turn's code_session_id, and a smaller sub-agent row finishing after the
+    // real turn used to silently win). This index serves that new query pattern the same way
+    // idx_api_usage_code_session (v36) served the old ORDER BY created_at.
+    if (v < 44) {
+      this.db.exec(`CREATE INDEX IF NOT EXISTS idx_api_usage_code_session_tokens ON api_usage(code_session_id, prompt_tokens);`)
+      this.db.exec(`PRAGMA user_version = 44;`)
+    }
   }
 
   listConversations(q?: string, kind: 'chat' | 'agent' | 'all' = 'all'): Conversation[] {
@@ -1521,15 +1532,35 @@ export class ConversationStore {
     } as P)
   }
 
-  /** Most recent completed gateway request attributed to a terminal-agent Code session
-   *  (ADR-284) — powers TerminalToolbar.tsx's composer-parity stats row the same way
-   *  `lastRealStats` already does for a 'turbollm' chat session's last turn. null when the
-   *  session has made no gateway requests yet (fresh session, or a non-terminal-agent one). */
+  /** The session's own largest completed gateway request (ADR-284, revised — founder-reported
+   *  "ctx fill jumps between full and empty in the same session") — powers TerminalToolbar.tsx's
+   *  composer-parity stats row and its Context ring the same way `lastRealStats` already does for
+   *  a 'turbollm' chat session's last turn. null when the session has made no gateway requests yet
+   *  (fresh session, or a non-terminal-agent one).
+   *
+   *  Deliberately the MAX prompt_tokens row, not literally the most-recently-INSERTED one. Every
+   *  request a real `claude` CLI process makes — the main conversation's own turn AND every
+   *  parallel Task-tool sub-agent it spawns — shares the SAME code_session_id: `resolveCodeSession`
+   *  (gateway.ts) derives it purely from the bearer token, and the CLI mints exactly one token
+   *  (ANTHROPIC_AUTH_TOKEN, set once at launch) for its whole process, sub-agents included. A
+   *  sub-agent's own prompt is a small, isolated sub-task — nothing like the full resent
+   *  conversation — so whichever of the two finishes last used to decide what the ring showed:
+   *  the real, large, ever-growing main-turn prompt one poll, a tiny sub-agent prompt the next,
+   *  with no change to the actual conversation in between. The MAX is the honest answer to "how
+   *  full has this session's context gotten" — a real Claude Code CLI resends the whole
+   *  conversation every turn, so its size only grows within one continuous conversation, and a
+   *  sub-agent (always smaller) can never legitimately raise that high-water mark.
+   *
+   *  Trade-off, accepted: after a real `/clear` inside the CLI (invisible to the daemon — a
+   *  terminal-agent session's turns are never persisted here, see ADR-297), this keeps reporting
+   *  the pre-clear high-water mark until the new conversation grows past it. A temporarily-stale-
+   *  high reading after a rare, deliberate user action beats an unpredictable full/empty flicker
+   *  on every ordinary agentic turn with sub-agents. */
   getLastApiUsageForSession(codeSessionId: string): { promptTokens: number; genTokens: number; promptTps: number | null; genTps: number | null } | null {
     const row = this.db.prepare(`
       SELECT prompt_tokens, gen_tokens, duration_ms, prompt_tps, gen_tps FROM api_usage
       WHERE code_session_id = $codeSessionId
-      ORDER BY created_at DESC LIMIT 1
+      ORDER BY prompt_tokens DESC, created_at DESC LIMIT 1
     `).get({ $codeSessionId: codeSessionId } as P) as unknown as { prompt_tokens: number; gen_tokens: number; duration_ms: number | null; prompt_tps: number | null; gen_tps: number | null } | undefined
     if (!row) return null
     // The engine's own per-phase rates when the row has them (ADR-300) — llama.cpp times prefill

--- a/turbollm/src/chat/db.ts
+++ b/turbollm/src/chat/db.ts
@@ -1532,13 +1532,12 @@ export class ConversationStore {
     } as P)
   }
 
-  /** The session's own largest completed gateway request (ADR-284, revised — founder-reported
-   *  "ctx fill jumps between full and empty in the same session") — powers TerminalToolbar.tsx's
-   *  composer-parity stats row and its Context ring the same way `lastRealStats` already does for
-   *  a 'turbollm' chat session's last turn. null when the session has made no gateway requests yet
-   *  (fresh session, or a non-terminal-agent one).
+  /** The session's own gateway-request stats (ADR-284, revised twice — founder-reported "ctx
+   *  fill jumps between full and empty in the same session", then a review pass on that same fix
+   *  catching that it had gone on to freeze the LAST-TURN stats too). Two different questions,
+   *  two different rows:
    *
-   *  Deliberately the MAX prompt_tokens row, not literally the most-recently-INSERTED one. Every
+   *  `ctxUsed` is the MAX prompt_tokens row, not literally the most-recently-INSERTED one. Every
    *  request a real `claude` CLI process makes — the main conversation's own turn AND every
    *  parallel Task-tool sub-agent it spawns — shares the SAME code_session_id: `resolveCodeSession`
    *  (gateway.ts) derives it purely from the bearer token, and the CLI mints exactly one token
@@ -1549,20 +1548,31 @@ export class ConversationStore {
    *  with no change to the actual conversation in between. The MAX is the honest answer to "how
    *  full has this session's context gotten" — a real Claude Code CLI resends the whole
    *  conversation every turn, so its size only grows within one continuous conversation, and a
-   *  sub-agent (always smaller) can never legitimately raise that high-water mark.
+   *  sub-agent (always smaller) can never legitimately raise that high-water mark. Trade-off,
+   *  accepted: after a real `/clear` inside the CLI (invisible to the daemon — a terminal-agent
+   *  session's turns are never persisted here, see ADR-297), this keeps reporting the pre-clear
+   *  high-water mark until the new conversation grows past it. A temporarily-stale-high ring
+   *  reading after a rare, deliberate user action beats an unpredictable full/empty flicker on
+   *  every ordinary agentic turn with sub-agents.
    *
-   *  Trade-off, accepted: after a real `/clear` inside the CLI (invisible to the daemon — a
-   *  terminal-agent session's turns are never persisted here, see ADR-297), this keeps reporting
-   *  the pre-clear high-water mark until the new conversation grows past it. A temporarily-stale-
-   *  high reading after a rare, deliberate user action beats an unpredictable full/empty flicker
-   *  on every ordinary agentic turn with sub-agents. */
-  getLastApiUsageForSession(codeSessionId: string): { promptTokens: number; genTokens: number; promptTps: number | null; genTps: number | null } | null {
+   *  `promptTokens`/`genTokens`/`promptTps`/`genTps` are the temporally-LAST row instead — these
+   *  power TerminalToolbar.tsx's composer-parity stats row, which reads as "your last turn", not
+   *  "session high-water mark". Sharing the MAX row here (the original version of this fix) meant
+   *  a sub-agent call landing after the real turn hid its own genTokens/tps behind the earlier,
+   *  larger turn's numbers, and after a `/clear` these froze at the pre-clear turn's numbers
+   *  forever, same failure shape as the ctxUsed bug this method was written to fix in the first
+   *  place. null when the session has made no gateway requests yet (fresh session, or a
+   *  non-terminal-agent one). */
+  getLastApiUsageForSession(codeSessionId: string): { ctxUsed: number; promptTokens: number; genTokens: number; promptTps: number | null; genTps: number | null } | null {
     const row = this.db.prepare(`
       SELECT prompt_tokens, gen_tokens, duration_ms, prompt_tps, gen_tps FROM api_usage
       WHERE code_session_id = $codeSessionId
-      ORDER BY prompt_tokens DESC, created_at DESC LIMIT 1
+      ORDER BY created_at DESC LIMIT 1
     `).get({ $codeSessionId: codeSessionId } as P) as unknown as { prompt_tokens: number; gen_tokens: number; duration_ms: number | null; prompt_tps: number | null; gen_tps: number | null } | undefined
     if (!row) return null
+    const ctxUsed = (this.db.prepare(`
+      SELECT MAX(prompt_tokens) as maxPromptTokens FROM api_usage WHERE code_session_id = $codeSessionId
+    `).get({ $codeSessionId: codeSessionId } as P) as unknown as { maxPromptTokens: number }).maxPromptTokens
     // The engine's own per-phase rates when the row has them (ADR-300) — llama.cpp times prefill
     // and decode separately and reports each, which is the only way either number can be right.
     //
@@ -1575,6 +1585,7 @@ export class ConversationStore {
     // engine reported none.
     const seconds = row.duration_ms != null && row.duration_ms > 0 ? row.duration_ms / 1000 : null
     return {
+      ctxUsed,
       promptTokens: row.prompt_tokens,
       genTokens: row.gen_tokens,
       promptTps: row.prompt_tps ?? (seconds ? row.prompt_tokens / seconds : null),

--- a/turbollm/src/cli-launch.model.test.ts
+++ b/turbollm/src/cli-launch.model.test.ts
@@ -3,7 +3,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { EventEmitter } from 'node:events'
-import { launchCli } from './cli-launch.js'
+import { launchCli, clampAutoCompactWindow } from './cli-launch.js'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -417,6 +417,89 @@ test('launchCli sets NO cap when the engine advertises no slot count', async () 
   try {
     await launchCli('claude', 6996, [], fn, undefined, fetchWithSlots(undefined))
     assert.equal(calls[0].env['CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS'], undefined)
+  } finally {
+    unsilence()
+  }
+})
+
+// ── CLAUDE_CODE_AUTO_COMPACT_WINDOW / CLAUDE_AUTOCOMPACT_PCT_OVERRIDE ──────────────────────────
+// Founder-reported: the terminal-agent `claude` CLI "never auto-compacts at 80%, always reaches
+// 100% and fails". Root cause (Claude Code's own docs, code-window#set-the-auto-compact-window):
+// with no override, the CLI compacts only once the conversation nears "the model's context
+// limit" — its OWN generic ~200K assumption for an unrecognized model, not the real, often much
+// smaller local ctx. Pinning CLAUDE_CODE_AUTO_COMPACT_WINDOW to the real loaded ctx (clamped to
+// the CLI's own documented [100_000, 1_000_000] range) fixes this for ctx >= 100K and tightens
+// the over-generous default below that; CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80 matches this
+// codebase's own established 80%-of-window convention (ADR-132).
+
+test('clampAutoCompactWindow: passes a value already inside the documented range through unchanged', () => {
+  assert.equal(clampAutoCompactWindow(200_000), 200_000)
+})
+
+test('clampAutoCompactWindow: floors at 100_000 for a small local context (e.g. 8K/32K)', () => {
+  assert.equal(clampAutoCompactWindow(8192), 100_000)
+  assert.equal(clampAutoCompactWindow(32768), 100_000)
+})
+
+test('clampAutoCompactWindow: ceilings at 1_000_000 for a very large context', () => {
+  assert.equal(clampAutoCompactWindow(2_000_000), 1_000_000)
+})
+
+test('clampAutoCompactWindow: rounds a non-integer ctx to the nearest whole token count', () => {
+  assert.equal(clampAutoCompactWindow(131_072.4), 131_072)
+})
+
+/** A status fetch that reports a real loaded-model ctx, mirroring fetchWithSlots above. */
+function fetchWithCtx(ctx: number | undefined): typeof fetch {
+  const fn = async (input: string | URL | globalThis.Request): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.includes('/api/v1/status')) {
+      const model: Record<string, unknown> = { key: MODELS[0].key, name: MODELS[0].name }
+      if (ctx !== undefined) model.ctx = ctx
+      return {
+        ok: true, status: 200,
+        json: async () => ({ engine: { state: 'running' }, model }),
+      } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }
+  return fn as unknown as typeof fetch
+}
+
+test('launchCli pins CLAUDE_CODE_AUTO_COMPACT_WINDOW to the real loaded ctx and sets the 80% override', async () => {
+  const { calls, fn } = makeSpawn()
+  const unsilence = silenceOutput()
+  try {
+    await launchCli('claude', 6996, [], fn, undefined, fetchWithCtx(200_000))
+    assert.equal(calls[0].env['CLAUDE_CODE_AUTO_COMPACT_WINDOW'], '200000')
+    assert.equal(calls[0].env['CLAUDE_AUTOCOMPACT_PCT_OVERRIDE'], '80')
+  } finally {
+    unsilence()
+  }
+})
+
+test('launchCli clamps CLAUDE_CODE_AUTO_COMPACT_WINDOW to the CLI-documented 100_000 floor for a small local ctx', async () => {
+  const { calls, fn } = makeSpawn()
+  const unsilence = silenceOutput()
+  try {
+    await launchCli('claude', 6996, [], fn, undefined, fetchWithCtx(8192))
+    assert.equal(calls[0].env['CLAUDE_CODE_AUTO_COMPACT_WINDOW'], '100000')
+  } finally {
+    unsilence()
+  }
+})
+
+test('launchCli sets NO CLAUDE_CODE_AUTO_COMPACT_WINDOW when the daemon reports no real ctx', async () => {
+  // Absent/zero ctx means "don't know" — guessing a window here would be worse than leaving the
+  // CLI's own generic default in place.
+  const { calls, fn } = makeSpawn()
+  const unsilence = silenceOutput()
+  try {
+    await launchCli('claude', 6996, [], fn, undefined, fetchWithCtx(undefined))
+    assert.equal(calls[0].env['CLAUDE_CODE_AUTO_COMPACT_WINDOW'], undefined)
+    // The 80% override is independent of knowing ctx — it only ever lowers the CLI's own
+    // threshold within whatever window it ends up using, so it's always safe to set.
+    assert.equal(calls[0].env['CLAUDE_AUTOCOMPACT_PCT_OVERRIDE'], '80')
   } finally {
     unsilence()
   }

--- a/turbollm/src/cli-launch.ts
+++ b/turbollm/src/cli-launch.ts
@@ -65,9 +65,45 @@ const SUPPORTED: Record<string, CliSpec> = {
 
 interface DaemonStatus {
   engine?: { state?: string; parallelSlots?: number }
-  model?: { name?: string; key?: string } | null
+  model?: { name?: string; key?: string; ctx?: number } | null
   lastLoaded?: { modelKey?: string } | null
 }
+
+// Claude Code CLI's own documented range for CLAUDE_CODE_AUTO_COMPACT_WINDOW (env-vars docs,
+// "Set the auto-compact window"): a plain token count from 100_000 to 1_000_000 — the env var
+// form accepts no smaller/larger value, no `k`/`M` suffix. Below this floor there is no
+// documented way to shrink the window further; see clampAutoCompactWindow's own doc comment.
+const CLAUDE_AUTO_COMPACT_WINDOW_MIN = 100_000
+const CLAUDE_AUTO_COMPACT_WINDOW_MAX = 1_000_000
+
+/** Claude Code auto-compacts once the conversation reaches "the model's context limit" — its
+ *  OWN belief about that limit, not the real engine's. For an unrecognized custom model behind a
+ *  custom ANTHROPIC_BASE_URL, Claude Code has no way to learn the real number (confirmed against
+ *  the CLI's own docs, 2026-08 — no env var declares a custom model's context window; only the
+ *  AUTO_COMPACT_WINDOW/PCT_OVERRIDE pair below tune WHEN it compacts, never WHAT it believes the
+ *  window is) and falls back to a generic assumption (the same 200K a stock Sonnet/Opus session
+ *  without extended context uses). A local model's REAL context is very often far smaller — 8K–
+ *  32K is common on consumer GPUs (see code-session.ts's own compactionSettingsFor comment) — so
+ *  the CLI keeps resending an ever-growing conversation nowhere near ITS assumed 80%-of-200K
+ *  danger zone while llama.cpp's real, much smaller n_ctx quietly overflows underneath it: the
+ *  CLI never sees "getting full", it just gets a hard error once the real engine runs out of
+ *  room. Pinning CLAUDE_CODE_AUTO_COMPACT_WINDOW to the REAL loaded ctx fixes this outright for
+ *  any local setup with ctx >= 100_000 (this repo's own docs describe several: 200K builds are
+ *  common), and meaningfully tightens the over-generous 200K-assumed default for everything down
+ *  to the documented 100_000 floor. Below that floor (an 8K/16K/32K local model) there is no
+ *  further, smaller value the CLI's env var accepts — this is a genuine, confirmed limit of the
+ *  real `claude` binary today, not something TurboLLM can compensate for from outside it. */
+export function clampAutoCompactWindow(ctx: number): number {
+  return Math.min(CLAUDE_AUTO_COMPACT_WINDOW_MAX, Math.max(CLAUDE_AUTO_COMPACT_WINDOW_MIN, Math.round(ctx)))
+}
+
+/** How full CLAUDE_CODE_AUTO_COMPACT_WINDOW is allowed to get before Claude Code compacts
+ *  (CLAUDE_AUTOCOMPACT_PCT_OVERRIDE, 1-100 — can only LOWER the CLI's own default, never raise
+ *  it). 80 matches this codebase's own established auto-compact convention for the exact same
+ *  kind of feature (ADR-132's "/compact auto-fires at 80% of the live context window", the
+ *  in-app pi-based Code session's own compactionSettingsFor) — one consistent number across both
+ *  surfaces rather than an arbitrary different one here. */
+export const CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '80'
 
 interface ModelEntry {
   key: string
@@ -739,6 +775,15 @@ export async function launchCli(
     // Opt into gateway model discovery: Claude Code queries our /v1/models at startup and
     // populates the /model picker with the local library (gateway synthesises the entries).
     CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: '1',
+    // Founder-reported: the ctx-fill display "jumps between full and empty" and the CLI "never
+    // auto-compacts at 80%, always reaches 100% and fails". The second half is Claude Code
+    // assuming a generic ~200K context window for our unrecognized model id and only compacting
+    // near THAT — see clampAutoCompactWindow's own doc comment for the full root cause and its
+    // documented [100_000, 1_000_000] floor/ceiling. Only set when the daemon actually reports a
+    // real ctx (status.model.ctx) — an absent/zero value means "don't know", and guessing a
+    // window here would be worse than leaving the CLI's own generic default in place.
+    ...(status.model?.ctx ? { CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(clampAutoCompactWindow(status.model.ctx)) } : {}),
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE,
     // Cap background-agent fan-out at what the engine can actually run concurrently.
     //
     // Claude Code spawns subagents in parallel, and each is a full, independent request to the

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -337,9 +337,11 @@ export function registerCodeRoutes(app: Hono, d: Deps, codeRuns?: CodeRunManager
   // TerminalToolbar.tsx polls this for the same prompt/gen-token + t/s readout the chat
   // composer's footer already shows from lastRealStats — a terminal-agent session has no
   // per-turn message stats of its own (the CLI drives its own requests), so this reads the
-  // most recent api_usage row the gateway attributed to this session instead (gateway.ts,
-  // session-auth.ts). `usage: null` (not an error) whenever the session hasn't made a
-  // gateway request yet — a perfectly normal, common state right after opening the terminal.
+  // api_usage rows the gateway attributed to this session instead (gateway.ts, session-auth.ts):
+  // `ctxUsed` from the largest, `promptTokens`/`genTokens`/`*Tps` from the most recent — see
+  // getLastApiUsageForSession's doc comment for why those are two different rows. `usage: null`
+  // (not an error) whenever the session hasn't made a gateway request yet — a perfectly normal,
+  // common state right after opening the terminal.
   app.get('/api/v1/code/sessions/:id/last-usage', (c) => {
     const id = c.req.param('id')
     const run = db.getAgentRun(id)

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { clampMaxTokens } from '../config/config'
-import { mapToOpenAI, streamToAnthropic, waitOrPing, type LiveProgress } from './anthropic'
+import { mapToOpenAI, streamToAnthropic, waitOrPing, pingWhilePending, messageStartEvent, type LiveProgress } from './anthropic'
 
 // ── clampMaxTokens ──────────────────────────────────────────────────────────
 
@@ -653,6 +653,71 @@ test('waitOrPing: a pending promise that eventually REJECTS still resolves "data
   // by real callers afterward (streamToAnthropic re-awaits it to surface the real error).
   pending.catch(() => { /* the real caller's job, not this assertion's */ })
   assert.equal(await waitOrPing(pending, 50), 'data')
+})
+
+// ── pingWhilePending (ADR-347: generalizes the same fixed-schedule ping loop to gateway.ts's
+// engine-slot queue wait and fetch() call, not just streamToAnthropic's own read loop — a
+// queued Task-tool sub-agent is exactly as silent to the client as a slow prefill was) ────────
+
+test('pingWhilePending: resolves to the pending value with no pings when it settles well within the window', async () => {
+  let pings = 0
+  const result = await pingWhilePending(Promise.resolve('ok'), () => { pings++ }, 50)
+  assert.equal(result, 'ok')
+  assert.equal(pings, 0)
+})
+
+test('pingWhilePending: pings on a fixed schedule while genuinely queued, then resolves once it settles', async () => {
+  let pings = 0
+  const pending = new Promise((resolve) => setTimeout(() => resolve('granted'), 90))
+  const result = await pingWhilePending(pending, () => { pings++ }, 20)
+  assert.equal(result, 'granted')
+  // ~90ms of waiting on a 20ms cadence must produce multiple pings — a lower bound, not an exact
+  // count, to avoid the same timer-jitter flakiness the streamToAnthropic ping tests avoid too.
+  assert.ok(pings >= 2, `expected multiple pings while queued, got ${pings}`)
+})
+
+test('pingWhilePending: propagates a rejection (e.g. a gate timeout) rather than swallowing it', async () => {
+  const pending = Promise.reject(new Error('gate_acquire_timeout'))
+  await assert.rejects(() => pingWhilePending(pending, () => {}, 50), /gate_acquire_timeout/)
+})
+
+test('pingWhilePending: emitPing errors do not stop the wait from eventually resolving', async () => {
+  const pending = new Promise((resolve) => setTimeout(() => resolve('ok'), 45))
+  let attempts = 0
+  const result = await pingWhilePending(pending, () => { attempts++; throw new Error('client write failed') }, 20)
+    .catch((e: Error) => e.message)
+  // A throwing emitPing rejects the whole wait immediately (the SSE write itself failed, so the
+  // connection is gone) rather than silently continuing to poll a dead connection.
+  assert.equal(result, 'client write failed')
+  assert.ok(attempts >= 1)
+})
+
+test('messageStartEvent: same shape streamToAnthropic used to yield inline, for gateway.ts to send ahead of the queue wait (ADR-347)', () => {
+  const evt = messageStartEvent('msg_abc123', 'local-model')
+  assert.equal(evt.event, 'message_start')
+  const parsed = JSON.parse(evt.data) as { type: string; message: { id: string; role: string; model: string; content: unknown[] } }
+  assert.equal(parsed.type, 'message_start')
+  assert.equal(parsed.message.id, 'msg_abc123')
+  assert.equal(parsed.message.role, 'assistant')
+  assert.equal(parsed.message.model, 'local-model')
+  assert.deepEqual(parsed.message.content, [])
+})
+
+test('streamToAnthropic: skipMessageStart omits the event the caller already sent itself', async () => {
+  const enc = new TextEncoder()
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'))
+      controller.enqueue(enc.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  const events = []
+  for await (const evt of streamToAnthropic(stream, 'local-model', 'msg_1', undefined, undefined, undefined, undefined, true)) {
+    events.push(evt.event)
+  }
+  assert.ok(!events.includes('message_start'), 'message_start must not be sent twice')
+  assert.ok(events.includes('content_block_start'), 'the real content must still stream normally')
 })
 
 test('streamToAnthropic emits ping frames while the upstream stalls, before any real data arrives', async () => {

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -686,6 +686,46 @@ test('streamToAnthropic emits ping frames while the upstream stalls, before any 
   assert.equal(events.at(-1)?.event, 'message_stop')
 })
 
+test('streamToAnthropic still pings on schedule when the upstream sends frequent progress-only chunks (real bug, live-verified)', async () => {
+  // The FIRST version of this fix raced a fresh full interval against reader.read() on every
+  // iteration, which passed a mocked single-delay stream but measured FALSE against the real
+  // engine: llama-server streams a `prompt_progress` chunk every few hundred ms throughout
+  // prefill, each one resolving `reader.read()` almost instantly and restarting the race before
+  // the ping timer could ever fire — even though none of those chunks reach the client (they're
+  // consumed for `onLive` only, never forwarded). This simulates exactly that: many small,
+  // fast-resolving, content-free reads spanning well longer than the ping interval.
+  const enc = new TextEncoder()
+  let sent = 0
+  const TOTAL_CHUNKS = 12
+  const CHUNK_GAP_MS = 6 // fast — each read resolves well within the ping interval
+  const upstream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (sent < TOTAL_CHUNKS) {
+        await new Promise((r) => setTimeout(r, CHUNK_GAP_MS))
+        controller.enqueue(enc.encode(`data: {"prompt_progress":{"processed":${sent + 1},"total":${TOTAL_CHUNKS}}}\n`))
+        sent++
+        return
+      }
+      controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"Hi"}}]}\n'))
+      controller.enqueue(enc.encode('data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}\n'))
+      controller.enqueue(enc.encode('data: [DONE]\n'))
+      controller.close()
+    },
+  })
+
+  const events: { event: string; data: string }[] = []
+  // 12 chunks * 6ms ≈ 72ms of progress-only traffic; a 20ms ping interval should still fire
+  // multiple times across that span if the schedule is truly fixed rather than reset per-read.
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping2', undefined, undefined, undefined, 20)) {
+    events.push(evt)
+  }
+
+  const pings = events.filter((e) => e.event === 'ping')
+  assert.ok(pings.length >= 2, `expected pings despite frequent progress-only reads, got ${pings.length}`)
+  const blob = events.map((e) => e.data).join('\n')
+  assert.ok(blob.includes('Hi'), 'the real turn still streamed through after the progress-only run')
+})
+
 test('streamToAnthropic emits NO ping frames on an ordinary fast turn', async () => {
   const upstream = sseStream([
     'data: {"choices":[{"delta":{"content":"Hello"}}]}',

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -4,7 +4,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { clampMaxTokens } from '../config/config'
-import { mapToOpenAI, streamToAnthropic, type LiveProgress } from './anthropic'
+import { mapToOpenAI, streamToAnthropic, waitOrPing, type LiveProgress } from './anthropic'
 
 // ── clampMaxTokens ──────────────────────────────────────────────────────────
 
@@ -626,4 +626,75 @@ test('streamToAnthropic emits cache_read_input_tokens: 0 when no timings field',
   assert.equal(parsed.usage.output_tokens, 30)
   assert.equal(parsed.usage.input_tokens, 80)
   assert.equal(parsed.usage.cache_read_input_tokens, 0)
+})
+
+// ── keep-alive pings during a slow prefill (founder-reported: Claude Code shows "Waiting for
+// API response, retrying in <n> minutes" while the model is still in prefill) ───────────────
+//
+// Claude Code's own idle-stream watchdog fires once 20s pass with no bytes at all on the
+// response stream. This gateway sent nothing until the engine's first real chunk, so any
+// local-model prefill over 20s (routine on a large/uncached prompt on consumer hardware) looked
+// identical to a stalled connection — even though the engine was working the whole time.
+
+test('waitOrPing: resolves "data" once the pending promise settles well within the window', async () => {
+  const pending = Promise.resolve('ok')
+  assert.equal(await waitOrPing(pending, 50), 'data')
+})
+
+test('waitOrPing: resolves "ping" when the pending promise has not settled by the deadline', async () => {
+  const pending = new Promise((resolve) => setTimeout(() => resolve('ok'), 200))
+  assert.equal(await waitOrPing(pending, 10), 'ping')
+})
+
+test('waitOrPing: a pending promise that eventually REJECTS still resolves "data", not a throw', async () => {
+  const pending = Promise.reject(new Error('engine crashed'))
+  // Prevent Node's own unhandled-rejection reporting for this deliberately-rejected promise —
+  // waitOrPing attaches its own handler, but the original `pending` reference is also awaited
+  // by real callers afterward (streamToAnthropic re-awaits it to surface the real error).
+  pending.catch(() => { /* the real caller's job, not this assertion's */ })
+  assert.equal(await waitOrPing(pending, 50), 'data')
+})
+
+test('streamToAnthropic emits ping frames while the upstream stalls, before any real data arrives', async () => {
+  const enc = new TextEncoder()
+  const upstream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      // Simulates a slow local-model prefill: nothing at all for a stretch longer than several
+      // ping intervals, then the real turn arrives.
+      setTimeout(() => {
+        controller.enqueue(enc.encode('data: {"choices":[{"delta":{"content":"Hi"}}]}\n'))
+        controller.enqueue(enc.encode('data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}\n'))
+        controller.enqueue(enc.encode('data: [DONE]\n'))
+        controller.close()
+      }, 65)
+    },
+  })
+
+  const events: { event: string; data: string }[] = []
+  // A short interval (20ms) so the test stays fast while still observing several pings during
+  // the simulated 65ms stall.
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping', undefined, undefined, undefined, 20)) {
+    events.push(evt)
+  }
+
+  const pings = events.filter((e) => e.event === 'ping')
+  assert.ok(pings.length >= 2, `expected several ping frames during the stall, got ${pings.length}`)
+  for (const p of pings) assert.deepEqual(JSON.parse(p.data), { type: 'ping' })
+  // The real turn still streamed through normally after the stall ended.
+  const blob = events.map((e) => e.data).join('\n')
+  assert.ok(blob.includes('Hi'))
+  assert.equal(events.at(-1)?.event, 'message_stop')
+})
+
+test('streamToAnthropic emits NO ping frames on an ordinary fast turn', async () => {
+  const upstream = sseStream([
+    'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+    'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}',
+    'data: [DONE]',
+  ])
+  const events: { event: string; data: string }[] = []
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_fast', undefined, undefined, undefined, 10_000)) {
+    events.push(evt)
+  }
+  assert.equal(events.filter((e) => e.event === 'ping').length, 0)
 })

--- a/turbollm/src/gateway/anthropic.test.ts
+++ b/turbollm/src/gateway/anthropic.test.ts
@@ -395,7 +395,7 @@ test('streamToAnthropic publishes prefill % then token counts, and never forward
 
   const live: LiveProgress[] = []
   const events: { event: string; data: string }[] = []
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_1', undefined, (p) => live.push(p))) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_1', { onLive: (p) => live.push(p) })) {
     events.push(evt)
   }
 
@@ -432,7 +432,7 @@ test('streamToAnthropic hands the engine\'s own prompt/gen rates to onUsage', as
     'data: [DONE]',
   ])
   let usage: { inputTokens: number; outputTokens: number; promptTps?: number; genTps?: number } | null = null
-  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tps', (u) => { usage = u })) { /* drain */ }
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tps', { onUsage: (u) => { usage = u } })) { /* drain */ }
 
   assert.ok(usage, 'onUsage must fire')
   const u = usage as unknown as { inputTokens: number; outputTokens: number; promptTps?: number; genTps?: number }
@@ -449,7 +449,7 @@ test('streamToAnthropic reports no rates at all when the engine sent none — ne
     'data: [DONE]',
   ])
   let usage: { promptTps?: number; genTps?: number } | null = null
-  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tps2', (u) => { usage = u })) { /* drain */ }
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tps2', { onUsage: (u) => { usage = u } })) { /* drain */ }
 
   assert.ok(usage)
   const u = usage as unknown as { promptTps?: number; genTps?: number }
@@ -477,7 +477,7 @@ test('streamToAnthropic reassembles a tool call whose arguments arrive across se
 
   let calls: { id: string; name: string; input: unknown }[] | null = null
   const events: { event: string; data: string }[] = []
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_tools', undefined, undefined, (c) => { calls = c })) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_tools', { onToolCalls: (c) => { calls = c } })) {
     events.push(evt)
   }
 
@@ -513,7 +513,7 @@ test('streamToAnthropic keeps two tool calls in the same turn apart by their ind
   ])
 
   let calls: { id: string; name: string; input: unknown }[] | null = null
-  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tools2', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_tools2', { onToolCalls: (c) => { calls = c } })) { /* drain */ }
 
   const observed = calls as unknown as { id: string; name: string; input: Record<string, string> }[]
   assert.deepEqual(observed.map((t) => [t.id, t.name]), [['toolu_a', 'Write'], ['toolu_b', 'Bash']])
@@ -531,7 +531,7 @@ test('streamToAnthropic still fires onToolCalls, with an empty list, for a turn 
     'data: [DONE]',
   ])
   let calls: unknown[] | null = null
-  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_notools', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_notools', { onToolCalls: (c) => { calls = c } })) { /* drain */ }
   assert.deepEqual(calls, [])
 })
 
@@ -543,7 +543,7 @@ test('streamToAnthropic drops a tool call whose argument fragments never form va
     'data: [DONE]',
   ])
   let calls: { id: string }[] | null = null
-  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_trunc', undefined, undefined, (c) => { calls = c })) { /* drain */ }
+  for await (const _ of streamToAnthropic(upstream, 'test-model', 'msg_trunc', { onToolCalls: (c) => { calls = c } })) { /* drain */ }
   assert.deepEqual((calls as unknown as { id: string }[]).map((t) => t.id), ['toolu_ok'])
 })
 
@@ -567,7 +567,7 @@ test('streamToAnthropic does NOT fire onToolCalls when the stream fails mid-turn
   let fired = false
   let usageFired = false
   const events: { event: string; data: string }[] = []
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_dead', () => { usageFired = true }, undefined, () => { fired = true })) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_dead', { onUsage: () => { usageFired = true }, onToolCalls: () => { fired = true } })) {
     events.push(evt)
   }
 
@@ -681,7 +681,7 @@ test('pingWhilePending: propagates a rejection (e.g. a gate timeout) rather than
   await assert.rejects(() => pingWhilePending(pending, () => {}, 50), /gate_acquire_timeout/)
 })
 
-test('pingWhilePending: emitPing errors do not stop the wait from eventually resolving', async () => {
+test('pingWhilePending: a throwing emitPing rejects the whole wait immediately (the connection is gone)', async () => {
   const pending = new Promise((resolve) => setTimeout(() => resolve('ok'), 45))
   let attempts = 0
   const result = await pingWhilePending(pending, () => { attempts++; throw new Error('client write failed') }, 20)
@@ -690,6 +690,23 @@ test('pingWhilePending: emitPing errors do not stop the wait from eventually res
   // connection is gone) rather than silently continuing to poll a dead connection.
   assert.equal(result, 'client write failed')
   assert.ok(attempts >= 1)
+})
+
+test('pingWhilePending: a resource `pending` resolves to is drained via onOrphan when emitPing fails first (review-caught leak, ADR-347)', async () => {
+  // Mirrors gateway.ts's real shape: `pending` is a GenerationGate.acquire() that eventually
+  // GRANTS a release function, but the client connection died first (emitPing threw) so nothing
+  // else will ever call it. Without onOrphan, that grant is silently abandoned — permanently
+  // shrinking the daemon's effective engine-slot capacity by one for its whole remaining life.
+  let released = false
+  const release = () => { released = true }
+  const pending = new Promise<() => void>((resolve) => setTimeout(() => resolve(release), 45))
+  await assert.rejects(
+    () => pingWhilePending(pending, () => { throw new Error('client gone') }, 20, (rel) => rel()),
+    /client gone/,
+  )
+  // The grant lands ~45ms after the ping failure at ~20ms — wait past it before asserting.
+  await new Promise((r) => setTimeout(r, 40))
+  assert.equal(released, true, 'the orphaned release must still be called, not leaked')
 })
 
 test('messageStartEvent: same shape streamToAnthropic used to yield inline, for gateway.ts to send ahead of the queue wait (ADR-347)', () => {
@@ -713,7 +730,7 @@ test('streamToAnthropic: skipMessageStart omits the event the caller already sen
     },
   })
   const events = []
-  for await (const evt of streamToAnthropic(stream, 'local-model', 'msg_1', undefined, undefined, undefined, undefined, true)) {
+  for await (const evt of streamToAnthropic(stream, 'local-model', 'msg_1', { skipMessageStart: true })) {
     events.push(evt.event)
   }
   assert.ok(!events.includes('message_start'), 'message_start must not be sent twice')
@@ -738,7 +755,7 @@ test('streamToAnthropic emits ping frames while the upstream stalls, before any 
   const events: { event: string; data: string }[] = []
   // A short interval (20ms) so the test stays fast while still observing several pings during
   // the simulated 65ms stall.
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping', undefined, undefined, undefined, 20)) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping', { pingIntervalMs: 20 })) {
     events.push(evt)
   }
 
@@ -781,7 +798,7 @@ test('streamToAnthropic still pings on schedule when the upstream sends frequent
   const events: { event: string; data: string }[] = []
   // 12 chunks * 6ms ≈ 72ms of progress-only traffic; a 20ms ping interval should still fire
   // multiple times across that span if the schedule is truly fixed rather than reset per-read.
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping2', undefined, undefined, undefined, 20)) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_ping2', { pingIntervalMs: 20 })) {
     events.push(evt)
   }
 
@@ -798,7 +815,7 @@ test('streamToAnthropic emits NO ping frames on an ordinary fast turn', async ()
     'data: [DONE]',
   ])
   const events: { event: string; data: string }[] = []
-  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_fast', undefined, undefined, undefined, 10_000)) {
+  for await (const evt of streamToAnthropic(upstream, 'test-model', 'msg_fast', { pingIntervalMs: 10_000 })) {
     events.push(evt)
   }
   assert.equal(events.filter((e) => e.event === 'ping').length, 0)

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -467,6 +467,14 @@ export async function* streamToAnthropic(
   try {
     outer: while (true) {
       const readPromise = reader.read()
+      // Attach a handler at creation time, unconditionally — the `remaining === 0` shortcut
+      // below can `yield` a ping without ever calling `waitOrPing` (the only place that used to
+      // attach one), leaving `readPromise` unhandled while the generator is suspended at that
+      // `yield`. If the upstream errors during that window, Node reports an unhandledRejection
+      // for a path this function already handles correctly one line down. This `.catch` only
+      // marks the promise handled for that purpose; `await readPromise` below still throws
+      // normally into the surrounding try/catch.
+      readPromise.catch(() => {})
       // Race against the REMAINING time on the fixed schedule, not a fresh full interval each
       // time — a naive "race against pingIntervalMs on every read" (the first version of this
       // fix) looked correct in isolation and passed against a mocked stream, but measured FALSE

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -460,14 +460,37 @@ export async function* streamToAnthropic(
   const dec = new TextDecoder()
   let buf = ''
   let failed = false
+  // Fixed cadence from stream start, NOT reset on every `reader.read()` resolution — see the
+  // ADR-342 postmortem below for why that distinction is load-bearing.
+  let nextPingAt = Date.now() + pingIntervalMs
 
   try {
     outer: while (true) {
       const readPromise = reader.read()
-      while ((await waitOrPing(readPromise, pingIntervalMs)) === 'ping') {
-        yield sse('ping', {})
+      // Race against the REMAINING time on the fixed schedule, not a fresh full interval each
+      // time — a naive "race against pingIntervalMs on every read" (the first version of this
+      // fix) looked correct in isolation and passed against a mocked stream, but measured FALSE
+      // against the real engine: llama-server streams a `prompt_progress` chunk roughly every
+      // few hundred ms throughout the whole prefill (return_progress: true, above) — each one
+      // resolves `reader.read()` almost instantly, restarting the race before the ping timer
+      // could ever fire, even though NONE of those chunks are forwarded to the client (they're
+      // swallowed below, `onLive` only) — so the CLIENT still saw total silence for the entire
+      // prefill. Live-verified: a 25s real prefill against a loaded 35B model produced zero
+      // pings under the per-read-reset version. This fixed-schedule version fires on schedule
+      // regardless of how many progress-only reads resolve in between.
+      let result: Awaited<ReturnType<typeof reader.read>>
+      while (true) {
+        const remaining = Math.max(0, nextPingAt - Date.now())
+        const outcome = remaining === 0 ? 'ping' : await waitOrPing(readPromise, remaining)
+        if (outcome === 'ping') {
+          yield sse('ping', {})
+          nextPingAt = Date.now() + pingIntervalMs
+          continue
+        }
+        result = await readPromise
+        break
       }
-      const { done, value } = await readPromise
+      const { done, value } = result
       if (done) break
       buf += dec.decode(value, { stream: true })
       const lines = buf.split('\n')

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -426,11 +426,22 @@ export function waitOrPing(pending: Promise<unknown>, ms: number): Promise<'data
  *  the engine had already accepted the request. Same fixed-cadence-from-start reasoning: a
  *  schedule that resets on every settle-check would starve under a `pending` that itself emits
  *  frequent progress, though callers here don't have that failure mode today. Resolves/rejects
- *  exactly as `pending` does; `emitPing` fires each time the deadline elapses first. */
+ *  exactly as `pending` does; `emitPing` fires each time the deadline elapses first.
+ *
+ *  `onOrphan`, if given, fires if `emitPing` itself throws (the client connection is gone, so the
+ *  wait can't usefully continue) and `pending` goes on to resolve anyway — e.g. gateway.ts's
+ *  `d.gate.acquire()` grants an engine slot to a caller who has already given up. Rethrowing
+ *  immediately here would silently ABANDON that grant: nothing would ever call the returned
+ *  release function, permanently shrinking the daemon's effective concurrency by one for its
+ *  whole remaining life (GenerationGate's own `drain()` doc comment calls out exactly this
+ *  failure class). `onOrphan` lets the caller drain whatever `pending` eventually produces
+ *  instead (review-caught, ADR-347 follow-up) — omit it for a `pending` with nothing to drain
+ *  (e.g. a plain `fetch()`, where an orphaned Response can just be garbage-collected). */
 export async function pingWhilePending<T>(
   pending: Promise<T>,
   emitPing: () => Promise<void> | void,
   pingIntervalMs: number = DEFAULT_PING_INTERVAL_MS,
+  onOrphan?: (value: T) => void,
 ): Promise<T> {
   pending.catch(() => {}) // same unhandled-rejection guard as the loop below — see anthropic.ts:481-492's comment
   let nextPingAt = Date.now() + pingIntervalMs
@@ -438,7 +449,12 @@ export async function pingWhilePending<T>(
     const remaining = Math.max(0, nextPingAt - Date.now())
     const outcome = remaining === 0 ? 'ping' : await waitOrPing(pending, remaining)
     if (outcome === 'ping') {
-      await emitPing()
+      try {
+        await emitPing()
+      } catch (e) {
+        if (onOrphan) pending.then(onOrphan).catch(() => {})
+        throw e
+      }
       nextPingAt = Date.now() + pingIntervalMs
       continue
     }
@@ -467,19 +483,24 @@ export function messageStartEvent(msgId: string, modelName: string): SseEvent {
   })
 }
 
+export interface StreamToAnthropicOptions {
+  onUsage?: (u: StreamUsage) => void
+  onLive?: (p: LiveProgress) => void
+  onToolCalls?: (calls: StreamToolCall[]) => void
+  pingIntervalMs?: number
+  /** Set when the caller already sent messageStartEvent() itself (gateway.ts, ADR-347) before
+   *  this generator was even constructed — e.g. right when the client's SSE connection opens,
+   *  ahead of queueing for an engine slot. Emitting it again here would send message_start twice. */
+  skipMessageStart?: boolean
+}
+
 export async function* streamToAnthropic(
   oaiStream: ReadableStream<Uint8Array>,
   modelName: string,
   msgId: string,
-  onUsage?: (u: StreamUsage) => void,
-  onLive?: (p: LiveProgress) => void,
-  onToolCalls?: (calls: StreamToolCall[]) => void,
-  pingIntervalMs: number = DEFAULT_PING_INTERVAL_MS,
-  // Set when the caller already sent messageStartEvent() itself (gateway.ts, ADR-347) before
-  // this generator was even constructed — e.g. right when the client's SSE connection opens,
-  // ahead of queueing for an engine slot. Emitting it again here would send message_start twice.
-  skipMessageStart: boolean = false,
+  opts: StreamToAnthropicOptions = {},
 ): AsyncGenerator<SseEvent> {
+  const { onUsage, onLive, onToolCalls, pingIntervalMs = DEFAULT_PING_INTERVAL_MS, skipMessageStart = false } = opts
   let blockIdx = 0
   let inThinking = false
   let inText = false

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -392,6 +392,32 @@ export type LiveProgress = { phase: 'prompt' | 'gen'; pct: number; outputTokens:
  *  never reports back, so the request stream is the only place the daemon ever sees them). */
 export type StreamToolCall = { id: string; name: string; input: unknown }
 
+// ── Keep-alive pings during a slow prefill (founder-reported: "Waiting for API response,
+// retrying in <n> minutes") ─────────────────────────────────────────────────────────────────
+// Claude Code's own idle-stream watchdog shows that banner (and eventually retries the whole
+// request) once 20 SECONDS pass with no bytes at all on the response stream — confirmed against
+// the CLI's own docs/issue reports, not assumed. The real Anthropic API avoids this by sending
+// periodic `event: ping` SSE frames during long-running turns; this gateway sent NONE, so any
+// local-model prefill over 20s (common — a large or uncached prompt on consumer hardware
+// routinely takes tens of seconds before the first output token) looked identical to a stalled
+// connection from the CLI's point of view, even though the engine was working the whole time.
+// Comfortably under the 20s threshold so a ping always lands well before the watchdog fires.
+export const DEFAULT_PING_INTERVAL_MS = 10_000
+
+/** Resolves `'data'` once `pending` settles (success OR failure — a rejection is surfaced by the
+ *  caller's own subsequent `await pending`, not swallowed here), or `'ping'` after `ms` if it
+ *  hasn't settled yet. Pure/exported so the keep-alive decision is unit-testable without a real
+ *  slow stream. Never leaks its timer: cleared on whichever path resolves first. */
+export function waitOrPing(pending: Promise<unknown>, ms: number): Promise<'data' | 'ping'> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve('ping'), ms)
+    pending.then(
+      () => { clearTimeout(timer); resolve('data') },
+      () => { clearTimeout(timer); resolve('data') },
+    )
+  })
+}
+
 export async function* streamToAnthropic(
   oaiStream: ReadableStream<Uint8Array>,
   modelName: string,
@@ -399,6 +425,7 @@ export async function* streamToAnthropic(
   onUsage?: (u: StreamUsage) => void,
   onLive?: (p: LiveProgress) => void,
   onToolCalls?: (calls: StreamToolCall[]) => void,
+  pingIntervalMs: number = DEFAULT_PING_INTERVAL_MS,
 ): AsyncGenerator<SseEvent> {
   let blockIdx = 0
   let inThinking = false
@@ -436,7 +463,11 @@ export async function* streamToAnthropic(
 
   try {
     outer: while (true) {
-      const { done, value } = await reader.read()
+      const readPromise = reader.read()
+      while ((await waitOrPing(readPromise, pingIntervalMs)) === 'ping') {
+        yield sse('ping', {})
+      }
+      const { done, value } = await readPromise
       if (done) break
       buf += dec.decode(value, { stream: true })
       const lines = buf.split('\n')

--- a/turbollm/src/gateway/anthropic.ts
+++ b/turbollm/src/gateway/anthropic.ts
@@ -418,6 +418,55 @@ export function waitOrPing(pending: Promise<unknown>, ms: number): Promise<'data
   })
 }
 
+/** Generalizes streamToAnthropic's own fixed-schedule ping loop (see the ADR-342 postmortem
+ *  below) to ANY long-running wait, not just a stream read — gateway.ts uses this to keep a
+ *  client's connection alive while queued for an engine slot (up to 600s, ADR-347) and while
+ *  waiting on `fetch()` to the engine, both of which are just as silent to the client as a slow
+ *  prefill and were invisible to the original ping fix, which only covered the read loop AFTER
+ *  the engine had already accepted the request. Same fixed-cadence-from-start reasoning: a
+ *  schedule that resets on every settle-check would starve under a `pending` that itself emits
+ *  frequent progress, though callers here don't have that failure mode today. Resolves/rejects
+ *  exactly as `pending` does; `emitPing` fires each time the deadline elapses first. */
+export async function pingWhilePending<T>(
+  pending: Promise<T>,
+  emitPing: () => Promise<void> | void,
+  pingIntervalMs: number = DEFAULT_PING_INTERVAL_MS,
+): Promise<T> {
+  pending.catch(() => {}) // same unhandled-rejection guard as the loop below — see anthropic.ts:481-492's comment
+  let nextPingAt = Date.now() + pingIntervalMs
+  while (true) {
+    const remaining = Math.max(0, nextPingAt - Date.now())
+    const outcome = remaining === 0 ? 'ping' : await waitOrPing(pending, remaining)
+    if (outcome === 'ping') {
+      await emitPing()
+      nextPingAt = Date.now() + pingIntervalMs
+      continue
+    }
+    return pending
+  }
+}
+
+/** The `message_start` event streamToAnthropic normally yields first, extracted so gateway.ts
+ *  can send it the moment it opens the client's SSE connection — before queueing for an engine
+ *  slot — instead of only once the engine has actually accepted the request. Real Anthropic
+ *  behavior: message_start marks the request being ACCEPTED, not generation starting; waiting
+ *  for engine bytes to send it would reintroduce exactly the silent gap ADR-347 exists to close.
+ *  Paired with streamToAnthropic's `skipMessageStart` so it's never sent twice. */
+export function messageStartEvent(msgId: string, modelName: string): SseEvent {
+  return sse('message_start', {
+    message: {
+      id: msgId,
+      type: 'message',
+      role: 'assistant',
+      content: [],
+      model: modelName,
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 1 },
+    },
+  })
+}
+
 export async function* streamToAnthropic(
   oaiStream: ReadableStream<Uint8Array>,
   modelName: string,
@@ -426,6 +475,10 @@ export async function* streamToAnthropic(
   onLive?: (p: LiveProgress) => void,
   onToolCalls?: (calls: StreamToolCall[]) => void,
   pingIntervalMs: number = DEFAULT_PING_INTERVAL_MS,
+  // Set when the caller already sent messageStartEvent() itself (gateway.ts, ADR-347) before
+  // this generator was even constructed — e.g. right when the client's SSE connection opens,
+  // ahead of queueing for an engine slot. Emitting it again here would send message_start twice.
+  skipMessageStart: boolean = false,
 ): AsyncGenerator<SseEvent> {
   let blockIdx = 0
   let inThinking = false
@@ -443,18 +496,7 @@ export async function* streamToAnthropic(
   let genTps = 0
   let liveOut = 0 // running generated-token count for the live engine-card row
 
-  yield sse('message_start', {
-    message: {
-      id: msgId,
-      type: 'message',
-      role: 'assistant',
-      content: [],
-      model: modelName,
-      stop_reason: null,
-      stop_sequence: null,
-      usage: { input_tokens: 0, output_tokens: 1 },
-    },
-  })
+  if (!skipMessageStart) yield messageStartEvent(msgId, modelName)
 
   const reader = oaiStream.getReader()
   const dec = new TextDecoder()

--- a/turbollm/src/gateway/gateway.errors.test.ts
+++ b/turbollm/src/gateway/gateway.errors.test.ts
@@ -182,3 +182,138 @@ test('POST /v1/messages with an already-aborted client signal reports a clear di
   const body = (await res.json()) as { error?: { message: string; type: string } }
   assert.equal(body.error?.message, 'Client disconnected before the engine responded.')
 })
+
+// ── /v1/messages streaming (stream: true) — same four failure classes as above, but the
+// response is already committed as a 200 SSE stream by the time any of these can be detected
+// (ADR-347), so the failure surfaces as a mid-stream `error` event instead of a JSON response with
+// a real status code. Review-caught gap: every case above used `stream: false`, so this behavior
+// change for the ONLY request shape Claude Code actually sends (it always streams) had zero
+// coverage. These tests document the accepted tradeoff explicitly, not just assert it's unchanged.
+
+const streamingMessagesBody = JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], max_tokens: 100, stream: true })
+
+/** Reads SSE `{event, data}` frames off a Response body as they arrive — same shape as
+ *  gateway.queue-ping.test.ts's own reader, duplicated locally rather than shared across test
+ *  files (matching this suite's existing per-file `withFakeEngine`/`fakeDeps` convention). */
+function sseEventReader(body: ReadableStream<Uint8Array>) {
+  const reader = body.getReader()
+  const dec = new TextDecoder()
+  let buf = ''
+  return {
+    async next(): Promise<{ event: string; data: string } | null> {
+      while (true) {
+        const frameEnd = buf.indexOf('\n\n')
+        if (frameEnd !== -1) {
+          const frame = buf.slice(0, frameEnd)
+          buf = buf.slice(frameEnd + 2)
+          const event = frame.match(/^event: (.+)$/m)?.[1] ?? ''
+          const data = frame.match(/^data: (.*)$/m)?.[1] ?? ''
+          return { event, data }
+        }
+        const { done, value } = await reader.read()
+        if (done) return null
+        buf += dec.decode(value, { stream: true })
+      }
+    },
+  }
+}
+
+async function firstNonPingEvent(body: ReadableStream<Uint8Array>): Promise<{ event: string; data: string }> {
+  const events = sseEventReader(body)
+  for (;;) {
+    const evt = await events.next()
+    assert.ok(evt, 'stream ended before a non-ping event arrived')
+    if (evt!.event !== 'message_start' && evt!.event !== 'ping') return evt!
+  }
+}
+
+test('POST /v1/messages (streaming) forwards the engine\'s real error as an SSE event on a 200, not a 400 JSON response', async () => {
+  const engine = await withFakeEngine((_req, res) => {
+    res.writeHead(400, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: { message: 'the request exceeds the available context size', type: 'invalid_request_error' } }))
+  })
+  try {
+    const app = new Hono()
+    registerGateway(app, fakeDeps(engine.url))
+    const res = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: streamingMessagesBody,
+    })
+    assert.equal(res.status, 200, 'a streaming response is always 200 once the SSE connection has opened')
+    assert.ok(res.body)
+    const evt = await firstNonPingEvent(res.body!)
+    assert.equal(evt.event, 'error')
+    const parsed = JSON.parse(evt.data) as { error: { type: string; message: string } }
+    assert.equal(parsed.error.type, 'invalid_request_error')
+    assert.equal(parsed.error.message, 'the request exceeds the available context size')
+  } finally {
+    await engine.close()
+  }
+})
+
+test('POST /v1/messages (streaming) falls back to raw text + a status-mapped type in the SSE error event when the engine body is not JSON', async () => {
+  const engine = await withFakeEngine((_req, res) => {
+    res.writeHead(503, { 'Content-Type': 'text/plain' })
+    res.end('CUDA out of memory')
+  })
+  try {
+    const app = new Hono()
+    registerGateway(app, fakeDeps(engine.url))
+    const res = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: streamingMessagesBody,
+    })
+    assert.equal(res.status, 200)
+    assert.ok(res.body)
+    const evt = await firstNonPingEvent(res.body!)
+    assert.equal(evt.event, 'error')
+    const parsed = JSON.parse(evt.data) as { error: { type: string; message: string } }
+    assert.equal(parsed.error.type, 'overloaded_error')
+    assert.equal(parsed.error.message, 'CUDA out of memory')
+  } finally {
+    await engine.close()
+  }
+})
+
+test('POST /v1/messages (streaming) reports an SSE error event, not a bodyless 500, when the engine fetch throws', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps()) // default fakeDeps target is genuinely unreachable
+
+  const res = await app.request('/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: streamingMessagesBody,
+  })
+
+  assert.equal(res.status, 200)
+  assert.ok(res.body)
+  const evt = await firstNonPingEvent(res.body!)
+  assert.equal(evt.event, 'error')
+  const parsed = JSON.parse(evt.data) as { error: { type: string; message: string } }
+  assert.equal(parsed.error.type, 'api_error')
+  assert.ok(parsed.error.message.length > 0, 'message must not be empty')
+})
+
+test('POST /v1/messages (streaming) with an already-aborted client signal reports a clear disconnect message as an SSE event', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+
+  const ac = new AbortController()
+  ac.abort() // simulate the client having already disconnected before the fetch fires
+
+  const res = await app.request('/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: streamingMessagesBody,
+    signal: ac.signal,
+  })
+
+  assert.equal(res.status, 200)
+  assert.ok(res.body)
+  const evt = await firstNonPingEvent(res.body!)
+  assert.equal(evt.event, 'error')
+  const parsed = JSON.parse(evt.data) as { error: { type: string; message: string } }
+  assert.equal(parsed.error.message, 'Client disconnected before the engine responded.')
+})

--- a/turbollm/src/gateway/gateway.queue-ping.test.ts
+++ b/turbollm/src/gateway/gateway.queue-ping.test.ts
@@ -9,7 +9,7 @@ import { test } from 'node:test'
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { Hono } from 'hono'
-import { registerGateway } from './gateway'
+import { registerGateway, type GatewayOptions } from './gateway'
 import { GenerationGate } from '../agents/gate'
 import type { Deps } from '../deps'
 
@@ -34,7 +34,12 @@ async function withFakeStreamingEngine(): Promise<{ url: string; close: () => Pr
   }
 }
 
-function fakeDeps(target: string, gate?: GenerationGate): Deps {
+/** `dbCalls` collects every `recordApiUsage` invocation — matching the mock shape
+ *  `gateway.code-activity.test.ts` already uses for the same dependency, so this doesn't silently
+ *  exercise a `d.db` that's `undefined` in the real handler (review-caught: an earlier version of
+ *  this mock omitted `db` entirely, and gateway.ts's own `catch { swallow }` around that call hid
+ *  the resulting TypeError, leaving the usage-recording half of the streaming path untested). */
+function fakeDeps(target: string, gate: GenerationGate | undefined, dbCalls: unknown[]): Deps {
   return {
     scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
     modelRouter: { route: async () => ({ target }) },
@@ -48,6 +53,7 @@ function fakeDeps(target: string, gate?: GenerationGate): Deps {
       setLiveGen: () => {},
     },
     registry: { active: () => ({ kind: 'llama.cpp' }) },
+    db: { recordApiUsage: (rec: unknown) => { dbCalls.push(rec) } },
     gate,
   } as unknown as Deps
 }
@@ -72,13 +78,16 @@ function sseEventReader(body: ReadableStream<Uint8Array>) {
   const dec = new TextDecoder()
   let buf = ''
   return {
-    /** Resolves with the next `event:` name once a full SSE frame has arrived, or null at EOF. */
-    async next(): Promise<string | null> {
+    /** Resolves with `{event, data}` for the next full SSE frame, or null at EOF. */
+    async next(): Promise<{ event: string; data: string } | null> {
       while (true) {
-        const m = buf.match(/^event: (.+)\n/m)
-        if (m) {
-          buf = buf.slice(buf.indexOf('\n\n') + 2)
-          return m[1]
+        const frameEnd = buf.indexOf('\n\n')
+        if (frameEnd !== -1) {
+          const frame = buf.slice(0, frameEnd)
+          buf = buf.slice(frameEnd + 2)
+          const event = frame.match(/^event: (.+)$/m)?.[1] ?? ''
+          const data = frame.match(/^data: (.*)$/m)?.[1] ?? ''
+          return { event, data }
         }
         const { done, value } = await reader.read()
         if (done) return null
@@ -94,9 +103,10 @@ test('POST /v1/messages (streaming): message_start arrives while still queued be
   const engine = await withFakeStreamingEngine()
   const gate = new GenerationGate(() => 1)
   const release = await gate.acquire('bg') // occupy the one slot so the real request must queue
+  const dbCalls: unknown[] = []
   try {
     const app = new Hono()
-    registerGateway(app, fakeDeps(engine.url, gate))
+    registerGateway(app, fakeDeps(engine.url, gate, dbCalls))
 
     const resPromise = app.request('/v1/messages', {
       method: 'POST',
@@ -110,7 +120,7 @@ test('POST /v1/messages (streaming): message_start arrives while still queued be
     assert.ok(res.body)
     const events = sseEventReader(res.body!)
     const first = await events.next()
-    assert.equal(first, 'message_start', 'message_start must be sent before queueing for the engine slot')
+    assert.equal(first?.event, 'message_start', 'message_start must be sent before queueing for the engine slot')
 
     // The streamSSE callback runs fire-and-forget (Hono's `run()` doesn't await it), so it may
     // not have reached its own gate.acquire() call the instant message_start's write is observed
@@ -119,28 +129,106 @@ test('POST /v1/messages (streaming): message_start arrives while still queued be
 
     release() // let the queued request proceed
 
-    const seen = [first]
+    const seen = [first!.event]
     for (;;) {
       const evt = await events.next()
       if (evt === null) break
-      seen.push(evt)
+      seen.push(evt.event)
     }
     assert.equal(seen.filter((e) => e === 'message_start').length, 1, 'message_start must never be sent twice')
     assert.ok(seen.includes('content_block_start'), 'the real engine content must still arrive once the queue clears')
     assert.ok(seen.includes('message_stop'))
+
+    // The usage-recording half of the streaming path (GitHub #71's durable record) must still
+    // fire once the queue clears and the real engine content streams through.
+    assert.equal(dbCalls.length, 1, 'recordApiUsage must fire exactly once for this turn')
+    assert.equal((dbCalls[0] as { source: string }).source, 'anthropic')
+    assert.equal((dbCalls[0] as { promptTokens: number }).promptTokens, 5)
   } finally {
     release()
     await engine.close()
   }
 })
 
-test('POST /v1/messages (streaming): a queue-wait failure (client already gone) surfaces as an SSE error event, not a bodyless/JSON one', async () => {
+test('POST /v1/messages (streaming): pings arrive while genuinely queued behind a busy gate', async () => {
+  const engine = await withFakeStreamingEngine()
+  const gate = new GenerationGate(() => 1)
+  const release = await gate.acquire('bg')
+  try {
+    const app = new Hono()
+    const opts: GatewayOptions = { pingIntervalMs: 20, gateAcquireTimeoutMs: 600_000 }
+    registerGateway(app, fakeDeps(engine.url, gate, []), opts)
+
+    const res = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: messagesBody,
+    })
+    assert.ok(res.body)
+    const events = sseEventReader(res.body!)
+
+    const first = await events.next()
+    assert.equal(first?.event, 'message_start')
+
+    // Hold the gate for several ping intervals before releasing — long enough that at least one
+    // ping must land on the wire while the request is still genuinely queued, not granted.
+    await new Promise((r) => setTimeout(r, 70))
+    const ping = await events.next()
+    assert.equal(ping?.event, 'ping', 'a ping must arrive while still queued, before the gate is ever released')
+    assert.deepEqual(JSON.parse(ping!.data), { type: 'ping' })
+
+    release()
+  } finally {
+    release()
+    await engine.close()
+  }
+})
+
+test('POST /v1/messages (streaming): a queue TIMEOUT (still genuinely queued, never released) surfaces as an SSE overloaded_error event, not a bodyless/JSON one', async () => {
+  const engine = await withFakeStreamingEngine()
+  const gate = new GenerationGate(() => 1)
+  const release = await gate.acquire('bg') // occupy the slot for the whole test — the real request must time out queued, never granted
+  try {
+    const app = new Hono()
+    // A short override (default is 600s) — this is exactly what a genuine timeout looks like,
+    // not the trivially-synchronous pre-aborted-signal case a prior version of this test covered.
+    // pingIntervalMs is deliberately LONGER than the timeout so no ping lands in between message_start
+    // and the error event — this test is about the timeout shape, not ping/timeout interleaving.
+    const opts: GatewayOptions = { pingIntervalMs: 5_000, gateAcquireTimeoutMs: 40 }
+    registerGateway(app, fakeDeps(engine.url, gate, []), opts)
+
+    const res = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: messagesBody,
+    })
+
+    // SSE streams always answer 200 — the failure has to show up as an `error` event in the body,
+    // not a 4xx/5xx status the way the non-streaming path reports the same failure class.
+    assert.equal(res.status, 200)
+    assert.ok(res.body)
+    const events = sseEventReader(res.body!)
+    const first = await events.next()
+    assert.equal(first?.event, 'message_start')
+    const second = await events.next()
+    assert.equal(second?.event, 'error', 'a genuine queue timeout must surface as an SSE error event')
+    const parsed = JSON.parse(second!.data) as { error: { type: string; message: string } }
+    assert.equal(parsed.error.type, 'overloaded_error')
+    assert.equal(parsed.error.message, 'Timed out waiting for a free engine slot.')
+    assert.equal(gate.stats().queued, 0, 'the timed-out waiter must remove itself from the queue')
+  } finally {
+    release()
+    await engine.close()
+  }
+})
+
+test('POST /v1/messages (streaming): a client already gone before queueing (pre-aborted signal) surfaces as an SSE invalid_request_error event', async () => {
   const engine = await withFakeStreamingEngine()
   const gate = new GenerationGate(() => 1)
   const release = await gate.acquire('bg') // occupy the slot so the real request queues and checks the signal
   try {
     const app = new Hono()
-    registerGateway(app, fakeDeps(engine.url, gate))
+    registerGateway(app, fakeDeps(engine.url, gate, []))
 
     const ac = new AbortController()
     ac.abort() // client already disconnected before this request would even start queueing
@@ -152,15 +240,16 @@ test('POST /v1/messages (streaming): a queue-wait failure (client already gone) 
       signal: ac.signal,
     })
 
-    // SSE streams always answer 200 — the failure has to show up as an `error` event in the body,
-    // not a 4xx/5xx status the way the non-streaming path reports the same failure class.
     assert.equal(res.status, 200)
     assert.ok(res.body)
     const events = sseEventReader(res.body!)
     const first = await events.next()
-    assert.equal(first, 'message_start')
+    assert.equal(first?.event, 'message_start')
     const second = await events.next()
-    assert.equal(second, 'error', 'the aborted queue wait must surface as an SSE error event')
+    assert.equal(second?.event, 'error', 'the aborted queue wait must surface as an SSE error event')
+    const parsed = JSON.parse(second!.data) as { error: { type: string; message: string } }
+    assert.equal(parsed.error.type, 'invalid_request_error')
+    assert.equal(parsed.error.message, 'Client disconnected while queued for the engine.')
   } finally {
     release()
     await engine.close()

--- a/turbollm/src/gateway/gateway.queue-ping.test.ts
+++ b/turbollm/src/gateway/gateway.queue-ping.test.ts
@@ -1,0 +1,168 @@
+// Regression coverage for ADR-347: gate.acquire() (up to 600s) and the engine fetch() both ran
+// BEFORE the client's SSE connection was ever opened, so a Task-tool sub-agent queued behind a
+// busy `--parallel 1` engine got zero bytes for the whole wait — invisible to the keep-alive ping
+// fix (ADR-342), which only covered the read loop AFTER the engine had already accepted the
+// request. Caught in review on the PR that shipped ADR-342, before it tagged. Fixed by opening the
+// SSE stream and sending message_start FIRST, then pinging through the queue wait and fetch() too.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Hono } from 'hono'
+import { registerGateway } from './gateway'
+import { GenerationGate } from '../agents/gate'
+import type { Deps } from '../deps'
+
+const LIBRARY = [{ key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' }]
+
+/** A real, ephemeral HTTP server standing in for the engine target, responding with a genuine
+ *  OpenAI-shaped SSE stream — the point of these tests is the CLIENT-facing ordering/pinging
+ *  around the queue wait, not the engine translation itself (already covered elsewhere). */
+async function withFakeStreamingEngine(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+    res.write('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n')
+    res.write('data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1}}\n\n')
+    res.write('data: [DONE]\n\n')
+    res.end()
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  }
+}
+
+function fakeDeps(target: string, gate?: GenerationGate): Deps {
+  return {
+    scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
+    modelRouter: { route: async () => ({ target }) },
+    store: { snapshot: () => ({ modelDefaults: { maxTokens: 0 }, gateway: { autoSwap: false } }) },
+    manager: {
+      status: () => ({ state: 'stopped', model: null }),
+      target: () => target,
+      generationStart: () => {},
+      generationEnd: () => {},
+      recordCompletion: () => {},
+      setLiveGen: () => {},
+    },
+    registry: { active: () => ({ kind: 'llama.cpp' }) },
+    gate,
+  } as unknown as Deps
+}
+
+/** Polls `check()` until it's true or `timeoutMs` elapses. Needed because the streamSSE callback
+ *  runs fire-and-forget (Hono's own `run()` helper doesn't await it) — reading the FIRST SSE
+ *  event only proves the write happened, not that the callback has reached its NEXT await yet,
+ *  so a synchronous check right after can race ahead of it. */
+async function waitUntil(check: () => boolean, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error(`waitUntil: condition never became true within ${timeoutMs}ms`)
+    await new Promise((r) => setTimeout(r, 2))
+  }
+}
+
+/** Reads SSE `event: ...` lines off a Response body as they arrive, decoded incrementally —
+ *  needed here specifically because the whole point is ORDERING (message_start must arrive
+ *  before the queued gate releases), which `res.text()` (waits for the full body) can't observe. */
+function sseEventReader(body: ReadableStream<Uint8Array>) {
+  const reader = body.getReader()
+  const dec = new TextDecoder()
+  let buf = ''
+  return {
+    /** Resolves with the next `event:` name once a full SSE frame has arrived, or null at EOF. */
+    async next(): Promise<string | null> {
+      while (true) {
+        const m = buf.match(/^event: (.+)\n/m)
+        if (m) {
+          buf = buf.slice(buf.indexOf('\n\n') + 2)
+          return m[1]
+        }
+        const { done, value } = await reader.read()
+        if (done) return null
+        buf += dec.decode(value, { stream: true })
+      }
+    },
+  }
+}
+
+const messagesBody = JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], max_tokens: 100, stream: true })
+
+test('POST /v1/messages (streaming): message_start arrives while still queued behind a busy gate, before the engine is ever contacted', async () => {
+  const engine = await withFakeStreamingEngine()
+  const gate = new GenerationGate(() => 1)
+  const release = await gate.acquire('bg') // occupy the one slot so the real request must queue
+  try {
+    const app = new Hono()
+    registerGateway(app, fakeDeps(engine.url, gate))
+
+    const resPromise = app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: messagesBody,
+    })
+
+    // The response (and its message_start) must be observable while the gate is STILL held —
+    // if this hangs, message_start is (wrongly) waiting on the queue instead of preceding it.
+    const res = await resPromise
+    assert.ok(res.body)
+    const events = sseEventReader(res.body!)
+    const first = await events.next()
+    assert.equal(first, 'message_start', 'message_start must be sent before queueing for the engine slot')
+
+    // The streamSSE callback runs fire-and-forget (Hono's `run()` doesn't await it), so it may
+    // not have reached its own gate.acquire() call the instant message_start's write is observed
+    // on this end — poll rather than assume synchronous ordering across the two coroutines.
+    await waitUntil(() => gate.stats().queued === 1)
+
+    release() // let the queued request proceed
+
+    const seen = [first]
+    for (;;) {
+      const evt = await events.next()
+      if (evt === null) break
+      seen.push(evt)
+    }
+    assert.equal(seen.filter((e) => e === 'message_start').length, 1, 'message_start must never be sent twice')
+    assert.ok(seen.includes('content_block_start'), 'the real engine content must still arrive once the queue clears')
+    assert.ok(seen.includes('message_stop'))
+  } finally {
+    release()
+    await engine.close()
+  }
+})
+
+test('POST /v1/messages (streaming): a queue-wait failure (client already gone) surfaces as an SSE error event, not a bodyless/JSON one', async () => {
+  const engine = await withFakeStreamingEngine()
+  const gate = new GenerationGate(() => 1)
+  const release = await gate.acquire('bg') // occupy the slot so the real request queues and checks the signal
+  try {
+    const app = new Hono()
+    registerGateway(app, fakeDeps(engine.url, gate))
+
+    const ac = new AbortController()
+    ac.abort() // client already disconnected before this request would even start queueing
+
+    const res = await app.request('/v1/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: messagesBody,
+      signal: ac.signal,
+    })
+
+    // SSE streams always answer 200 — the failure has to show up as an `error` event in the body,
+    // not a 4xx/5xx status the way the non-streaming path reports the same failure class.
+    assert.equal(res.status, 200)
+    assert.ok(res.body)
+    const events = sseEventReader(res.body!)
+    const first = await events.next()
+    assert.equal(first, 'message_start')
+    const second = await events.next()
+    assert.equal(second, 'error', 'the aborted queue wait must surface as an SSE error event')
+  } finally {
+    release()
+    await engine.close()
+  }
+})

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -11,7 +11,7 @@ import { engineModelAlias } from '../engines/compat'
 import { presentedKey } from '../auth'
 import { sessionAuth } from '../code/session-auth'
 import { classifyHarness } from '../telemetry/classify'
-import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, messageStartEvent, pingWhilePending, type AnthropicRequest, type StreamToolCall } from './anthropic'
+import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, messageStartEvent, pingWhilePending, DEFAULT_PING_INTERVAL_MS, type AnthropicRequest, type StreamToolCall } from './anthropic'
 import { applyAgentGuidance } from './agent-guidance'
 import {
   extractSearchQuery,
@@ -92,9 +92,13 @@ function asClientStatus(status: number): ContentfulStatusCode {
   return (status >= 400 && status <= 599 ? status : 500) as ContentfulStatusCode
 }
 
-/** Classifies a `d.gate.acquire()` failure into one {status, type, message} shape shared by
- *  both the streaming (SSE `error` event, ADR-347) and non-streaming (JSON error response) call
- *  sites, so the two paths can't silently drift in wording or classification. */
+/** Classifies a `d.gate.acquire()` failure into one {status, type, message} shape shared by both
+ *  the streaming (SSE `error` event, ADR-347 — `status` unused there, a stream is always 200 by
+ *  the time it can fail this way) and non-streaming (JSON error response, where `status` is what
+ *  the client actually sees) call sites, so `type`/`message` wording can't silently drift between
+ *  them. The gate-acquire and fetch() SEQUENCES themselves remain two separate copies (streaming
+ *  needs to open the SSE connection before either call; non-streaming doesn't) — this only
+ *  centralizes how a failure from either gets described. */
 function classifyGateError(e: unknown): { status: ContentfulStatusCode; type: string; message: string } {
   const aborted = (e as Error).message === 'gate_acquire_aborted'
   return aborted
@@ -116,7 +120,18 @@ function classifyFetchError(e: unknown, ac: AbortController): { status: Contentf
   }
 }
 
-export function registerGateway(app: Hono, d: Deps): void {
+/** Test-only overrides for values otherwise hardcoded below (ADR-347 review follow-up) — the
+ *  600s gate-acquire timeout and the 10s ping cadence can't otherwise be exercised by a fast
+ *  unit test without either sleeping for real or never observing a ping/timeout at all. Omit in
+ *  production; `registerGateway(app, d)` behaves exactly as before. */
+export interface GatewayOptions {
+  pingIntervalMs?: number
+  gateAcquireTimeoutMs?: number
+}
+
+export function registerGateway(app: Hono, d: Deps, opts: GatewayOptions = {}): void {
+  const pingIntervalMs = opts.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS
+  const gateAcquireTimeoutMs = opts.gateAcquireTimeoutMs ?? 600_000
   // ── POST /v1/messages — Anthropic translation (spec 06 §2) ───────────────
 
   app.post('/v1/messages', async (c) => {
@@ -279,120 +294,139 @@ export function registerGateway(app: Hono, d: Deps): void {
         // nothing keeps waiting on a connection nobody will read the response of.
         stream.onAbort(() => ac.abort())
         const ping = () => stream.writeSSE({ event: 'ping', data: JSON.stringify({ type: 'ping' }) })
+        // Outer catch-all: everything expected already writes its own well-formed SSE `error`
+        // event and returns below — this only exists for whatever ISN'T expected (this callback
+        // now does real work: gate/fetch/JSON, any of which could throw something new later). Not
+        // using streamSSE's own `onError` third argument (hono/streaming): it unconditionally
+        // ALSO writes its own `data: e.message` frame afterward — a bare string, not the
+        // `{type:'error', error:{...}}` shape an Anthropic-protocol client expects — so passing
+        // both would send two error events, one malformed.
         try {
-          await stream.writeSSE(messageStartEvent(msgId, modelName))
+          try {
+            await stream.writeSSE(messageStartEvent(msgId, modelName))
 
-          if (d.gate) {
+            if (d.gate) {
+              try {
+                // Never proceed un-slotted on failure — that would silently breach the very
+                // limit this exists to enforce, and intermittently, which is worse than a clean
+                // error. onOrphan: if the client is already gone by the time a slot grants (a
+                // ping write failed first, below), the grant must still be released rather than
+                // silently leaked — an un-drained release permanently shrinks the daemon's
+                // effective engine concurrency by one for its whole remaining life (review-caught,
+                // ADR-347 follow-up).
+                gateRelease = await pingWhilePending(
+                  d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: gateAcquireTimeoutMs }),
+                  ping,
+                  pingIntervalMs,
+                  (release) => release(),
+                )
+              } catch (e) {
+                const { type, message } = classifyGateError(e)
+                await stream.writeSSE({ event: 'error', data: JSON.stringify({ type: 'error', error: { type, message } }) })
+                return
+              }
+            }
+
+            // Mark the completion in-flight so the engine card's live "Generating…" indicator
+            // counts Claude-CLI (Anthropic-protocol) traffic too — paired with generationEnd in
+            // the outer finally below (generationStarted guards it: never call generationEnd for
+            // a start that never happened, e.g. a gate timeout above).
+            d.manager.generationStart()
+            generationStarted = true
+
+            // For terminal-agent usage attribution/stats (ADR-284) — wall-clock request
+            // duration, the simplest signal available without touching streamToAnthropic's own
+            // callback shape (it doesn't currently surface the engine's per-request timings the
+            // way the OpenAI-shaped helpers below already do). An approximation, not a
+            // literally-measured prefill/gen split.
+            const requestStart = Date.now()
+            let res: Response
             try {
-              // Never proceed un-slotted on failure — that would silently breach the very
-              // limit this exists to enforce, and intermittently, which is worse than a clean
-              // error.
-              gateRelease = await pingWhilePending(
-                d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: 600_000 }),
+              res = await pingWhilePending(
+                fetch(`${target}/v1/chat/completions`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify(oaiBody),
+                  signal: ac.signal,
+                }),
                 ping,
+                pingIntervalMs,
+                // No onOrphan: an orphaned Response has nothing to release — its body is simply
+                // never read and gets garbage-collected, unlike gate.acquire()'s grant above.
               )
             } catch (e) {
-              const { type, message } = classifyGateError(e)
+              const { type, message } = classifyFetchError(e, ac)
               await stream.writeSSE({ event: 'error', data: JSON.stringify({ type: 'error', error: { type, message } }) })
               return
             }
-          }
 
-          // Mark the completion in-flight so the engine card's live "Generating…" indicator
-          // counts Claude-CLI (Anthropic-protocol) traffic too — paired with generationEnd in
-          // the outer finally below (generationStarted guards it: never call generationEnd for
-          // a start that never happened, e.g. a gate timeout above).
-          d.manager.generationStart()
-          generationStarted = true
+            if (!res.ok || !res.body) {
+              // Forward the engine's REAL status + whatever structured error it returned,
+              // instead of flattening every distinct failure (bad request, model
+              // incompatibility, overload, crash) to the same hardcoded 'api_error' — that
+              // flattening is what made bugs #1-#4 in a Code session all read identically from
+              // the terminal, with no way to tell them apart.
+              const { message, type } = await describeEngineError(res)
+              await stream.writeSSE({
+                event: 'error',
+                data: JSON.stringify({ type: 'error', error: { type: type ?? anthropicErrorType(res.status), message } }),
+              })
+              return
+            }
 
-          // For terminal-agent usage attribution/stats (ADR-284) — wall-clock request
-          // duration, the simplest signal available without touching streamToAnthropic's own
-          // callback shape (it doesn't currently surface the engine's per-request timings the
-          // way the OpenAI-shaped helpers below already do). An approximation, not a
-          // literally-measured prefill/gen split.
-          const requestStart = Date.now()
-          let res: Response
-          try {
-            res = await pingWhilePending(
-              fetch(`${target}/v1/chat/completions`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(oaiBody),
-                signal: ac.signal,
-              }),
-              ping,
-            )
-          } catch (e) {
-            const { type, message } = classifyFetchError(e, ac)
-            await stream.writeSSE({ event: 'error', data: JSON.stringify({ type: 'error', error: { type, message } }) })
-            return
-          }
-
-          if (!res.ok || !res.body) {
-            // Forward the engine's REAL status + whatever structured error it returned,
-            // instead of flattening every distinct failure (bad request, model
-            // incompatibility, overload, crash) to the same hardcoded 'api_error' — that
-            // flattening is what made bugs #1-#4 in a Code session all read identically from
-            // the terminal, with no way to tell them apart.
-            const { message, type } = await describeEngineError(res)
-            await stream.writeSSE({
-              event: 'error',
-              data: JSON.stringify({ type: 'error', error: { type: type ?? anthropicErrorType(res.status), message } }),
+            // Record session stats (B4) from the final usage the generator observes.
+            // Fail-safe: the callback is only invoked best-effort and swallows nothing
+            // that affects the client stream.
+            const gen = streamToAnthropic(res.body, modelName, msgId, {
+              onUsage: (u) => {
+                try {
+                  // The engine's own per-phase rates now ride along (ADR-300). This path —
+                  // Anthropic streaming, i.e. every Claude Code request — was the one place
+                  // that passed NO timings at all, so the engine card fell back to whatever the
+                  // last non-gateway request left behind and a terminal-agent session's stats
+                  // row had to divide both token counts by one wall-clock, reading decode ~6x
+                  // too low.
+                  d.manager.recordCompletion({
+                    inputTokens: u.inputTokens, outputTokens: u.outputTokens,
+                    promptTps: u.promptTps, genTps: u.genTps,
+                  })
+                  // Durable counterpart to the ephemeral session counter above (GitHub #71) —
+                  // the session counter resets on engine restart and was never
+                  // persisted/surfaced.
+                  d.db.recordApiUsage({
+                    source: 'anthropic', modelKey: req.model ?? null, promptTokens: u.inputTokens, genTokens: u.outputTokens,
+                    codeSessionId: anthropicCodeSessionId, durationMs: Date.now() - requestStart,
+                    promptTps: u.promptTps, genTps: u.genTps, harness: anthropicHarness,
+                  })
+                } catch { /* swallow — stats are best-effort */ }
+              },
+              // Live per-request progress for the engine card (prefill % + token count),
+              // so Claude Code traffic shows the same live row as in-app chat.
+              onLive: (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
+              // Coding-activity attribution for terminal-agent sessions — see
+              // observeCodeSessionTurn. Nothing to attribute for any other client.
+              onToolCalls: (calls) => {
+                if (!anthropicCodeSessionId) return
+                try { observeCodeSessionTurn(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
+              },
+              skipMessageStart: true, // already sent above, before the queue wait
             })
-            return
+            // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
+            // Raw ReadableStream does not — chunks buffer until the response completes,
+            // which makes Claude CLI (and any Anthropic-protocol client) appear "slow".
+            for await (const evt of gen) {
+              await stream.writeSSE({ event: evt.event, data: evt.data })
+            }
+          } finally {
+            ac.abort() // also tear down the upstream on normal completion / write error
+            if (generationStarted) d.manager.generationEnd()
+            gateRelease?.()
           }
-
-          // Record session stats (B4) from the final usage the generator observes.
-          // Fail-safe: the callback is only invoked best-effort and swallows nothing
-          // that affects the client stream.
-          const gen = streamToAnthropic(
-            res.body,
-            modelName,
-            msgId,
-            (u) => {
-              try {
-                // The engine's own per-phase rates now ride along (ADR-300). This path —
-                // Anthropic streaming, i.e. every Claude Code request — was the one place
-                // that passed NO timings at all, so the engine card fell back to whatever the
-                // last non-gateway request left behind and a terminal-agent session's stats
-                // row had to divide both token counts by one wall-clock, reading decode ~6x
-                // too low.
-                d.manager.recordCompletion({
-                  inputTokens: u.inputTokens, outputTokens: u.outputTokens,
-                  promptTps: u.promptTps, genTps: u.genTps,
-                })
-                // Durable counterpart to the ephemeral session counter above (GitHub #71) —
-                // the session counter resets on engine restart and was never
-                // persisted/surfaced.
-                d.db.recordApiUsage({
-                  source: 'anthropic', modelKey: req.model ?? null, promptTokens: u.inputTokens, genTokens: u.outputTokens,
-                  codeSessionId: anthropicCodeSessionId, durationMs: Date.now() - requestStart,
-                  promptTps: u.promptTps, genTps: u.genTps, harness: anthropicHarness,
-                })
-              } catch { /* swallow — stats are best-effort */ }
-            },
-            // Live per-request progress for the engine card (prefill % + token count),
-            // so Claude Code traffic shows the same live row as in-app chat.
-            (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
-            // Coding-activity attribution for terminal-agent sessions — see
-            // observeCodeSessionTurn. Nothing to attribute for any other client.
-            (calls) => {
-              if (!anthropicCodeSessionId) return
-              try { observeCodeSessionTurn(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
-            },
-            undefined,
-            true, // skipMessageStart — already sent above, before the queue wait
-          )
-          // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
-          // Raw ReadableStream does not — chunks buffer until the response completes,
-          // which makes Claude CLI (and any Anthropic-protocol client) appear "slow".
-          for await (const evt of gen) {
-            await stream.writeSSE({ event: evt.event, data: evt.data })
-          }
-        } finally {
-          ac.abort() // also tear down the upstream on normal completion / write error
-          if (generationStarted) d.manager.generationEnd()
-          gateRelease?.()
+        } catch (e) {
+          await stream.writeSSE({
+            event: 'error',
+            data: JSON.stringify({ type: 'error', error: { type: 'api_error', message: (e as Error)?.message || 'Internal gateway error.' } }),
+          }).catch(() => {})
         }
       })
     }
@@ -402,7 +436,7 @@ export function registerGateway(app: Hono, d: Deps): void {
     let gateRelease: (() => void) | null = null
     if (d.gate) {
       try {
-        gateRelease = await d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: 600_000 })
+        gateRelease = await d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: gateAcquireTimeoutMs })
       } catch (e) {
         const { status, type, message } = classifyGateError(e)
         return c.json({ type: 'error', error: { type, message } }, status)

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -11,7 +11,7 @@ import { engineModelAlias } from '../engines/compat'
 import { presentedKey } from '../auth'
 import { sessionAuth } from '../code/session-auth'
 import { classifyHarness } from '../telemetry/classify'
-import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, type AnthropicRequest, type StreamToolCall } from './anthropic'
+import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, messageStartEvent, pingWhilePending, type AnthropicRequest, type StreamToolCall } from './anthropic'
 import { applyAgentGuidance } from './agent-guidance'
 import {
   extractSearchQuery,
@@ -90,6 +90,30 @@ function anthropicErrorType(status: number): string {
  *  out-of-range status from a misbehaving engine can't crash response construction. */
 function asClientStatus(status: number): ContentfulStatusCode {
   return (status >= 400 && status <= 599 ? status : 500) as ContentfulStatusCode
+}
+
+/** Classifies a `d.gate.acquire()` failure into one {status, type, message} shape shared by
+ *  both the streaming (SSE `error` event, ADR-347) and non-streaming (JSON error response) call
+ *  sites, so the two paths can't silently drift in wording or classification. */
+function classifyGateError(e: unknown): { status: ContentfulStatusCode; type: string; message: string } {
+  const aborted = (e as Error).message === 'gate_acquire_aborted'
+  return aborted
+    ? { status: 400, type: 'invalid_request_error', message: 'Client disconnected while queued for the engine.' }
+    : { status: 503, type: 'overloaded_error', message: 'Timed out waiting for a free engine slot.' }
+}
+
+/** Same reasoning as classifyGateError, for a failed `fetch()` to the engine. */
+function classifyFetchError(e: unknown, ac: AbortController): { status: ContentfulStatusCode; type: string; message: string } {
+  const err = e as Error & { cause?: unknown }
+  const isAbort = err.name === 'AbortError' || ac.signal.aborted
+  const cause = err.cause instanceof Error ? `: ${err.cause.message}` : ''
+  return {
+    status: 500,
+    type: 'api_error',
+    message: isAbort
+      ? 'Client disconnected before the engine responded.'
+      : `${err.message || 'Engine unreachable.'}${cause}`,
+  }
 }
 
 export function registerGateway(app: Hono, d: Deps): void {
@@ -231,40 +255,161 @@ export function registerGateway(app: Hono, d: Deps): void {
     // ANTHROPIC_TIMEOUT to 300s, so in practice the CLIENT gives up first and its abort unqueues
     // this wait cleanly. That makes the timeout a leak-detector (gate.ts's original purpose)
     // rather than something a legitimately-queued subagent can trip.
-    let gateRelease: (() => void) | null = null
-    if (d.gate) {
-      try {
-        gateRelease = await d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: 600_000 })
-      } catch (e) {
-        // Never proceed un-slotted on failure — that would silently breach the very limit this
-        // exists to enforce, and intermittently, which is worse than a clean error.
-        const aborted = (e as Error).message === 'gate_acquire_aborted'
-        return c.json(
-          {
-            type: 'error',
-            error: aborted
-              ? { type: 'invalid_request_error', message: 'Client disconnected while queued for the engine.' }
-              : { type: 'overloaded_error', message: 'Timed out waiting for a free engine slot.' },
-          },
-          aborted ? 400 : 503,
-        )
-      }
-    }
-
-    // Mark the completion in-flight so the engine card's live "Generating…"
-    // indicator counts Claude-CLI (Anthropic-protocol) traffic too. Each branch
-    // below pairs this with generationEnd so the counter can never leak.
-    d.manager.generationStart()
 
     // Propagate client cancellation to the engine: if Claude Code drops this turn, the
     // upstream request is aborted instead of running to completion and queuing behind
     // the engine's slots forever.
     const ac = clientAbort(c)
 
-    // For terminal-agent usage attribution/stats (ADR-284) — wall-clock request duration, the
-    // simplest signal available without touching streamToAnthropic's own callback shape (it
-    // doesn't currently surface the engine's per-request timings the way the OpenAI-shaped
-    // helpers below already do). An approximation, not a literally-measured prefill/gen split.
+    if (req.stream) {
+      // ── ADR-347: the gate wait above and the fetch() below are exactly as silent to the
+      // client as the slow-prefill gap the keep-alive ping fix (ADR-342) closed — a Task-tool
+      // sub-agent fanned out against a busy `--parallel 1` engine can queue behind
+      // gate.acquire() for up to 600s with ZERO bytes reaching Claude Code, tripping its
+      // idle-stream watchdog before generation even starts (plausibly the actual scenario
+      // behind the founder's original report, caught in review on this same PR). Fixed by
+      // opening the client's SSE connection and sending message_start FIRST — before queueing
+      // at all — then pinging through both the queue wait and the fetch(), not just the
+      // engine's own read loop the way the original fix did.
+      const msgId = `msg_${randomUUID().replace(/-/g, '')}`
+      return streamSSE(c, async (stream) => {
+        let gateRelease: (() => void) | null = null
+        let generationStarted = false
+        // Client went away mid-stream (including while still queued or fetching) → abort so
+        // nothing keeps waiting on a connection nobody will read the response of.
+        stream.onAbort(() => ac.abort())
+        const ping = () => stream.writeSSE({ event: 'ping', data: JSON.stringify({ type: 'ping' }) })
+        try {
+          await stream.writeSSE(messageStartEvent(msgId, modelName))
+
+          if (d.gate) {
+            try {
+              // Never proceed un-slotted on failure — that would silently breach the very
+              // limit this exists to enforce, and intermittently, which is worse than a clean
+              // error.
+              gateRelease = await pingWhilePending(
+                d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: 600_000 }),
+                ping,
+              )
+            } catch (e) {
+              const { type, message } = classifyGateError(e)
+              await stream.writeSSE({ event: 'error', data: JSON.stringify({ type: 'error', error: { type, message } }) })
+              return
+            }
+          }
+
+          // Mark the completion in-flight so the engine card's live "Generating…" indicator
+          // counts Claude-CLI (Anthropic-protocol) traffic too — paired with generationEnd in
+          // the outer finally below (generationStarted guards it: never call generationEnd for
+          // a start that never happened, e.g. a gate timeout above).
+          d.manager.generationStart()
+          generationStarted = true
+
+          // For terminal-agent usage attribution/stats (ADR-284) — wall-clock request
+          // duration, the simplest signal available without touching streamToAnthropic's own
+          // callback shape (it doesn't currently surface the engine's per-request timings the
+          // way the OpenAI-shaped helpers below already do). An approximation, not a
+          // literally-measured prefill/gen split.
+          const requestStart = Date.now()
+          let res: Response
+          try {
+            res = await pingWhilePending(
+              fetch(`${target}/v1/chat/completions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(oaiBody),
+                signal: ac.signal,
+              }),
+              ping,
+            )
+          } catch (e) {
+            const { type, message } = classifyFetchError(e, ac)
+            await stream.writeSSE({ event: 'error', data: JSON.stringify({ type: 'error', error: { type, message } }) })
+            return
+          }
+
+          if (!res.ok || !res.body) {
+            // Forward the engine's REAL status + whatever structured error it returned,
+            // instead of flattening every distinct failure (bad request, model
+            // incompatibility, overload, crash) to the same hardcoded 'api_error' — that
+            // flattening is what made bugs #1-#4 in a Code session all read identically from
+            // the terminal, with no way to tell them apart.
+            const { message, type } = await describeEngineError(res)
+            await stream.writeSSE({
+              event: 'error',
+              data: JSON.stringify({ type: 'error', error: { type: type ?? anthropicErrorType(res.status), message } }),
+            })
+            return
+          }
+
+          // Record session stats (B4) from the final usage the generator observes.
+          // Fail-safe: the callback is only invoked best-effort and swallows nothing
+          // that affects the client stream.
+          const gen = streamToAnthropic(
+            res.body,
+            modelName,
+            msgId,
+            (u) => {
+              try {
+                // The engine's own per-phase rates now ride along (ADR-300). This path —
+                // Anthropic streaming, i.e. every Claude Code request — was the one place
+                // that passed NO timings at all, so the engine card fell back to whatever the
+                // last non-gateway request left behind and a terminal-agent session's stats
+                // row had to divide both token counts by one wall-clock, reading decode ~6x
+                // too low.
+                d.manager.recordCompletion({
+                  inputTokens: u.inputTokens, outputTokens: u.outputTokens,
+                  promptTps: u.promptTps, genTps: u.genTps,
+                })
+                // Durable counterpart to the ephemeral session counter above (GitHub #71) —
+                // the session counter resets on engine restart and was never
+                // persisted/surfaced.
+                d.db.recordApiUsage({
+                  source: 'anthropic', modelKey: req.model ?? null, promptTokens: u.inputTokens, genTokens: u.outputTokens,
+                  codeSessionId: anthropicCodeSessionId, durationMs: Date.now() - requestStart,
+                  promptTps: u.promptTps, genTps: u.genTps, harness: anthropicHarness,
+                })
+              } catch { /* swallow — stats are best-effort */ }
+            },
+            // Live per-request progress for the engine card (prefill % + token count),
+            // so Claude Code traffic shows the same live row as in-app chat.
+            (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
+            // Coding-activity attribution for terminal-agent sessions — see
+            // observeCodeSessionTurn. Nothing to attribute for any other client.
+            (calls) => {
+              if (!anthropicCodeSessionId) return
+              try { observeCodeSessionTurn(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
+            },
+            undefined,
+            true, // skipMessageStart — already sent above, before the queue wait
+          )
+          // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
+          // Raw ReadableStream does not — chunks buffer until the response completes,
+          // which makes Claude CLI (and any Anthropic-protocol client) appear "slow".
+          for await (const evt of gen) {
+            await stream.writeSSE({ event: evt.event, data: evt.data })
+          }
+        } finally {
+          ac.abort() // also tear down the upstream on normal completion / write error
+          if (generationStarted) d.manager.generationEnd()
+          gateRelease?.()
+        }
+      })
+    }
+
+    // ── Non-streaming: the client just waits for one whole response, so there's no
+    // idle-connection watchdog to defeat — keeps the original un-pinged gate/fetch sequence. ──
+    let gateRelease: (() => void) | null = null
+    if (d.gate) {
+      try {
+        gateRelease = await d.gate.acquire('bg', { signal: c.req.raw.signal, timeoutMs: 600_000 })
+      } catch (e) {
+        const { status, type, message } = classifyGateError(e)
+        return c.json({ type: 'error', error: { type, message } }, status)
+      }
+    }
+
+    d.manager.generationStart()
     const requestStart = Date.now()
     let res: Response
     try {
@@ -277,21 +422,8 @@ export function registerGateway(app: Hono, d: Deps): void {
     } catch (e) {
       d.manager.generationEnd()
       gateRelease?.()
-      const err = e as Error & { cause?: unknown }
-      const isAbort = err.name === 'AbortError' || ac.signal.aborted
-      const cause = err.cause instanceof Error ? `: ${err.cause.message}` : ''
-      return c.json(
-        {
-          type: 'error',
-          error: {
-            type: 'api_error',
-            message: isAbort
-              ? 'Client disconnected before the engine responded.'
-              : `${err.message || 'Engine unreachable.'}${cause}`,
-          },
-        },
-        500,
-      )
+      const { status, type, message } = classifyFetchError(e, ac)
+      return c.json({ type: 'error', error: { type, message } }, status)
     }
 
     if (!res.ok || !res.body) {
@@ -306,64 +438,6 @@ export function registerGateway(app: Hono, d: Deps): void {
         { type: 'error', error: { type: type ?? anthropicErrorType(res.status), message } },
         asClientStatus(res.status),
       )
-    }
-
-    if (req.stream) {
-      const msgId = `msg_${randomUUID().replace(/-/g, '')}`
-      // Record session stats (B4) from the final usage the generator observes.
-      // Fail-safe: the callback is only invoked best-effort and swallows nothing
-      // that affects the client stream.
-      const gen = streamToAnthropic(
-        res.body,
-        modelName,
-        msgId,
-        (u) => {
-          try {
-            // The engine's own per-phase rates now ride along (ADR-300). This path — Anthropic
-            // streaming, i.e. every Claude Code request — was the one place that passed NO
-            // timings at all, so the engine card fell back to whatever the last non-gateway
-            // request left behind and a terminal-agent session's stats row had to divide both
-            // token counts by one wall-clock, reading decode ~6x too low.
-            d.manager.recordCompletion({
-              inputTokens: u.inputTokens, outputTokens: u.outputTokens,
-              promptTps: u.promptTps, genTps: u.genTps,
-            })
-            // Durable counterpart to the ephemeral session counter above (GitHub #71) — the
-            // session counter resets on engine restart and was never persisted/surfaced.
-            d.db.recordApiUsage({
-              source: 'anthropic', modelKey: req.model ?? null, promptTokens: u.inputTokens, genTokens: u.outputTokens,
-              codeSessionId: anthropicCodeSessionId, durationMs: Date.now() - requestStart,
-              promptTps: u.promptTps, genTps: u.genTps, harness: anthropicHarness,
-            })
-          } catch { /* swallow — stats are best-effort */ }
-        },
-        // Live per-request progress for the engine card (prefill % + token count),
-        // so Claude Code traffic shows the same live row as in-app chat.
-        (live) => { try { d.manager.setLiveGen(live) } catch { /* best-effort */ } },
-        // Coding-activity attribution for terminal-agent sessions — see
-        // observeCodeSessionTurn. Nothing to attribute for any other client.
-        (calls) => {
-          if (!anthropicCodeSessionId) return
-          try { observeCodeSessionTurn(d, anthropicCodeSessionId, calls) } catch { /* swallow */ }
-        },
-      )
-      // streamSSE flushes each chunk immediately through Node.js's HTTP layer.
-      // Raw ReadableStream does not — chunks buffer until the response completes,
-      // which makes Claude CLI (and any Anthropic-protocol client) appear "slow".
-      return streamSSE(c, async (stream) => {
-        // Client went away mid-stream → abort the engine fetch so it stops generating
-        // (the generator's finally then cancels the upstream body reader).
-        stream.onAbort(() => ac.abort())
-        try {
-          for await (const evt of gen) {
-            await stream.writeSSE({ event: evt.event, data: evt.data })
-          }
-        } finally {
-          ac.abort() // also tear down the upstream on normal completion / write error
-          d.manager.generationEnd()
-          gateRelease?.()
-        }
-      })
     }
 
     try {

--- a/turbollm/src/terminal/terminal-routes.test.ts
+++ b/turbollm/src/terminal/terminal-routes.test.ts
@@ -11,7 +11,7 @@
 // so it's testable without a live PTY/daemon (mirrors code-session.ts's codeEventToFrame).
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { buildTerminalLaunchCommand, canSeedFirstMessage, MAX_SEEDED_MESSAGE_CHARS } from './terminal-routes'
+import { buildTerminalLaunchCommand, canSeedFirstMessage, normalizeSeededMessage, MAX_SEEDED_MESSAGE_CHARS } from './terminal-routes'
 import { quotePtyShellArg } from '../util/shell-command'
 
 test('buildTerminalLaunchCommand: a genuinely first-ever launch registers this session\'s own id', () => {
@@ -186,9 +186,35 @@ test('canSeedFirstMessage: refuses a message ending in a backslash', () => {
   assert.equal(canSeedFirstMessage(`look in C:${BS}repo`, 'claude'), true, 'an interior backslash is fine')
 })
 
-test('canSeedFirstMessage: refuses control characters', () => {
-  assert.equal(canSeedFirstMessage('line one\nline two', 'claude'), false)
-  assert.equal(canSeedFirstMessage('tab\there', 'claude'), false)
+// Founder-reported, 2026-08-07: a fresh Code session's first message silently never reached the
+// CLI. Root cause: the composer's own hint text advertises "Shift+Enter for newline", so a
+// multi-line task description is the NORMAL case — but the ORIGINAL UNSEEDABLE range (every
+// control byte from U+0000 through U+001F) refused newline/CR/tab right along with the genuinely
+// dangerous control bytes, so almost any multi-sentence task silently produced an empty terminal.
+// Line breaks/tabs are now folded to spaces instead of being rejected.
+
+test('canSeedFirstMessage: a message containing newlines or tabs is now seedable (folded, not rejected)', () => {
+  assert.equal(canSeedFirstMessage('line one\nline two', 'claude'), true)
+  assert.equal(canSeedFirstMessage('tab\there', 'claude'), true)
+  assert.equal(canSeedFirstMessage('para one\r\n\r\npara two', 'claude'), true, 'CRLF and blank lines fold too')
+})
+
+test('canSeedFirstMessage: still refuses a genuinely dangerous control byte (not just any control byte)', () => {
+  assert.equal(canSeedFirstMessage('drop a bell\x07here', 'claude'), false)
+  assert.equal(canSeedFirstMessage('nul\x00byte', 'claude'), false)
+})
+
+test('normalizeSeededMessage: folds line breaks and tabs to single spaces and re-trims', () => {
+  assert.equal(normalizeSeededMessage('line one\nline two'), 'line one line two')
+  assert.equal(normalizeSeededMessage('tab\there'), 'tab here')
+  assert.equal(normalizeSeededMessage('para one\n\npara two'), 'para one para two', 'a run of breaks collapses to ONE space, not a stutter')
+  assert.equal(normalizeSeededMessage('trailing newline\n'), 'trailing newline', 'folding can expose new trailing whitespace — must still trim')
+})
+
+test('buildTerminalLaunchCommand: a multi-line first message reaches the CLI as one folded, quoted line', () => {
+  const cmd = buildTerminalLaunchCommand('claude', 6996, 'tok', 'sess', false, undefined, 'auto', 'fix the bug\nand add a test')
+  assert.ok(cmd.includes(quotePtyShellArg('fix the bug and add a test')), cmd)
+  assert.ok(!cmd.includes('\n'), 'the launch command itself must never contain a literal newline')
 })
 
 test('buildTerminalLaunchCommand: an unseedable message is omitted, never mangled onto the line', () => {

--- a/turbollm/src/terminal/terminal-routes.ts
+++ b/turbollm/src/terminal/terminal-routes.ts
@@ -95,8 +95,8 @@ const AUTO_MODE_ALLOWED_TOOLS: Partial<Record<string, readonly string[]>> = {
  *  half-sent instruction is worse than a message the user can see was not sent. */
 export const MAX_SEEDED_MESSAGE_CHARS = 4000
 
-/** Characters that do not survive the trip to the CLI intact, so a message containing them is not
- *  seeded at all.
+/** Characters that do not survive the trip to the CLI intact even after normalization (below), so
+ *  a message containing one is not seeded at all.
  *
  *  Measured, not assumed (pre-release review, 2026-08-01). The launch command is parsed by
  *  PowerShell before `turbollm launch` ever re-spawns the CLI, and PowerShell 5.1 does not escape
@@ -108,17 +108,40 @@ export const MAX_SEEDED_MESSAGE_CHARS = 4000
  *  PowerShell's own native-argument marshalling.
  *
  *  Not seeding is the honest outcome: the user retypes the message (exactly the behaviour before
- *  seeding existed), rather than the agent silently acting on a corrupted version of it. */
-const UNSEEDABLE = /["\u0000-\u001f]/
+ *  seeding existed), rather than the agent silently acting on a corrupted version of it.
+ *
+ *  Deliberately narrower than "every C0 control code" (founder-reported, 2026-08-07: a fresh
+ *  Code session's first message silently never reached the CLI). The composer's own hint text
+ *  advertises "Shift+Enter for newline", so a multi-line task description is the NORMAL case, not
+ *  an edge case — and the original `\u0000-\u001f` range caught `\n`/`\r`/`\t` right along with
+ *  the genuinely dangerous control bytes, so almost any multi-sentence task silently produced an
+ *  empty terminal. Line breaks and tabs are folded to spaces by `normalizeSeededMessage` instead
+ *  of being rejected — measured safe (they cannot smuggle a `"` or a trailing `\` past the fold).
+ *  What's still blocked here is the genuine remainder: a literal quote, and any other non-
+ *  printable control byte (NUL, ESC, …) that has no safe single-line form and could otherwise
+ *  inject a terminal escape sequence once it reaches the PTY. */
+const UNSEEDABLE = /["\u0000-\u0008\u000b\u000c\u000e-\u001f]/
 
-/** Whether this message can be handed to the CLI as a launch argument. */
+/** Fold a message's own line breaks and tabs into plain spaces before it crosses the PowerShell
+ *  `-Command "…"` boundary — see UNSEEDABLE's own comment for why a literal one can't survive
+ *  that trip today. Collapses a run of them to ONE space (so a blank line between paragraphs
+ *  doesn't read as a stutter) and re-trims the result, since folding can expose new leading/
+ *  trailing whitespace (e.g. a message ending in `\n`). Pure/exported so both the eligibility
+ *  check and the actual quoted text agree on exactly what "the message" is. */
+export function normalizeSeededMessage(message: string): string {
+  return message.replace(/[\r\n\t]+/g, ' ').trim()
+}
+
+/** Whether this message can be handed to the CLI as a launch argument. Tests the NORMALIZED text
+ *  (line breaks/tabs already folded) — a message that's only "unseedable" because of a newline is
+ *  seedable once folded; `MAX_SEEDED_MESSAGE_CHARS` and UNSEEDABLE both apply to that same text. */
 export function canSeedFirstMessage(message: string, agent: string): boolean {
   if (agent !== 'claude') return false
-  const trimmed = message.trim()
-  if (trimmed.length === 0 || trimmed.length > MAX_SEEDED_MESSAGE_CHARS) return false
-  if (UNSEEDABLE.test(trimmed)) return false
+  const normalized = normalizeSeededMessage(message)
+  if (normalized.length === 0 || normalized.length > MAX_SEEDED_MESSAGE_CHARS) return false
+  if (UNSEEDABLE.test(normalized)) return false
   // A trailing backslash is mangled into a quote by the same marshalling.
-  if (trimmed.endsWith('\\')) return false
+  if (normalized.endsWith('\\')) return false
   return true
 }
 
@@ -161,7 +184,7 @@ export function buildTerminalLaunchCommand(
   // Quoting matters more than usual here — this is arbitrary user prose reaching a command line,
   // where an apostrophe in "don't" would otherwise terminate the string.
   const promptArg = firstMessage && canSeedFirstMessage(firstMessage, agent)
-    ? ` ${quotePtyShellArg(firstMessage.trim())}`
+    ? ` ${quotePtyShellArg(normalizeSeededMessage(firstMessage))}`
     : ''
   return `turbollm launch ${agent}${promptArg} --port ${port} --token ${token}${sessionArg}${modeArg}${allowedArg}`
 }

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -6,6 +6,7 @@ import type { Status } from '../lib/types'
 import { useRoutinesWithLatestRun } from '../lib/routine-queries'
 import { useSettings } from '../lib/queries'
 import { track } from '../lib/api'
+import { rememberWorkspacePath, resolveNavTarget } from '../lib/workspace-nav'
 import { StateChip } from './StateChip'
 import { BoltMark } from './Logo'
 import { EngineProvisionBanner } from './EngineProvisionBanner'
@@ -66,6 +67,13 @@ function NavRail({
   const engineState = status?.engine.state ?? 'stopped'
   const activeDownloads = status?.downloads.active ?? 0
 
+  // Record the current /workspace/* sub-route (Chat conversation, Code session, or Routines) so
+  // the Workspace nav item can return here later instead of always landing on a new chat — see
+  // workspace-nav.ts's own header comment for the founder-reported bug this fixes.
+  useEffect(() => {
+    rememberWorkspacePath(pathname)
+  }, [pathname])
+
   // Routines parked at needs_approval (spec 20 §2.1). Read live on every render — nothing is
   // latched — and `useRoutinesWithLatestRun` polls on its own (15s on both the routines list and
   // each routine's runs), so this clears itself once an approval is answered from anywhere,
@@ -117,7 +125,7 @@ function NavRail({
       const editable = (document.activeElement as HTMLElement | null)?.isContentEditable
       if (tag === 'INPUT' || tag === 'TEXTAREA' || editable) return
       e.preventDefault()
-      navigate(NAV[idx].to)
+      navigate(resolveNavTarget(NAV[idx].to))
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
@@ -171,7 +179,7 @@ function NavRail({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Link
-                    to={to}
+                    to={resolveNavTarget(to)}
                     aria-label={badge ? `${label} (${badge} ${badgeNoun})` : label}
                     aria-current={isActive ? 'page' : undefined}
                     className={cn(
@@ -248,23 +256,30 @@ function NavRail({
 }
 
 function MobileNav() {
+  // Computed manually off the STATIC `to` (same as NavRail above), not left to NavLink's own
+  // `isActive` — that matches against the `to` PROP, which for Workspace is now a moving target
+  // (resolveNavTarget's remembered sub-route). A NavLink-computed isActive would go stale the
+  // moment the user is on a DIFFERENT Workspace sub-route than whichever one happens to be
+  // remembered right now, reading "not active" while genuinely inside Workspace.
+  const { pathname } = useLocation()
   return (
     <nav className="flex shrink-0 border-t border-border bg-panel-2 md:hidden">
-      {NAV.map(({ to, label, icon: Icon }) => (
-        <NavLink
-          key={to}
-          to={to}
-          className={({ isActive }: { isActive: boolean }) =>
-            cn(
+      {NAV.map(({ to, label, icon: Icon }) => {
+        const isActive = pathname === to || pathname.startsWith(`${to}/`)
+        return (
+          <NavLink
+            key={to}
+            to={resolveNavTarget(to)}
+            className={cn(
               'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-[10px] transition-colors',
               isActive ? 'text-accent' : 'text-muted',
-            )
-          }
-        >
-          <Icon size={20} />
-          <span>{label}</span>
-        </NavLink>
-      ))}
+            )}
+          >
+            <Icon size={20} />
+            <span>{label}</span>
+          </NavLink>
+        )
+      })}
     </nav>
   )
 }

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -131,7 +131,7 @@ export function updateCodeSessionThinkingBudget(id: string, tokens: number): Pro
  *  — the CLI drives its own requests directly, so this is the terminal-session equivalent of
  *  a chat session's lastRealStats. `usage` is null (not an error) before the session's first
  *  gateway request. */
-export function getCodeSessionLastUsage(id: string): Promise<{ usage: { promptTokens: number; genTokens: number; promptTps: number | null; genTps: number | null } | null }> {
+export function getCodeSessionLastUsage(id: string): Promise<{ usage: { ctxUsed: number; promptTokens: number; genTokens: number; promptTps: number | null; genTps: number | null } | null }> {
   return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/last-usage`)
 }
 

--- a/turbollm/web/src/lib/workspace-nav.test.ts
+++ b/turbollm/web/src/lib/workspace-nav.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getLastWorkspacePath, rememberWorkspacePath, resolveNavTarget } from './workspace-nav'
+
+describe('workspace-nav', () => {
+  beforeEach(() => { sessionStorage.clear() })
+
+  it('defaults to plain Chat when nothing has been remembered yet', () => {
+    expect(getLastWorkspacePath()).toBe('/workspace/chat')
+  })
+
+  it('remembers a Code session sub-route and returns it later', () => {
+    rememberWorkspacePath('/workspace/code/abc123')
+    expect(getLastWorkspacePath()).toBe('/workspace/code/abc123')
+  })
+
+  it('remembers a Chat conversation sub-route', () => {
+    rememberWorkspacePath('/workspace/chat/xyz789')
+    expect(getLastWorkspacePath()).toBe('/workspace/chat/xyz789')
+  })
+
+  it('remembers Routines too', () => {
+    rememberWorkspacePath('/workspace/routines/some-routine')
+    expect(getLastWorkspacePath()).toBe('/workspace/routines/some-routine')
+  })
+
+  it('leaving Workspace for another section does not overwrite what was remembered', () => {
+    rememberWorkspacePath('/workspace/code/abc123')
+    rememberWorkspacePath('/usage')
+    rememberWorkspacePath('/models')
+    rememberWorkspacePath('/settings')
+    expect(getLastWorkspacePath()).toBe('/workspace/code/abc123')
+  })
+
+  it('resolveNavTarget resolves the Workspace entry to the remembered path', () => {
+    rememberWorkspacePath('/workspace/code/abc123')
+    expect(resolveNavTarget('/workspace')).toBe('/workspace/code/abc123')
+  })
+
+  it('resolveNavTarget passes every other nav entry through unchanged', () => {
+    rememberWorkspacePath('/workspace/code/abc123')
+    expect(resolveNavTarget('/usage')).toBe('/usage')
+    expect(resolveNavTarget('/models')).toBe('/models')
+    expect(resolveNavTarget('/engines')).toBe('/engines')
+    expect(resolveNavTarget('/customize')).toBe('/customize')
+    expect(resolveNavTarget('/developer')).toBe('/developer')
+    expect(resolveNavTarget('/settings')).toBe('/settings')
+  })
+
+  it('bare /workspace (not a real sub-route) is never remembered or returned', () => {
+    rememberWorkspacePath('/workspace/code/abc123')
+    rememberWorkspacePath('/workspace')
+    expect(getLastWorkspacePath()).toBe('/workspace/code/abc123')
+  })
+})

--- a/turbollm/web/src/lib/workspace-nav.ts
+++ b/turbollm/web/src/lib/workspace-nav.ts
@@ -1,0 +1,45 @@
+// Remembers which /workspace/* sub-route (a Chat conversation, a Code session, or Routines) the
+// user last had open, so clicking/pressing the Workspace nav item from elsewhere in the app
+// (Usage, Models, Engines, ...) returns to it — instead of always landing on a blank new chat.
+//
+// Founder-reported: "workspace -> code -> a particular chat -> usage -> back to workspace" landed
+// on a NEW chat, not the Code session that was actually open. Root cause: Shell.tsx's NAV array
+// hardcodes the Workspace entry's `to` as the literal string '/workspace', which App.tsx's own
+// `<Route path="/workspace" element={<Navigate to="/workspace/chat" replace />} />` always
+// resolves to plain Chat — there was never anywhere for "which sub-route" to be remembered.
+//
+// Session-scoped (sessionStorage, not localStorage) — this is "where was I in this browser
+// session", not a durable cross-session preference like theme/fontSize (stores/ui.ts). A fresh
+// browser session starts clean on Chat, same as today.
+
+const KEY = 'tllm.workspace.lastPath'
+const DEFAULT_PATH = '/workspace/chat'
+
+/** The /workspace/* path to return to. Falls back to plain Chat when nothing's been recorded yet
+ *  (fresh session) or storage is unavailable (private browsing). */
+export function getLastWorkspacePath(): string {
+  try {
+    const v = sessionStorage.getItem(KEY)
+    return v && v.startsWith('/workspace/') ? v : DEFAULT_PATH
+  } catch {
+    return DEFAULT_PATH
+  }
+}
+
+/** Call on every route change (Shell.tsx). No-op for anything outside /workspace — leaving
+ *  Workspace for another section must not overwrite what was remembered there. */
+export function rememberWorkspacePath(pathname: string): void {
+  if (!pathname.startsWith('/workspace/')) return
+  try {
+    sessionStorage.setItem(KEY, pathname)
+  } catch {
+    /* private browsing / storage disabled — the nav link just falls back to the default */
+  }
+}
+
+/** Resolve a NAV entry's static `to` to its real navigation target — only the Workspace entry is
+ *  dynamic; every other entry passes through unchanged. Centralized so the desktop rail, the
+ *  Ctrl+1-9 shortcut, and the mobile nav bar (Shell.tsx, three separate render sites) can't drift. */
+export function resolveNavTarget(to: string): string {
+  return to === '/workspace' ? getLastWorkspacePath() : to
+}

--- a/turbollm/web/src/lib/workspace-sidebar.test.ts
+++ b/turbollm/web/src/lib/workspace-sidebar.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useWorkspaceSidebarOpen } from './workspace-sidebar'
+
+describe('useWorkspaceSidebarOpen', () => {
+  beforeEach(() => { sessionStorage.clear() })
+
+  it('defaults to expanded (open) when nothing has been remembered yet', () => {
+    const { result } = renderHook(() => useWorkspaceSidebarOpen())
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('setSidebarOpen(false) collapses it and persists the change', () => {
+    const { result } = renderHook(() => useWorkspaceSidebarOpen())
+    act(() => { result.current[1](false) })
+    expect(result.current[0]).toBe(false)
+    expect(sessionStorage.getItem('tllm.workspace.sidebarOpen')).toBe('0')
+  })
+
+  it('supports a functional updater, same as plain useState', () => {
+    const { result } = renderHook(() => useWorkspaceSidebarOpen())
+    act(() => { result.current[1]((prev) => !prev) })
+    expect(result.current[0]).toBe(false)
+    act(() => { result.current[1]((prev) => !prev) })
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('a fresh mount (simulating switching to a different Workspace screen) picks up the collapsed state left by a previous mount', () => {
+    const first = renderHook(() => useWorkspaceSidebarOpen())
+    act(() => { first.result.current[1](false) })
+    first.unmount()
+
+    // A different screen (e.g. navigating from Code to Chat) mounts its own call to the hook —
+    // this is the actual founder-reported flow: collapse in one screen, it should still read
+    // collapsed after switching to another.
+    const second = renderHook(() => useWorkspaceSidebarOpen())
+    expect(second.result.current[0]).toBe(false)
+  })
+
+  it('reads a stored expanded value back correctly, not just the collapsed one', () => {
+    sessionStorage.setItem('tllm.workspace.sidebarOpen', '1')
+    const { result } = renderHook(() => useWorkspaceSidebarOpen())
+    expect(result.current[0]).toBe(true)
+  })
+})

--- a/turbollm/web/src/lib/workspace-sidebar.ts
+++ b/turbollm/web/src/lib/workspace-sidebar.ts
@@ -1,0 +1,53 @@
+// Remembers whether the Workspace conversation sidebar (ConversationSidebar.tsx — shared across
+// Chat, Code Home, Code Session, Routines Panel, and Routine Edit; five identical
+// `useState(true)` call sites before this) is expanded or collapsed, so collapsing it survives
+// the same "leave Workspace, come back" flow workspace-nav.ts fixes for which sub-route is open —
+// founder-reported as a follow-up to that fix ("you just did the bare minimum").
+//
+// Session-scoped (sessionStorage), same convention as workspace-nav.ts and for the same reason:
+// this is "how I left it this session", not a durable cross-session preference like theme/
+// fontSize (stores/ui.ts). ONE shared flag, not one per screen — it's the same physical sidebar
+// component reused across every Workspace mode, so collapsing it in Code and then switching to
+// Chat should show it collapsed there too, exactly as if it were one persistent piece of UI chrome.
+
+import { useCallback, useState } from 'react'
+
+const KEY = 'tllm.workspace.sidebarOpen'
+
+function readStoredSidebarOpen(): boolean {
+  try {
+    const v = sessionStorage.getItem(KEY)
+    // No stored value yet (fresh session) defaults to expanded — the pre-existing
+    // `useState(true)` default at every call site this replaces.
+    return v === null ? true : v === '1'
+  } catch {
+    return true
+  }
+}
+
+function writeStoredSidebarOpen(open: boolean): void {
+  try {
+    sessionStorage.setItem(KEY, open ? '1' : '0')
+  } catch {
+    /* private browsing / storage disabled — falls back to in-memory only for this mount */
+  }
+}
+
+/** Drop-in replacement for `useState(true)` at each of the five Workspace sidebar call sites —
+ *  same `[sidebarOpen, setSidebarOpen]` shape (including functional updater support), so every
+ *  existing call site swaps in with a one-line change. Each mounted screen reads the CURRENT
+ *  stored value at mount time and writes back on every change, so switching screens within
+ *  Workspace (which mounts a different screen component, each with its own call to this hook)
+ *  stays in sync without any cross-component subscription machinery — the write from the screen
+ *  you're leaving always lands before the read from the screen you're entering. */
+export function useWorkspaceSidebarOpen(): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const [sidebarOpen, setSidebarOpenState] = useState(readStoredSidebarOpen)
+  const setSidebarOpen = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
+    setSidebarOpenState((prev) => {
+      const resolved = typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next
+      writeStoredSidebarOpen(resolved)
+      return resolved
+    })
+  }, [])
+  return [sidebarOpen, setSidebarOpen]
+}

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -8,6 +8,7 @@ import { useBuiltinAgentOverrides, useChatAgents, useEngines, useModelActions, u
 import type { ChatSseEvent, Conversation, LiveToolCall, Message } from '../lib/chat-types'
 import { appendTextDelta, upsertToolCall, type LiveBlock } from '../lib/live-timeline'
 import { ApiError, downloadChatExport, getDebugSnapshot, getShareUrl, importChat, track } from '../lib/api'
+import { useWorkspaceSidebarOpen } from '../lib/workspace-sidebar'
 import { Button } from '../components/ui/button'
 import {
   DropdownMenu,
@@ -99,7 +100,7 @@ export function ChatScreen({ embedded, convIdOverride }: { embedded?: boolean; c
   const [editingId, setEditingId] = useState<string | null>(null)
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
   const [showScrollBtn, setShowScrollBtn] = useState(false)
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useWorkspaceSidebarOpen()
   // Below md the sidebar is an off-canvas drawer, hidden until opened from the header.
   const isDesktop = useIsDesktop()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)

--- a/turbollm/web/src/screens/code/CodeHomeScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeHomeScreen.tsx
@@ -10,6 +10,7 @@ import { ApiError, track } from '../../lib/api'
 import { useGitBranch, useModelActions, useModels, useStatus } from '../../lib/queries'
 import { createCodeSession } from '../../lib/code-api'
 import { useCodeStats } from '../../lib/code-queries'
+import { useWorkspaceSidebarOpen } from '../../lib/workspace-sidebar'
 import type { CodeStatsRange } from '../../lib/code-types'
 import { ConversationSidebar } from '../chat/ConversationSidebar'
 import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle } from '../chat/SidebarResizeHandle'
@@ -195,7 +196,7 @@ export function CodeHomeScreen() {
   // Sidebar column — same collapse/resize state shape as ChatScreen.tsx (shared
   // constants/handle via SidebarResizeHandle.tsx) so the two modes feel like one
   // continuous surface, not two independently-behaving screens.
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useWorkspaceSidebarOpen()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const sidebarRef = useRef<HTMLDivElement>(null)

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -845,11 +845,14 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
               // forever. Measured live on 2026-07-29 against the founder's own `claude` session:
               // persisted message said 30,645 tokens / 15% (written two days earlier, and the
               // number in the screenshot that prompted this fix) while the CLI's actual context
-              // at that moment was 98,259 / 49%. The last gateway request's prompt size IS this
-              // conversation's real current context — an Anthropic-style CLI resends the whole
-              // conversation every turn — and it's already polled for the footer's ↑ figure, so
-              // it costs nothing extra and is the same quantity `ctxUsed` means for a chat turn.
-              ctxUsed={lastUsage?.promptTokens ?? 0}
+              // at that moment was 98,259 / 49%. The session's largest gateway request's prompt
+              // size IS this conversation's real current context — an Anthropic-style CLI resends
+              // the whole conversation every turn. `ctxUsed` here is deliberately a DIFFERENT
+              // field from `lastPromptTokens` below (db.ts's getLastApiUsageForSession splits
+              // them): this one is the session high-water mark, that one is literally the last
+              // gateway request's own stats — a parallel Task-tool sub-agent call can be the most
+              // recent request without being the biggest one.
+              ctxUsed={lastUsage?.ctxUsed ?? 0}
               ctxMax={ctxMax}
               thinkingBudget={thinkingBudget}
               onThinkingBudgetChange={setThinkingBudget}

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -14,6 +14,7 @@ import {
 import { CodeSessionClient, type LiveState } from '../../lib/code-session-client'
 import { matchCodeCommand, pickerCodeCommands } from '../../lib/code-commands'
 import { toggleDisplayPref } from '../../lib/code-display-prefs'
+import { useWorkspaceSidebarOpen } from '../../lib/workspace-sidebar'
 import { Button, buttonVariants } from '../../components/ui/button'
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
@@ -261,7 +262,7 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
   const userScrolledUp = useRef(false)
   const [showScrollBtn, setShowScrollBtn] = useState(false)
 
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useWorkspaceSidebarOpen()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const sidebarRef = useRef<HTMLDivElement>(null)

--- a/turbollm/web/src/screens/routines/RoutineEditPage.tsx
+++ b/turbollm/web/src/screens/routines/RoutineEditPage.tsx
@@ -20,6 +20,7 @@ import { RoutineStatusBadge } from '../../components/routines/RoutineStatusBadge
 import { describeRoutineError } from '../../lib/routine-api'
 import { describeScheduleRule, emptyRoutineDraft, isRoutineDraftComplete, routineToDraft, type RoutineDraft } from '../../lib/routine-form'
 import { useRoutine, useRoutineMutations, useRoutineRuns } from '../../lib/routine-queries'
+import { useWorkspaceSidebarOpen } from '../../lib/workspace-sidebar'
 import { deriveRoutineDisplayStatus } from '../../lib/routine-status'
 import type { Routine, RoutineRun, ScheduleRule } from '../../lib/routine-types'
 import { cn } from '../../lib/utils'
@@ -69,7 +70,7 @@ function draftsEqual(a: RoutineDraft, b: RoutineDraft): boolean {
 function RoutinesModeShell({ children }: { children: ReactNode }) {
   const navigate = useNavigate()
   const isDesktop = useIsDesktop()
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useWorkspaceSidebarOpen()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const sidebarRef = useRef<HTMLDivElement>(null)

--- a/turbollm/web/src/screens/routines/RoutinesPanel.tsx
+++ b/turbollm/web/src/screens/routines/RoutinesPanel.tsx
@@ -8,6 +8,7 @@ import { cn } from '../../lib/utils'
 import { useIsDesktop } from '../../lib/useIsDesktop'
 import { ConversationSidebar } from '../chat/ConversationSidebar'
 import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle } from '../chat/SidebarResizeHandle'
+import { useWorkspaceSidebarOpen } from '../../lib/workspace-sidebar'
 
 /** Workspace's Routines mode with nothing selected — `/workspace/routines`. The list itself now
  *  lives in ConversationSidebar.tsx (a real peer of the Chat conversation list and Code session
@@ -24,7 +25,7 @@ import { readSavedSidebarWidth, SIDEBAR_MIN_W, sidebarMaxW, SidebarResizeHandle 
 export function RoutinesPanel() {
   const navigate = useNavigate()
   const isDesktop = useIsDesktop()
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [sidebarOpen, setSidebarOpen] = useWorkspaceSidebarOpen()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(() => Math.min(Math.max(readSavedSidebarWidth(), SIDEBAR_MIN_W), sidebarMaxW()))
   const sidebarRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- **Terminal ctx-fill flicker + auto-compact never firing**: `getLastApiUsageForSession` now picks the session's max-`prompt_tokens` row instead of the latest-inserted one (parallel Task-tool sub-agent calls share the main turn's `code_session_id` and could overwrite the Context ring with a smaller number). `launchCli` now pins `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to the real loaded model's ctx (clamped to Claude Code's documented range) and sets `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80`, so the CLI compacts against the real local context window instead of assuming ~200K.
- **Multi-line first message reaching the claude CLI**: `canSeedFirstMessage`'s UNSEEDABLE filter no longer rejects the whole U+0000-U+001F control-byte range (newline/CR/tab included) — line breaks/tabs are folded to spaces before the eligibility check instead of disqualifying the whole message.
- **Anthropic gateway keep-alive pings during slow prefill**: `streamToAnthropic` now emits periodic `event: ping` SSE frames on a fixed schedule while waiting on the upstream reader, so Claude Code's own idle-stream watchdog no longer shows a false "Waiting for API response, retrying..." banner during a slow local-model prefill (>20s, routine on a large/uncached prompt).
- **Workspace nav item returns to the last-open sub-route**: `Shell.tsx`'s NAV array hardcoded the Workspace entry's `to` as `/workspace`, which always resolved to plain Chat — there was nowhere to remember "which sub-route" was open. New `workspace-nav.ts` tracks the last-visited `/workspace/*` sub-route (session-scoped), consulted by the desktop rail, the Ctrl+1-9 shortcut, and the mobile nav bar.
- **Workspace sidebar collapsed state now persists per session**: all five Workspace screens had their own identical `useState(true)` for `sidebarOpen`, reset on every remount. New shared `useWorkspaceSidebarOpen()` hook (`workspace-sidebar.ts`, session-scoped, same convention as `workspace-nav.ts`) is a drop-in replacement at all five call sites.

## Test plan
- [x] Full web test suite: 425/425 pass (33 files)
- [x] `tsc --noEmit` clean
- [x] Live-verified in a real browser: multi-line first message seeds correctly, Workspace nav returns to the exact prior sub-route, sidebar collapse survives a screen switch
- [x] Live-verified against the real engine: keep-alive pings land on schedule during a genuine 25s+ prefill stall