### PR TITLE
feat(mcp-catalog): add MCP Web Engine to curated local MCP catalog

### DIFF
--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -405,7 +405,7 @@ export const LOCAL_MCPS: LocalEntry[] = [
     uvx: true,
     argNote: 'Requires a running SearXNG instance.',
     envs: [
-      { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082/search)', required: false },
+      { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082/search)', required: true },
     ],
   },
 ]

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -396,6 +396,17 @@ export const LOCAL_MCPS: LocalEntry[] = [
       { key: 'CONTEXT7_API_KEY', desc: 'Optional — from context7.com/dashboard for higher rate limits', required: false },
     ],
   },
+  {
+    id: 'mcp-web-engine',
+    name: 'MCP Web Engine',
+    cat: 'Search',
+    desc: 'Privacy-first, self-hostable & SSRF-hardened web search engine and scraper for AI agents.',
+    cmd: 'npx -y mcp-web-engine',
+    envs: [
+      { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082)', required: false },
+      { key: 'PORT', desc: 'HTTP/SSE server port (default: 5050)', required: false },
+    ],
+  },
 ]
 
 export const CLOUD_CATS: string[] = ['All', ...new Set(CLOUD_MCPS.map((m) => m.cat))]

--- a/turbollm/web/src/lib/mcp-catalog.ts
+++ b/turbollm/web/src/lib/mcp-catalog.ts
@@ -401,10 +401,11 @@ export const LOCAL_MCPS: LocalEntry[] = [
     name: 'MCP Web Engine',
     cat: 'Search',
     desc: 'Privacy-first, self-hostable & SSRF-hardened web search engine and scraper for AI agents.',
-    cmd: 'npx -y mcp-web-engine',
+    cmd: 'uvx mcp-web-engine',
+    uvx: true,
+    argNote: 'Requires a running SearXNG instance.',
     envs: [
-      { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082)', required: false },
-      { key: 'PORT', desc: 'HTTP/SSE server port (default: 5050)', required: false },
+      { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082/search)', required: false },
     ],
   },
 ]


### PR DESCRIPTION
### Summary
Adds **MCP Web Engine** ([Arbolencio/mcp-web-engine](https://github.com/Arbolencio/mcp-web-engine)) to the curated local MCP server catalog in `turbollm/web/src/lib/mcp-catalog.ts`.

### Highlights
- **Privacy-First & SSRF-Hardened:** Self-hostable web search & scraping engine for AI agents.
- **Zero API Key Needed:** Integrates directly with self-hosted SearXNG meta-search (`http://127.0.0.1:8082`).
- **Published npm package:** Executable stdio MCP server via `npx -y mcp-web-engine`.

### Catalog Configuration
```ts
{
  id: 'mcp-web-engine',
  name: 'MCP Web Engine',
  cat: 'Search',
  desc: 'Privacy-first, self-hostable & SSRF-hardened web search engine and scraper for AI agents.',
  cmd: 'npx -y mcp-web-engine',
  envs: [
    { key: 'SEARXNG_URL', desc: 'SearXNG meta-search endpoint (default: http://127.0.0.1:8082)', required: false },
    { key: 'PORT', desc: 'HTTP/SSE server port (default: 5050)', required: false },
  ],
}
```