### PR TITLE
fix(bench): auto-tune spill false-positive on NextN pinned host memory

### DIFF
--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -562,6 +562,11 @@ export class BenchRunner {
     const budgetMb = gpuBudgetMb(sys, base)
     // Host memory this config pins regardless of offload, measured from the probes below.
     let spillFloorMb: number | null = null
+    // True when budgetMb/vramAbsMb below are a multi-GPU SUM (a layer/row split across >1 card)
+    // rather than one card's own numbers — the proximity/floor corroboration is unsound there
+    // (see spill.ts's `isSpilling` doc: a card can be individually saturated and demoting while
+    // the pool still reads roomy), so it falls back to the pre-fix tolerance-only check.
+    const pooled = sys.gpus.length > 1 && base.gpu.splitMode !== 'none'
 
     if (sys.gpus.length > 0) {
       // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with enough headroom VRAM.
@@ -578,8 +583,8 @@ export class BenchRunner {
         await this.settleGpu(sys)
         // Learn this config's fixed host-memory cost from probes that had VRAM to spare, so the
         // near-the-ceiling candidate the search is heading for isn't rejected for it (see spillFloor).
-        spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb)
-        const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb)
+        spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb, pooled)
+        const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb, pooled)
         if (verdict.decision === 'fits') {
           bestNgl = mid // fits with headroom AND isn't spilling → record, try MORE GPU layers
           lo = mid + 1
@@ -600,7 +605,7 @@ export class BenchRunner {
     // Same two ways the real run can invalidate a probe-accepted config as in moeSearch: exceeding
     // the VRAM headroom, or SPILLING once prefill allocates its compute buffers (invisible to a
     // load-only probe). Back off one layer for either.
-    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb) && bestNgl > 0) {
+    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb, pooled) && bestNgl > 0) {
       this.emit(`ngl=${bestNgl} spilled ${Math.round(found.cand.spillMb as number)} MB once actually generating (the load-only probe could not see this) — retrying at ngl=${bestNgl - 1}`)
       const safer = await this.benchAt(entry, sys, { ...base, ngl: bestNgl - 1 }, caps, results, `ngl=${bestNgl - 1} (spill backoff)`)
       if (safer) { found = safer; bestNgl = bestNgl - 1 }
@@ -680,6 +685,9 @@ export class BenchRunner {
     let bestN: number | null = null
     // Host memory this config pins regardless of offload, measured from the probes below.
     let spillFloorMb: number | null = null
+    // See denseSearch's identical line — proximity/floor corroboration is unsound once
+    // budgetMb/vramAbsMb are a multi-GPU sum, so a pooled split falls back to tolerance-only.
+    const pooled = sys.gpus.length > 1 && base.gpu.splitMode !== 'none'
 
     while (lo <= hi && !this.cancelled && Date.now() <= this.deadline) {
       const mid = Math.floor((lo + hi) / 2)
@@ -689,8 +697,8 @@ export class BenchRunner {
       await this.settleGpu(sys)
       // Learn this config's fixed host-memory cost from probes that had VRAM to spare, so the
       // near-the-ceiling candidate the search is heading for isn't rejected for it (see spillFloor).
-      spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb)
-      const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb)
+      spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb, pooled)
+      const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb, pooled)
       if (verdict.decision === 'fits') {
         bestN = mid // fits with headroom AND isn't spilling → record, try FEWER CPU experts
         hi = mid - 1
@@ -734,7 +742,7 @@ export class BenchRunner {
     // Two ways the real run can invalidate a config the load-only probe accepted: it can exceed the
     // VRAM headroom (ADR-217), or it can SPILL once prefill allocates its compute buffers — which
     // the probe cannot see, because it never generates. Back off one step for either.
-    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb) && foundN < maxN) {
+    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb, pooled) && foundN < maxN) {
       this.emit(`nCpuMoe=${foundN} spilled ${Math.round(found.cand.spillMb as number)} MB once actually generating (the load-only probe could not see this) — retrying at nCpuMoe=${foundN + 1}`)
       const safer = await this.benchAt(entry, sys, { ...base, nCpuMoe: foundN + 1 }, caps, results, `nCpuMoe=${foundN + 1} (spill backoff)`)
       if (safer) { found = safer; foundN = foundN + 1 }
@@ -1649,9 +1657,12 @@ export function probeVerdict(
   /** Host memory this config pins at ANY offload, learned from earlier probes — see `spillFloor`.
    *  Null (the default) means nothing has been measured yet and nothing is subtracted. */
   spillFloorMb: number | null = null,
+  /** True when `budgetMb`/`probe.vramAbsMb` are a multi-GPU SUM rather than one card's own
+   *  numbers — see `isSpilling`'s `pooled` doc for why the corroboration must be skipped there. */
+  pooled = false,
 ): ProbeVerdict {
   if (probe.outcome === 'oom') return { decision: 'offload-more', reason: 'oom' }
-  if (isSpilling(probe.spillMb, probe.vramAbsMb, budgetMb, spillFloorMb)) {
+  if (isSpilling(probe.spillMb, probe.vramAbsMb, budgetMb, spillFloorMb, pooled)) {
     return { decision: 'offload-more', reason: 'spill', shortfallMb: probe.spillMb as number }
   }
   // Free VRAM below the user's configured headroom → too tight, offload more.

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -17,7 +17,7 @@ import type { Registry } from '../engines/registry'
 import type { Engine } from '../config/config'
 import type { Scanner, ModelEntry } from '../models/scanner'
 import { deriveDefault, estimateVram, gpuBudgetMb, profileToArgs, resolveProfile, type GpuProfile, type LoadProfile } from '../models/profile'
-import { isSpilling, spillMb } from './spill'
+import { isSpilling, spillFloor, spillMb } from './spill'
 import { getSysInfo, type SysInfo } from '../sysinfo/sysinfo'
 import type { HfClient } from '../hf/hf'
 import { inferRepoFromPath } from '../api/path-utils'
@@ -560,6 +560,8 @@ export class BenchRunner {
     // edge. Computed unconditionally (0 on a CPU-only box) so the Phase-2 re-check below can reuse
     // it too (ADR-217) — `overHeadroom` treats a ≤0 budget as "never over".
     const budgetMb = gpuBudgetMb(sys, base)
+    // Host memory this config pins regardless of offload, measured from the probes below.
+    let spillFloorMb: number | null = null
 
     if (sys.gpus.length > 0) {
       // Binary search ngl ∈ [0, blockCount] for the HIGHEST that loads with enough headroom VRAM.
@@ -574,7 +576,10 @@ export class BenchRunner {
         const probe = await this.probeVram(entry, sys, { ...base, ngl: mid }, caps)
         this.pushProbe(results, base, 'ngl', mid, probe)
         await this.settleGpu(sys)
-        const verdict = probeVerdict(probe, budgetMb, headroomMb)
+        // Learn this config's fixed host-memory cost from probes that had VRAM to spare, so the
+        // near-the-ceiling candidate the search is heading for isn't rejected for it (see spillFloor).
+        spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb)
+        const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb)
         if (verdict.decision === 'fits') {
           bestNgl = mid // fits with headroom AND isn't spilling → record, try MORE GPU layers
           lo = mid + 1
@@ -595,7 +600,7 @@ export class BenchRunner {
     // Same two ways the real run can invalidate a probe-accepted config as in moeSearch: exceeding
     // the VRAM headroom, or SPILLING once prefill allocates its compute buffers (invisible to a
     // load-only probe). Back off one layer for either.
-    if (found && isSpilling(found.cand.spillMb) && bestNgl > 0) {
+    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb) && bestNgl > 0) {
       this.emit(`ngl=${bestNgl} spilled ${Math.round(found.cand.spillMb as number)} MB once actually generating (the load-only probe could not see this) — retrying at ngl=${bestNgl - 1}`)
       const safer = await this.benchAt(entry, sys, { ...base, ngl: bestNgl - 1 }, caps, results, `ngl=${bestNgl - 1} (spill backoff)`)
       if (safer) { found = safer; bestNgl = bestNgl - 1 }
@@ -673,6 +678,8 @@ export class BenchRunner {
     // fewer probes per sweep. See spill.ts for why derivation was removed.
     let lo = 0, hi = maxN
     let bestN: number | null = null
+    // Host memory this config pins regardless of offload, measured from the probes below.
+    let spillFloorMb: number | null = null
 
     while (lo <= hi && !this.cancelled && Date.now() <= this.deadline) {
       const mid = Math.floor((lo + hi) / 2)
@@ -680,7 +687,10 @@ export class BenchRunner {
       const probe = await this.probeVram(entry, sys, { ...base, nCpuMoe: mid }, caps)
       this.pushProbe(results, base, 'nCpuMoe', mid, probe)
       await this.settleGpu(sys)
-      const verdict = probeVerdict(probe, budgetMb, headroomMb)
+      // Learn this config's fixed host-memory cost from probes that had VRAM to spare, so the
+      // near-the-ceiling candidate the search is heading for isn't rejected for it (see spillFloor).
+      spillFloorMb = spillFloor(spillFloorMb, probe.spillMb, probe.vramAbsMb, budgetMb)
+      const verdict = probeVerdict(probe, budgetMb, headroomMb, spillFloorMb)
       if (verdict.decision === 'fits') {
         bestN = mid // fits with headroom AND isn't spilling → record, try FEWER CPU experts
         hi = mid - 1
@@ -724,7 +734,7 @@ export class BenchRunner {
     // Two ways the real run can invalidate a config the load-only probe accepted: it can exceed the
     // VRAM headroom (ADR-217), or it can SPILL once prefill allocates its compute buffers — which
     // the probe cannot see, because it never generates. Back off one step for either.
-    if (found && isSpilling(found.cand.spillMb) && foundN < maxN) {
+    if (found && isSpilling(found.cand.spillMb, found.cand.vramAbsMb, budgetMb, spillFloorMb) && foundN < maxN) {
       this.emit(`nCpuMoe=${foundN} spilled ${Math.round(found.cand.spillMb as number)} MB once actually generating (the load-only probe could not see this) — retrying at nCpuMoe=${foundN + 1}`)
       const safer = await this.benchAt(entry, sys, { ...base, nCpuMoe: foundN + 1 }, caps, results, `nCpuMoe=${foundN + 1} (spill backoff)`)
       if (safer) { found = safer; foundN = foundN + 1 }
@@ -1636,9 +1646,12 @@ export function probeVerdict(
   probe: { outcome: BenchCandidate['outcome']; vramAbsMb: number | null; spillMb: number | null },
   budgetMb: number,
   headroomMb: number,
+  /** Host memory this config pins at ANY offload, learned from earlier probes — see `spillFloor`.
+   *  Null (the default) means nothing has been measured yet and nothing is subtracted. */
+  spillFloorMb: number | null = null,
 ): ProbeVerdict {
   if (probe.outcome === 'oom') return { decision: 'offload-more', reason: 'oom' }
-  if (isSpilling(probe.spillMb)) {
+  if (isSpilling(probe.spillMb, probe.vramAbsMb, budgetMb, spillFloorMb)) {
     return { decision: 'offload-more', reason: 'spill', shortfallMb: probe.spillMb as number }
   }
   // Free VRAM below the user's configured headroom → too tight, offload more.

--- a/turbollm/src/bench/spill.test.ts
+++ b/turbollm/src/bench/spill.test.ts
@@ -11,7 +11,13 @@
 // that pinned that machinery are gone with it; what remains pins the measurement.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { spillMb, isSpilling, SPILL_TOLERANCE_MB } from './spill'
+import { spillMb, isSpilling, spillFloor, SPILL_TOLERANCE_MB, SPILL_PROXIMITY_MB } from './spill'
+
+// The founder's card, used by every case below that needs a budget.
+const CARD = 16303
+// A reading taken while the card is saturated — the state a real spill is measured in (see spill.ts:
+// once the driver demotes, used-VRAM pins at the ceiling and stops responding to placement).
+const SATURATED = 15823
 
 // ---- spillMb: the delta across a model load ---------------------------------
 
@@ -43,15 +49,18 @@ test('spillMb: null when either reading is unavailable — callers must not read
 test('isSpilling: separates every real reading measured on Qwen3.6-35B-A3B @200k', () => {
   // Baseline 285.3 MiB subtracted. Under the allowance these are driver overhead, not displaced
   // weights; over it, real spill.
-  for (const under of [0, 186, 442]) assert.equal(isSpilling(under), false, `${under} MiB flagged`)
-  for (const over of [698, 2210, 2914]) assert.equal(isSpilling(over), true, `${over} MiB missed`)
+  // Those readings were all taken with the card saturated (15823-15828 MiB of 16303), so the
+  // proximity corroboration is satisfied throughout and the tolerance alone decides.
+  for (const under of [0, 186, 442]) assert.equal(isSpilling(under, SATURATED, CARD), false, `${under} MiB flagged`)
+  for (const over of [698, 2210, 2914]) assert.equal(isSpilling(over, SATURATED, CARD), true, `${over} MiB missed`)
 })
 
 test('isSpilling: fails OPEN on an unavailable reading', () => {
   // Apple Metal has no discrete VRAM to spill out of; a localized Windows may not resolve the
   // counter name. Both must behave exactly as before spill detection existed — asserting a spill we
   // did not measure would drive those machines to maximum CPU offload for no reason.
-  assert.equal(isSpilling(null), false)
+  assert.equal(isSpilling(null, SATURATED, CARD), false)
+  assert.equal(isSpilling(null, null, 0), false)
 })
 
 test('the measured signal separates fitting from spilling across a 4x model-size range', () => {
@@ -68,8 +77,118 @@ test('the measured signal separates fitting from spilling across a 4x model-size
   const spills = [3199.5, 3647.5, 6343.5]
   assert.ok(Math.max(...fits) < SPILL_TOLERANCE_MB, 'every no-spill reading is under the allowance')
   assert.ok(Math.min(...spills) > SPILL_TOLERANCE_MB * 6, 'every real spill is far above it')
-  for (const f of fits) assert.equal(isSpilling(f), false)
-  for (const s of spills) assert.equal(isSpilling(s), true)
+  for (const f of fits) assert.equal(isSpilling(f, SATURATED, CARD), false)
+  for (const s of spills) assert.equal(isSpilling(s, SATURATED, CARD), true)
+})
+
+// ---- the fixed-cost floor: host memory a config ALWAYS pins, at any offload -----------------
+
+test('isSpilling: host memory pinned while the card has room to spare is not a spill', () => {
+  // Live A/B, 2026-08-15, RTX 5070 Ti (16303 MiB) — Qwen3.8-27B Q3_K_S, ctx 71168, q8_0 KV, ngl=32.
+  // The ONLY difference between the two runs is the speculative setting:
+  //   speculative=off    shared delta 178 MB   dedicated 7950 MiB
+  //   speculative=nextn  shared delta 594 MB   dedicated 9672 MiB
+  // Enabling NextN makes llama.cpp build a second (MTP draft) context — "common_speculative_init_
+  // result: creating MTP draft context against the target model" in the engine log — and its
+  // host-side buffers are pinned into GPU-visible memory, so Windows counts them under shared
+  // usage. That is 416 MB the model DELIBERATELY placed in host memory with 6.6 GB of dedicated
+  // VRAM still free. It is not the driver demoting anything, and no amount of extra CPU offload
+  // removes it.
+  assert.equal(isSpilling(178, 7950, CARD), false, 'the no-spec baseline was never in question')
+  assert.equal(isSpilling(594, 9672, CARD), false, 'NextN\'s pinned draft buffers are not a spill')
+})
+
+test('isSpilling: a fixed floor stays a floor at every offload the search tries', () => {
+  // The sweep that exposed this (auto-tune of the same model, 2026-08-15) rejected all six probes
+  // and ended "No candidate completed successfully." Spill is DEAD FLAT across the whole range
+  // while dedicated VRAM swings 2601 -> 11877 MiB: nothing the offload knob does can shrink it,
+  // which is the signature of a fixed cost rather than displaced weights.
+  const sweep: Array<[ngl: number, vramAbs: number, spill: number]> = [
+    [32, 9981, 594],
+    [15, 5971, 594],
+    [7, 4079, 592],
+    [3, 3129, 594],
+    [1, 2601, 588],
+    [0, 11877, 594],
+  ]
+  for (const [ngl, vramAbs, spill] of sweep) {
+    assert.equal(isSpilling(spill, vramAbs, CARD), false, `ngl=${ngl} still rejected as spill`)
+  }
+})
+
+test('isSpilling: still catches every real spill, which is measured at a saturated card', () => {
+  // The readings this detector was built for. All were taken with used-VRAM pinned at the ceiling
+  // (15823-15828 MiB of 16303) — that pinning IS how the driver behaves once it demotes, so the
+  // corroboration below never gets in the way of a genuine spill.
+  for (const over of [698, 2210, 2914, 3199.5, 3647.5, 6343.5]) {
+    assert.equal(isSpilling(over, SATURATED, CARD), true, `${over} MiB missed`)
+  }
+  // And the case the spill check exists to catch: 15813 MiB passed a 15928 MiB fit line as a
+  // "clean fit" while 698 MiB sat in host memory. Still caught.
+  assert.equal(isSpilling(698, 15813, CARD), true)
+})
+
+test('isSpilling: corroboration needs a VRAM reading and a budget — without either, fail as before', () => {
+  // Unknown VRAM or no GPU budget must not silently disable spill detection; those boxes keep
+  // exactly the behaviour they had before the corroboration existed.
+  assert.equal(isSpilling(2914, null, CARD), true)
+  assert.equal(isSpilling(2914, 9672, 0), true)
+})
+
+test('isSpilling: the corroboration line sits between the two regimes with room on both sides', () => {
+  // Real spills were measured within 490 MB of the ceiling; the NextN floor sat 6322 MB below it.
+  // Anything in that gap works, so the exact value is not load-bearing — but it must clear the
+  // measured saturation band by a margin.
+  assert.ok(CARD - SATURATED < SPILL_PROXIMITY_MB, 'a saturated card is inside the window')
+  assert.ok(SPILL_PROXIMITY_MB < CARD - 9672, 'the NextN reading is well outside it')
+})
+
+// ---- spillFloor: measuring the fixed cost from probes the search already runs ----------------
+
+test('spillFloor: only probes with VRAM to spare can measure the floor', () => {
+  // Far below the ceiling: the card demonstrably had room, so this reading IS the fixed cost.
+  assert.equal(spillFloor(null, 607, 9672, CARD), 607)
+  // Tighter reading at another roomy probe lowers the bound.
+  assert.equal(spillFloor(607, 594, 14626, CARD), 594)
+  // A higher one does not raise it — the floor is the tightest bound seen.
+  assert.equal(spillFloor(594, 653, 13682, CARD), 594)
+  // Near the ceiling nothing is provable, so such probes never contribute.
+  assert.equal(spillFloor(594, 300, SATURATED, CARD), 594)
+  assert.equal(spillFloor(null, 300, SATURATED, CARD), null)
+})
+
+test('spillFloor: unusable readings leave the floor untouched', () => {
+  assert.equal(spillFloor(594, null, 9672, CARD), 594)
+  assert.equal(spillFloor(594, 607, null, CARD), 594)
+  assert.equal(spillFloor(594, 607, 9672, 0), 594, 'no GPU budget proves nothing')
+})
+
+test('the measured floor is what saves the config the search actually wants', () => {
+  // The run that proved the proximity rule works, 2026-08-15. The sweep completed and chose
+  // ngl=55 — then the post-bench check re-read the SAME NextN floor at a candidate sitting 3 MB
+  // inside the proximity window, called it spill, and backed off to ngl=54:
+  //     ngl=55  vram 15282  spill 552  ->  5.735 t/s
+  //     ngl=54  vram 14984  spill 653  ->  4.309 t/s   (what it handed back: 25% slower)
+  // Proximity cannot help here — the winner is SUPPOSED to sit near the ceiling.
+  assert.equal(isSpilling(552, 15282, CARD), true, 'proximity alone still rejects the winner')
+
+  // The floor the sweep had already measured, for free, from its own roomy probes.
+  let floor: number | null = null
+  for (const [spill, vram] of [[607, 9672], [595, 13682], [594, 14626], [594, 15144]] as const) {
+    floor = spillFloor(floor, spill, vram, CARD)
+  }
+  assert.equal(floor, 594, 'ngl=55 at 15144 MiB is inside the window and must not count')
+  assert.equal(isSpilling(552, 15282, CARD, floor), false, 'floor subtracted -> no bogus backoff')
+  assert.equal(isSpilling(653, 14984, CARD, floor), false)
+})
+
+test('subtracting the floor does not hide a real spill — it sharpens it', () => {
+  // The no-spill baselines that WOULD be measured as the floor on those same runs were 157-198 MB,
+  // so subtracting one moves a genuine 2914 MB spill to ~2730 — nowhere near the tolerance.
+  assert.equal(isSpilling(2914, SATURATED, CARD, 198), true)
+  assert.equal(isSpilling(698, SATURATED, CARD, 157), true)
+  // Even against the much larger NextN floor, real spill still reads as real spill.
+  assert.equal(isSpilling(3199.5, SATURATED, CARD, 594), true)
 })
 
 test('the baseline is NOT a constant, which is why it is measured rather than assumed', () => {
@@ -78,5 +197,5 @@ test('the baseline is NOT a constant, which is why it is measured rather than as
   const observed = [157, 159, 161, 177, 181, 198, 285.3]
   assert.ok(Math.max(...observed) - Math.min(...observed) > 100, 'baseline genuinely varies')
   // All of them still sit under the allowance, so none is mistaken for spill.
-  for (const b of observed) assert.equal(isSpilling(b), false)
+  for (const b of observed) assert.equal(isSpilling(b, SATURATED, CARD), false)
 })

--- a/turbollm/src/bench/spill.test.ts
+++ b/turbollm/src/bench/spill.test.ts
@@ -11,7 +11,7 @@
 // that pinned that machinery are gone with it; what remains pins the measurement.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { spillMb, isSpilling, spillFloor, SPILL_TOLERANCE_MB, SPILL_PROXIMITY_MB } from './spill'
+import { spillMb, isSpilling, spillFloor, SPILL_TOLERANCE_MB, SPILL_PROXIMITY_MB, SPILL_FLOOR_CAP_MB } from './spill'
 
 // The founder's card, used by every case below that needs a budget.
 const CARD = 16303
@@ -198,4 +198,62 @@ test('the baseline is NOT a constant, which is why it is measured rather than as
   assert.ok(Math.max(...observed) - Math.min(...observed) > 100, 'baseline genuinely varies')
   // All of them still sit under the allowance, so none is mistaken for spill.
   for (const b of observed) assert.equal(isSpilling(b, SATURATED, CARD), false)
+})
+
+// ---- pooled (multi-GPU): the corroboration is unsound on a summed pool, so it's disabled -----
+// From independent Opus review of this fix, 2026-08-16: on a multi-GPU layer split, vramAbsMb and
+// budgetMb are both summed across cards. A card can be individually saturated and genuinely
+// demoting to host memory while the SUMMED pool still reads as roomy, because another card has
+// room — the exact case the corroboration exists to distinguish, made unrecoverable by the sum.
+
+test('isSpilling: pooled=true skips proximity — a real spill is not exempted just because the POOL has room', () => {
+  // 2x16 GB layer split, budget=32606. Card 0 saturated and actively demoting 3000 MB; card 1 has
+  // 8000 MiB free. Pool reads 23828/32606 — 8778 MB "free", comfortably outside the 1024 MB
+  // proximity window — so the unpooled check would exempt a real, measured spill.
+  assert.equal(isSpilling(3000, 23828, 32606), false, 'sanity: unpooled DOES get fooled by the sum')
+  assert.equal(isSpilling(3000, 23828, 32606, null, true), true, 'pooled: falls back to tolerance, catches it')
+})
+
+test('spillFloor: pooled=true never learns — a roomy-looking pool must not teach a floor from a spilling card', () => {
+  // Same scenario: without the guard this genuinely-spilling probe becomes the "fixed cost" and
+  // is then subtracted from every later candidate too, including ones actually at the pool ceiling.
+  assert.equal(spillFloor(null, 3000, 23828, 32606, true), null, 'pooled: nothing learned')
+  // Sanity: unpooled DOES learn from it — capped at SPILL_FLOOR_CAP_MB (2048), not the raw 3000,
+  // since that cap applies regardless of pooling (see the floor-cap tests below).
+  assert.equal(spillFloor(null, 3000, 23828, 32606, false), SPILL_FLOOR_CAP_MB)
+})
+
+test('pooled=true still catches an unambiguous spill (both cards at the sum ceiling)', () => {
+  // Not exercising the multi-GPU gap here — the pool itself is over tolerance with no free room
+  // anywhere, so pooled and unpooled must agree: this is real spill either way.
+  assert.equal(isSpilling(2914, 32000, 32606, null, true), true)
+  assert.equal(isSpilling(2914, 32000, 32606, null, false), true)
+})
+
+test('pooled=true is the default-off path — single-GPU callers are unaffected', () => {
+  // Every test above this point calls isSpilling/spillFloor with pooled defaulted (false) and
+  // still passes unmodified — the parameter is additive, not a behavior change for the hardware
+  // this module was built and validated on.
+  assert.equal(isSpilling(594, 9672, CARD), false)
+  assert.equal(spillFloor(null, 607, 9672, CARD), 607)
+})
+
+// ---- SPILL_FLOOR_CAP_MB: one noisy roomy probe must not permanently mask real spill -----------
+
+test('spillFloor: capped so a spuriously-inflated roomy reading cannot become an unbounded floor', () => {
+  // Some OTHER process allocates a large chunk of shared memory during exactly one roomy probe's
+  // window — spillFloor has no way to tell that apart from a real fixed cost, but the cap bounds
+  // the damage: no floor can ever exceed SPILL_FLOOR_CAP_MB (2048), which sits comfortably under
+  // every real spill this module has ever measured (smallest: 698 MB) while clearing every real
+  // fixed cost seen so far (NextN: 416 MB) with room to spare.
+  const noisy = spillFloor(null, 5000, 9000, CARD) // e.g. another app burst-allocated during this probe
+  assert.equal(noisy, SPILL_FLOOR_CAP_MB)
+  // A real spill well above the cap is still caught — the cap doesn't just relabel a huge floor
+  // as "safe", it stops that floor from ever being trusted enough to clear a genuine spill.
+  assert.equal(isSpilling(6343.5, SATURATED, CARD, noisy), true)
+})
+
+test('spillFloor: the cap does not interfere with real, sane floors', () => {
+  assert.equal(spillFloor(null, 416, 9672, CARD), 416)
+  assert.equal(spillFloor(416, 594, 14626, CARD), 416)
 })

--- a/turbollm/src/bench/spill.ts
+++ b/turbollm/src/bench/spill.ts
@@ -60,13 +60,92 @@ export function spillMb(baselineSharedMb: number | null, loadedSharedMb: number 
   return Math.max(0, loadedSharedMb - baselineSharedMb)
 }
 
-/** The decision the search makes. Fails OPEN — an unavailable reading returns false rather than
- *  true, matching `overHeadroom`'s existing "unknown VRAM never blocks" contract (bench.ts).
- *  Claiming a spill we did not measure would drive a machine with no spill telemetry (Apple Metal,
- *  or a Windows install where the counter cannot be resolved) toward maximum CPU offload for no
- *  reason — a worse failure than not detecting spill at all. Those machines simply behave as they
- *  did before spill detection existed. */
-export function isSpilling(spill: number | null): boolean {
+/** How close to its own capacity the GPU must be before host-backed memory is credible as SPILL.
+ *
+ *  Spill means the driver DEMOTED an allocation it could not fit — and WDDM only does that once
+ *  dedicated memory is exhausted. So a load that puts memory on the host while the card still has
+ *  gigabytes free did not spill; it pinned host memory ON PURPOSE, and no amount of extra CPU
+ *  offload will ever remove it.
+ *
+ *  Measured 2026-08-15 on the same RTX 5070 Ti (16303 MiB), Qwen3.8-27B Q3_K_S @ ctx 71168:
+ *  turning NextN on adds 416 MB of shared usage (178 -> 594) because llama.cpp builds a second
+ *  MTP draft context whose host-side buffers are pinned into GPU-visible memory. That 594 clears
+ *  {@link SPILL_TOLERANCE_MB} at EVERY offload — dead flat across ngl 0-32 while dedicated VRAM
+ *  swung 2601-11877 MiB — so the search rejected all six probes and auto-tune finished with no
+ *  winner at all ("No candidate completed successfully"). NextN is only the case that surfaced it;
+ *  any engine or fork that pins host buffers lands in the same trap, which is why the guard is
+ *  stated in terms of the physics rather than special-cased to speculative decoding.
+ *
+ *  1024 sits in a wide empty gap, so its exact value is not load-bearing: every real spill in the
+ *  matrix above was read with used-VRAM pinned within 490 MB of the ceiling (that pinning IS the
+ *  post-demotion behaviour this module documents), while the NextN floor sat 6322 MB below it. */
+export const SPILL_PROXIMITY_MB = 1024
+
+/** The decision the search makes: is this candidate's host-backed memory DISPLACED WEIGHTS (real
+ *  spill — offload more) or a fixed cost of the configuration (leave the search alone)?
+ *
+ *  Two conditions, both required. The reading must clear {@link SPILL_TOLERANCE_MB}, and the card
+ *  must actually be near enough to full for demotion to be the explanation — see
+ *  {@link SPILL_PROXIMITY_MB}. Without the second condition a config-fixed pinned allocation is
+ *  indistinguishable from spill, and because it is fixed, the search's only response (offload more)
+ *  never reduces it — so every candidate is rejected and the sweep returns nothing.
+ *
+ *  Fails OPEN — an unavailable reading returns false rather than true, matching `overHeadroom`'s
+ *  existing "unknown VRAM never blocks" contract (bench.ts). Claiming a spill we did not measure
+ *  would drive a machine with no spill telemetry (Apple Metal, or a Windows install where the
+ *  counter cannot be resolved) toward maximum CPU offload for no reason — a worse failure than not
+ *  detecting spill at all. Those machines simply behave as they did before spill detection existed.
+ *
+ *  The corroboration itself fails CLOSED, the other way round: an unknown `vramAbsMb` or a zero
+ *  `budgetMb` cannot rule a spill out, so the verdict falls back to the tolerance alone — exactly
+ *  the behaviour that shipped before this check existed.
+ *
+ *  KNOWN LIMITATION (multi-GPU): both figures are summed across cards, so one saturated card
+ *  spilling while another sits half-empty can read as "plenty of room" and have its spill
+ *  discounted. A layer split balances residency across cards, which makes that lopsided case
+ *  unlikely rather than impossible; closing it properly needs a per-adapter reading, which the
+ *  WDDM counter can give (it is per-LUID) but `readGpuSharedMb` currently sums away.
+ *
+ *  @param vramAbsMb ABSOLUTE GPU VRAM in use for this candidate, MB (null when unreadable).
+ *  @param budgetMb  The VRAM budget for this split — see `gpuBudgetMb`. 0 when there is no GPU. */
+export function isSpilling(
+  spill: number | null,
+  vramAbsMb: number | null,
+  budgetMb: number,
+  floorMb: number | null = null,
+): boolean {
   if (spill === null) return false
-  return spill > SPILL_TOLERANCE_MB
+  if (spill - (floorMb ?? 0) <= SPILL_TOLERANCE_MB) return false
+  if (vramAbsMb !== null && budgetMb > 0 && vramAbsMb < budgetMb - SPILL_PROXIMITY_MB) return false
+  return true
+}
+
+/** Accumulate the sweep's measured FLOOR — the host-backed memory this configuration pins no matter
+ *  where the offload knob sits — from probes the search is already doing. Free: no extra loads.
+ *
+ *  A probe only qualifies when its VRAM sits further than {@link SPILL_PROXIMITY_MB} below the
+ *  budget. At that distance the card demonstrably had room, so whatever it put in host memory it
+ *  put there ON PURPOSE — which makes that reading a direct measurement of the fixed cost, and the
+ *  smallest such reading the tightest bound on it.
+ *
+ *  WHY THIS IS NEEDED ON TOP OF THE PROXIMITY RULE. Proximity alone protects a candidate only while
+ *  it is far from the ceiling; the config the search actually WANTS is the one packed right up
+ *  against it, where proximity necessarily stops discriminating. Measured live 2026-08-15, the run
+ *  that proved the proximity rule works: the sweep found ngl=55 (15282 MiB of 16303 — inside the
+ *  proximity window by 3 MB), read the same ~594 MB NextN floor as 552, called it spill, and backed
+ *  off to ngl=54 — which benched **4.31 t/s against 55's 5.74**. Auto-tune completed and then
+ *  handed back a config 25% slower than the one it had already measured. Subtracting the floor
+ *  (594, from the probes at 9672/13682/14626 MiB) leaves 0 and the backoff never fires.
+ *
+ *  Null floor ⇒ no qualifying probe ran (CPU-only box, unreadable counter, or every probe sat near
+ *  the ceiling) ⇒ {@link isSpilling} subtracts nothing and behaves exactly as it does without this. */
+export function spillFloor(
+  floorMb: number | null,
+  spill: number | null,
+  vramAbsMb: number | null,
+  budgetMb: number,
+): number | null {
+  if (spill === null || vramAbsMb === null || budgetMb <= 0) return floorMb
+  if (vramAbsMb >= budgetMb - SPILL_PROXIMITY_MB) return floorMb // too close to the ceiling to prove anything
+  return floorMb === null ? spill : Math.min(floorMb, spill)
 }

--- a/turbollm/src/bench/spill.ts
+++ b/turbollm/src/bench/spill.ts
@@ -81,6 +81,21 @@ export function spillMb(baselineSharedMb: number | null, loadedSharedMb: number 
  *  post-demotion behaviour this module documents), while the NextN floor sat 6322 MB below it. */
 export const SPILL_PROXIMITY_MB = 1024
 
+/** Ceiling on the floor `spillFloor` will accumulate — bounds a single noisy roomy probe from
+ *  permanently masking real spill for the rest of a sweep.
+ *
+ *  `spillFloor`'s reading is *machine-wide* shared-memory usage (deliberate — see `spillMb` — so
+ *  static desktop/compositor usage cancels out of the delta). That also means another process
+ *  allocating shared memory during exactly one roomy probe's window inflates that probe's spill
+ *  reading, and if it happens to be the SMALLEST roomy reading seen (`spillFloor` takes the min),
+ *  it becomes the floor — silently, since a probe can't tell "noise" from "this config's real
+ *  fixed cost". Pre-fix that noise cost one self-correcting false positive on the next probe;
+ *  post-fix, uncapped, it would become a false NEGATIVE that survives into the post-bench backoff
+ *  check too. Every measured real cause of a floor is far below this: NextN's was 416 MB, the
+ *  smallest genuine spill in this module's own matrix is 698 MB — 2048 clears the former with
+ *  headroom while still being far under the latter, so a real spill can never hide behind it. */
+export const SPILL_FLOOR_CAP_MB = 2048
+
 /** The decision the search makes: is this candidate's host-backed memory DISPLACED WEIGHTS (real
  *  spill — offload more) or a fixed cost of the configuration (leave the search alone)?
  *
@@ -100,23 +115,35 @@ export const SPILL_PROXIMITY_MB = 1024
  *  `budgetMb` cannot rule a spill out, so the verdict falls back to the tolerance alone — exactly
  *  the behaviour that shipped before this check existed.
  *
- *  KNOWN LIMITATION (multi-GPU): both figures are summed across cards, so one saturated card
- *  spilling while another sits half-empty can read as "plenty of room" and have its spill
- *  discounted. A layer split balances residency across cards, which makes that lopsided case
- *  unlikely rather than impossible; closing it properly needs a per-adapter reading, which the
- *  WDDM counter can give (it is per-LUID) but `readGpuSharedMb` currently sums away.
+ *  MULTI-GPU: gated OFF entirely by `pooled` below — see that parameter's doc for why the
+ *  corroboration is unsound, not just imprecise, once `vramAbsMb`/`budgetMb` are a summed pool.
  *
  *  @param vramAbsMb ABSOLUTE GPU VRAM in use for this candidate, MB (null when unreadable).
- *  @param budgetMb  The VRAM budget for this split — see `gpuBudgetMb`. 0 when there is no GPU. */
+ *  @param budgetMb  The VRAM budget for this split — see `gpuBudgetMb`. 0 when there is no GPU.
+ *  @param pooled    True when `vramAbsMb`/`budgetMb` are summed across more than one GPU (a
+ *    layer/row split) rather than one card's own numbers. Disables BOTH the proximity check and
+ *    the floor: on a pool, a card can be individually saturated and actively demoting — the
+ *    exact condition this function exists to catch — while the SUM still reads as roomy, because
+ *    the other card(s) have room. Verified live against this module's own functions on a 2x16 GB
+ *    layer split (2026-08-16 review): `isSpilling(3000, 23828, 32606, null, false)` (a card
+ *    genuinely spilling 3000 MB while the pool sits 8778 MB under budget) returned `false` when
+ *    the pooled check ran — and the floor accumulator is worse, since it would then take that
+ *    real spill as this config's "fixed cost" and use it to discount every later candidate too,
+ *    including ones sitting right at the pool's own ceiling. Fixing this for real needs a
+ *    per-adapter reading (the WDDM counter is per-LUID; `readGpuSharedMb`/`readGpuVramMb` sum it
+ *    away) — until then, `pooled: true` just falls back to the tolerance-only check that shipped
+ *    before this module existed, on exactly the configurations single-GPU testing never covers. */
 export function isSpilling(
   spill: number | null,
   vramAbsMb: number | null,
   budgetMb: number,
   floorMb: number | null = null,
+  pooled = false,
 ): boolean {
   if (spill === null) return false
-  if (spill - (floorMb ?? 0) <= SPILL_TOLERANCE_MB) return false
-  if (vramAbsMb !== null && budgetMb > 0 && vramAbsMb < budgetMb - SPILL_PROXIMITY_MB) return false
+  const floor = pooled ? 0 : Math.min(floorMb ?? 0, SPILL_FLOOR_CAP_MB)
+  if (spill - floor <= SPILL_TOLERANCE_MB) return false
+  if (!pooled && vramAbsMb !== null && budgetMb > 0 && vramAbsMb < budgetMb - SPILL_PROXIMITY_MB) return false
   return true
 }
 
@@ -138,14 +165,21 @@ export function isSpilling(
  *  (594, from the probes at 9672/13682/14626 MiB) leaves 0 and the backoff never fires.
  *
  *  Null floor ⇒ no qualifying probe ran (CPU-only box, unreadable counter, or every probe sat near
- *  the ceiling) ⇒ {@link isSpilling} subtracts nothing and behaves exactly as it does without this. */
+ *  the ceiling) ⇒ {@link isSpilling} subtracts nothing and behaves exactly as it does without this.
+ *
+ *  `pooled: true` never learns anything (returns `floorMb` unchanged) — see {@link isSpilling}'s
+ *  `pooled` doc: on a multi-GPU pool, a "roomy" probe can be a genuinely spilling card sitting
+ *  next to an empty one, and learning a floor from that would make the mistake worse, not better,
+ *  since it then discounts every later candidate by however much that card was really spilling. */
 export function spillFloor(
   floorMb: number | null,
   spill: number | null,
   vramAbsMb: number | null,
   budgetMb: number,
+  pooled = false,
 ): number | null {
-  if (spill === null || vramAbsMb === null || budgetMb <= 0) return floorMb
+  if (pooled || spill === null || vramAbsMb === null || budgetMb <= 0) return floorMb
   if (vramAbsMb >= budgetMb - SPILL_PROXIMITY_MB) return floorMb // too close to the ceiling to prove anything
-  return floorMb === null ? spill : Math.min(floorMb, spill)
+  const learned = floorMb === null ? spill : Math.min(floorMb, spill)
+  return Math.min(learned, SPILL_FLOOR_CAP_MB)
 }


### PR DESCRIPTION
## Summary
- Auto-tune's spill check flagged NextN's fixed ~416 MB pinned MTP-draft-context host memory as real spill, since it never shrinks regardless of offload — causing a sweep to reject every candidate and finish with "No candidate completed successfully."
- `isSpilling` now requires the card to actually be near capacity (`SPILL_PROXIMITY_MB`) before host memory counts as spill, since WDDM only demotes on exhaustion — plus `spillFloor`, which measures each config's fixed cost from its own roomy probes and subtracts it, protecting the near-the-ceiling winning candidate that proximity alone can't.

## Test plan
- [x] `npm test` — 2,495 pass, 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] Live re-run on real hardware (RTX 5070 Ti, Qwen3.8-27B + NextN): sweep previously died with no winner; now completes, full GPU offload (65/65 layers), 9.43 t/s at 200k ctx, no bogus backoff