### PR TITLE
fix(engines): AMD APU boxes no longer default to ROCm; re-download re-registers a disabled backend

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -49,7 +49,7 @@ import { recommendEngines } from '../engines/recommend'
 import { engineAcceptsFormat, engineRejectsAudioModel } from '../engines/compat'
 import { ScannerError, type ModelEntry } from '../models/scanner'
 import { estimateVram, type LoadProfile, profileToArgs, resolveProfile, vllmProfileToArgs } from '../models/profile'
-import { getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
+import { amdApuOnly, getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
 import { HfError, type HfSortOption } from '../hf/hf'
 import { DownloadError } from '../downloads/downloads'
 import { BenchError } from '../bench/bench'
@@ -194,7 +194,7 @@ export function registerApi(app: Hono, d: Deps): void {
   app.get('/api/v1/engines/backends', (c) => {
     const sys = getSysInfo()
     const vendor = primaryVendor(sys)
-    const recommended = recommendBackendId(vendor, sys.gpus.length > 0)
+    const recommended = recommendBackendId(vendor, sys.gpus.length > 0, undefined, amdApuOnly(sys))
     const root = join(d.store.dir(), 'engines')
     const active = d.registry.active()
     const regEngines = d.registry.list().engines
@@ -246,10 +246,17 @@ export function registerApi(app: Hono, d: Deps): void {
     const root = join(d.store.dir(), 'engines')
     // First-install only: seed the pinned LLAMA_BUILD. When ANY build of this backend is
     // already on disk (tag-agnostic — an update may have de-pinned it off LLAMA_BUILD,
-    // ADR-085), this is a no-op so we never re-download a working install. The real upstream
-    // check is the Update path's job, which resolves the REAL latest tag honestly.
+    // ADR-085), this is a no-op download-wise so we never re-download a working install. The
+    // real upstream check is the Update path's job, which resolves the REAL latest tag honestly.
+    // GitHub #102: "Disable" only unregisters the engine (files stay on disk, ManagedEngines.tsx),
+    // so a disabled backend hits exactly this branch — re-register + activate it here too, or
+    // "Download" on a disabled backend silently does nothing forever (the binary is already
+    // there, so there was never anything to actually download).
     const existing = installedBackendBuild(root, def.id)
     if (existing) {
+      let eng = d.registry.list().engines.find((e) => e.binPath === existing.bin)
+      if (!eng) eng = (await d.registry.add(`llama.cpp ${existing.tag} (${def.id})`, existing.bin)).engine
+      d.registry.activate(eng.id)
       return c.json({ accepted: false, alreadyInstalled: true, build: existing.tag })
     }
     { const busy = engineWorkBusy(d); if (busy) return err(c, 409, 'engine_already_running', busy) }

--- a/turbollm/src/engines/download.test.ts
+++ b/turbollm/src/engines/download.test.ts
@@ -3,7 +3,7 @@
 // used by turboquantAssetUrl to pick the right release asset per OS.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { scoreAsset, pickReleaseAsset } from './download'
+import { scoreAsset, pickReleaseAsset, recommendBackendId } from './download'
 import type { ReleaseAsset } from './download'
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -168,5 +168,24 @@ test('pickReleaseAsset returns Windows asset for win32/x64', () => {
   ]
   const result = pickReleaseAsset(assets, 'win32', 'x64')
   assert.equal(result?.name, 'llama-win-x64.zip')
+})
+
+// ─── recommendBackendId ─────────────────────────────────────────────────────
+// GitHub #103: turbollm always defaulted an AMD GPU to ROCm when a ROCm prebuilt exists for
+// this platform, even on AMD APUs/iGPUs (e.g. Radeon 860M) that ROCm doesn't support on
+// Windows — Vulkan should win there instead. Runs on the CI machine's real platform (both
+// win32 and linux ship a rocm + vulkan prebuilt), skipped elsewhere.
+const hasRocmAndVulkan = process.platform === 'win32' || process.platform === 'linux'
+
+test('recommendBackendId: AMD with a discrete GPU still picks ROCm', { skip: !hasRocmAndVulkan && 'requires a platform with both rocm and vulkan prebuilts' }, () => {
+  assert.equal(recommendBackendId('amd', true, undefined, false), 'rocm')
+})
+
+test('recommendBackendId: AMD APU-only (amdApuOnly=true) skips ROCm for Vulkan', { skip: !hasRocmAndVulkan && 'requires a platform with both rocm and vulkan prebuilts' }, () => {
+  assert.equal(recommendBackendId('amd', true, undefined, true), 'vulkan')
+})
+
+test('recommendBackendId: amdApuOnly is irrelevant to other vendors', { skip: process.platform !== 'win32' && 'requires a platform with a CUDA prebuilt (win32 only — no Linux CUDA prebuilt upstream)' }, () => {
+  assert.equal(recommendBackendId('nvidia', true, undefined, true), 'cuda')
 })
 

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -100,8 +100,19 @@ export function availableBackends(tag = LLAMA_BUILD): BackendDef[] {
   throw new Error(`unsupported platform: ${plat()}/${process.arch}`)
 }
 
-/** The fastest backend for the detected GPU vendor. */
-export function recommendBackendId(vendor: GpuVendor, hasGpu: boolean, tag = LLAMA_BUILD): BackendId {
+/** The fastest backend for the detected GPU vendor. `amdApuOnly` — true when every detected
+ *  AMD adapter is an integrated GPU (GitHub #103: e.g. Radeon 860M / other Ryzen AI APUs) —
+ *  skips ROCm even when a ROCm build exists for this platform. ROCm's Windows/Linux support
+ *  matrix already excludes most discrete consumer Radeon cards (see enumWindowsGpus's rocm-smi
+ *  comment); it excludes integrated Radeon graphics even more consistently, so defaulting an
+ *  APU-only box to ROCm reliably picks a backend that can't load a model at all. Vulkan always
+ *  works there. Ignored (irrelevant) when a discrete AMD GPU is present. */
+export function recommendBackendId(
+  vendor: GpuVendor,
+  hasGpu: boolean,
+  tag = LLAMA_BUILD,
+  amdApuOnly = false,
+): BackendId {
   const ids = new Set(availableBackends(tag).map((b) => b.id))
   if (plat() === 'darwin') return 'metal'
   if (!hasGpu) return 'cpu'
@@ -111,7 +122,7 @@ export function recommendBackendId(vendor: GpuVendor, hasGpu: boolean, tag = LLA
       pick = ids.has('cuda') ? 'cuda' : 'vulkan' // no Linux CUDA prebuilt
       break
     case 'amd':
-      pick = ids.has('rocm') ? 'rocm' : 'vulkan'
+      pick = !amdApuOnly && ids.has('rocm') ? 'rocm' : 'vulkan'
       break
     case 'intel':
       pick = ids.has('sycl') ? 'sycl' : 'vulkan'

--- a/turbollm/src/engines/manager.mmproj-fallback.test.ts
+++ b/turbollm/src/engines/manager.mmproj-fallback.test.ts
@@ -1,0 +1,88 @@
+// GitHub report: Qwen3.6-35B-A3B fails to load with its own correct, official mmproj —
+// llama.cpp's mtmd n_embd compatibility check has a confirmed, still-open upstream bug for
+// this architecture (ggml-org/llama.cpp#20899). TurboLLM can't validate mmproj/model
+// compatibility itself without reimplementing (and inheriting the bugs of) llama.cpp's own
+// check, so instead the FIRST load attempt retries once without --mmproj when it dies with a
+// multimodal-load failure, rather than leaving an otherwise-loadable model unloaded.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mmprojFallbackNote, mmprojFallbackOpts, stripMmprojArgs } from './manager'
+import type { ErrInfo, StartOpts } from './manager'
+
+function opts(extraArgs: string[]): StartOpts {
+  return {
+    engine: { id: 'e', name: 'llama.cpp', binPath: '/bin/llama-server', kind: 'llama-server', version: '', capabilities: { kvTypes: [], flags: [] }, addedAt: '' },
+    model: { key: 'm', name: 'Qwen3.6-35B-A3B', quant: 'Q4_K_M', ctx: 4096, vision: true },
+    modelPath: '/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf',
+    extraArgs,
+  }
+}
+
+function err(logTail: string[]): ErrInfo {
+  return { code: 'engine_exited', message: 'The engine process exited unexpectedly.', exitCode: 1, logTail }
+}
+
+const MISMATCH_LOG = [
+  "E mtmd_init_from_file: error: mismatch between text model (n_embd = 2048) and mmproj (n_embd = 5120)",
+  "hint: you may be using wrong mmproj",
+  "E srv    load_model: failed to load multimodal model, 'D:\\models\\mmproj-BF16.gguf'",
+]
+
+// ─── stripMmprojArgs ─────────────────────────────────────────────────────────
+
+test('stripMmprojArgs removes --mmproj and its path value', () => {
+  const out = stripMmprojArgs(['-m', 'model.gguf', '--mmproj', 'mmproj.gguf', '--ctx-size', '4096'])
+  assert.deepEqual(out, ['-m', 'model.gguf', '--ctx-size', '4096'])
+})
+
+test('stripMmprojArgs removes --no-mmproj-offload', () => {
+  const out = stripMmprojArgs(['--mmproj', 'p.gguf', '--no-mmproj-offload', '--jinja'])
+  assert.deepEqual(out, ['--jinja'])
+})
+
+test('stripMmprojArgs is a no-op when neither flag is present', () => {
+  const args = ['-m', 'model.gguf', '--ctx-size', '4096']
+  assert.deepEqual(stripMmprojArgs(args), args)
+})
+
+// ─── mmprojFallbackOpts ──────────────────────────────────────────────────────
+
+test('mmprojFallbackOpts returns a retry with --mmproj stripped on a multimodal load failure', () => {
+  const fallback = mmprojFallbackOpts(opts(['-m', 'x.gguf', '--mmproj', 'mmproj.gguf']), err(MISMATCH_LOG))
+  assert.ok(fallback)
+  assert.deepEqual(fallback.extraArgs, ['-m', 'x.gguf'])
+  // Everything else about opts is passed through unchanged.
+  assert.equal(fallback.modelPath, '/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf')
+})
+
+test('mmprojFallbackOpts returns null when the load had no --mmproj to begin with', () => {
+  assert.equal(mmprojFallbackOpts(opts(['-m', 'x.gguf']), err(MISMATCH_LOG)), null)
+})
+
+test('mmprojFallbackOpts returns null for an unrelated crash (self-limiting: no retry storm)', () => {
+  const unrelated = err(['E srv  load_model: failed to open GGUF file: no such file or directory'])
+  assert.equal(mmprojFallbackOpts(opts(['-m', 'x.gguf', '--mmproj', 'mmproj.gguf']), unrelated), null)
+})
+
+test('mmprojFallbackOpts is self-limiting: retrying its own output finds nothing to strip', () => {
+  const first = mmprojFallbackOpts(opts(['-m', 'x.gguf', '--mmproj', 'mmproj.gguf']), err(MISMATCH_LOG))
+  assert.ok(first)
+  // If the retry ALSO failed with the same signature, a second call must not find another
+  // --mmproj to strip — this is what actually prevents an infinite retry loop.
+  assert.equal(mmprojFallbackOpts(first, err(MISMATCH_LOG)), null)
+})
+
+// ─── mmprojFallbackNote ──────────────────────────────────────────────────────
+
+test('mmprojFallbackNote carries the original mismatch lines forward', () => {
+  const note = mmprojFallbackNote(err(MISMATCH_LOG))
+  assert.match(note, /n_embd = 2048/)
+  assert.match(note, /n_embd = 5120/)
+  assert.match(note, /retrying once without --mmproj/)
+  assert.match(note, /not necessarily a wrong or corrupt file/)
+})
+
+test('mmprojFallbackNote falls back to the last few log lines when nothing matches the known patterns', () => {
+  const note = mmprojFallbackNote(err(['some other unrelated engine output']))
+  assert.match(note, /some other unrelated engine output/)
+})

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -201,6 +201,17 @@ export class Manager {
         if (hooks?.beforeStart) await hooks.beforeStart()
         await this.startInternal(opts)
         await this.awaitNotStarting()
+        // GitHub report (Qwen3.6-35B-A3B): the multimodal projector can fail to load even with
+        // the model's own correct, official mmproj — see mmprojFallbackOpts's doc comment. Retry
+        // ONCE, text-only, instead of leaving a model that could otherwise run fine unloaded.
+        if (this.state === 'error' && this.errInfo) {
+          const fallback = mmprojFallbackOpts(opts, this.errInfo)
+          if (fallback) {
+            const note = mmprojFallbackNote(this.errInfo)
+            await this.startInternal(fallback, note)
+            await this.awaitNotStarting()
+          }
+        }
         // Both routes.ts call sites fire load() without awaiting, so the outcome
         // is not observable to the caller. Reporting it here — the single atomic
         // swap entry point — is what makes any future call site instrumented for
@@ -253,7 +264,7 @@ export class Manager {
     while (this.state === 'starting' && Date.now() < deadline) await sleep(200)
   }
 
-  private async startInternal(opts: StartOpts): Promise<void> {
+  private async startInternal(opts: StartOpts, retryNote?: string): Promise<void> {
     if (this.state === 'starting' || this.state === 'running' || this.state === 'stopping') {
       throw new BusyError()
     }
@@ -293,6 +304,7 @@ export class Manager {
       `[turbollm] starting engine "${opts.engine.name}" on internal port ${port} ` +
         `(127.0.0.1 only — the engine's own port, NOT the TurboLLM app/UI port).\n`,
     )
+    if (retryNote) logStream.write(retryNote)
 
     // KV prompt-cache persistence (F-014): when ComfyUI coordination + the opt-in are on
     // and this is a llama.cpp engine whose caps allow the flag, point llama-server at the
@@ -1037,6 +1049,53 @@ function killPidTree(pid: number): void {
   } else {
     try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
   }
+}
+
+/** Strips `--mmproj <path>` and `--no-mmproj-offload` — the two flags profileToArgs adds
+ *  when (and only when) `p.useMmproj` is true — without touching anything else. Used to
+ *  retry a load as if useMmproj were false, without persisting that to the saved profile
+ *  (useMmproj is intentionally self-healing to the model's own vision capability — see
+ *  profile.ts's resolve() comment — so a permanent false would just get overwritten). */
+export function stripMmprojArgs(args: string[]): string[] {
+  const out: string[] = []
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--mmproj') { i++; continue } // also skip its path value
+    if (args[i] === '--no-mmproj-offload') continue
+    out.push(args[i])
+  }
+  return out
+}
+
+/** GitHub report (2026-08): Qwen3.6-35B-A3B fails to load with its own correct, official
+ *  mmproj — llama.cpp error `mismatch between text model (n_embd = 2048) and mmproj
+ *  (n_embd = 5120)`, hinting "wrong mmproj". It isn't: this is a confirmed, still-open
+ *  upstream bug (ggml-org/llama.cpp#20899, auto-closed stale rather than fixed) in the
+ *  `qwen35moe`/`qwen3moe` + `qwen3vl_merger` compatibility check specifically — other
+ *  reporters hit the identical crash with the identical model. TurboLLM can't validate
+ *  mmproj/model compatibility itself without reimplementing (and inheriting the bugs of)
+ *  llama.cpp's own internal check, so instead of leaving an otherwise-loadable model
+ *  unloaded, retry the FIRST load attempt once without --mmproj when it dies with a
+ *  multimodal-load failure. Self-limiting: `fallback`'s own extraArgs carry no --mmproj,
+ *  so a second failure (of any kind) just surfaces normally — no further retry, no loop. */
+export function mmprojFallbackOpts(opts: StartOpts, err: ErrInfo): StartOpts | null {
+  if (!opts.extraArgs.includes('--mmproj')) return null
+  if (!/failed to load multimodal model/i.test(err.logTail.join('\n'))) return null
+  return { ...opts, extraArgs: stripMmprojArgs(opts.extraArgs) }
+}
+
+/** The log note written at the top of the fallback attempt's (freshly truncated) log —
+ *  carries the original crash's key lines forward so the user isn't left staring at a
+ *  clean-looking retry log with no explanation for why vision silently isn't available. */
+export function mmprojFallbackNote(err: ErrInfo): string {
+  const relevant = err.logTail.filter((l) => /mismatch between text model|failed to load multimodal model|mtmd_init_from_file/i.test(l))
+  const summary = (relevant.length ? relevant : err.logTail.slice(-3)).join('\n')
+  return (
+    `[turbollm] the multimodal projector failed to load on the first attempt:\n${summary}\n` +
+    `[turbollm] retrying once without --mmproj (text-only). This can happen even with the ` +
+    `model's own correct, official mmproj file on some architectures due to open llama.cpp ` +
+    `bugs (e.g. github.com/ggml-org/llama.cpp/issues/20899 for Qwen3.6-35B-A3B) — not ` +
+    `necessarily a wrong or corrupt file on your end. Vision won't be available this session.\n\n`
+  )
 }
 
 function readTail(path: string, n: number): string[] {

--- a/turbollm/src/engines/seed.ts
+++ b/turbollm/src/engines/seed.ts
@@ -4,7 +4,7 @@
 // No-ops if any engine is already configured. Never throws.
 import type { Registry } from './registry'
 import type { ProvisionState } from './provision-state'
-import { getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
+import { amdApuOnly, getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
 import { LLAMA_BUILD, fallbackChain, provisionBackend, recommendBackendId, type BackendId, type ProvisionProgress } from './download'
 
 const VALID_BACKENDS: BackendId[] = ['cuda', 'rocm', 'sycl', 'vulkan', 'metal', 'cpu']
@@ -30,7 +30,9 @@ export async function seedDefaultEngines(
 
   let chain
   try {
-    const recommended = forced && VALID_BACKENDS.includes(forced) ? forced : recommendBackendId(vendor, hasGpu, tag)
+    const recommended = forced && VALID_BACKENDS.includes(forced)
+      ? forced
+      : recommendBackendId(vendor, hasGpu, tag, amdApuOnly(sys))
     chain = fallbackChain(recommended, tag)
     if (forced) {
       console.log(`seed: TURBOLLM_SEED_BACKEND=${forced} → backend ${recommended} (skipping live GPU detection)`)

--- a/turbollm/src/sysinfo/sysinfo.test.ts
+++ b/turbollm/src/sysinfo/sysinfo.test.ts
@@ -9,7 +9,9 @@ import {
   parseKfdNodes,
   pciSlotToKfdIds,
   linuxGpuFromLspci,
+  amdApuOnly,
 } from './sysinfo'
+import type { SysInfo } from './sysinfo'
 
 // rocm-smi --showmeminfo vram --json output for an RX 7900 XTX (24GB). The WMI
 // AdapterRAM fallback would cap this at ~4GB; rocm-smi reports the true total.
@@ -99,6 +101,29 @@ test('isIntegratedGpuName: discrete AMD cards are NOT integrated', () => {
   assert.equal(isIntegratedGpuName('AMD Radeon RX 7900 XTX'), false)
   assert.equal(isIntegratedGpuName('AMD Radeon PRO W7900'), false)
   assert.equal(isIntegratedGpuName('AMD Instinct MI300X'), false)
+})
+
+// GitHub #103: recommendBackendId needs to know when the ONLY AMD adapter present is an
+// APU/iGPU (ROCm doesn't support most of these on Windows), so it can skip ROCm for Vulkan.
+const sysWith = (...gpus: SysInfo['gpus']): SysInfo => ({ os: 'win32/x64', cpu: 'test', cores: 8, ramMB: 32000, gpus })
+
+test('amdApuOnly: true for a single AMD iGPU (e.g. Radeon 860M)', () => {
+  assert.equal(amdApuOnly(sysWith({ name: 'AMD Radeon 860M', vramMb: 16000, vendor: 'amd', unified: true })), true)
+})
+
+test('amdApuOnly: false when a discrete AMD GPU is present', () => {
+  assert.equal(amdApuOnly(sysWith({ name: 'AMD Radeon RX 7900 XTX', vramMb: 24000, vendor: 'amd' })), false)
+})
+
+test('amdApuOnly: false when an AMD iGPU sits alongside a discrete AMD GPU', () => {
+  assert.equal(amdApuOnly(sysWith(
+    { name: 'AMD Radeon 780M', vramMb: 16000, vendor: 'amd', unified: true },
+    { name: 'AMD Radeon RX 7900 XTX', vramMb: 24000, vendor: 'amd' },
+  )), false)
+})
+
+test('amdApuOnly: false when there is no AMD adapter at all', () => {
+  assert.equal(amdApuOnly(sysWith({ name: 'NVIDIA RTX 5070 Ti', vramMb: 16000, vendor: 'nvidia' })), false)
 })
 
 test('isIntegratedGpuName: NVIDIA and unrelated names are NOT integrated', () => {

--- a/turbollm/src/sysinfo/sysinfo.ts
+++ b/turbollm/src/sysinfo/sysinfo.ts
@@ -50,6 +50,15 @@ export function primaryVendor(info: SysInfo = getSysInfo()): GpuVendor {
   return best
 }
 
+/** True when every detected AMD adapter is integrated (an APU iGPU, `unified: true`) —
+ *  i.e. there's no discrete AMD card to fall back on. Used by backend selection (GitHub
+ *  #103) to avoid defaulting an AMD APU box to ROCm, which doesn't support most integrated
+ *  Radeon graphics. False when there's no AMD adapter at all, or at least one is discrete. */
+export function amdApuOnly(info: SysInfo = getSysInfo()): boolean {
+  const amd = info.gpus.filter((g) => g.vendor === 'amd')
+  return amd.length > 0 && amd.every((g) => g.unified)
+}
+
 export function classifyVendor(name: string): GpuVendor {
   const n = name.toLowerCase()
   if (/nvidia|geforce|rtx|gtx|quadro|tesla/.test(n)) return 'nvidia'


### PR DESCRIPTION
## Summary
- Fixes #103: `recommendBackendId` always preferred ROCm for any AMD-vendor GPU when a ROCm prebuilt exists for the platform, with no check for whether the specific card supports it. AMD's ROCm Windows support excludes most integrated Radeon graphics (Radeon 860M / other Ryzen AI APUs included), so an APU-only box got defaulted into a backend that can't load a model. New `amdApuOnly()` (`sysinfo.ts`) reports true when every detected AMD adapter is integrated; `recommendBackendId` now skips ROCm for Vulkan in that case, wired into both the seed-on-first-run path and `GET /engines/backends`.
- Fixes #102: "Disable" on a llama.cpp backend only unregisters it from the app registry and leaves the binary on disk. The install route's disk-based short-circuit (skip re-download when a build already exists) returned `alreadyInstalled` and stopped, without re-registering the now-orphaned build — so clicking "Download" on a disabled backend looked like it did nothing, forever. That branch now re-registers + activates the existing build.
- Fixes a third report (Qwen3.6-35B-A3B multimodal load crash): the model's own correct, official mmproj gets rejected by a confirmed, still-open upstream llama.cpp bug (ggml-org/llama.cpp#20899) in the qwen35moe/qwen3moe + qwen3vl_merger compatibility check — not a wrong/corrupt file on the user's end. `Manager.load()` (`manager.ts`) now retries a load once without `--mmproj` when the first attempt dies with a multimodal-load failure, instead of leaving an otherwise-loadable model unloaded. Self-limiting by construction (the retry's own args carry no `--mmproj`, so a second failure just surfaces normally).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 2409/2409 passing (16 new unit tests: 7 covering `amdApuOnly()`/`recommendBackendId`'s APU-only branch, 9 covering the mmproj retry helpers)
- [ ] Live-verify on an AMD APU box if possible before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)