### PR TITLE
fix(models): rename the "Parallel slots" label to "Parallel requests"

### DIFF
--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -646,7 +646,7 @@ export function ModelDetailDialog({
 
             {isLlamaCpp && (
             <Section>
-              <Row label="Parallel slots">
+              <Row label="Parallel requests">
                 <NumberInput value={draft.parallel} min={1} max={16} onChange={(v) => set('parallel', v)} />
               </Row>
               <Row label="K cache type" hint="turbo* are TurboQuant-fork exclusive.">
@@ -1034,7 +1034,7 @@ function AutoTuneResultDialog({
                   <ConfigRow label="Context length" value={`${result.params.ctx.toLocaleString()} tok`} />
                   <ConfigRow label="KV cache type" value={result.params.kvTypeK} />
                   <ConfigRow label="Flash attention" value={result.params.flashAttn} />
-                  {result.params.parallel > 1 && <ConfigRow label="Parallel slots" value={result.params.parallel} />}
+                  {result.params.parallel > 1 && <ConfigRow label="Parallel requests" value={result.params.parallel} />}
 
                   <ConfigSection title="Sampling" />
                   {s ? (


### PR DESCRIPTION
Renames the UI label `Parallel slots` → `Parallel requests` in the model detail dialog.

"Slots" is llama.cpp's internal term for the `--parallel` arg; "requests" is what the number actually means to someone sizing concurrency in the UI. Sentence case matches the neighbouring labels ("Flash attention", "Context length", "KV cache type").

Two sites, both in `turbollm/web/src/screens/models/ModelDetailDialog.tsx`:
- the llama.cpp load-settings `Row`
- the auto-tune result summary `ConfigRow`

Label-only — the underlying `parallel` param, its wiring, and `Manager.parallelSlots()` are all untouched.

## Verification
- `npm run typecheck` (turbollm) — clean
- `npx tsc --noEmit` (turbollm/web) — clean
- `npm run build` (web) — succeeds; all 129 JS chunks parse, every `index.html` asset ref resolves
- Verified live in the running app: the load-settings dialog renders `Parallel requests`, and `Parallel slots` no longer appears