### PR TITLE
fix(gguf): recognize APEX mixed-precision MoE quants

### DIFF
--- a/turbollm/src/gguf/gguf.test.ts
+++ b/turbollm/src/gguf/gguf.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { parseGguf } from './gguf'
+import { parseGguf, quantFromName } from './gguf'
 
 const T_UINT32 = 4
 const T_BOOL = 7
@@ -308,4 +308,64 @@ test('a plain dense model reports no attention-layout metadata at all', () => {
       assert.equal(meta.nativeCtx, 8192)
     },
   )
+})
+
+// ---- general.name bogus-value guard (issue #165) ------------------------------------
+// apex-quant's GGUFs all declare general.name "Safetensors" — apparently a leftover
+// staging-directory name from its conversion pipeline, not the model name. Confirmed
+// against a real download: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF's I-Nano file has
+// general.name "Safetensors" while general.file_type correctly reads IQ2_XXS.
+
+test('a known storage-format word in general.name is treated as absent', () => {
+  withGgufFile(
+    [
+      ['general.architecture', 'qwen35moe'],
+      ['general.name', 'Safetensors'],
+    ],
+    (path) => {
+      assert.equal(parseGguf(path).name, '', 'caller falls back to the filename instead')
+    },
+  )
+})
+
+test('general.name guard is case-insensitive and covers the other known container words', () => {
+  for (const bogus of ['GGUF', 'PyTorch', 'pytorch_model', 'BIN', 'Checkpoint', 'onnx']) {
+    withGgufFile([['general.name', bogus]], (path) => {
+      assert.equal(parseGguf(path).name, '', `"${bogus}" must be rejected`)
+    })
+  }
+})
+
+test('a real model name that merely contains a format word as a substring survives', () => {
+  // The guard matches the full value, not a substring — must not reject legitimate names.
+  withGgufFile([['general.name', 'Safetensors Finetune 7B']], (path) => {
+    assert.equal(parseGguf(path).name, 'Safetensors Finetune 7B')
+  })
+})
+
+// ---- quantFromName (issue #165) ------------------------------------------------------
+
+test('quantFromName still recognizes standard llama.cpp quant tokens', () => {
+  assert.equal(quantFromName('llama-3-8b-instruct-Q4_K_M.gguf'), 'Q4_K_M')
+  assert.equal(quantFromName('model-IQ3_XS.gguf'), 'IQ3_XS')
+  assert.equal(quantFromName('model-F16.gguf'), 'F16')
+})
+
+test('quantFromName recognizes APEX mixed-precision MoE tiers', () => {
+  // Real filenames from mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF.
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-Balanced.gguf'), 'APEX-BALANCED')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-Compact.gguf'), 'APEX-COMPACT')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-I-Balanced.gguf'), 'APEX-I-BALANCED')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf'), 'APEX-I-COMPACT')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-I-Mini.gguf'), 'APEX-I-MINI')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-I-Nano.gguf'), 'APEX-I-NANO')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf'), 'APEX-I-QUALITY')
+  assert.equal(quantFromName('Qwen3.6-35B-A3B-APEX-MTP-Quality.gguf'), 'APEX-QUALITY')
+  // The apex-quant project's own doc-style naming (no extra infix token).
+  assert.equal(quantFromName('model-apex-i-quality.gguf'), 'APEX-I-QUALITY')
+  assert.equal(quantFromName('model-apex-mini.gguf'), 'APEX-MINI')
+})
+
+test('quantFromName falls back to "?" when nothing recognizable is present', () => {
+  assert.equal(quantFromName('random-model-name.gguf'), '?')
 })

--- a/turbollm/src/gguf/gguf.ts
+++ b/turbollm/src/gguf/gguf.ts
@@ -91,6 +91,14 @@ const FTYPE: Record<number, string> = {
   28: 'IQ4_XS', 30: 'BF16',
 }
 
+// general.name values that are a storage-format word, not an actual model name — some
+// conversion pipelines fall back to the source checkpoint directory's name when the HF
+// config has none, and that directory is sometimes just a generic staging folder (e.g.
+// apex-quant's GGUFs all declare general.name "Safetensors" — issue #165). No real model
+// is named after its own file format, so treat these as if the key were absent and let
+// the caller fall back to the filename instead.
+const BOGUS_GENERAL_NAMES = new Set(['safetensors', 'gguf', 'pytorch', 'pytorch_model', 'bin', 'checkpoint', 'onnx'])
+
 // GGUF value types.
 const T_UINT8 = 0, T_INT8 = 1, T_UINT16 = 2, T_INT16 = 3, T_UINT32 = 4, T_INT32 = 5,
   T_FLOAT32 = 6, T_BOOL = 7, T_STRING = 8, T_ARRAY = 9, T_UINT64 = 10, T_INT64 = 11,
@@ -267,7 +275,10 @@ export function parseGguf(path: string): GgufMeta {
       const key = r.str()
       const t = r.u32()
       if (key === 'general.architecture') m.arch = String(readScalar(r, t))
-      else if (key === 'general.name') m.name = String(readScalar(r, t))
+      else if (key === 'general.name') {
+        const v = String(readScalar(r, t))
+        if (!BOGUS_GENERAL_NAMES.has(v.toLowerCase())) m.name = v
+      }
       else if (key === 'general.file_type') m.quant = FTYPE[Number(readScalar(r, t))] ?? ''
       else if (key === 'general.size_label') m.sizeLabel = String(readScalar(r, t))
       else if (key.endsWith('.context_length')) m.nativeCtx = readNumberOrMax(r, t)
@@ -329,8 +340,15 @@ export function parseGguf(path: string): GgufMeta {
   }
 }
 
-/** Best-effort quant from a filename token when general.file_type is absent/unknown. */
+/** Best-effort quant from a filename token when general.file_type is absent/unknown.
+ *  Also recognizes APEX (localai-org/apex-quant, issue #165) mixed-precision MoE quants,
+ *  which don't use llama.cpp's IQ-/Q-_K naming — just a tier word (optionally imatrix-
+ *  calibrated, prefixed "I-") after "APEX" in the filename, e.g.
+ *  "Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf" → "APEX-I-QUALITY". */
 export function quantFromName(filename: string): string {
   const m = filename.match(/(I?Q\d[A-Z0-9_]*|BF16|F16|F32)/i)
-  return m ? m[1].toUpperCase() : '?'
+  if (m) return m[1].toUpperCase()
+  const apex = filename.match(/APEX(?:-[A-Za-z0-9]+){0,3}?-(I-)?(NANO|MINI|COMPACT|BALANCED|QUALITY)(?=\.|$|-)/i)
+  if (apex) return `APEX-${apex[1] ? 'I-' : ''}${apex[2].toUpperCase()}`
+  return '?'
 }


### PR DESCRIPTION
## Summary
- `quantFromName()` now recognizes apex-quant's (localai-org/apex-quant) tier naming (`Nano`/`Mini`/`Compact`/`Balanced`/`Quality`, optionally imatrix-calibrated `I-` prefix) so APEX GGUF repo files on the Discover tab show a real quant label instead of `?`.
- `parseGguf()` now treats a small set of known storage-format words in `general.name` (confirmed via a real download: apex-quant writes the literal string `"Safetensors"`, apparently a leftover staging-directory name from its conversion pipeline) as absent, so the model name falls back to the filename instead of displaying "Safetensors".

Root cause confirmed by downloading and parsing the real GGUF header from `mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF` — `general.file_type` already parses fine (e.g. `IQ2_XXS`), only `general.name` and the filename-only quant fallback were affected.

Closes #165

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — 2445/2445 passing, including new regression tests in `gguf.test.ts` for both the `general.name` guard and the APEX tier regex
- [x] Verified against the real APEX GGUF header bytes downloaded from HuggingFace (not just synthetic fixtures)