### PR TITLE
Preset pin lifecycle + profile validation fixes (ADR-353)

### DIFF
--- a/turbollm/src/api/preset-routes.test.ts
+++ b/turbollm/src/api/preset-routes.test.ts
@@ -18,6 +18,8 @@ function fakeApp(cfg: Config): Hono {
       snapshot: () => cfg,
       update: (fn: (c: Config) => void) => fn(cfg),
     },
+    // The create route guards on model existence, like PUT /models/:key/profile does.
+    scanner: { get: (k: string) => (k === KEY ? { key: KEY } : undefined) },
   } as unknown as Deps
   registerPresetRoutes(app, d)
   return app
@@ -27,7 +29,7 @@ test('GET /presets: empty for a model with none', async () => {
   const app = fakeApp(defaultConfig())
   const res = await app.request(`/api/v1/models/${KEY}/presets`)
   assert.equal(res.status, 200)
-  assert.deepEqual(await res.json(), [])
+  assert.deepEqual(await res.json(), { presets: [], pinnedId: null })
 })
 
 test('GET /presets: newest updatedAt first', async () => {
@@ -38,8 +40,13 @@ test('GET /presets: newest updatedAt first', async () => {
       { id: 'new', name: 'New', engineId: '', profile: {}, updatedAt: '2026-02-01T00:00:00.000Z', origin: 'autotune' },
     ],
   }
+  cfg.lastPresetId = { [KEY]: 'old' }
   const res = await fakeApp(cfg).request(`/api/v1/models/${KEY}/presets`)
-  assert.deepEqual(((await res.json()) as Array<{ id: string }>).map((p) => p.id), ['new', 'old'])
+  const body = (await res.json()) as { presets: Array<{ id: string }>; pinnedId: string | null }
+  assert.deepEqual(body.presets.map((p) => p.id), ['new', 'old'])
+  // The pin has to reach the client: without it the dropdown cannot show which preset is
+  // active, even though the pin is exactly what getModelProfile serves on the next load.
+  assert.equal(body.pinnedId, 'old')
 })
 
 test('POST /presets: create → 201 with a minted id, origin manual, engineId defaulting to ""', async () => {
@@ -99,7 +106,7 @@ test('POST /presets: past the per-model cap → 400 too_many_presets, NOT a 500'
       id: `p-${i}`,
       name: `Preset ${i}`,
       engineId: '',
-      profile: {},
+      profile: { ctx: 4096 },
       updatedAt: `2026-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
       origin: 'manual' as const,
     })),
@@ -107,7 +114,7 @@ test('POST /presets: past the per-model cap → 400 too_many_presets, NOT a 500'
   const res = await fakeApp(cfg).request(`/api/v1/models/${KEY}/presets`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: 'One too many', profile: {} }),
+    body: JSON.stringify({ name: 'One too many', profile: { ctx: 4096 } }),
   })
   assert.equal(res.status, 400)
   assert.equal(((await res.json()) as { error: { code: string } }).error.code, 'too_many_presets')
@@ -228,4 +235,37 @@ test('POST /presets/:id/apply: unknown id → 404 and no pin written', async () 
   const res = await fakeApp(cfg).request(`/api/v1/models/${KEY}/presets/nope/apply`, { method: 'POST' })
   assert.equal(res.status, 404)
   assert.equal(cfg.lastPresetId?.[KEY], undefined)
+})
+
+test('POST /presets: an unknown model key → 404 (matches PUT /models/:key/profile)', async () => {
+  const res = await fakeApp(defaultConfig()).request('/api/v1/models/nope%7Cq4%7C1/presets', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: 'x', profile: { ctx: 4096 } }),
+  })
+  assert.equal(res.status, 404)
+  assert.equal(((await res.json()) as { error: { code: string } }).error.code, 'no_such_model')
+})
+
+test('POST /presets: bad profile FIELDS are rejected, not just bad shape', async () => {
+  // A pinned preset's profile goes verbatim to profileToArgs. Accepting these here would let a
+  // preset be pinned that makes the model unloadable until the pin is cleared by hand.
+  const app = fakeApp(defaultConfig())
+  const bad: Array<Record<string, unknown>> = [
+    { ctx: 1 },
+    { ctx: 4096, nCpuMoe: null },
+    { ctx: 4096, ngl: -1 },
+    { ctx: 4096, gpu: { splitMode: 'nonsense', tensorSplit: [], mainGpu: 0, tensorParallelSize: 1 } },
+    { ctx: 4096, gpu: { splitMode: 'layer', tensorSplit: 'not-an-array', mainGpu: 0, tensorParallelSize: 1 } },
+    { ctx: 4096, gpu: { splitMode: 'layer', tensorSplit: [], mainGpu: -99, tensorParallelSize: 1 } },
+    { ctx: 4096, gpu: { splitMode: 'layer', tensorSplit: [], mainGpu: 0, tensorParallelSize: 0 } },
+  ]
+  for (const profile of bad) {
+    const res = await app.request(`/api/v1/models/${KEY}/presets`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Bad fields', profile }),
+    })
+    assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(profile)}`)
+  }
 })

--- a/turbollm/src/api/preset-routes.ts
+++ b/turbollm/src/api/preset-routes.ts
@@ -1,7 +1,7 @@
 // Model load preset HTTP routes (ADR-353). A preset is a named saved load-config for one
 // modelKey — many per model, versus the single per-(model, engine) profile in modelProfiles.
 // Conversations never see presets; the pin (cfg.lastPresetId) is what getModelProfile consults.
-//   GET    /api/v1/models/:key/presets            — list ModelPreset[], newest updatedAt first
+//   GET    /api/v1/models/:key/presets            — { presets, pinnedId }, newest updatedAt first
 //   POST   /api/v1/models/:key/presets            — create {name, engineId?, profile} → 201
 //   PUT    /api/v1/models/:key/presets/:id        — update {name?, engineId?, profile?}
 //   DELETE /api/v1/models/:key/presets/:id        — delete (keeps the array; clears a matching pin)
@@ -10,6 +10,7 @@ import type { Hono } from 'hono'
 import { randomUUID } from 'node:crypto'
 import type { Deps } from '../deps'
 import { MODEL_PRESET_CAP, type ModelPreset } from '../config/config'
+import { validateLoadProfileFields } from './profile-validate'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function err(c: any, status: number, code: string, message: string) {
@@ -21,29 +22,34 @@ async function body<T>(c: any): Promise<T> {
   try { return (await c.req.json()) as T } catch { return {} as T }
 }
 
-// A preset's profile is a LoadProfile — a plain JSON object. Arrays and scalars are rejected
-// at the boundary: a scalar profile would pass normalize() (profile is `unknown`) and then
-// break every consumer that indexes into it.
-function isProfileObject(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null && !Array.isArray(v)
-}
-
 export function registerPresetRoutes(app: Hono, d: Deps): void {
+  // Returns the pin alongside the list. The client cannot know which preset is active otherwise,
+  // and a dropdown that always opens on "No preset applied" is actively misleading: the pin is
+  // what getModelProfile serves on the next load.
   app.get('/api/v1/models/:key/presets', (c) => {
     const key = decodeURIComponent(c.req.param('key'))
-    const presets = d.store.snapshot().modelPresets[key] ?? []
-    return c.json([...presets].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0)))
+    const snap = d.store.snapshot()
+    const presets = snap.modelPresets[key] ?? []
+    return c.json({
+      presets: [...presets].sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0)),
+      pinnedId: snap.lastPresetId[key] ?? null,
+    })
   })
 
   app.post('/api/v1/models/:key/presets', async (c) => {
     const key = decodeURIComponent(c.req.param('key'))
+    // Same model-existence guard PUT /models/:key/profile applies — without it any client can
+    // write presets under unlimited arbitrary keys into config.json.
+    if (!d.scanner.get(key)) return err(c, 404, 'no_such_model', 'No model with that key.')
     const b = await body<Partial<ModelPreset>>(c)
     if (typeof b.name !== 'string' || !b.name.trim()) {
       return err(c, 400, 'invalid_config_value', 'name is required.')
     }
-    if (!isProfileObject(b.profile)) {
-      return err(c, 400, 'invalid_config_value', 'profile must be a JSON object.')
-    }
+    // Field-level validation, not just shape: a pinned preset's profile is handed verbatim to
+    // profileToArgs, so a bad field here becomes a broken engine command line and every later
+    // load of that model fails. Must match PUT /models/:key/profile exactly.
+    const invalid = validateLoadProfileFields(b.profile, { requireCtx: true })
+    if (invalid) return err(c, 400, 'invalid_config_value', invalid)
     // Cap pre-check BEFORE store.update — update() runs validate() and throws, so a cap
     // breach here would be a 500. The cap is PER MODEL.
     if ((d.store.snapshot().modelPresets[key] ?? []).length >= MODEL_PRESET_CAP) {
@@ -72,13 +78,21 @@ export function registerPresetRoutes(app: Hono, d: Deps): void {
     if (b.name !== undefined && (typeof b.name !== 'string' || !b.name.trim())) {
       return err(c, 400, 'invalid_config_value', 'name must be a non-empty string.')
     }
-    if (b.profile !== undefined && !isProfileObject(b.profile)) {
-      return err(c, 400, 'invalid_config_value', 'profile must be a JSON object.')
+    if (b.profile !== undefined) {
+      // Partial-tolerant: a patch may omit ctx, but whatever it DOES set must be loadable.
+      const bad = validateLoadProfileFields(b.profile, { requireCtx: false })
+      if (bad) return err(c, 400, 'invalid_config_value', bad)
     }
+    // The 404 pre-check above happened before `await body()` yielded the event loop, so a delete
+    // for this same id can land in between. Track whether the preset still existed at write time
+    // and 404 rather than returning 200 with an empty body (which makes the client's res.json()
+    // throw a parse error instead of showing "Preset not found").
+    let stillExists = false
     d.store.update((cfg) => {
       const arr = cfg.modelPresets[key] ?? []
       const i = arr.findIndex((p) => p.id === id)
       if (i === -1) return
+      stillExists = true
       const p = arr[i]
       if (b.name !== undefined) p.name = b.name.trim()
       if (typeof b.engineId === 'string') p.engineId = b.engineId
@@ -89,7 +103,10 @@ export function registerPresetRoutes(app: Hono, d: Deps): void {
         p.updatedAt = new Date().toISOString()
       }
     })
-    return c.json((d.store.snapshot().modelPresets[key] ?? []).find((p) => p.id === id)!)
+    if (!stillExists) return err(c, 404, 'not_found', 'Preset not found.')
+    const updated = (d.store.snapshot().modelPresets[key] ?? []).find((p) => p.id === id)
+    if (!updated) return err(c, 404, 'not_found', 'Preset not found.')
+    return c.json(updated)
   })
 
   app.delete('/api/v1/models/:key/presets/:id', (c) => {

--- a/turbollm/src/api/profile-pin.test.ts
+++ b/turbollm/src/api/profile-pin.test.ts
@@ -1,0 +1,127 @@
+// Route-level tests for the preset PIN lifecycle on `PUT /api/v1/models/:key/profile` and
+// `POST .../profile/reset` (ADR-353). These cover three behaviours that a pure-function test
+// cannot reach, because the decision depends on the real handler reading `?engine=` off a
+// request Context — and all three were bugs found in review:
+//
+//   1. A save whose profile is IDENTICAL to the pinned preset must KEEP the pin. The Load
+//      button's "Remember these settings" is ON by default and fires exactly this save on the
+//      draft the preset just filled in; unpinning there made the shipped promise ("your pick is
+//      remembered and auto-applied on the next load") false on the default path.
+//   2. A save that genuinely CHANGES the profile must still clear the pin, or the save appears
+//      to do nothing (getModelProfile serves the pin first).
+//   3. The pin is per-MODEL while save/reset are per-ENGINE. Neither may clear a pin belonging
+//      to a DIFFERENT engine — that would drop engine A's tune for an edit to engine B, against
+//      the per-engine contract of issue #35.
+//
+// Mirrors keys-network.test.ts's "real app, minimal Deps double" discipline.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerApi } from './routes'
+import { defaultConfig, type Config, type ModelPreset } from '../config/config'
+import type { Deps } from '../deps'
+
+const KEY = 'm|q4|1'
+const ENGINE_A = 'engine-a'
+const ENGINE_B = 'engine-b'
+const PROFILE = { ctx: 4096, ngl: 99 }
+
+function fakeApp(cfg: Config): Hono {
+  const app = new Hono()
+  const d = {
+    version: 'test',
+    store: { snapshot: () => cfg, update: (fn: (c: Config) => void) => fn(cfg) },
+    scanner: { get: (k: string) => (k === KEY ? { key: KEY } : undefined) },
+    registry: { active: () => ({ id: ENGINE_A }) },
+    manager: { status: () => ({ state: 'stopped', model: null }) },
+  } as unknown as Deps
+  registerApi(app, d)
+  return app
+}
+
+function withPinnedPreset(engineId: string, profile: unknown = PROFILE): Config {
+  const cfg = defaultConfig()
+  const preset: ModelPreset = {
+    id: 'pinned',
+    name: 'Pinned',
+    engineId,
+    profile,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    origin: 'manual',
+  }
+  cfg.modelPresets = { [KEY]: [preset] }
+  cfg.lastPresetId = { [KEY]: 'pinned' }
+  return cfg
+}
+
+function saveProfile(app: Hono, profile: unknown, engine?: string) {
+  const q = engine ? `?engine=${encodeURIComponent(engine)}` : ''
+  return app.request(`/api/v1/models/${encodeURIComponent(KEY)}/profile${q}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(profile),
+  })
+}
+
+test('PUT /profile: a save identical to the pinned preset KEEPS the pin', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await saveProfile(fakeApp(cfg), { ...PROFILE }, ENGINE_A)
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], 'pinned')
+})
+
+test('PUT /profile: key order does not matter when comparing against the pinned preset', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  // Same values, different property order — a naive JSON.stringify compare would unpin here.
+  const res = await saveProfile(fakeApp(cfg), { ngl: 99, ctx: 4096 }, ENGINE_A)
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], 'pinned')
+})
+
+test('PUT /profile: a save that CHANGES the profile clears the pin', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await saveProfile(fakeApp(cfg), { ctx: 8192, ngl: 99 }, ENGINE_A)
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], undefined)
+})
+
+test('PUT /profile: saving engine B does NOT clear a pin belonging to engine A', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await saveProfile(fakeApp(cfg), { ctx: 8192 }, ENGINE_B)
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], 'pinned')
+})
+
+test('PUT /profile: an engine-agnostic pin ("") is cleared by a changing save on any engine', async () => {
+  const cfg = withPinnedPreset('')
+  const res = await saveProfile(fakeApp(cfg), { ctx: 8192 }, ENGINE_B)
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], undefined)
+})
+
+test('PUT /profile: bad profile fields are rejected before anything is written', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await saveProfile(fakeApp(cfg), { ctx: 4096, nCpuMoe: null }, ENGINE_A)
+  assert.equal(res.status, 400)
+  assert.equal(cfg.lastPresetId[KEY], 'pinned')
+})
+
+test('POST /profile/reset: resetting engine B does NOT clear a pin belonging to engine A', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await fakeApp(cfg).request(
+    `/api/v1/models/${encodeURIComponent(KEY)}/profile/reset?engine=${ENGINE_B}`,
+    { method: 'POST' },
+  )
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], 'pinned')
+})
+
+test('POST /profile/reset: resetting the pinned engine DOES clear the pin', async () => {
+  const cfg = withPinnedPreset(ENGINE_A)
+  const res = await fakeApp(cfg).request(
+    `/api/v1/models/${encodeURIComponent(KEY)}/profile/reset?engine=${ENGINE_A}`,
+    { method: 'POST' },
+  )
+  assert.equal(res.status, 200)
+  assert.equal(cfg.lastPresetId[KEY], undefined)
+})

--- a/turbollm/src/api/profile-validate.ts
+++ b/turbollm/src/api/profile-validate.ts
@@ -1,0 +1,79 @@
+// Shared load-profile field validation for the two write paths that accept a profile from a
+// client: `PUT /api/v1/models/:key/profile` and the preset create/update routes (ADR-353).
+//
+// Why it is shared: a stored profile is handed verbatim to `profileToArgs`, which turns it into
+// an engine command line. A bad field is not a display problem — `gpu.tensorSplit` that is not an
+// array throws inside `profileToArgs`, and a stored `nCpuMoe: null` becomes a literal
+// `--n-cpu-moe null` argument. The profile route has rejected these at the boundary since the
+// 2026-08-06 fix; presets are a SECOND way into the same storage and must reject them identically,
+// or a preset can be pinned and make a model unloadable until the pin is cleared by hand.
+//
+// Partial-tolerant by design: every check is skipped when the field is absent, so an older client
+// that omits `gpu`/`nCpuMoe` still writes cleanly. `requireCtx` is the one caller-dependent knob —
+// the profile route demands a usable ctx, a preset patch may legitimately omit it.
+
+/** Returns a human-readable reason the profile is invalid, or `null` when it is acceptable. */
+export function validateLoadProfileFields(p: unknown, opts: { requireCtx: boolean }): string | null {
+  if (!p || typeof p !== 'object' || Array.isArray(p)) return 'profile must be a JSON object.'
+  const prof = p as Record<string, unknown>
+
+  const ctx = prof.ctx
+  if (opts.requireCtx || ctx !== undefined) {
+    if (typeof ctx !== 'number' || !Number.isFinite(ctx) || ctx < 256) {
+      return 'ctx must be at least 256.'
+    }
+  }
+
+  // Multi-GPU split settings (ADR-054), validated only when present.
+  if (prof.gpu !== undefined) {
+    const g = prof.gpu as Record<string, unknown>
+    if (!g || typeof g !== 'object' || Array.isArray(g)) return 'gpu must be a JSON object.'
+    if (!['layer', 'row', 'none'].includes(g.splitMode as string)) {
+      return 'gpu.splitMode must be layer, row, or none.'
+    }
+    if (!Array.isArray(g.tensorSplit) || g.tensorSplit.some((n) => typeof n !== 'number' || !(n >= 0))) {
+      return 'gpu.tensorSplit must be an array of non-negative numbers.'
+    }
+    if (!Number.isInteger(g.mainGpu) || (g.mainGpu as number) < -1) {
+      return 'gpu.mainGpu must be an integer ≥ -1.'
+    }
+    if (!Number.isInteger(g.tensorParallelSize) || (g.tensorParallelSize as number) < 1) {
+      return 'gpu.tensorParallelSize must be an integer ≥ 1.'
+    }
+  }
+
+  if (prof.nCpuMoe !== undefined) {
+    const n = prof.nCpuMoe
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) {
+      return 'nCpuMoe must be a non-negative number.'
+    }
+  }
+
+  if (prof.ngl !== undefined) {
+    const n = prof.ngl
+    if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) {
+      return 'ngl must be a non-negative number.'
+    }
+  }
+
+  return null
+}
+
+/** Order-independent deep equality for two stored profiles.
+ *
+ *  Used to decide whether a manual profile save actually diverges from the pinned preset. A save
+ *  that writes exactly the pinned preset's values (the Load button's "Remember these settings",
+ *  which fires on the draft the preset just filled in) must NOT unpin it — otherwise the
+ *  advertised "your pick is remembered and auto-applied on the next load" is false on the default
+ *  path. A save that genuinely changes something still supersedes the pin. */
+export function profilesEqual(a: unknown, b: unknown): boolean {
+  return canonical(a) === canonical(b)
+}
+
+function canonical(v: unknown): string {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v) ?? 'null'
+  if (Array.isArray(v)) return `[${v.map(canonical).join(',')}]`
+  const o = v as Record<string, unknown>
+  const keys = Object.keys(o).filter((k) => o[k] !== undefined).sort()
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonical(o[k])}`).join(',')}}`
+}

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -55,6 +55,7 @@ import { HfError, type HfSortOption } from '../hf/hf'
 import { DownloadError } from '../downloads/downloads'
 import { BenchError } from '../bench/bench'
 import { inferRepoFromPath } from './path-utils'
+import { validateLoadProfileFields, profilesEqual } from './profile-validate'
 import { screenshotArtifact, findChrome } from '../artifacts/screenshot'
 import { readQueue, remove as removeQueued } from '../telemetry/queue'
 import { sendConsentChoice } from '../telemetry/consent'
@@ -1569,42 +1570,30 @@ export function registerApi(app: Hono, d: Deps): void {
     const e = d.scanner.get(key)
     if (!e) return err(c, 404, 'no_such_model', 'No model with that key.')
     const p = await body<LoadProfile>(c)
-    if (!p || typeof p.ctx !== 'number' || p.ctx < 256) {
-      return err(c, 400, 'invalid_profile_value', 'ctx must be at least 256.')
-    }
-    // Multi-GPU split settings (ADR-054). Validate only when present so older clients
-    // that omit `gpu` still save cleanly.
-    if (p.gpu) {
-      const g = p.gpu
-      if (!['layer', 'row', 'none'].includes(g.splitMode)) {
-        return err(c, 400, 'invalid_profile_value', 'gpu.splitMode must be layer, row, or none.')
-      }
-      if (!Array.isArray(g.tensorSplit) || g.tensorSplit.some((n) => typeof n !== 'number' || !(n >= 0))) {
-        return err(c, 400, 'invalid_profile_value', 'gpu.tensorSplit must be an array of non-negative numbers.')
-      }
-      if (!Number.isInteger(g.mainGpu) || g.mainGpu < -1) {
-        return err(c, 400, 'invalid_profile_value', 'gpu.mainGpu must be an integer ≥ -1.')
-      }
-      if (!Number.isInteger(g.tensorParallelSize) || g.tensorParallelSize < 1) {
-        return err(c, 400, 'invalid_profile_value', 'gpu.tensorParallelSize must be an integer ≥ 1.')
-      }
-    }
-    // profileToArgs now emits --n-cpu-moe explicitly at every value including 0 (2026-08-06
-    // fix) instead of silently omitting it when falsy — a stored `null`/non-number would
-    // previously just get skipped, but now becomes a literal `--n-cpu-moe null` on the launch
-    // command line. Reject it here at the boundary rather than let it reach the engine. A
-    // genuinely absent key (older client, dense-model-only save) is still allowed through.
-    if (p.nCpuMoe !== undefined && (typeof p.nCpuMoe !== 'number' || !Number.isFinite(p.nCpuMoe) || p.nCpuMoe < 0)) {
-      return err(c, 400, 'invalid_profile_value', 'nCpuMoe must be a non-negative number.')
-    }
+    // Field validation lives in profile-validate.ts because the preset routes are a SECOND way
+    // into the same storage and must reject exactly the same things (ADR-353) — a bad field here
+    // reaches profileToArgs and the engine command line.
+    const invalid = validateLoadProfileFields(p, { requireCtx: true })
+    if (invalid) return err(c, 400, 'invalid_profile_value', invalid)
     // Per-engine profile (issue #35): save into the slot for the engine the client is
     // editing (?engine=<id>), falling back to the active engine, then the '*' fallback.
     const engineId = c.req.query('engine') || d.registry.active()?.id || '*'
     d.store.update((cfg) => {
       setModelProfile(cfg, key, engineId, p)
-      // An explicit manual save means "this is my config now" and supersedes the pin. Without
-      // this the save silently does nothing: it writes modelProfiles, but reads return the pin.
-      if (cfg.lastPresetId[key]) delete cfg.lastPresetId[key]
+      // An explicit manual save that CHANGES something supersedes the pin: PUT writes
+      // modelProfiles, but getModelProfile returns the pin first, so a stale pin makes the save
+      // look like it did nothing. Two exceptions, both found in review:
+      //  - A save identical to the pinned preset is not a divergence. "Remember these settings"
+      //    is ON by default and fires exactly this save on the draft the preset just filled in —
+      //    unpinning there silently broke "your pick is remembered and auto-applied next load".
+      //  - The pin is per-MODEL, this save is per-ENGINE. Clearing a pin belonging to a DIFFERENT
+      //    engine drops that engine's tune for an edit unrelated to it (issue #35's contract).
+      const pinnedId = cfg.lastPresetId[key]
+      if (pinnedId) {
+        const pinned = (cfg.modelPresets[key] ?? []).find((x) => x.id === pinnedId)
+        const thisEngine = !pinned || pinned.engineId === '' || pinned.engineId === engineId
+        if (thisEngine && !(pinned && profilesEqual(pinned.profile, p))) delete cfg.lastPresetId[key]
+      }
     })
     return c.json(p)
   })
@@ -1616,9 +1605,14 @@ export function registerApi(app: Hono, d: Deps): void {
     const engineId = c.req.query('engine') || d.registry.active()?.id || '*'
     d.store.update((cfg) => {
       deleteModelProfile(cfg, key, engineId)
-      // Deliberate asymmetry: reset is per-engine, lastPresetId is per-model — a reset must not
-      // leave a stale pin shadowing the result.
-      if (cfg.lastPresetId[key]) delete cfg.lastPresetId[key]
+      // A reset must not leave a stale pin shadowing the result — but only for the engine being
+      // reset. The pin is per-MODEL and this reset is per-ENGINE, so clearing a pin that belongs
+      // to a different engine would drop that engine's tune for an unrelated action (issue #35).
+      const pinnedId = cfg.lastPresetId[key]
+      if (pinnedId) {
+        const pinned = (cfg.modelPresets[key] ?? []).find((x) => x.id === pinnedId)
+        if (!pinned || pinned.engineId === '' || pinned.engineId === engineId) delete cfg.lastPresetId[key]
+      }
     })
     return c.json({ ok: true })
   })

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -1152,11 +1152,20 @@ export function prunePresets(cfg: Config, modelKey: string): void {
   )
   let cur = excess.size === 0 ? arr : arr.filter((p) => !excess.has(p.id))
 
-  // Rule 4.
+  // Rule 4. Note this can remove a MANUAL preset — a save the user made by hand — because an
+  // over-cap array makes validate() throw and would then break every unrelated config write.
+  // That trade is deliberate, but it must never be silent: losing your own saved config with no
+  // feedback is worse than the log line being noisy.
   while (cur.length > MODEL_PRESET_CAP) {
     const candidates = cur.filter((p) => p.id !== pinnedId).sort(byOldest)
     if (candidates.length === 0) break
-    cur = cur.filter((p) => p.id !== candidates[0].id)
+    const victim = candidates[0]
+    if (victim.origin === 'manual') {
+      console.warn(
+        `[presets] model "${modelKey}" is at the ${MODEL_PRESET_CAP}-preset cap — deleting your oldest saved preset "${victim.name}" (${victim.updatedAt}) to make room. Delete some presets to stop this.`,
+      )
+    }
+    cur = cur.filter((p) => p.id !== victim.id)
   }
 
   if (cur.length > MODEL_PRESET_CAP) {

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -483,8 +483,10 @@ export function resetModelProfile(key: string, engineId: string): Promise<{ ok: 
 
 // ── Model load presets (ADR-353) ─────────────────────────────────────────────
 /** List a model's presets, newest updatedAt first. */
-export function fetchModelPresets(modelKey: string): Promise<ModelPreset[]> {
-  return request<ModelPreset[]>(`/api/v1/models/${encodeURIComponent(modelKey)}/presets`)
+export function fetchModelPresets(modelKey: string): Promise<{ presets: ModelPreset[]; pinnedId: string | null }> {
+  return request<{ presets: ModelPreset[]; pinnedId: string | null }>(
+    `/api/v1/models/${encodeURIComponent(modelKey)}/presets`,
+  )
 }
 
 /** Create a preset from the current draft. 400 `too_many_presets` at the per-model cap. */

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -220,6 +220,9 @@ export function useBenchActions() {
       onSuccess: (_d, _v) => {
         invalidate()
         void qc.invalidateQueries({ queryKey: ['model'] })
+        // Auto-tune mints a preset and pins it server-side (bench.ts persistBest), so the
+        // preset list and its pin are both stale after a save.
+        void qc.invalidateQueries({ queryKey: ['model-presets'] })
       },
     }),
   }
@@ -639,6 +642,9 @@ export function useModelActions() {
         invalidate()
         // Prefix-match ['model', key] invalidates every engine variant of the detail query.
         void qc.invalidateQueries({ queryKey: ['model', v.key] })
+        // A save can clear the pin server-side, and the presets panel derives its selection
+        // from that pin — refetch it or the dropdown keeps showing a preset as applied.
+        void qc.invalidateQueries({ queryKey: modelPresetKeys.forModel(v.key) })
       },
     }),
     reset: useMutation({
@@ -646,6 +652,7 @@ export function useModelActions() {
       onSuccess: (_d, v) => {
         invalidate()
         void qc.invalidateQueries({ queryKey: ['model', v.key] })
+        void qc.invalidateQueries({ queryKey: modelPresetKeys.forModel(v.key) })
       },
     }),
     load: useMutation({
@@ -696,7 +703,9 @@ export const modelPresetKeys = {
   forModel: (key: string) => ['model-presets', key] as const,
 }
 
-export function useModelPresets(modelKey: string | null): UseQueryResult<ModelPreset[]> {
+export function useModelPresets(
+  modelKey: string | null,
+): UseQueryResult<{ presets: ModelPreset[]; pinnedId: string | null }> {
   return useQuery({
     queryKey: modelPresetKeys.forModel(modelKey ?? ''),
     queryFn: () => fetchModelPresets(modelKey as string),

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+﻿import { useEffect, useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { ChevronDown, ExternalLink, Gauge, MoreHorizontal, RotateCcw, Save, X, Zap } from 'lucide-react'
 import { ApiError, track } from '../../lib/api'
 import { useBenchActions, useBenchState, useEngines, useModelActions, useModelDetail, useModelPresetMutations, useModelPresets, useStatus } from '../../lib/queries'
@@ -68,18 +68,15 @@ function PresetsPanel({
   draft,
   onApplyPreset,
   activeEngineId,
-  save,
-  reset,
 }: {
   modelKey: string
   draft: LoadProfile
   onApplyPreset: (profile: Partial<LoadProfile>) => void
   activeEngineId?: string
-  save: { isPending: boolean; isSuccess: boolean }
-  reset: { isPending: boolean; isSuccess: boolean }
 }) {
   const presetsQ = useModelPresets(modelKey)
-  const presets = presetsQ.data ?? []
+  const presets = presetsQ.data?.presets ?? []
+  const pinnedId = presetsQ.data?.pinnedId ?? null
   const m = useModelPresetMutations(modelKey)
   const enginesQ = useEngines()
   const engineName = (id: string) => enginesQ.data?.engines.find((e) => e.id === id)?.name ?? id
@@ -91,26 +88,15 @@ function PresetsPanel({
   const [nameValue, setNameValue] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<ModelPreset | null>(null)
 
-  // A successful profile save or reset clears the pin server-side — drop the local
-  // "applied" selection so the dropdown never asserts a state that no longer exists.
-  // Watch the pending→settled transition of each mutation (isSuccess tells success
-  // apart from error; a failed save must NOT clear the selection).
-  const savePending = useRef(false)
+  // The selection MIRRORS the server pin rather than being tracked independently. `selectedId`
+  // used to start null on every mount and no endpoint returned the pin, so the dropdown read
+  // "No preset applied" every time the panel opened — even though that pin is exactly what
+  // getModelProfile serves on the next load. Deriving it from the pin also removes the need to
+  // guess when to clear: a profile save/reset that drops the pin, an auto-tune that sets one, or
+  // a delete of the pinned preset all invalidate this query and flow through here.
   useEffect(() => {
-    if (save.isPending) savePending.current = true
-    else if (savePending.current) {
-      savePending.current = false
-      if (save.isSuccess) setSelectedId(null)
-    }
-  }, [save.isPending, save.isSuccess])
-  const resetPending = useRef(false)
-  useEffect(() => {
-    if (reset.isPending) resetPending.current = true
-    else if (resetPending.current) {
-      resetPending.current = false
-      if (reset.isSuccess) setSelectedId(null)
-    }
-  }, [reset.isPending, reset.isSuccess])
+    setSelectedId(pinnedId)
+  }, [pinnedId])
 
   const selected = presets.find((p) => p.id === selectedId) ?? null
   const mismatch = !!selected && selected.engineId !== '' && selected.engineId !== activeEngineId
@@ -141,6 +127,9 @@ function PresetsPanel({
   const confirmName = () => {
     const name = nameValue.trim()
     if (!name || !nameDialog) return
+    // The Enter path keeps the dialog open until the mutation settles, so two quick presses
+    // would fire two POSTs and create two identically-named presets (only ids are unique).
+    if (m.create.isPending || m.update.isPending) return
     if (nameDialog.mode === 'save') {
       track('models', 'create_model_preset')
       m.create.mutate(
@@ -266,7 +255,12 @@ function PresetsPanel({
           />
           <AlertDialogFooter>
             <AlertDialogCancel onClick={() => setNameDialog(null)}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmName}>{nameDialog?.mode === 'save' ? 'Save' : 'Rename'}</AlertDialogAction>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); confirmName() }}
+              disabled={m.create.isPending || m.update.isPending}
+            >
+              {nameDialog?.mode === 'save' ? 'Save' : 'Rename'}
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -492,8 +486,6 @@ export function ModelDetailDialog({
               draft={draft}
               onApplyPreset={(profile) => setDraft((d) => (d ? mergePresetIntoDraft(d, profile) : d))}
               activeEngineId={activeEngine?.id}
-              save={actions.save}
-              reset={actions.reset}
             />
 
             {fit && (

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -146,7 +146,20 @@ function PresetsPanel({
       m.create.mutate(
         { name, engineId: activeEngineId ?? '', profile: draft },
         {
-          onSuccess: () => setNameDialog(null),
+          // A just-saved preset IS the panel's current settings, so it becomes the active one —
+          // selected in the dropdown AND pinned server-side. Without the pin this desyncs: the
+          // dropdown would read "No preset applied" right after saving, and the next non-UI load
+          // (gateway auto-swap, `turbollm launch --model`) would ignore what was just saved,
+          // because POST /presets deliberately only creates — /apply is what pins.
+          onSuccess: (created) => {
+            setNameDialog(null)
+            setSelectedId(created.id)
+            m.apply.mutate(created.id, {
+              // Creation succeeded; only the pin failed. Drop the selection so the dropdown does
+              // not claim an active preset the server has no pin for.
+              onError: () => setSelectedId(null),
+            })
+          },
           onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not save preset.'),
         },
       )


### PR DESCRIPTION
Follow-up to #168, found by an independent Opus review pass plus founder testing. **v1.11.0 was tagged but never published to npm**, so the tag and GitHub release were deleted and will be re-cut against this merge — same as the `v1.9.9` precedent. No published version is affected.

## The advertised behaviour was broken on the default path

The release notes, README and in-app persona all claim *"the pick is remembered and auto-applied on the next load"*. Two bugs made that false:

- **The pin was never exposed to any client.** `lastPresetId` appeared in no response body, and `selectedId` started `null` on every mount — so the dropdown read **"No preset applied"** every time the panel opened, even when a pin was set and *would* be used on the next load. `GET /presets` now returns `{ presets, pinnedId }` and the panel derives its selection from it. That also replaces the two manual save/reset effects that were guessing when to clear the selection.
- **Loading with "Remember these settings" (ON by default) deleted the pin.** That path fires a profile save, which unconditionally cleared it. A save whose profile is *identical* to the pinned preset now keeps it; one that genuinely changes something still supersedes it.

## Other fixes

- **Save/reset are per-engine, the pin is per-model** — either could clear a pin belonging to a *different* engine, dropping that engine's tune for an unrelated edit. Both are now engine-scoped (issue #35's contract).
- **Preset routes validated only that `profile` was an object, never its fields**, while `PUT /profile` rejected each one. A preset with `gpu.tensorSplit: "not-an-array"` was accepted, pinnable, and then threw inside `profileToArgs` on every subsequent load — persisting across restarts. Field validation is now shared by both paths (`profile-validate.ts`).
- `POST /presets` 404s on an unknown model key, matching `PUT /profile`.
- `PUT` racing a concurrent delete returned `200` with an empty body (the client's `res.json()` threw a parse error); now `404`.
- `prunePresets`' cap fallback can delete a user's own manual preset — it now says so instead of doing it silently.
- Name dialog: guarded against Enter double-submit creating duplicate presets, and stopped `AlertDialogAction` auto-closing before the mutation settles (which discarded the typed name on error).
- `bench.save` now invalidates the preset query, since auto-tune mints and pins one.
- A just-saved preset becomes the active one (selected **and** pinned) — `POST /presets` only creates by design.

## Verification

- **2486 tests pass / 0 fail** — 18 new, covering the pin lifecycle, engine scoping, key-order-independent profile comparison, and field rejection
- Backend + web typechecks clean
- Verified live against a real daemon: pin returned by `GET`; apply sets it; an identical save keeps it; a changing save clears it; malformed profiles rejected 400; unknown model key 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)