### PR TITLE
fix(dual-GPU): auto-tune's single-GPU gate judged the wrong KV type; onboarding sized a 2-GPU box as one card (ADR-379)

### DIFF
--- a/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
+++ b/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
@@ -1,0 +1,96 @@
+# Dual-GPU auto-tune — THE REQUIREMENT
+
+> Written 2026-08-22 after the founder got angry at how this was being handled.
+> Read this **first** in any session touching dual-GPU. It exists so the deviation
+> described below does not happen again.
+
+---
+
+## THE ASK — one sentence
+
+**Find the best auto-tune setup for a dual-GPU machine, and prove it through the GUI.**
+
+That is the whole requirement. Not an investigation, not a root-cause writeup, not a set of
+PRs. A configuration that is demonstrably the best available on two GPUs.
+
+## HARD RULES
+
+1. **GUI ONLY. No scripts.** Do not drive the daemon with `bench_vs_chat.py`, curl,
+   in-page `fetch`, or notebook cells to produce the answer. The founder must be able to see
+   and reproduce every step in the interface a real user has. Scripts were the wrong
+   instrument and produced numbers no user could ever get to.
+2. **Deliver the setting, not the theory.** The output is "use these values, here is the
+   tok/s". Mechanism is a footnote, not the deliverable.
+3. **Finish one thing before starting another.**
+
+## WHY THE FOUNDER IS FRUSTRATED — do not repeat this
+
+Direct quote: *"you are making me angry now. I am pissed how you are acting with this dual
+gpu setup. Why is this so difficult and why you keep deviating."*
+
+The pattern that caused it, honestly stated:
+
+- **Chased mechanism instead of the deliverable.** Three ADRs, four PRs, a docs refresh and
+  long cross-session messages. Not one of them answered "what settings should I use on two
+  GPUs?"
+- **Repeatedly asserted, then retracted.** Claimed the slowdown was a PCIe activation copy
+  (arithmetically impossible), that dual was slower than single (measured *faster*), that the
+  daemon proxy was halving throughput (it costs 4%), that clean probes refuted the spill
+  hypothesis (that path is inert on Linux — untestable either way). Each retraction cost the
+  founder's time.
+- **Shipped a "fix" that would have made things 8% worse** (`deriveDefault` → single-GPU),
+  caught only because it was measured afterwards.
+- **Left the thing actually asked for undone.** A Layer-vs-Row comparison was explicitly
+  requested and never ran — twice — because the Kaggle session died and attention went
+  elsewhere instead of restarting it.
+- **Used scripts for everything**, so the numbers never corresponded to what a GUI user sees.
+
+The founder's own diagnosis was sharper than several of mine, twice:
+- *"it uses VRAM usage to auto tune"* — correct; the `ngl` search is probe-driven, so the
+  VRAM **estimate** was never the cause of the search's behaviour.
+- *"when model + KV cache calc exceeds single gpu then why to try that"* — correct, and
+  exactly the ADR-379 bug.
+
+## WHAT IS ALREADY MEASURED — do not re-derive any of this
+
+Hardware: Kaggle 2× Tesla T4, 15360 MB each, **30720 MB pooled**, 4 vCPU, 31 GB RAM.
+
+- **A layer split is a sequential pipeline.** The cards do not work on one token at the same
+  time. Dual GPU buys **capacity, not speed** for single-stream decode. Measured: GPU1 at
+  98–99% util while GPU0 sat at 74%.
+- **CPU offload is the only thing that really costs throughput.** MoE 22.9 GB: 0 experts on
+  CPU = 57.5 t/s; 8 experts on CPU = 24.8 t/s. No split geometry comes close to that effect.
+- **Context is nearly free.** 8k → 128k costs about 1% of decode. KV measured at
+  ~0.069 MB/token, roughly 4× less than the declared geometry implies.
+- **A single T4 OOMs** on both 27B models tested. Dual is the only way to run them at all.
+- **Q6_K is ~3× slower than Q4_K_XL** on T4 (4.3 vs 12.4 t/s), both fully GPU-resident.
+  Unexplained — but it means **quant choice matters more here than any tuning knob**.
+- **Auto-tune's number is not comparable to a quick chat test.** It benches at 0.75 × ctx
+  capped at 32k. The same config measured 7.8 t/s at a 2,521-token prompt and 6.26 t/s at
+  32k. Not a regression — two points on one curve.
+- **Best MoE result so far:** Qwen3.6-35B-A3B Q4_K_XL (22.9 GB), `nCpuMoe 0`, both cards
+  loaded, ctx 32k → **~56 t/s**.
+- **Best dense result so far:** Qwen3.8-27B Q4_0 (16.1 GB), `ngl all`, ctx 188k → ~7.8 t/s.
+
+## THE PLAN — what "done" looks like
+
+Through the GUI, on a live dual-T4 session:
+
+1. Load a model that actually suits two T4s. **Q4_K_XL-class — not Q8, not Q6_K.**
+2. Run Auto-tune from the GUI. Record what it picks and the tok/s it reports.
+3. Try the alternatives by hand in the GUI panel — at minimum **Split mode: Layer vs Row**,
+   which was requested and never tested — and record tok/s for each.
+4. Deliver: **"these are the settings, this is the tok/s, this is why it beats the others."**
+
+Anything else — ADRs, PRs, mechanism — is out of scope until that exists.
+
+## STATE AS OF WRITING
+
+- Kaggle notebook: `sonijisons/turbollm-one-click-dual-t4`, tracks `main`, GPU T4 ×2,
+  internet on, `turboquant-cuda-t4` attached. The session dies when idle, and
+  `/kaggle/working` does **not** survive it, so the model must be re-downloaded each time.
+- Fastest model route with no download: attach dataset
+  `tahsinekajolasalami/qwen36-35b-a3b-gguf` (Qwen3.6-35B-A3B UD-Q4_K_XL, 22.9 GB) as an
+  Input — it mounts at `/kaggle/input`, which `serve.sh` already registers.
+- Open PR #190 (ADR-379 KV gate + onboarding pooling) — unit-tested, **not verified on the
+  box**. Does not block this requirement.

--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -1,0 +1,154 @@
+# Dual-GPU bugs — found on a real 2× Tesla T4 box
+
+All of these were reproduced on Kaggle 2× Tesla T4 (15360 MB each, **30720 MB pooled**)
+running TurboLLM **v1.11.6**, unless marked otherwise. Companion to
+`DUAL-GPU-AUTOTUNE-REQUIREMENT.md`.
+
+Status key: **FIXED (PR #190)** · **OPEN** · **UNEXPLAINED** (real observation, no diagnosis)
+
+---
+
+## Theme 1 — "multi-GPU" was written as `gpus[0]` in at least four places
+
+The pooled budget is the correct one for the default layer split (`gpuBudgetMb` sums every
+card). Every site below instead read the *first* card and reported half the machine.
+
+### BUG-1 · Onboarding recommends a model for half the hardware — **FIXED (PR #190)**
+- **Where:** `turbollm/src/api/onboarding-routes.ts`, `hardwareFactsFromSysInfo()`
+- **Was:** `const primaryVramMb = info.gpus[0]?.vramMb ?? 0` → `usableVramMb`
+- **Impact:** `usableVramMb` feeds `recommend()`, which picks the model band from
+  `minVramMb`/`maxVramMb`. A 2×16 GB box resolved against **15 GB** and was offered a model
+  it could hold twice over — silently, no warning.
+- **Fix:** use `detectHardware(info).vramMb`, which already sums the primary vendor and drops
+  an iGPU that merely shares system RAM (ADR-306/ADR-189).
+
+### BUG-2 · Onboarding "Your machine" shows one card — **FIXED (PR #190)**
+- **Where:** `turbollm/web/src/screens/onboarding/steps/WelcomeStep.tsx:15`
+- **Was:** `const gpu = backends?.gpus?.[0]`
+- **Observed live:** `Your machine — Tesla T4 · 15 GB VRAM` on a 2× T4 box, while the Engines
+  hero on the *same machine* correctly said `2× Tesla T4 · 30 GB`.
+- **Fix:** `primaryVendorSummary()` — the helper that already existed because the Engines hero
+  had this exact bug first. Renders `2× Tesla T4` / `30 GB VRAM`.
+
+### BUG-3 · Quant picker falsely warns of spill, steering users to a worse quant — **OPEN**
+- **Where:** Models → Discover → quant dropdown (web). Same `gpus[0]` family; call site not
+  yet located.
+- **Observed live:** selecting `Q3_K_XL · 16.8 GB` on a 30.7 GB box shows
+  **"Larger than your VRAM — will spill to system RAM. (16.8 GB file · 15 GB VRAM)"**.
+  Also shows *"Tight fit — may slow under desktop load. (10.0 GB file · 15 GB VRAM)"* for a
+  10 GB quant that is nowhere near tight.
+- **Why this is the worst of the three:** it does not merely mis-report, it **actively pushes
+  users onto a smaller, lower-quality quant than their hardware can run**, at the exact moment
+  they choose one. A 16.8 GB model on 30.7 GB of VRAM will not spill.
+- **Fix:** same as BUG-1/2 — judge against the pooled budget.
+
+### BUG-4 · `estimateVram` cannot express "one card is full" — **PARTIALLY ADDRESSED**
+- **Where:** `turbollm/src/models/profile.ts`, `estimateVram()`
+- **Problem:** computes one scalar and compares it to `gpuBudgetMb`, the *summed* pool. A
+  config pinning GPU1 at its ceiling while GPU0 sits nearly empty reads as comfortably fitting.
+- **Measured:** `--n-cpu-moe 24` on Qwen3.6-35B-A3B Q8_0 → **1707 MB / 14693 MB**. That is
+  16.4 GB against a 30.7 GB pool — "53%, fits" — with GPU1 one step from OOM.
+- **Addressed by:** `estimateVramPerGpu()` (v1.11.4), used by the bench. **But `estimateVram`
+  itself is still what the UI shows**, so the GUI's VRAM bar retains the flaw.
+
+---
+
+## Theme 2 — auto-tune
+
+### BUG-5 · Single-GPU gate judged a KV type the run would never use — **FIXED (PR #190, ADR-379)**
+- **Where:** `turbollm/src/bench/bench.ts`, `pickSplitStrategies()`
+- **Was:** feasibility judged with `bestFitKv` (the *smallest* KV the engine offers), justified
+  by "the inner KV sweep can pick it to fit". **ADR-219 removed that sweep** — auto-tune runs on
+  whatever KV the user selected, so the gate answered a hypothetical.
+- **Measured cost**, dense Qwen3.8-27B Q4_0 at ctx 188416 with the user's `q8_0`:
+  ```
+  split strategy → single-GPU (GPU 0)     ← never should have been offered
+  probe ngl=32 → oom ; 15 → ok ; 23 → ok ; 27 → ok ; 29 → ok ; 28 → ok (14090 MB)
+  bench ngl=28 → TIMEOUT                  ← ~13 min burned, no result
+  split strategy → layer-split across 2 GPUs   ← correct all along
+  ```
+  True ceiling `ngl 28/65 = 0.43`, below the 0.5 gate; measured against `turbo4` it cleared it.
+- **Fix:** judge on `base.kvTypeK`. Threshold deliberately left at 0.5 — raising it for dense
+  was tried and reverted because it also rejected GitHub #62 at ~0.72.
+
+### BUG-6 · Auto-tune never tries row / tensor-parallel split — **OPEN, likely the biggest miss**
+- **Where:** `turbollm/src/bench/bench.ts`, `pickSplitStrategies()` — only ever generates
+  `{single-GPU, layer-split}`. `row` is never a candidate.
+- **Current justification in code:** *"Row-split is a deliberate follow-up: its per-layer
+  all-reduce rarely pays off on PCIe-only multi-GPU."*
+- **Evidence that this is wrong on modern cards:** a user running Qwen3.8-27B-UD-Q6_K on
+  **2× RTX 5060 Ti** with `--split-mode tensor` reports **68.33 t/s** generation (80.04% draft
+  acceptance, 2.77 tokens/forward-pass). A layer split makes the two cards a **sequential
+  pipeline** — measured here as GPU1 at 98–99% util while GPU0 sat at 74% — so it buys capacity,
+  not speed. Row is the only mode where both cards work the same layer at once.
+- **Impact:** auto-tune is **structurally incapable** of finding the best configuration on a
+  dual-GPU box, on any hardware.
+- **Fix:** add a row candidate and let measured t/s decide, as the design already does for
+  single-vs-layer. Cheap: the winner is chosen by measurement, so on PCIe-only boxes where row
+  loses, it simply loses.
+
+### BUG-7 · `estimateVramPerGpu` ignores `ngl` for MoE — **OPEN (mine, ADR-379 follow-up)**
+- **Where:** `turbollm/src/models/profile.ts`, `estimateVramPerGpu()`
+- **Problem:** `residentLayers = m.moe ? blocks : Math.max(0, Math.min(p.ngl, blocks))`.
+  Deliberate for the `--n-cpu-moe` case (attention stays resident, `ngl` is not the knob) but
+  **wrong when the user actually lowers `ngl` on an MoE** — it then reports "fits" at `ngl 0`.
+- **Field evidence:** a reporter's panel showed `~10.8 / 24.5 GB · fits comfortably` at
+  **GPU layers: 0**. A dense model at `ngl 0` would estimate ~0; 10.8 GB is this MoE branch
+  firing.
+
+### BUG-8 · Auto-tune can end with no config at all at deep context — **OPEN**
+- **Observed:** dense Qwen3.8-27B Q6_K at ctx 131072 — search correctly walked `ngl` 65 → 57,
+  loaded it, prefilled to 100%, then `bench error: No candidate completed successfully`. No
+  winner, no fallback. The same model at 65536 was fine (`ngl 65`, 27786 MB).
+- **Mechanism (measured):** the bench prompt is capped at 32k tokens
+  (`BENCH_MAX_PROMPT_TOKENS`), so any candidate with many dense layers on CPU blows the
+  10-minute per-test cap. If every candidate in a strategy times out, the sweep ends empty.
+- **Note there are THREE independent paths to this same error string**, and they are not
+  alternatives:
+  1. **timeouts** (above) — measured here
+  2. **unified memory** — ADR-380 Decision 1, measured on a Ryzen APU, fixed
+  3. **tolerance-only spill detection when `pooled` is true** (`b9d7066`, live since v1.11.1) —
+     **untested, not refuted**. Cannot be exercised on Linux (`isSpilling` returns false on a
+     null reading; WDDM demotion is a Windows behaviour). Needs the reporter's OS to settle.
+
+### BUG-9 · The bench log cannot record which split strategy won — **OPEN**
+- **Where:** `BenchCandidate.params` (`turbollm/src/bench/bench.ts`) has
+  `ctx/ngl/nCpuMoe/parallel/kvTypeK/flashAttn` and **no `gpu` field**.
+- **Impact:** `pickSplitStrategies` actively chooses between strategies, and the winner record
+  cannot say which one produced the winning tok/s. Makes every "was it the split?" question
+  unanswerable after the fact.
+
+---
+
+## Theme 3 — UI correctness
+
+### BUG-10 · A stale "Tuned:" success renders above a fresh failure — **OPEN**
+- **Where:** `turbollm/web/src/components/ModelDetailDialog.tsx:1152`
+- **Problem:** `Tuned: N tok/s · settings applied below` is drawn from the stored past result
+  **regardless of `resultError`**.
+- **Field evidence:** the reporter's screenshot shows `Tuned: 15.3 tok/s on your machine ·
+  settings applied below` sitting directly above `No candidate completed successfully.`
+
+---
+
+## Observations without a diagnosis — do not "fix" blind
+
+### OBS-1 · Q6_K is ~3× slower than Q4_K_XL on T4 — **UNEXPLAINED**
+Same 27B family, both **fully GPU-resident**, only 1.25× more bytes: Q4_K_XL 12.4 t/s vs Q6_K
+4.3 t/s. Suspect poor Q6_K dequant kernels on sm_75. If it holds, it is a **quant-selection
+guideline that matters more than any tuning knob** on T4-class hardware.
+
+### OBS-2 · Dense loads are work-imbalanced while memory is balanced — **UNEXPLAINED**
+GPU1 at 98–99% util, GPU0 at 74%, with 12525 / 13019 MiB. Byte-balancing does not address this,
+and `deriveTensorSplit` deliberately declines dense models. Consistent with the sequential
+pipeline, but the 74% floor is not explained by it.
+
+---
+
+## Not a bug — recorded so it stops being re-reported
+
+**"Auto-tune made my model slower."** Auto-tune benches at `0.75 × ctx` capped at 32k tokens; a
+quick chat test uses a short prompt. The same config measured **7.8 t/s at a 2,521-token prompt
+and 6.26 t/s at 32k**. Two points on one curve, not a regression. The auto-tune/chat gap measured
+on-design is **70%**, of which ~19 points is methodology (engine-internal `predicted_per_second`
+vs wall-clock streaming), ~10 points run-to-run, and only **4%** the daemon's proxy hop.

--- a/turbollm/src/api/onboarding-routes.test.ts
+++ b/turbollm/src/api/onboarding-routes.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { applyOnboardingPatch } from './onboarding-routes'
+import { applyOnboardingPatch, hardwareFactsFromSysInfo } from './onboarding-routes'
+import type { SysInfo } from '../sysinfo/sysinfo'
 
 test('applyOnboardingPatch: setting a profile leaves status pending', () => {
   const out = applyOnboardingPatch(
@@ -50,4 +51,43 @@ test('applyOnboardingPatch: everLoadedModel is not a client-settable field — a
     1000,
   )
   assert.equal(out.everLoadedModel, false)
+})
+
+// ---- hardwareFactsFromSysInfo ------------------------------------------------
+// Onboarding used to size the machine from gpus[0], so a dual-GPU box resolved its model
+// recommendation against ONE card and was offered a model it could hold twice over. The
+// budget has to match gpuBudgetMb, which sums every card for the default layer split.
+
+function sys(gpus: Array<{ vramMb: number; vendor?: string; unified?: boolean }>, ramMB = 64000): SysInfo {
+  return {
+    os: 'linux/x64', cpu: 'test', cores: 16, ramMB,
+    gpus: gpus.map((g, i) => ({
+      name: `gpu${i}`, vramMb: g.vramMb,
+      vendor: (g.vendor ?? 'nvidia') as SysInfo['gpus'][number]['vendor'],
+      ...(g.unified === undefined ? {} : { unified: g.unified }),
+    })),
+  } as SysInfo
+}
+
+test('hardwareFactsFromSysInfo: dual-GPU pools both cards, not just the first', () => {
+  const hw = hardwareFactsFromSysInfo(sys([{ vramMb: 15360 }, { vramMb: 15360 }]))
+  assert.equal(hw.usableVramMb, 30720, 'a 2x15 GB box must size as 30 GB, not 15')
+})
+
+test('hardwareFactsFromSysInfo: single GPU is unchanged', () => {
+  assert.equal(hardwareFactsFromSysInfo(sys([{ vramMb: 24000 }])).usableVramMb, 24000)
+})
+
+test('hardwareFactsFromSysInfo: CPU-only reports no VRAM', () => {
+  assert.equal(hardwareFactsFromSysInfo(sys([])).usableVramMb, 0)
+})
+
+test('hardwareFactsFromSysInfo: a non-primary-vendor GPU does not inflate the budget', () => {
+  // An Intel iGPU beside an NVIDIA dGPU is common and cannot be offloaded to.
+  const hw = hardwareFactsFromSysInfo(sys([{ vramMb: 16384 }, { vramMb: 8192, vendor: 'intel' }]))
+  assert.equal(hw.usableVramMb, 16384)
+})
+
+test('hardwareFactsFromSysInfo: still reports unified memory when present', () => {
+  assert.equal(hardwareFactsFromSysInfo(sys([{ vramMb: 32000, vendor: 'apple', unified: true }])).unifiedMemory, true)
 })

--- a/turbollm/src/api/onboarding-routes.ts
+++ b/turbollm/src/api/onboarding-routes.ts
@@ -16,8 +16,8 @@ import {
   type OnboardingState, type ProfileId,
 } from '../onboarding/state'
 import { recommend, type HardwareFacts } from '../onboarding/recommend'
-import { getSysInfo } from '../sysinfo/sysinfo'
 import { detectHardware } from '../engines/hardware'
+import { getSysInfo, type SysInfo } from '../sysinfo/sysinfo'
 import type { ConfigStore } from '../config/config'
 import type { Emitter } from '../telemetry/emit'
 
@@ -37,19 +37,25 @@ function isT0(hw: HardwareFacts): boolean {
  *  memory tiering is out of scope here (spec 25 §12 open question); until
  *  resolved, only discrete/dedicated VRAM is treated as `usableVramMb`.
  *
- *  `unifiedMemory` comes from `detectHardware()` rather than a local
- *  `gpus.some(g => g.unified)`, because `some()` answers the wrong question.
- *  It reports true for an Intel iGPU sitting beside an NVIDIA dGPU — a box
- *  whose `usableVramMb` is real, dedicated VRAM — and `recommend()` would then
- *  charge that card's VRAM against system RAM for no reason. `detectHardware`
- *  computes it over the adapters it actually summed, so it means what the
- *  joint-pool constraint needs it to mean: "this GPU budget IS system RAM".
- *  GitHub #164. */
-export function hardwareFactsFromSysInfo(): HardwareFacts {
-  const info = getSysInfo()
-  const primaryVramMb = info.gpus[0]?.vramMb ?? 0
-  const { unifiedMemory } = detectHardware(info)
-  return { usableVramMb: primaryVramMb, systemRamMb: info.ramMB, unifiedMemory }
+ *  BOTH fields come from `detectHardware()`, and that is the point: it is the single place
+ *  that knows which adapters actually count, so neither can drift from the loader.
+ *
+ *  `usableVramMb` is the whole primary-vendor pool, NOT `gpus[0]`. A multi-GPU box pools its
+ *  VRAM for inference — `gpuBudgetMb` sums it for any layer/row split, which is the default —
+ *  so sizing from one card recommended a model for half the machine: a 2x16 GB box resolved
+ *  against 15 GB and was offered a model it could hold twice over, silently. `detectHardware`
+ *  also drops an iGPU that merely shares system RAM (ADR-306/ADR-189), so the pool cannot be
+ *  inflated by a card nothing can be offloaded to.
+ *
+ *  `unifiedMemory` comes from the same call rather than a local `gpus.some(g => g.unified)`,
+ *  because `some()` answers the wrong question. It reports true for an Intel iGPU sitting
+ *  beside an NVIDIA dGPU — a box whose `usableVramMb` is real, dedicated VRAM — and
+ *  `recommend()` would then charge that card's VRAM against system RAM for no reason.
+ *  `detectHardware` computes it over the adapters it actually summed, so it means what the
+ *  joint-pool constraint needs it to mean: "this GPU budget IS system RAM". GitHub #164. */
+export function hardwareFactsFromSysInfo(info: SysInfo = getSysInfo()): HardwareFacts {
+  const { vramMb, unifiedMemory } = detectHardware(info)
+  return { usableVramMb: vramMb, systemRamMb: info.ramMB, unifiedMemory }
 }
 
 /** Pure, so the transition rules are testable without a server. `now` is

--- a/turbollm/src/bench/bench.split.test.ts
+++ b/turbollm/src/bench/bench.split.test.ts
@@ -179,3 +179,48 @@ test('single-GPU box → left alone', () => {
   const p = base(one, { ctx: 8192, nCpuMoe: 24, ngl: 99 }, m)
   assert.deepEqual(withBalancedSplit(p, m, one).gpu.tensorSplit, [])
 })
+
+// ---- ADR-379: the single-GPU gate judges the KV that will actually run ------------------
+// Live failure this fixes, 2x Tesla T4 (2x15360 MB), dense Qwen3.8-27B Q4_0 16.1 GB at
+// ctx 188416 with the user's q8_0 KV. The gate used to measure feasibility with the SMALLEST KV
+// the engine offers, so it opened a single-GPU branch whose real ceiling was ngl 28/65 = 0.43.
+// Bench log: probe ngl=32 oom, then 15/23/27/29/28 ok, then "bench ngl=28 -> TIMEOUT", then it
+// finally moved to the layer-split. ~13 minutes and a timeout for a branch that never could work.
+
+const T4x2_REAL = sys([15360, 15360])
+const DENSE_27B = { sizeBytes: 16_056_478_688, moe: false, blockCount: 65, arch: 'qwen3' } as Partial<ModelEntry>
+
+test('ADR-379: a dense model that needs both cards is NOT offered single-GPU', () => {
+  const m = model(DENSE_27B)
+  const p = base(T4x2_REAL, { ctx: 188416, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'q8_0' }, m)
+  const strats = pickSplitStrategies(m, T4x2_REAL, p, caps)
+  assert.ok(!strats.some((g) => g.splitMode === 'none'), 'single-GPU must not be offered')
+  assert.equal(strats.length, 1)
+  assert.equal(strats[0].splitMode, 'layer')
+})
+
+test('ADR-379: the verdict is not changed by a smaller KV the run will never use', () => {
+  // The old gate swapped in turbo4 here and flipped the answer. The engine still OFFERS turbo4 --
+  // caps is unchanged -- so this pins that offering it is no longer enough to open the branch.
+  const m = model(DENSE_27B)
+  const p = base(T4x2_REAL, { ctx: 188416, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'q8_0' }, m)
+  assert.ok(caps.kvTypes.includes('turbo4'), 'precondition: a smaller KV type is available')
+  assert.ok(!pickSplitStrategies(m, T4x2_REAL, p, caps).some((g) => g.splitMode === 'none'))
+})
+
+test('ADR-379: a dense model that comfortably fits one card still gets single-GPU (GitHub #62)', () => {
+  const m = model({ sizeBytes: 8_000_000_000, moe: false, blockCount: 32, arch: 'qwen3' })
+  const p = base(T4x2_REAL, { ctx: 4096, ngl: 99 }, m)
+  const strats = pickSplitStrategies(m, T4x2_REAL, p, caps)
+  assert.equal(strats[0].splitMode, 'none', 'tried first -- the likely winner')
+})
+
+test('ADR-379: the 0.5 threshold is untouched, so GitHub #62 still gets its shot', () => {
+  // Guards against fixing the gate by raising the bar, which was tried and reverted: it
+  // rejected the reported 0.43 case but also rejected #62 at ~0.72, which must still be
+  // offered. The KV type is what separates them, not the threshold.
+  const m = model({ sizeBytes: 15_000_000_000, blockCount: 32, nativeCtx: 8192 })
+  const s16 = sys([16000, 16000])
+  const strats = pickSplitStrategies(m, s16, base(s16, { ctx: 8192 }, m), caps)
+  assert.equal(strats[0].splitMode, 'none')
+})

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1569,8 +1569,6 @@ export function pickSplitStrategies(
   // Single-GPU: as much of the model as this ONE card can hold. Judge feasibility with the SMALLEST
   // quality-preserving KV the engine offers (the inner KV sweep can pick it to fit), so a model that
   // only fits one card with turbo4 still gets the single-GPU branch it would win on.
-  const kvOpts = pickKvQuants(base.kvTypeK, caps.kvTypes)
-  const bestFitKv = kvOpts.reduce((a, b) => (kvBytes(b) < kvBytes(a) ? b : a), kvOpts[0] ?? base.kvTypeK)
   const mainGpu = base.gpu.mainGpu >= 0 ? base.gpu.mainGpu : 0
   const single: GpuProfile = { ...base.gpu, splitMode: 'none', mainGpu, tensorSplit: [] }
   // Feasibility is NOT "does the model fit at FULL GPU offload" — the inner offload search
@@ -1584,7 +1582,20 @@ export function pickSplitStrategies(
   // find the largest GPU-resident fraction this ONE card can hold and offer single-GPU only when
   // CPU wouldn't end up doing the majority of the work — below that, the summed multi-GPU pool
   // (kept as today's fallback either way) is the sounder bet.
-  const singleFrac = maxGpuFraction(entry, sys, { ...base, gpu: single, kvTypeK: bestFitKv, kvTypeV: bestFitKv })
+  //
+  // The 0.5 threshold is deliberately UNCHANGED. Raising it for dense models (partial residency
+  // hurts far more when every parameter is active) was tried and reverted: the KV fix below
+  // already rejects the reported failure at 0.43, while GitHub #62's "just missed the card" case
+  // computes ~0.72 and must still be offered. A higher bar fixed nothing extra and broke #62.
+  //
+  // Judged with the KV type that will ACTUALLY be used (ADR-379). This used to judge with the
+  // smallest KV the engine offers, justified by "the inner KV sweep can pick it to fit" — but
+  // ADR-219 removed that sweep, so nothing downstream can shrink the KV any more and the gate was
+  // answering a hypothetical. Live on 2x T4: a dense 27B at ctx 188416 with the user's q8_0 has a
+  // true single-card ceiling of ngl 28/65 = 0.43, but measured against turbo4 it cleared 0.5, so
+  // the doomed branch was opened anyway — six probes and a 10-minute bench TIMEOUT before falling
+  // through to the layer-split that was right from the start.
+  const singleFrac = maxGpuFraction(entry, sys, { ...base, gpu: single })
   if (singleFrac >= 0.5) strategies.push(single)
 
   // The profile's current split (default: layer across all GPUs) — always kept, as the fallback for

--- a/turbollm/web/src/screens/onboarding/steps/WelcomeStep.tsx
+++ b/turbollm/web/src/screens/onboarding/steps/WelcomeStep.tsx
@@ -1,5 +1,6 @@
 import { Check, Cpu, HardDrive, Loader2, MonitorSmartphone } from 'lucide-react'
 import { useEngineBackends, useStatus } from '../../../lib/queries'
+import { primaryVendorSummary } from '../../../lib/vram'
 import type { StepComponentProps } from '../OnboardingScreen'
 
 /** Step 0 — Welcome + hardware readout (spec 25 §4). Shows what was actually
@@ -12,7 +13,11 @@ export default function WelcomeStep({ onContinue }: StepComponentProps) {
   const { data: status } = useStatus()
   const { data: backends } = useEngineBackends(status?.engineProvision?.active ?? false)
   const provision = status?.engineProvision
-  const gpu = backends?.gpus?.[0]
+  // Summarise EVERY card, not gpus[0]. A dual-GPU box read as a single card here — one name and
+  // one card's VRAM — while the rest of the app already shows "2× … 30 GB". primaryVendorSummary
+  // is the same helper the Engines hero uses (it sums the primary vendor and drops an iGPU that
+  // only shares system RAM, ADR-306), so the two readouts cannot drift apart again.
+  const hw = primaryVendorSummary(backends?.gpus ?? [])
 
   const provisionDone = !provision || (!provision.active && provision.phase !== 'error')
   const provisionFailed = provision?.phase === 'error'
@@ -38,11 +43,15 @@ export default function WelcomeStep({ onContinue }: StepComponentProps) {
         <div className="grid grid-cols-2 gap-3">
           <div className="flex items-center gap-2">
             <Cpu size={14} className="text-muted" />
-            <span className="text-sm text-ink">{gpu ? gpu.name : 'CPU only'}</span>
+            <span className="text-sm text-ink">
+              {hw.gpuName ? (hw.count > 1 ? `${hw.count}× ${hw.gpuName}` : hw.gpuName) : 'CPU only'}
+            </span>
           </div>
           <div className="flex items-center gap-2">
             <HardDrive size={14} className="text-muted" />
-            <span className="text-sm text-ink">{gpu ? `${Math.round(gpu.vramMb / 1024)} GB VRAM` : 'No discrete GPU'}</span>
+            <span className="text-sm text-ink">
+              {hw.gpuName ? `${Math.round(hw.vramMb / 1024)} GB VRAM` : 'No discrete GPU'}
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
fix(bench): the single-GPU gate judged a KV type the run would never use (ADR-379)

pickSplitStrategies decides whether to try single-GPU at all by asking how much of the
model one card can hold. It asked that question with `bestFitKv` — the SMALLEST KV type
the engine offers — rather than the KV type actually selected. The comment gave the
reason: "the inner KV sweep can pick it to fit". ADR-219 removed that sweep. Auto-tune
now runs on whatever KV type the user already has, so nothing downstream can shrink it
and the gate was answering a hypothetical.

At a deep context the KV dominates everything, so that substitution flips the answer.
Measured live on 2x Tesla T4, dense Qwen3.8-27B Q4_0 16.1 GB, ctx 188416, user's q8_0:

  0.  split strategy -> single-GPU (GPU 0)     <- should never have been offered
  1.  probe ngl=32 -> oom
  2.  probe ngl=15 -> ok (9676 MB)
  3.  probe ngl=23 -> ok (12442 MB)
  4.  probe ngl=27 -> ok (13826 MB)
  5.  probe ngl=29 -> ok (14354 MB)
  6.  probe ngl=28 -> ok (14090 MB)            <- one card's real ceiling
  7.  bench ngl=28 -> TIMEOUT                  <- ~13 min, no result
  8.  split strategy -> layer-split across 2 GPUs
  9.  probe ngl=32 -> ok (16576 MB)  ... 61 -> ok (26540 MB)

The true ceiling is ngl 28/65 = 0.43, below the 0.5 gate; judged against turbo4 it
cleared it. So the tuner spent six probes and a full 10-minute bench timeout on a branch
that could not work, running the model with 37 of 65 DENSE layers on four slow vCPUs —
which is what the user saw and reported as "auto-tune made it slower".

The threshold is deliberately left at 0.5. Raising it for dense models — partial
residency costs far more when every parameter is active — was implemented and then
REVERTED: it rejected this case at 0.43 but also rejected GitHub #62 at ~0.72, which
must still be offered. The KV type is what separates the two, not the threshold, so the
minimal fix is the correct one. That reasoning is now a comment so it is not
re-litigated, and a test pins #62 against exactly that mistake.

Four tests: the reported config is no longer offered single-GPU; offering a smaller KV
type in caps no longer changes the verdict; a dense model that comfortably fits one card
still gets it; and #62 still gets its shot.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
