### PR TITLE
feat(onboarding): wire one-click recovery to failed model loads (ADR-338 Decision 4)

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -61,7 +61,7 @@ import { readQueue, remove as removeQueued } from '../telemetry/queue'
 import { sendConsentChoice } from '../telemetry/consent'
 import { readSentLog } from '../telemetry/log'
 import { TELEMETRY_SCHEMA_VERSION } from '../telemetry/schema'
-import { classifyProvisionFailure } from '../telemetry/classify'
+import { classifyLoadFailure, classifyProvisionFailure } from '../telemetry/classify'
 import { registerOnboardingRoutes } from './onboarding-routes'
 import { startEngine, stopEngine, type EngineStartBody } from './engine-lifecycle'
 import { enqueueDownload, listDownloads, removeDownload } from './download-lifecycle'
@@ -111,7 +111,16 @@ export function registerApi(app: Hono, d: Deps): void {
     // must not read the former as the latter.
     const launchCommand = d.manager.launchCommand()
     const engine: Record<string, unknown> = { ...core.engine }
-    if (ms.err) engine.error = ms.err
+    // `failReason` (ADR-338 Decision 4): the SAME `classifyLoadFailure` the telemetry
+    // path already runs on this exact object, now also handed to the UI so a failed load
+    // can offer a one-click recovery instead of dead-ending on "Copy log". Classified
+    // here rather than in the web bundle on purpose — one classifier, server-side, so the
+    // remedy a user is offered can never disagree with the reason we recorded.
+    //
+    // Unlike `logTail` this is a closed enum and carries no path or free text, so it is
+    // safe by construction; it rides with `error` only because that is the thing it
+    // describes.
+    if (ms.err) engine.error = { ...ms.err, failReason: classifyLoadFailure(ms.err) }
     if (launchCommand) engine.launchCommand = launchCommand
     return c.json({
       version: d.version,

--- a/turbollm/src/api/status-fail-reason.test.ts
+++ b/turbollm/src/api/status-fail-reason.test.ts
@@ -1,0 +1,130 @@
+// `GET /api/v1/status` classifies a failed load so the UI can offer a remedy
+// (ADR-338 Decision 4). Route-level rather than a unit test of `classifyLoadFailure`
+// — that classifier already has its own tests; what was untested, and what actually
+// broke the feature for a year, is that the answer never reached a client.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { registerApi } from './routes'
+import type { Deps } from '../deps'
+
+type ErrLike = { code: string; message: string; exitCode: number; logTail: string[] }
+
+// Double mirrors link-routes.status.test.ts's — the status route reads more of
+// Manager/registry than this feature touches, and a thinner stub 500s.
+function appWithEngineError(dataDir: string, err: ErrLike | undefined) {
+  const cfg: Record<string, unknown> = {
+    daemon: { lanBind: false, requireApiKey: false, port: 6996, machineId: 'm', machineName: 'test' },
+    apiKeys: [],
+    links: [],
+    telemetry: { level: 'off', machineId: 'm' },
+  }
+  const app = new Hono()
+  const d = {
+    version: 'test',
+    store: { snapshot: () => cfg, update: (fn: (c: never) => void) => fn(cfg as never), dir: () => dataDir },
+    manager: {
+      status: () => ({
+        state: err ? 'error' : 'running',
+        err: err ?? null,
+        port: 8081,
+        pid: 4242,
+        model: { key: 'qwen3-35b', name: 'Qwen3 35B', quant: 'Q4_K_M', ctx: 32768, vision: false },
+      }),
+      launchCommand: () => undefined,
+      parallelSlots: () => 4,
+      sessionStats: () => null,
+      liveGeneration: () => null,
+    },
+    registry: {
+      active: () => ({ id: 'eng-1', name: 'llama.cpp', kind: 'llama.cpp', binPath: '/opt/turbollm/engines/llama-server' }),
+    },
+    bench: { status: () => ({ state: 'idle' }) },
+    downloads: { activeCount: () => 0 },
+    provision: { get: () => undefined },
+    build: { get: () => undefined },
+    tunnel: { snapshot: () => null },
+  } as unknown as Deps
+  registerApi(app, d)
+  return app
+}
+
+async function statusEngine(err: ErrLike | undefined) {
+  const dir = mkdtempSync(join(tmpdir(), 'tl-status-'))
+  try {
+    const res = await appWithEngineError(dir, err).request('/api/v1/status')
+    const body = (await res.json()) as { engine?: { error?: { failReason?: string } } }
+    return body.engine
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('status classifies an OOM load failure so the UI can offer a smaller quant', async () => {
+  const engine = await statusEngine({
+    code: 'model_load_failed',
+    message: 'failed to load model',
+    exitCode: -1,
+    logTail: ['ggml_backend_cuda_buffer_type_alloc_buffer: cudaMalloc failed: out of memory'],
+  })
+  assert.equal(engine?.error?.failReason, 'oom')
+})
+
+// Order is load-bearing in the classifier: real OOM output ALSO contains
+// "error loading model", so a naive top-down scan reports bad_gguf and sends
+// the user to re-download a model that is not corrupt. Pinned here because the
+// remedy offered differs entirely between the two.
+test('an OOM that also looks like a load error is still classified as OOM, not corruption', async () => {
+  const engine = await statusEngine({
+    code: 'model_load_failed',
+    message: 'error loading model',
+    exitCode: -1,
+    logTail: ['unable to allocate backend buffer'],
+  })
+  assert.equal(engine?.error?.failReason, 'oom')
+})
+
+test('a readiness timeout is classified from its structured code', async () => {
+  const engine = await statusEngine({
+    code: 'readiness_timeout',
+    message: 'did not become ready',
+    exitCode: -1,
+    logTail: [],
+  })
+  assert.equal(engine?.error?.failReason, 'timeout')
+})
+
+// The UI falls back to 'other' on a missing field, and 'other' still yields actions —
+// but the daemon should be explicit rather than relying on that fallback.
+test('an unrecognised failure is reported as other, never omitted', async () => {
+  const engine = await statusEngine({
+    code: 'engine_exited',
+    message: 'something nobody has seen before',
+    exitCode: 3,
+    logTail: [],
+  })
+  assert.equal(engine?.error?.failReason, 'other')
+})
+
+test('no engine error means no error block at all — the field is not fabricated', async () => {
+  const engine = await statusEngine(undefined)
+  assert.equal(engine?.error, undefined)
+})
+
+// The classification must not cost the caller the diagnostics it already had.
+test('classifying preserves the original message, exitCode and logTail', async () => {
+  const engine = await statusEngine({
+    code: 'model_load_failed',
+    message: 'out of memory',
+    exitCode: -1,
+    logTail: ['line one', 'line two'],
+  })
+  const err = engine?.error as unknown as ErrLike & { failReason: string }
+  assert.equal(err.failReason, 'oom')
+  assert.equal(err.message, 'out of memory')
+  assert.equal(err.exitCode, -1)
+  assert.deepEqual(err.logTail, ['line one', 'line two'])
+})

--- a/turbollm/web/src/components/EngineLoadErrorBanner.tsx
+++ b/turbollm/web/src/components/EngineLoadErrorBanner.tsx
@@ -4,7 +4,8 @@ import { X } from 'lucide-react'
 import type { EngineError, Status } from '../lib/types'
 import { Button } from './ui/button'
 import { CopyButton } from './ui/copy-button'
-import { track } from '../lib/api'
+import { track, loadModel } from '../lib/api'
+import { LoadFailureRecovery } from './LoadFailureRecovery'
 
 /** Every distinct `errInfo` the backend produces (`manager.ts` — `onTerminated`,
  *  `readiness`'s timeout/model-load-failure branches) is a fresh object literal, so
@@ -33,6 +34,7 @@ function errorKey(error: EngineError | undefined): string | null {
  */
 export function EngineLoadErrorBanner({ status }: { status: Status | undefined }) {
   const [dismissedKey, setDismissedKey] = useState<string | null>(null)
+  const [showLaunch, setShowLaunch] = useState(false)
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const state = status?.engine.state
@@ -40,6 +42,21 @@ export function EngineLoadErrorBanner({ status }: { status: Status | undefined }
   const key = errorKey(error)
 
   if (state !== 'error' || !error || key === dismissedKey) return null
+
+  /** Re-attempt the load that just failed. `status.model` is null after a failure, so the
+   *  key comes from `lastLoaded` — the daemon's config-tracked record of what the user
+   *  asked for, which survives the failure. Returns whether it worked, so the recovery
+   *  event can report a real `outcome` rather than assuming the click succeeded. */
+  async function retryLoad(): Promise<boolean> {
+    const key = status?.lastLoaded
+    if (!key) return false
+    try {
+      await loadModel(key)
+      return true
+    } catch {
+      return false
+    }
+  }
 
   return (
     <div
@@ -71,6 +88,29 @@ export function EngineLoadErrorBanner({ status }: { status: Status | undefined }
           <X size={14} />
         </button>
       </div>
+      {/* ADR-338 Decision 4's invariant — no failure terminates without a next action.
+          Until this, the banner offered only "Copy log" and "Dismiss": diagnostics, not
+          remedies. `failReason` falls back to 'other' when the daemon predates the field
+          (or could not classify), and 'other' still yields actions, so this can never
+          render an empty row. */}
+      <LoadFailureRecovery
+        failure={error.failReason ?? 'other'}
+        launchCommand={status?.engine.launchCommand}
+        onRetry={async () => {
+          const ok = await retryLoad()
+          if (ok) setDismissedKey(key)
+          return ok
+        }}
+        onShowLaunchCommand={() => setShowLaunch((v) => !v)}
+      />
+      {showLaunch && status?.engine.launchCommand && (
+        <pre
+          className="mt-1.5 max-h-32 overflow-auto rounded-md px-3 py-2 font-mono text-[12px] leading-[1.5]"
+          style={{ background: 'var(--log-bg)', color: 'var(--log-ink)' }}
+        >
+          {status.engine.launchCommand}
+        </pre>
+      )}
       {error.logTail && error.logTail.length > 0 && (
         <pre
           className="mt-1.5 max-h-32 overflow-auto rounded-md px-3 py-2 font-mono text-[12px] leading-[1.5]"

--- a/turbollm/web/src/components/LoadFailureRecovery.test.tsx
+++ b/turbollm/web/src/components/LoadFailureRecovery.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { LoadFailureRecovery } from './LoadFailureRecovery'
+import { LOAD_FAILURES } from '../screens/onboarding/recovery'
+import type { LoadFailure } from '../lib/types'
+
+const trackRecovery = vi.fn()
+const navigate = vi.fn()
+
+vi.mock('../lib/api', () => ({
+  trackRecovery: (...args: unknown[]) => trackRecovery(...args),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+beforeEach(() => {
+  trackRecovery.mockClear()
+  navigate.mockClear()
+})
+
+function renderFor(failure: LoadFailure, props: Partial<Parameters<typeof LoadFailureRecovery>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <LoadFailureRecovery failure={failure} {...props} />
+    </MemoryRouter>,
+  )
+}
+
+describe('LoadFailureRecovery', () => {
+  // ADR-338 Decision 4's invariant, enforced at the UI layer rather than only in the map.
+  it.each(LOAD_FAILURES)('renders at least one action for %s — no dead ends', (failure) => {
+    renderFor(failure)
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
+  })
+
+  it('reports the snake_case telemetry id, not the kebab-case UI id', async () => {
+    renderFor('oom')
+    await userEvent.click(screen.getByRole('button', { name: 'Choose a smaller quant' }))
+    expect(trackRecovery).toHaveBeenCalledWith('oom', 'lower_quant_retry', 'ok')
+  })
+
+  it('reports outcome "ok" when a retry succeeds', async () => {
+    renderFor('timeout', { onRetry: async () => true })
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(trackRecovery).toHaveBeenCalledWith('timeout', 'retry', 'ok')
+  })
+
+  // The whole point of the event is `outcome`; a retry that silently reported 'ok'
+  // regardless would make the recovery half look like it worked when it did not.
+  it('reports outcome "fail" when a retry fails', async () => {
+    renderFor('timeout', { onRetry: async () => false })
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(trackRecovery).toHaveBeenCalledWith('timeout', 'retry', 'fail')
+  })
+
+  it('reports "fail" when there is nothing to retry, rather than a false success', async () => {
+    renderFor('timeout')
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(trackRecovery).toHaveBeenCalledWith('timeout', 'retry', 'fail')
+  })
+
+  it('a thrown retry is reported as a failure, not an unhandled error', async () => {
+    renderFor('timeout', { onRetry: async () => { throw new Error('boom') } })
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(trackRecovery).toHaveBeenCalledWith('timeout', 'retry', 'fail')
+  })
+
+  it('hands off to Engines when there is no engine to load with', async () => {
+    renderFor('no_engine')
+    await userEvent.click(screen.getByRole('button', { name: 'Set up an engine' }))
+    expect(navigate).toHaveBeenCalledWith('/engines')
+    expect(trackRecovery).toHaveBeenCalledWith('no_engine', 'back_to_engine', 'ok')
+  })
+
+  // 'lower-quant-retry' and 'redownload' deliberately navigate rather than re-running the
+  // same load: neither is a reload of the same config, and firing onRetry would make the
+  // button lie about what it did.
+  it('does not silently re-run the same load for quant/re-download remedies', async () => {
+    const onRetry = vi.fn(async () => true)
+    renderFor('bad_gguf', { onRetry })
+    await userEvent.click(screen.getByRole('button', { name: 'Re-download the model' }))
+    expect(onRetry).not.toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith('/models')
+  })
+
+  it('an unclassified failure still offers the launch command — the last-resort next action', () => {
+    const onShowLaunchCommand = vi.fn()
+    renderFor('other', { launchCommand: 'llama-server --model foo.gguf', onShowLaunchCommand })
+    expect(screen.getByRole('button', { name: 'Show launch command and diagnostics' })).toBeTruthy()
+  })
+})

--- a/turbollm/web/src/components/LoadFailureRecovery.tsx
+++ b/turbollm/web/src/components/LoadFailureRecovery.tsx
@@ -1,0 +1,142 @@
+/**
+ * One-click recovery for a failed model load (ADR-338 Decision 4, spec 25 §7).
+ *
+ * The pieces this sits on top of all pre-existed and were never connected:
+ *   - `classifyLoadFailure` (daemon) reduced every failure to a closed enum, wired
+ *     only to telemetry. It now also rides on `status.engine.error.failReason`.
+ *   - `recovery.ts` maps each enum member to actions, exhaustively. It had zero callers.
+ *   - `POST /api/v1/telemetry/recovery` forwards `onboarding_recovery`. Nothing called it.
+ *
+ * This component is the missing UI layer, and it is what makes the invariant real:
+ * **no failure may terminate without a next action.** Before it, a failed load offered
+ * "Copy log" and "Dismiss" — diagnostics, not remedies.
+ *
+ * Every action reports `onboarding_recovery { failure, action, outcome }`. That event is
+ * the ROI measurement for the whole recovery half (ADR-338 Decision 8); a button that
+ * does not report is a button whose value can never be argued for later.
+ */
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button } from './ui/button'
+import { recoveryFor, type RecoveryAction, type RecoveryActionId } from '../screens/onboarding/recovery'
+import type { LoadFailure } from '../lib/types'
+import { trackRecovery } from '../lib/api'
+
+/** kebab (UI ids) → snake (`RECOVERY_ACTIONS`, the telemetry enum). Two vocabularies
+ *  already existed on either side of the wire; this is the single crossing point, so
+ *  the mapping lives here instead of being spelled at each call site. */
+const ACTION_EVENT_ID: Record<RecoveryActionId, string> = {
+  'retry': 'retry',
+  'use-existing-folder': 'use_existing_folder',
+  'alt-build-variant': 'alt_build_variant',
+  'hf-search': 'hf_search',
+  'llamafile': 'llamafile',
+  'build-from-source': 'build_from_source',
+  'smaller-quant': 'smaller_quant',
+  'show-path-fix': 'show_path_fix',
+  'lower-quant-retry': 'lower_quant_retry',
+  'redownload': 'redownload',
+  'alt-engine': 'alt_engine',
+  'longer-timeout': 'longer_timeout',
+  'back-to-engine': 'back_to_engine',
+  'resume': 'resume',
+  'show-launch-command': 'show_launch_command',
+}
+
+export interface LoadFailureRecoveryProps {
+  failure: LoadFailure
+  /** Shown by `show-launch-command`, the remedy for an unclassified failure: the exact
+   *  argv the daemon last spawned. Absent when no engine is current. */
+  launchCommand?: string
+  /** Retry the load that just failed. Resolves to whether it worked, which is what the
+   *  `outcome` field of the event reports — so "we offered a fix" and "the fix worked"
+   *  stay separable in the data. */
+  onRetry?: () => Promise<boolean>
+  onShowLaunchCommand?: () => void
+}
+
+export function LoadFailureRecovery({
+  failure,
+  launchCommand,
+  onRetry,
+  onShowLaunchCommand,
+}: LoadFailureRecoveryProps) {
+  const navigate = useNavigate()
+  const [busy, setBusy] = useState<RecoveryActionId | null>(null)
+  const actions = recoveryFor(failure)
+
+  async function run(action: RecoveryAction) {
+    if (busy) return
+    setBusy(action.id)
+    let outcome: 'ok' | 'fail' = 'ok'
+    try {
+      switch (action.id) {
+        // A genuine re-attempt of the same load — the only actions whose success is
+        // knowable here. Deliberately NOT 'lower-quant-retry' or 'redownload': neither
+        // is a reload of the same config, and wiring them here would make the button
+        // lie about what it did.
+        case 'retry':
+        case 'resume':
+          outcome = onRetry ? ((await onRetry()) ? 'ok' : 'fail') : 'fail'
+          break
+        case 'show-launch-command':
+          onShowLaunchCommand?.()
+          break
+        // Hand-offs. `outcome: 'ok'` here means "the user was taken somewhere they can
+        // fix it", NOT "the model loaded" — the follow-on `model_load` event is what
+        // says whether it actually worked, and joining the two is the analysis.
+        case 'back-to-engine':
+        case 'alt-engine':
+        case 'alt-build-variant':
+        case 'build-from-source':
+        case 'llamafile':
+          navigate('/engines')
+          break
+        // Hand-offs to the Models screen, where the quant picker and the re-download
+        // both live. A true single-click "retry one quant lower" needs the model's
+        // available-quant list, which this banner does not have — routing to the place
+        // that does is honest; pretending to have retried would not be.
+        case 'smaller-quant':
+        case 'lower-quant-retry':
+        case 'redownload':
+        case 'hf-search':
+        case 'use-existing-folder':
+          navigate('/models')
+          break
+        case 'show-path-fix':
+        case 'longer-timeout':
+          navigate('/settings')
+          break
+      }
+    } catch {
+      outcome = 'fail'
+    } finally {
+      setBusy(null)
+    }
+    // Best-effort and deliberately unawaited-for-correctness: a telemetry failure must
+    // never make a recovery look like it failed.
+    trackRecovery(failure, ACTION_EVENT_ID[action.id], outcome)
+  }
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2">
+      {actions.map((action) => (
+        <Button
+          key={action.id}
+          size="sm"
+          variant={action.primary ? 'default' : 'outline'}
+          className="h-6 px-2 text-[12px]"
+          disabled={busy !== null}
+          onClick={() => void run(action)}
+        >
+          {busy === action.id ? 'Working…' : action.label}
+        </Button>
+      ))}
+      {failure === 'other' && launchCommand && (
+        <span className="text-[12px] text-muted">
+          No specific cause detected — the launch command usually shows why.
+        </span>
+      )}
+    </div>
+  )
+}

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -1,6 +1,19 @@
 // Shared TS types mirroring the Go daemon API JSON (spec 02). Keep these in sync
 // with the daemon contract; the typed client in lib/api.ts returns these shapes.
 
+/** Mirrors the daemon's `FAIL_REASONS` (src/telemetry/core/enums.ts), which is what
+ *  `classifyLoadFailure` returns. Declared here because this file is the designated
+ *  mirror of the daemon contract; `screens/onboarding/recovery.ts` checks its runtime
+ *  array against this union rather than re-declaring it, so the two cannot drift. */
+export type LoadFailure =
+  | 'oom'
+  | 'no_engine'
+  | 'bad_gguf'
+  | 'unsupported_arch'
+  | 'timeout'
+  | 'cancelled'
+  | 'other'
+
 export type EngineState =
   | 'stopped'
   | 'starting'
@@ -13,6 +26,11 @@ export type EngineError = {
   message: string
   exitCode?: number
   logTail?: string[]
+  /** Server-side classification of this failure (`classifyLoadFailure`, ADR-338
+   *  Decision 4). Drives the one-click recovery offered in the error banner.
+   *  Optional because a daemon older than the field simply omits it — the UI
+   *  then falls back to `other`, which still offers a next action. */
+  failReason?: LoadFailure
 }
 
 /** Active engine runtime state from GET /api/v1/status (spec 02 §1). */
@@ -134,6 +152,10 @@ export type Status = {
   version: string
   engine: EngineRuntime
   model: LoadedModel | null
+  /** Key of the last model the user loaded, config-tracked by the daemon and sent on
+   *  every status poll. Survives a FAILED load — `model` above is null then — which is
+   *  what makes a one-click retry of the thing that just broke possible at all. */
+  lastLoaded?: string
   engineStats?: EngineStats | null
   liveGeneration?: LiveGeneration | null
   bench: BenchState

--- a/turbollm/web/src/screens/onboarding/recovery.ts
+++ b/turbollm/web/src/screens/onboarding/recovery.ts
@@ -9,10 +9,16 @@
  *  `Record<AnyFailure, ...>` below is exhaustive, so adding a member to either
  *  enum without adding a recovery is a COMPILE error, not a runtime dead end. */
 
-export const LOAD_FAILURES = ['oom', 'no_engine', 'bad_gguf', 'unsupported_arch', 'timeout', 'cancelled', 'other'] as const
+import type { LoadFailure } from '../../lib/types'
+
+/** `satisfies` (not a plain `as const`) is the load-bearing part: it makes this array
+ *  provably identical to the `LoadFailure` union in `lib/types.ts`, which mirrors the
+ *  daemon's own enum. Adding a reason on the daemon side and forgetting it here is a
+ *  COMPILE error, the same guarantee the exhaustive `Record` below already gives. */
+export const LOAD_FAILURES = ['oom', 'no_engine', 'bad_gguf', 'unsupported_arch', 'timeout', 'cancelled', 'other'] as const satisfies readonly LoadFailure[]
 export const PROVISION_FAILURES = ['network', 'no_asset', 'unsupported_platform', 'disk_full', 'permission_denied'] as const
 
-export type LoadFailure = (typeof LOAD_FAILURES)[number]
+export type { LoadFailure }
 export type ProvisionFailure = (typeof PROVISION_FAILURES)[number]
 export type AnyFailure = LoadFailure | ProvisionFailure
 
@@ -41,11 +47,11 @@ const MAP: Record<AnyFailure, RecoveryAction[]> = {
   disk_full: [a('smaller-quant', 'Choose a smaller model', true), a('retry', 'Retry')],
   permission_denied: [a('show-path-fix', 'Show how to fix permissions', true), a('retry', 'Retry')],
   // Load
-  oom: [a('lower-quant-retry', 'Retry with a smaller quant', true), a('smaller-quant', 'Choose a smaller model')],
+  oom: [a('lower-quant-retry', 'Choose a smaller quant', true), a('smaller-quant', 'Choose a smaller model')],
   no_engine: [a('back-to-engine', 'Set up an engine', true)],
   bad_gguf: [a('redownload', 'Re-download the model', true), a('hf-search', 'Choose a different model')],
   unsupported_arch: [a('alt-engine', 'Try an engine that supports it', true), a('hf-search', 'Choose a different model')],
-  timeout: [a('retry', 'Retry with a longer timeout', true), a('smaller-quant', 'Choose a smaller model')],
+  timeout: [a('retry', 'Retry', true), a('smaller-quant', 'Choose a smaller model')],
   cancelled: [a('resume', 'Resume', true)],
   other: [a('show-launch-command', 'Show launch command and diagnostics', true), a('retry', 'Retry')],
 }


### PR DESCRIPTION
ADR-338 Decision 4's invariant is that **no failure may terminate without a next action**. Until this, a failed model load offered "Open Engines", "Copy log" and "Dismiss" — diagnostics, not remedies.

## Almost all of this already existed and was never connected

| Piece | Before this PR |
|---|---|
| `classifyLoadFailure` — every failure to a closed enum | ✅ existed, wired **only** to telemetry |
| `recovery.ts` — all 12 enum members → actions, exhaustive + tested | ✅ existed, **zero callers** |
| `POST /api/v1/telemetry/recovery` + `trackRecovery()` | ✅ both existed, **nothing called them** |
| UI layer | ❌ missing |
| `failReason` on the wire | ❌ missing |

So this PR adds the missing UI layer plus the one field that made it impossible.

## Changes

- **`routes.ts`** — `GET /status` now sends `engine.error.failReason`, from the **same** `classifyLoadFailure` the telemetry path already runs on that exact object. Classified server-side on purpose: the remedy a user is offered can never disagree with the reason we recorded. It is a closed enum with no path or free text, unlike the `logTail` it rides beside.
- **`LoadFailureRecovery`** (new) — renders `recoveryFor(failure)`, executes each action, and reports `onboarding_recovery { failure, action, outcome }` for every one. That event is the ROI measurement for the entire recovery half (Decision 8) and had **never fired a single time in production**.
- **`EngineLoadErrorBanner`** — hosts it, with a real retry driven by `status.lastLoaded` (`status.model` is null after a failure, so `lastLoaded` is the only key that survives it).
- **`LoadFailure`** now has one definition, in `lib/types.ts` (the designated mirror of the daemon contract). `recovery.ts` checks its array against it with `satisfies`, so a new reason on the daemon side becomes a **compile error** rather than a silent dead end.

## Buttons that would have lied

Three labels promised things a plain reload does not do. Rather than wire them to a reload:

- `lower-quant-retry` and `redownload` now **hand off to the Models screen**, where the quant picker and the re-download actually live.
- Two labels corrected: *"Retry with a smaller quant"* → *"Choose a smaller quant"*; *"Retry with a longer timeout"* → *"Retry"*.
- Only `retry` and `resume` re-run the same load — the only two whose success this banner can actually observe. Everything else reports `outcome: 'ok'` meaning *"the user reached somewhere they can fix it"*, with the follow-on `model_load` event saying whether it truly worked.

## Measurement note — the scoping figure was stale

The "28% of loads fail" number this was scoped against no longer holds:

| Version | Fail rate |
|---|---|
| 1.11.2 | **13.6%** |
| 1.11.1 | 17.4% |
| 1.10.6 | 33.7% |

And the priority guidance in `TODO.md` is inverted: it names `unsupported_arch` as a top cause, but on current versions it is the **smallest at 3.1%**. Real split: **`other` 69.2%**, `bad_gguf` 12.3%, `oom` 10.4%, `timeout` 5.0%.

Resolving `other` needs the `errorCode` field, which only reached users in **1.11.6, published today** — v1.11.3/4/5 were tagged and GitHub-released but never `npm publish`ed, so no user had it. The second pass should wait for that data rather than guess at 265 failures.

## Verification

- Backend: **3365 pass / 0 fail** (`npm test`), `npm run typecheck` clean
- Web: **659 pass / 56 files**, `tsc --noEmit` clean
- New: 6 route-level tests for the classification reaching a client (including that OOM output containing *"error loading model"* is still classified `oom`, not `bad_gguf` — the two offer opposite remedies), and 15 component tests including that a failed retry reports `outcome: 'fail'` rather than a false success.

**Not yet done:** live verification needs a rebuilt `webdist` and a daemon restart against a real failed load. Deferred deliberately per `CLAUDE.md` hard rule 5 rather than taking the daemon offline mid-session.
