### PR TITLE
fix(models): quant label wrong for unsloth dynamic (UD) GGUFs

### DIFF
--- a/turbollm/src/config/config.test.ts
+++ b/turbollm/src/config/config.test.ts
@@ -23,6 +23,7 @@ import {
   defaultConfig,
   deleteModelProfile,
   getModelProfile,
+  migrateModelKey,
   prunePresets,
   setModelProfile,
   type Config,
@@ -606,4 +607,77 @@ test('preset seeding: a present-but-empty presets array is NOT re-seeded', () =>
   } finally {
     cleanup(path)
   }
+})
+
+// ---- migrateModelKey (2026-08-16) -----------------------------------------------------------
+// The scanner's `key` embeds its derived quant label (`name|quant|sizeBytes`), so correcting how
+// that label is derived (filename beats a misleading `general.file_type`, e.g. unsloth's dynamic
+// quants reporting Q4_K_S/Q4_K_M for a 2-bit file) changes the key for every model it affects.
+// Everything a user already saved under the old key — a tuned profile, a named preset, a pin, a
+// measured bench result — must move with it, not vanish.
+
+test('migrateModelKey moves every section keyed on the old model key', () => {
+  const cfg = defaultConfig()
+  const oldKey = 'qwen3.8-27b|Q4_K_S|10319907904'
+  const newKey = 'qwen3.8-27b|IQ2_M|10319907904'
+  setModelProfile(cfg, oldKey, 'engine-a', flatProfile({ ctx: 200000 }))
+  const preset: ModelPreset = {
+    id: 'p1', name: 'Saved', engineId: 'engine-a', profile: flatProfile(),
+    updatedAt: '2026-08-15T00:00:00.000Z', origin: 'manual',
+  }
+  cfg.modelPresets[oldKey] = [preset]
+  cfg.lastPresetId[oldKey] = 'p1'
+  cfg.benchResults[oldKey] = { modelKey: oldKey, tps: 41.65, ttftMs: 18797, vramMb: 15328, params: { ctx: 8192, ngl: 99, nCpuMoe: 0, parallel: 1, kvTypeK: 'q8_0', flashAttn: 'on' }, ts: '2026-08-15T09:51:16.751Z' }
+  cfg.lastLoaded = { modelKey: oldKey, engineId: 'engine-a' }
+
+  const moved = migrateModelKey(cfg, oldKey, newKey)
+  assert.equal(moved, true)
+
+  // Old key is gone everywhere.
+  assert.equal(cfg.modelProfiles[oldKey], undefined)
+  assert.equal(cfg.modelPresets[oldKey], undefined)
+  assert.equal(cfg.lastPresetId[oldKey], undefined)
+  assert.equal(cfg.benchResults[oldKey], undefined)
+
+  // New key carries everything, unchanged in content.
+  assert.equal((cfg.modelProfiles[newKey]['engine-a'].profile as { ctx: number }).ctx, 200000)
+  assert.equal(cfg.modelPresets[newKey][0].id, 'p1')
+  assert.equal(cfg.lastPresetId[newKey], 'p1')
+  assert.equal(cfg.benchResults[newKey].tps, 41.65)
+  // The bench result's own embedded modelKey field is re-stamped too, not left pointing at a
+  // key that no longer exists anywhere else in the config.
+  assert.equal(cfg.benchResults[newKey].modelKey, newKey)
+  assert.equal(cfg.lastLoaded.modelKey, newKey)
+})
+
+test('migrateModelKey is a no-op — and reports false — when nothing was ever saved under the old key', () => {
+  const cfg = defaultConfig()
+  const moved = migrateModelKey(cfg, 'never-saved|Q4_K_S|123', 'never-saved|IQ2_M|123')
+  assert.equal(moved, false)
+  assert.deepEqual(cfg, defaultConfig())
+})
+
+test('migrateModelKey never clobbers data that already exists under the new key', () => {
+  const cfg = defaultConfig()
+  const oldKey = 'm|Q4_K_S|1'
+  const newKey = 'm|IQ2_M|1'
+  setModelProfile(cfg, oldKey, 'e', flatProfile({ ctx: 111 }))
+  setModelProfile(cfg, newKey, 'e', flatProfile({ ctx: 222 })) // already-correct data, hypothetically
+  cfg.benchResults[oldKey] = { modelKey: oldKey, tps: 1, ttftMs: 1, vramMb: 1, params: { ctx: 8192, ngl: 99, nCpuMoe: 0, parallel: 1, kvTypeK: 'q8_0', flashAttn: 'on' }, ts: 't' }
+  cfg.benchResults[newKey] = { modelKey: newKey, tps: 999, ttftMs: 1, vramMb: 1, params: { ctx: 8192, ngl: 99, nCpuMoe: 0, parallel: 1, kvTypeK: 'q8_0', flashAttn: 'on' }, ts: 't2' }
+
+  migrateModelKey(cfg, oldKey, newKey)
+
+  // newKey's pre-existing data survives untouched...
+  assert.equal((cfg.modelProfiles[newKey].e.profile as { ctx: number }).ctx, 222)
+  assert.equal(cfg.benchResults[newKey].tps, 999)
+  // ...and oldKey's now-orphaned data is simply left in place rather than overwriting it.
+  assert.equal((cfg.modelProfiles[oldKey].e.profile as { ctx: number }).ctx, 111)
+})
+
+test('migrateModelKey: renaming to the same key is a no-op', () => {
+  const cfg = defaultConfig()
+  setModelProfile(cfg, 'm|q4|1', 'e', flatProfile())
+  const moved = migrateModelKey(cfg, 'm|q4|1', 'm|q4|1')
+  assert.equal(moved, false)
 })

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -1306,6 +1306,50 @@ export function setModelProfile(cfg: Config, modelKey: string, engineId: string,
   ;(cfg.modelProfiles[modelKey] ??= {})[engineId] = { profile, updatedAt: new Date().toISOString() }
 }
 
+/** Move every piece of state keyed on `oldKey` to `newKey` — profiles, presets, the preset pin,
+ *  the bench result, and `lastLoaded` — and returns whether anything actually moved.
+ *
+ *  Exists for one reason: `modelKey` embeds the scanner's derived quant label
+ *  (`name|quant|sizeBytes`), so fixing how that label is derived changes the key for any model
+ *  the fix affects — silently orphaning every tuned profile, named preset, and measured bench
+ *  result a user already saved under the old, mislabeled key (2026-08-16: `general.file_type`
+ *  reporting Q4_K_S/Q4_K_M for GGUFs that were actually 2-bit — see `quantFromName` callers).
+ *  A user who already ran auto-tune and saved a preset should not lose it just because the label
+ *  it was keyed on got more accurate.
+ *
+ *  `newKey` is left untouched wherever it already has data — this only ever runs against a key
+ *  that was, by construction, unreachable before the fix that computes it landed, so a real
+ *  collision would mean something else migrated first; never clobber that. */
+export function migrateModelKey(cfg: Config, oldKey: string, newKey: string): boolean {
+  if (oldKey === newKey) return false
+  let moved = false
+  if (cfg.modelProfiles[oldKey] && !cfg.modelProfiles[newKey]) {
+    cfg.modelProfiles[newKey] = cfg.modelProfiles[oldKey]
+    delete cfg.modelProfiles[oldKey]
+    moved = true
+  }
+  if (cfg.modelPresets[oldKey] && !cfg.modelPresets[newKey]) {
+    cfg.modelPresets[newKey] = cfg.modelPresets[oldKey]
+    delete cfg.modelPresets[oldKey]
+    moved = true
+  }
+  if (cfg.lastPresetId[oldKey] && !cfg.lastPresetId[newKey]) {
+    cfg.lastPresetId[newKey] = cfg.lastPresetId[oldKey]
+    delete cfg.lastPresetId[oldKey]
+    moved = true
+  }
+  if (cfg.benchResults[oldKey] && !cfg.benchResults[newKey]) {
+    cfg.benchResults[newKey] = { ...cfg.benchResults[oldKey], modelKey: newKey }
+    delete cfg.benchResults[oldKey]
+    moved = true
+  }
+  if (cfg.lastLoaded.modelKey === oldKey) {
+    cfg.lastLoaded = { ...cfg.lastLoaded, modelKey: newKey }
+    moved = true
+  }
+  return moved
+}
+
 /** Delete a model's saved profile for one engine only (issue #35). Prunes the per-model
  *  map when its last slot is removed so `hasProfile`-style emptiness checks stay accurate. */
 export function deleteModelProfile(cfg: Config, modelKey: string, engineId: string): void {

--- a/turbollm/src/gguf/gguf.test.ts
+++ b/turbollm/src/gguf/gguf.test.ts
@@ -369,3 +369,29 @@ test('quantFromName recognizes APEX mixed-precision MoE tiers', () => {
 test('quantFromName falls back to "?" when nothing recognizable is present', () => {
   assert.equal(quantFromName('random-model-name.gguf'), '?')
 })
+
+// ---- quantFromName delimiter-anchoring + last-match (2026-08-16 review of scanner.ts's dynamic-
+// quant fix) — this function is now TRUSTED OVER metadata on a mismatch, so a false positive here
+// no longer gets harmlessly shadowed; it becomes the label users see. All three cases below were
+// verified live against the unanchored, first-match version this replaced. ------------------------
+
+test('quantFromName does not read a quant token out of ordinary filename text', () => {
+  // "seq2seq" contains "q2se" — the old unanchored regex matched it as "Q2SEQ". The real quant,
+  // "Q8_0", is delimited on both sides and must win instead.
+  assert.equal(quantFromName('flan-t5-seq2seq-base-Q8_0.gguf'), 'Q8_0')
+  // A release/date token that happens to read as Q<digit> — the old regex took "Q4" from "2025Q4".
+  assert.equal(quantFromName('model-2025Q4-release-Q8_0.gguf'), 'Q8_0')
+})
+
+test('quantFromName takes the LAST anchored match — a naming-convention prefix can also anchor', () => {
+  // "Q2.5" here is a Qwen2.5-family finetune naming convention, not a quant — and it DOES satisfy
+  // the delimiter anchor (string start, then "."), so anchoring alone isn't enough. The real quant
+  // token is the one every quantizer convention places at the end, right before the extension.
+  assert.equal(quantFromName('Q2.5-Veltha-14B-Q4_K_M.gguf'), 'Q4_K_M')
+})
+
+test('quantFromName: anchoring does not break split-file or dot-separated real quant tokens', () => {
+  assert.equal(quantFromName('model-Q4_K_XL-00001-of-00002.gguf'), 'Q4_K_XL')
+  assert.equal(quantFromName('model.Q5_K_M.gguf'), 'Q5_K_M')
+  assert.equal(quantFromName('model-q4_0.gguf'), 'Q4_0')
+})

--- a/turbollm/src/gguf/gguf.ts
+++ b/turbollm/src/gguf/gguf.ts
@@ -340,14 +340,30 @@ export function parseGguf(path: string): GgufMeta {
   }
 }
 
-/** Best-effort quant from a filename token when general.file_type is absent/unknown.
- *  Also recognizes APEX (localai-org/apex-quant, issue #165) mixed-precision MoE quants,
- *  which don't use llama.cpp's IQ-/Q-_K naming — just a tier word (optionally imatrix-
- *  calibrated, prefixed "I-") after "APEX" in the filename, e.g.
- *  "Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf" → "APEX-I-QUALITY". */
+/** Best-effort quant from a filename token when `general.file_type` is absent/unreliable — also
+ *  the token this scanner now TRUSTS OVER metadata for a mismatched dynamic quant (2026-08-16, see
+ *  `scanner.ts`'s `entryFor`), so a false positive here is no longer harmlessly shadowed by
+ *  metadata; it becomes the displayed label. Two requirements exist because of that:
+ *
+ *  1. DELIMITER-ANCHORED, not a bare substring search. An unanchored match reads a quant token out
+ *     of ordinary filename text that merely CONTAINS a Q-then-digit run: "seq2seq" in
+ *     "flan-t5-seq2seq-base-Q8_0.gguf" matched "Q2SEQ"; "2025Q4-release" matched a date as "Q4";
+ *     both verified live (2026-08-16 review). Requiring a `-`/`_`/`.`/space (or a string edge) on
+ *     BOTH sides of the token closes this without narrowing what real quant filenames look like —
+ *     every quantizer already delimits the token that way.
+ *  2. LAST match, not first. A real Qwen2.5-family model name can itself read as a quant token —
+ *     "Q2.5-Veltha-14B-Q4_K_M.gguf" anchors on BOTH "Q2" (the naming prefix) and "Q4_K_M" (the
+ *     real quant, right before the extension). Every quantizer convention puts the actual quant
+ *     token at the END of the filename (immediately before `.gguf` or a split suffix), so the
+ *     last anchored match is the one to trust — confirmed against this codebase's whole existing
+ *     corpus (issue #165's APEX names, this scanner's own UD-prefixed fixtures) with no case where
+ *     taking the last match picks the wrong token. */
 export function quantFromName(filename: string): string {
-  const m = filename.match(/(I?Q\d[A-Z0-9_]*|BF16|F16|F32)/i)
-  if (m) return m[1].toUpperCase()
+  const matches = [...filename.matchAll(/(?:^|[-_. ])(I?Q\d(?:_[A-Za-z0-9]+)*|BF16|F16|F32)(?=$|[-_. ])/gi)]
+  if (matches.length > 0) return matches[matches.length - 1][1].toUpperCase()
+  // APEX (localai-org/apex-quant, issue #165) mixed-precision MoE quants don't use llama.cpp's
+  // IQ-/Q-_K naming at all — just a tier word (optionally imatrix-calibrated, prefixed "I-") after
+  // "APEX" in the filename, e.g. "Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf" → "APEX-I-QUALITY".
   const apex = filename.match(/APEX(?:-[A-Za-z0-9]+){0,3}?-(I-)?(NANO|MINI|COMPACT|BALANCED|QUALITY)(?=\.|$|-)/i)
   if (apex) return `APEX-${apex[1] ? 'I-' : ''}${apex[2].toUpperCase()}`
   return '?'

--- a/turbollm/src/models/scanner.quant-precedence.test.ts
+++ b/turbollm/src/models/scanner.quant-precedence.test.ts
@@ -1,0 +1,173 @@
+// Filename beats a misleading `general.file_type` (2026-08-16, live report).
+//
+// Two real files on the founder's box: `Qwen3.8-27B-UD-IQ2_M.gguf` (a 10.3 GB, 2-bit-class
+// unsloth "dynamic" quant) and `Muse-Glimmer-30B-UD-Q2_K_XL.gguf` (also 2-bit) both carried a
+// `general.file_type` of Q4_K_S / Q4_K_M — llama.cpp's own single-enum "most common tensor type"
+// summary, which for a dynamic quant is dominated by the many small attention/norm tensors kept
+// at 4-bit, not the few huge MoE/FFN tensors actually pushed to 2-bit to hit the file's size. The
+// scanner used to trust that field over the filename whenever it was present, so both models
+// displayed as roughly twice their real bit-width — the one number users rely on to judge output
+// quality. Checked against the whole local catalog before flipping the precedence: every one of
+// 26 GGUFs where filename and metadata disagreed either matched at the same bit-width (filename
+// just carried MORE information, e.g. "Q4_K_XL" vs "Q4_K_M") or was this exact bug — zero cases
+// favored metadata (see ADR in decision-log for the full comparison).
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { defaultConfig, migrateModelKey, type Config, type ConfigStore } from '../config/config'
+import { Scanner } from './scanner'
+
+const T_UINT32 = 4
+const T_STRING = 8
+
+/** Minimal valid GGUF v3 header — same construction as gguf.test.ts's own helper, kept local
+ *  per this codebase's convention of not sharing helpers across test files. */
+function buildGguf(kvs: Array<[string, string | number]>): Buffer {
+  const parts: Buffer[] = []
+  const u32 = (n: number) => { const b = Buffer.alloc(4); b.writeUInt32LE(n); return b }
+  const u64 = (n: number) => { const b = Buffer.alloc(8); b.writeBigUInt64LE(BigInt(n)); return b }
+  const str = (s: string) => { const body = Buffer.from(s, 'utf8'); return Buffer.concat([u64(body.length), body]) }
+  parts.push(u32(0x46554747), u32(3), u64(0), u64(kvs.length)) // magic, version, tensorCount, kvCount
+  for (const [key, value] of kvs) {
+    parts.push(str(key))
+    if (typeof value === 'string') parts.push(u32(T_STRING), str(value))
+    else parts.push(u32(T_UINT32), u32(value))
+  }
+  return Buffer.concat(parts)
+}
+
+// FTYPE ordinals actually seen on the mislabeled files (spill.ts's sibling table, gguf.ts).
+const FTYPE_Q4_K_S = 14
+const FTYPE_Q4_K_M = 15
+
+// walk() only records .gguf files >= 1 MiB — pad past that floor, same as scanner.mmproj.test.ts.
+const MIN_SIZE = (1 << 20) + 16
+
+function writeGguf(dir: string, filename: string, kvs: Array<[string, string | number]>): string {
+  const path = join(dir, filename)
+  const header = buildGguf(kvs)
+  const body = header.length >= MIN_SIZE ? header : Buffer.concat([header, Buffer.alloc(MIN_SIZE - header.length)])
+  writeFileSync(path, body)
+  return path
+}
+
+/** In-memory stand-in for ConfigStore: `update()` mutates the same object `snapshot()` returns —
+ *  real ConfigStore also validates + persists to disk, neither of which this test needs, only the
+ *  read-your-own-write semantics the scanner's migration path depends on. */
+function memStore(root: string, seed: Partial<Config> = {}): ConfigStore {
+  const cfg: Config = { ...defaultConfig(), modelDirs: [root], ...seed }
+  return {
+    dir: () => root,
+    snapshot: () => cfg,
+    update: (fn: (c: Config) => void) => { fn(cfg) },
+  } as unknown as ConfigStore
+}
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'turbollm-quant-test-'))
+  return root
+}
+
+test('filename wins when it disagrees with a present general.file_type (the real bug)', async () => {
+  const root = makeRoot()
+  try {
+    writeGguf(root, 'Qwen3.8-27B-UD-IQ2_M.gguf', [
+      ['general.architecture', 'qwen3'],
+      ['general.file_type', FTYPE_Q4_K_S], // the misleading metadata actually observed
+    ])
+    const scanner = new Scanner(memStore(root))
+    await scanner.rescan()
+    const models = scanner.list().models
+    assert.equal(models.length, 1)
+    assert.equal(models[0].quant, 'IQ2_M') // NOT "Q4_K_S"
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('metadata is still used when the filename carries no recognizable quant token', async () => {
+  const root = makeRoot()
+  try {
+    writeGguf(root, 'custom-export.gguf', [
+      ['general.architecture', 'qwen3'],
+      ['general.file_type', FTYPE_Q4_K_M],
+    ])
+    const scanner = new Scanner(memStore(root))
+    await scanner.rescan()
+    const models = scanner.list().models
+    assert.equal(models.length, 1)
+    assert.equal(models[0].quant, 'Q4_K_M') // metadata is the only source available here
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('filename and metadata agreeing (the common case) is unaffected', async () => {
+  const root = makeRoot()
+  try {
+    writeGguf(root, 'model-Q4_K_M.gguf', [
+      ['general.architecture', 'qwen3'],
+      ['general.file_type', FTYPE_Q4_K_M],
+    ])
+    const scanner = new Scanner(memStore(root))
+    await scanner.rescan()
+    assert.equal(scanner.list().models[0].quant, 'Q4_K_M')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('a rescan migrates a saved profile/preset/bench-result from the old (mislabeled) key to the new one', async () => {
+  const root = makeRoot()
+  try {
+    writeGguf(root, 'Qwen3.8-27B-UD-IQ2_M.gguf', [
+      ['general.architecture', 'qwen3'],
+      ['general.file_type', FTYPE_Q4_K_S],
+    ])
+    // Learn the real key the scanner derives for this exact file (name-cleaning is an
+    // implementation detail of `cleanName`, not something this test should have to reproduce) —
+    // an empty-config scan first, then derive the pre-fix key by swapping only the quant segment.
+    const probe = new Scanner(memStore(root))
+    await probe.rescan()
+    const newKey = probe.list().models[0].key
+    const oldKey = newKey.replace('|IQ2_M|', '|Q4_K_S|')
+    assert.notEqual(oldKey, newKey, 'sanity: the key actually contains the quant segment we expect')
+
+    const store = memStore(root)
+    store.update((cfg) => {
+      cfg.modelProfiles[oldKey] = { 'engine-a': { profile: { ctx: 200000 }, updatedAt: '2026-08-15T00:00:00.000Z' } }
+      cfg.benchResults[oldKey] = {
+        modelKey: oldKey, tps: 41.65, ttftMs: 18797, vramMb: 15328,
+        params: { ctx: 200000, ngl: 65, nCpuMoe: 0, parallel: 1, kvTypeK: 'q4_0', flashAttn: 'on' },
+        ts: '2026-08-15T09:51:16.751Z',
+      }
+    })
+
+    const scanner = new Scanner(store)
+    await scanner.rescan()
+
+    const cfg = store.snapshot()
+    assert.equal(cfg.modelProfiles[oldKey], undefined, 'old key cleared')
+    assert.equal(cfg.benchResults[oldKey], undefined, 'old key cleared')
+    assert.equal((cfg.modelProfiles[newKey]?.['engine-a']?.profile as { ctx: number } | undefined)?.ctx, 200000)
+    assert.equal(cfg.benchResults[newKey]?.tps, 41.65)
+    assert.equal(cfg.benchResults[newKey]?.modelKey, newKey)
+
+    // A second rescan (the normal steady state) finds nothing left to migrate and stays stable.
+    await scanner.rescan()
+    const cfg2 = store.snapshot()
+    assert.equal(cfg2.benchResults[newKey]?.tps, 41.65)
+    assert.equal(Object.keys(cfg2.benchResults).length, 1) // no duplicate/second entry created
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('migrateModelKey is exported and usable standalone (sanity — full behavior covered in config.test.ts)', () => {
+  const cfg = defaultConfig()
+  cfg.benchResults['old|Q4_K_S|1'] = { modelKey: 'old|Q4_K_S|1', tps: 1, ttftMs: 1, vramMb: 1, params: { ctx: 1, ngl: 1, nCpuMoe: 0, parallel: 1, kvTypeK: 'f16', flashAttn: 'on' }, ts: 't' }
+  assert.equal(migrateModelKey(cfg, 'old|Q4_K_S|1', 'new|IQ2_M|1'), true)
+  assert.equal(cfg.benchResults['new|IQ2_M|1'].tps, 1)
+})

--- a/turbollm/src/models/scanner.ts
+++ b/turbollm/src/models/scanner.ts
@@ -2,7 +2,7 @@
 // headers, group split/mmproj files, and expose a rich model list. Path-cached.
 import { existsSync, lstatSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
-import type { ConfigStore } from '../config/config'
+import { migrateModelKey, type ConfigStore } from '../config/config'
 import { GgufError, type GgufMeta, parseGguf, quantFromName } from '../gguf/gguf'
 
 export interface ModelEntry {
@@ -203,6 +203,9 @@ export class Scanner {
   private lastScanAt = ''
   private cache = new Map<string, CacheRow>()
   private cachePath: string
+  // [legacyKey, key] pairs discovered during the CURRENT rescan — see the comment in `entryFor`
+  // for why these are batched into one config write instead of applied as they're found.
+  private pendingKeyMigrations: Array<[string, string]> = []
 
   constructor(private store: ConfigStore) {
     this.cachePath = join(store.dir(), 'models-cache.json')
@@ -272,11 +275,17 @@ export class Scanner {
         if (existsSync(d)) walk(d, scan)
         await tick()
       }
+      this.pendingKeyMigrations = []
       const gguf = await this.build(scan.ggufs)
       const mlx = scan.mlxDirs.map((dir) => mlxEntryFor(dir))
       this.entries = [...gguf, ...mlx].sort((a, b) => a.name.localeCompare(b.name))
       this.lastScanAt = new Date().toISOString()
       this.saveCache()
+      // One config write for the whole scan (see `entryFor`), not one per affected model.
+      if (this.pendingKeyMigrations.length > 0) {
+        const pairs = this.pendingKeyMigrations
+        this.store.update((cfg) => { for (const [oldKey, newKey] of pairs) migrateModelKey(cfg, oldKey, newKey) })
+      }
     } finally {
       this.scanning = false
     }
@@ -372,13 +381,44 @@ export class Scanner {
     }
 
     const fileName = basename(path)
-    const quant = meta?.quant || quantFromName(fileName)
+    // Filename wins over the GGUF's own `general.file_type` when it parses (issue: Q2/IQ2 dynamic
+    // quants reporting as Q4). That metadata field is llama.cpp's own single-enum summary of a
+    // model's tensor quant types, and for mixed/dynamic quantizations (unsloth's "UD" line, which
+    // deliberately varies bit-width per tensor to hit a size target) it is computed by MOST-COMMON
+    // TENSOR, not by byte size — so a file whose few, huge, size-dominant tensors were pushed down
+    // to 2-bit to shrink it can still report Q4_K_S/Q4_K_M, because the many small attention/norm
+    // tensors kept at 4-bit outnumber them. Verified live 2026-08-16: `Qwen3.8-27B-UD-IQ2_M.gguf`
+    // (10.3 GB — a 2-bit-class file) read `general.file_type` = 14 (Q4_K_S); same for
+    // `Muse-Glimmer-30B-UD-Q2_K_XL.gguf` reading 15 (Q4_K_M) — both silently misrepresenting a
+    // 2-bit model as 4-bit, the one number users actually rely on to judge output quality.
+    // Filename is trustworthy here for the same reason `BOGUS_GENERAL_NAMES` already distrusts a
+    // different metadata field below: every quantizer in the ecosystem (llama.cpp's own `quantize`,
+    // bartowski, mradermacher, unsloth, …) names its output after the real quant, because that
+    // filename IS the tool's own record of what it produced — nobody hand-renames a GGUF to a
+    // different quant label. Checked against the full local catalog (26 GGUFs, 7 disagreements):
+    // 5 were the filename carrying MORE information than metadata at the same bit-width (e.g.
+    // "Q4_K_XL" vs "Q4_K_M" — unsloth's own recipe label, not a lie), and the other 2 were exactly
+    // this bug. Zero cases favored metadata.
+    const quant = quantFromName(fileName) !== '?' ? quantFromName(fileName) : meta?.quant || '?'
     const name = meta?.name || cleanName(fileName)
     const vision = mmprojPath !== null
     const arch = meta?.arch ?? 'unknown'
+    const key = `${name.toLowerCase()}|${quant}|${sizeBytes}`
+
+    // The key this same file would have gotten under the PRE-fix precedence (metadata trusted
+    // over filename) — if that differs, any profile/preset/bench-result a user saved before the
+    // fix landed is sitting under the old key and needs to move. See `migrateModelKey`.
+    const legacyQuant = meta?.quant || quantFromName(fileName)
+    const legacyKey = `${name.toLowerCase()}|${legacyQuant}|${sizeBytes}`
+    // Queued, not applied here: this runs once per file on EVERY scan (a rescan can fire on every
+    // file-watch tick), and `ConfigStore.update` clones + validates + writes the whole config to
+    // disk. Batching every candidate from this scan into one `update()` call in `rescan()` keeps
+    // that cost to once per scan instead of once per affected model — `migrateModelKey` itself is
+    // a cheap no-op once there is nothing left under `legacyKey` to move.
+    if (legacyKey !== key) this.pendingKeyMigrations.push([legacyKey, key])
 
     return {
-      key: `${name.toLowerCase()}|${quant}|${sizeBytes}`,
+      key,
       name,
       path,
       dir,


### PR DESCRIPTION
## Summary
- `Qwen3.8-27B-UD-IQ2_M.gguf` (2-bit) showed as `Q4_K_S`, `Muse-Glimmer-30B-UD-Q2_K_XL.gguf` (2-bit) showed as `Q4_K_M` — llama.cpp's `general.file_type` is a "most common tensor type" summary that, for a dynamic/mixed quant, is dominated by the many small 4-bit-kept tensors rather than the few huge 2-bit tensors that actually shrink the file.
- `quantFromName(filename)` now wins over metadata whenever it parses (falls back to metadata only when the filename has no recognizable quant token). Checked against the full local catalog (26 GGUFs): zero cases favored metadata over filename.
- Since the model key embeds the quant label, fixing it changes the key for affected models — `migrateModelKey` moves any profile/preset/pin/bench-result already saved under the old key to the new one during the same scan, so existing tunes aren't orphaned by the relabel.

## Test plan
- [x] `npm test` — 2,504 pass, 0 fail (new: `config.test.ts` migrateModelKey cases, `scanner.quant-precedence.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] Live verify on real hardware: both mislabeled models now show correct quant after rescan; Qwen3.8's existing tuned profile (ngl 65, 200k ctx) and bench result (41.65 t/s) confirmed intact under the new key, old key confirmed gone