### PR TITLE
chore(release): v1.10.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,8 @@ switch between CUDA / ROCm / Metal / SYCL / Vulkan / CPU at any time (it downloa
 you choose, LM Studio-style).
 
 **Engine types.** **llama.cpp / GGUF**, **KoboldCpp** and **llamafile** (GGUF, every OS),
-**MLX** (macOS), and **vLLM** (Linux + NVIDIA) are all first-class engine kinds — install from
-the curated catalog, pick the right one per model, and switch from a single dropdown.
+**MLX** and **MLX-VLM** (macOS), and **vLLM** (Linux + NVIDIA) are all first-class engine kinds —
+install from the curated catalog, pick the right one per model, and switch from a single dropdown.
 
 **Fully supervised.** Every engine runs under a real state machine: health-gated readiness,
 graceful stop, an **idle auto-stop** watchdog, and **live logs + clear error surfacing** in

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -23,15 +23,31 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
+### Nothing yet.
+
+## [1.10.8] - 2026-08-13
+
 ### Added
 - **MLX-VLM engine** (macOS Apple Silicon only, pip). Vision-language models on Apple's MLX
   framework — Qwen-VL, Gemma vision variants, LLaVA, and more — via an OpenAI-compatible
   `mlx_vlm.server`. No context/GPU-layer/KV knobs to set at load time; sampling is
   per-conversation only, same as Rapid-MLX.
 
+### Fixed
+- **APEX quantized GGUFs (localai-org/apex-quant) are now detected correctly.** These models
+  were showing up with the model name literally displayed as "Safetensors" (confirmed: the
+  files declare that string in a metadata field that isn't actually the model name — apparently
+  a leftover from their conversion pipeline), and their quant tier wasn't recognized on the
+  Discover tab. The name now falls back to the filename, and APEX's tier names (Nano / Mini /
+  Compact / Balanced / Quality, optionally imatrix-calibrated) are recognized directly. If you
+  already had an APEX model downloaded and tuned/pinned under its old "Safetensors" name, its
+  saved load profile and pin won't carry over to the corrected name — re-run Auto-Tune once
+  after updating. (#165)
+
 ### Discord
 - **MLX-VLM is now a supported engine** — run vision-language models (Qwen-VL, Gemma vision,
   LLaVA, and more) locally on Apple Silicon with one-click install, no compiling required.
+- **Fixed APEX quantized models** showing up with the wrong name and an unrecognized quant tier.
 
 ## [1.10.7] - 2026-08-11
 

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -265,7 +265,8 @@ const ALL: CatalogEngine[] = [
       'macOS (Apple Silicon) only. Loads the same MLX-format model directories as the MLX engine. ' +
       'Some architectures (e.g. Qwen-VL, SmolVLM) additionally need torch + torchvision, which are ' +
       'not installed automatically. If a model fails to load with a "missing image processor" ' +
-      'error, run: uv pip install --python <this engine\'s venv>/bin/python torch torchvision. ' +
+      'error, locate the bootstrapped uv binary (find ~/.turbollm/engines/uv -name uv -type f) ' +
+      'and run: <that uv path> pip install --python <this engine\'s venv>/bin/python torch torchvision. ' +
       'Tool/function calling is architecture-dependent: mlx-vlm only turns a `tools` array into ' +
       'real tool calls for the handful of chat templates it has a matching parser for. Other ' +
       'models accept the request without error but never call a tool (confirmed live on ' +

--- a/turbollm/src/engines/manager.ts
+++ b/turbollm/src/engines/manager.ts
@@ -656,9 +656,10 @@ export class Manager {
       // lifespan startup, so the socket never even binds on a preload failure — see
       // mlxVlmServerCommand's docblock) and a plain process exit already surfaces via
       // the exit handler above with a generic message; we still check it here because
-      // this path additionally recovers the real traceback line (e.g. "Failed to load
-      // model: ...") for a much more useful error than "exited unexpectedly". Detect a
-      // fatal load-failure traceback in the log and surface it as an engine error
+      // this path additionally recovers a real traceback line — when the crash trips one
+      // of detectPyLoadFailure's gate patterns; a bare "Failed to load model: ..." line on
+      // its own does not — for a much more useful error than "exited unexpectedly". Detect
+      // a fatal load-failure traceback in the log and surface it as an engine error
       // instead. (Checked before probeReady so we win the race.)
       if (kind === 'mlx' || kind === 'rapid-mlx' || kind === 'mlx-vlm' || kind === 'vllm' || kind === 'sglang') {
         const loadErr = detectPyLoadFailure(readTail(this.logPathStr, 200))

--- a/turbollm/src/engines/mlx-vlm.ts
+++ b/turbollm/src/engines/mlx-vlm.ts
@@ -17,8 +17,8 @@
 // it's a large (multi-hundred-MB+) dependency that most mlx-vlm model families don't
 // need, and bundling it unconditionally would bloat every install for a subset of
 // architectures. If a user hits this error, the fix is a one-off
-// `uv pip install --python <this venv>/bin/python torch torchvision` into the venv
-// at `<root>/mlx-vlm/venv`.
+// `<bootstrapped uv binary> pip install --python <root>/mlx-vlm/venv/bin/python torch
+// torchvision` — see catalog.ts's mlx-vlm `note` for the user-facing version of this.
 import { existsSync, rmSync } from 'node:fs'
 import { execFile } from 'node:child_process'
 import { join } from 'node:path'

--- a/turbollm/src/models/scanner.cache-version.test.ts
+++ b/turbollm/src/models/scanner.cache-version.test.ts
@@ -1,0 +1,102 @@
+// Regression test for the CACHE_VERSION gap caught by pre-release review (v1.10.8, issue
+// #165): parseGguf() started rejecting a bogus general.name like "Safetensors" (gguf.ts),
+// but a model already sitting in models-cache.json under the OLD CACHE_VERSION would keep
+// replaying that stale, wrong cached name forever — entryFor() only calls parseGguf again
+// when the file's size/mtime changed, never on a code change. Bumping CACHE_VERSION is what
+// forces every cached row to re-parse once, which is the only thing that makes a parseGguf
+// fix actually reach a model a user already had scanned before upgrading.
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import type { ConfigStore } from '../config/config'
+import { Scanner } from './scanner'
+
+const T_UINT32 = 4
+const T_STRING = 8
+
+function buildGguf(kvs: Array<[string, string | number]>): Buffer {
+  const parts: Buffer[] = []
+  const u32 = (n: number) => { const b = Buffer.alloc(4); b.writeUInt32LE(n); return b }
+  const u64 = (n: number) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(BigInt(n)); return b }
+  const str = (s: string) => { const body = Buffer.from(s, 'utf8'); return Buffer.concat([u64(body.length), body]) }
+
+  parts.push(u32(0x46554747)) // magic "GGUF"
+  parts.push(u32(3)) // version
+  parts.push(u64(0)) // tensorCount
+  parts.push(u64(kvs.length)) // kvCount
+  for (const [key, value] of kvs) {
+    parts.push(str(key))
+    if (typeof value === 'string') {
+      parts.push(u32(T_STRING))
+      parts.push(str(value))
+    } else {
+      parts.push(u32(T_UINT32))
+      parts.push(u32(value))
+    }
+  }
+  return Buffer.concat(parts)
+}
+
+function makeTmpRoot(): string {
+  const dir = join(tmpdir(), `turbollm-cacheversion-test-${Date.now()}-${Math.floor(Math.random() * 1e9)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+/** Minimal ConfigStore stub: the Scanner only reads dir() (cache location) and
+ *  snapshot().modelDirs (what to walk). Cache lives under the same temp root. */
+function stubStore(root: string): ConfigStore {
+  return {
+    dir: () => root,
+    snapshot: () => ({ modelDirs: [root] }),
+  } as unknown as ConfigStore
+}
+
+test('a stale cache row from an OLDER CACHE_VERSION is re-parsed, not replayed', async () => {
+  const root = makeTmpRoot()
+  try {
+    // walk() only records .gguf files >= 1 MiB — pad well past that with trailing bytes
+    // parseGguf never reads (it stops once it has consumed kvCount keys).
+    const header = buildGguf([
+      ['general.architecture', 'qwen35moe'],
+      ['general.name', 'Safetensors'], // the bogus value apex-quant actually writes
+    ])
+    const padded = Buffer.concat([header, Buffer.alloc((1 << 20) + 16)])
+    const path = join(root, 'model-apex.gguf')
+    writeFileSync(path, padded)
+    const st = statSync(path)
+
+    // Simulate a cache written by a build whose CACHE_VERSION predates the general.name
+    // guard: it already has this exact file's size/mtime, with the un-guarded bogus name.
+    writeFileSync(
+      join(root, 'models-cache.json'),
+      JSON.stringify({
+        version: 4, // CACHE_VERSION as of v1.10.7, before the general.name guard shipped
+        entries: {
+          [path]: {
+            size: st.size,
+            mtime: st.mtimeMs,
+            meta: {
+              arch: 'qwen35moe', name: 'Safetensors', quant: 'Q6_K', sizeLabel: '', nativeCtx: 0,
+              blockCount: 0, embedLen: 0, headCountKv: 0, headDim: 0, expertCount: 0, nextnLayers: 0,
+              hasChatTemplate: false, slidingWindow: 0, slidingWindowPattern: [], headDimSwa: 0,
+              headCountKvPerLayer: [], fullAttentionInterval: 0, ssmInnerSize: 0, ssmStateSize: 0,
+              ssmConvKernel: 0,
+            },
+          },
+        },
+      }),
+    )
+
+    const scanner = new Scanner(stubStore(root))
+    await scanner.rescan()
+    const entry = scanner.list().models.find((m) => m.format === 'gguf')
+    assert.ok(entry, 'expected one GGUF entry')
+    assert.notEqual(entry.name, 'Safetensors', 'a version mismatch must force a re-parse, not replay the stale cached name')
+    assert.equal(entry.name, 'model apex', 'falls back to the cleaned filename once re-parsed')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -82,11 +82,17 @@ interface CacheRow {
   meta: GgufMeta
 }
 
-// Bump when GgufMeta gains a field so on-disk caches re-parse (see loadCache).
+// Bump when GgufMeta gains a field, OR when parseGguf's interpretation of an existing
+// field changes, so on-disk caches re-parse (see loadCache) instead of replaying a stale
+// value.
 // 4: attention-layout fields (sliding window / hybrid-SSM layout, ADR-223) — rows cached
 // by an older build predate the new keys, so re-parsing is what makes the improved KV
 // estimate actually apply to already-scanned models instead of only to new ones.
-const CACHE_VERSION = 4
+// 5: general.name now rejects known storage-format placeholder values (issue #165) —
+// without this bump, a model already in the cache with a bogus cached name (e.g. an APEX
+// GGUF's literal "Safetensors") keeps replaying it forever, since entryFor() only calls
+// parseGguf() again when size/mtime changed.
+const CACHE_VERSION = 5
 
 /** Optional attention-layout metadata the GGUF parser surfaces (ADR-223).
  *

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -196,6 +196,8 @@ const TURBOLLM_KNOWLEDGE =
   'Google\'s TurboQuant quantization engine — fork of llama.cpp for turbo-quantized models. Same llama-server interface as llama.cpp. Adds KV types `turbo3` and `turbo4`. On Windows: prebuilt has a UCRT defect; build from source with the in-app build tool.\n\n' +
   '**MLX** (macOS Apple Silicon only):\n' +
   'Loads MLX-format safetensors from HuggingFace or local dirs. KV/ctx controls hidden (dynamic sizing). If a model fails to load, TurboLLM detects the traceback instead of hanging and shows `model_load_failed`. Incomplete MLX shards show a re-download button.\n\n' +
+  '**MLX-VLM** (macOS Apple Silicon only, pip):\n' +
+  'Vision-language models on MLX — Qwen-VL, Gemma vision variants, LLaVA, and more — via `mlx_vlm.server`, a separate pip package, uv-provisioned into its own venv. No context/GPU-layer/KV knobs to set at load time, and no sampling-arg flags either (`mlx_vlm.server` has none) — sampling is per-conversation only, same as MLX.\n\n' +
   '**vLLM** (Linux / WSL2 only):\n' +
   'High-throughput engine for safetensors. Requires the vLLM venv (provisioned in-app). Hard dependency on `uvloop` (POSIX-only) — on Windows it fails immediately with a clear message directing the user to WSL2/Linux.\n\n' +
 


### PR DESCRIPTION
## Summary
Patch release bundling two changes since v1.10.7:
- **MLX-VLM engine** (PR #161) — vision-language models on Apple Silicon MLX.
- **APEX quant detection fix** (PR #166, issue #165) — apex-quant GGUFs no longer show up named "Safetensors" with an unrecognized quant tier.

Release-prep on this branch, driven by an Opus pre-release review of the full diff since v1.10.7:
- Bumped `CACHE_VERSION` — the APEX fix was a no-op for already-scanned models without this (HIGH finding, confirmed).
- Documented the load-profile/pin reset for affected models in the changelog (MEDIUM finding).
- Fixed a fragile/wrong `uv pip install` command in the MLX-VLM catalog note (LOW finding).
- Fixed a misleading comment about `detectPyLoadFailure`'s traceback recovery (LOW finding).
- Added MLX-VLM to the TurboLLM Expert persona knowledge base + rebuilt the web bundle.
- Synced the root README mirror.
- Bumped `turbollm/package.json` to 1.10.8, updated `turbollm/CHANGELOG.md`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 2449/2453 passing (4 pre-existing skips), including a new regression test proving the CACHE_VERSION bump actually fixes the reported bug for already-cached models