### PR TITLE
Dual-GPU: the measured best config for Qwen3.8-27B Q4 on 2x T4, plus a row-split candidate for auto-tune

### DIFF
--- a/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
+++ b/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
@@ -52,15 +52,16 @@ identical prompt at once:
 harvested, and it is the only lever found in this whole exercise that beats the single-stream
 ceiling.
 
-**`parallel` is never swept by auto-tune.** In `bench.ts` it appears exactly twice — `parallel:
-base.parallel` and `parallel: profile.parallel` — both of which merely *record* whatever the user
-set. The field is already carried through `BenchCandidate.params`, so the plumbing exists; nothing
-varies it.
+**DECIDED — auto-tune honours the user's `Parallel requests` setting and does not tune it**
+(founder call, 2026-08-22). Today's code already does exactly that: `parallel: base.parallel` and
+`parallel: profile.parallel` in `bench.ts` pass the profile's value straight through. **No code
+change is required, and none should be made.**
 
-**Whether to act on this is a product call, not a tuning one.** It raises throughput for a serving
-or multi-agent workload and does nothing for one person chatting — that user just sees 12 tok/s
-become 9. Auto-tune optimises single-stream tok/s today, so sweeping `parallel` would need a
-target to optimise *for* before it means anything.
+The measurement stays because it is useful to *users* — someone running a serving or multi-agent
+workload on two cards should know that raising Parallel requests is where the headroom is. It is
+not auto-tune's call to make: the tuner optimises single-stream tok/s, by which `parallel=2` is a
+25% regression it would be right to reject, and trading a chatting user's latency for a throughput
+number they never asked for is exactly the kind of silent override the tuner should not do.
 
 ### The three findings that matter beyond this one box
 

--- a/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
+++ b/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
@@ -44,9 +44,35 @@ TurboQuant CUDA (T4), model `Qwen3.8-27B-UD-Q4_K_XL` (17.9 GB, 65 blocks, ships 
    nearly free — and it is the only geometry that could ever reproduce the reference config.
    Implemented; see BUG-6.
 
-**Honest gap:** auto-tune's own end-to-end answer for this model was never captured — its first
-candidate (single-GPU) ate the budget at this depth, and the sweep was cancelled twice. The table
-above is hand-measured. Whether auto-tune *lands* on the Layer/200k config is still unverified.
+### Does auto-tune find this on its own? **Yes — verified end to end.**
+
+A full sweep was run from the GUI on the same base and allowed to finish. Its "Auto-tune complete"
+dialog:
+
+| Auto-tune's pick | Value |
+|---|---|
+| GPU layers | **65** |
+| Context length | **200,192** |
+| KV cache type | **q8_0** |
+| Flash attention | **on** |
+| Generation speed (measured) | 7.5 tok/s |
+| Prefill speed | 246 tok/s |
+| VRAM used | ~23,724 MB |
+| First token | **108,027 ms** |
+
+**It converged on exactly the hand-tuned config** — same layer split, same all-65 residency, same
+ctx, same KV. Auto-tune is *correct* for this model; what it is not is *fast*: the run takes the
+better part of an hour, and it spends the first chunk of that on a single-GPU candidate that
+cannot win (see BUG-5 / ADR-379).
+
+Its **7.5 tok/s vs the 11.5–12 tok/s measured in chat is not a discrepancy** — it is the documented
+methodology gap. The bench prompt is `0.75 × ctx` capped at 32k tokens; a chat turn starts from a
+short prompt. Same config, two depths on one curve. The `First token: 108,027 ms` is the honest
+price of a 32k-token prefill at this depth on T4s, and is the number worth quoting to anyone asking
+what 200k on two T4s actually feels like.
+
+Auto-tune also surfaced a correct advisory of its own: *"This result used the q8_0 KV cache type. A
+different type (e.g. q4_0) may run faster, at some output quality cost."*
 
 ---
 

--- a/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
+++ b/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
@@ -33,6 +33,35 @@ TurboQuant CUDA (T4), model `Qwen3.8-27B-UD-Q4_K_XL` (17.9 GB, 65 blocks, ships 
 | ctx 200,192 with **q8_0 for both** K and V | ~32.0 / 30.7 GB — still over. |
 | **Single-GPU** (auto-tune's own first candidate) | Loads, but the probe finds only `ngl 31/65`, leaving 34 **dense** layers on 4 vCPUs. Observed crawling at `prefill 46%`; consumed the full per-test cap and could never win. |
 
+### Concurrency is the one real headroom left — and auto-tune never looks for it
+
+A layer split is pipeline **placement**, not pipeline **execution**. At batch=1 there is nothing to
+overlap: GPU 0 computes layers 0–32, hands off, then idles while GPU 1 finishes — which is exactly
+the measured `GPU1 98–99% / GPU0 74%` imbalance. Real pipelining needs more than one request in
+flight.
+
+Measured in the GUI, same config, only `Parallel requests` changed, two chat tabs firing the
+identical prompt at once:
+
+| Parallel requests | Per stream | **Aggregate** |
+|---|---|---|
+| 1 | 11.5–12 tok/s | **~12 tok/s** |
+| **2** | 9.0 tok/s each (stable over 4+ min, 589 and 667 tokens) | **18.0 tok/s** |
+
+**+50% aggregate throughput for −25% per-stream latency.** That is the idle 26% of GPU 0 being
+harvested, and it is the only lever found in this whole exercise that beats the single-stream
+ceiling.
+
+**`parallel` is never swept by auto-tune.** In `bench.ts` it appears exactly twice — `parallel:
+base.parallel` and `parallel: profile.parallel` — both of which merely *record* whatever the user
+set. The field is already carried through `BenchCandidate.params`, so the plumbing exists; nothing
+varies it.
+
+**Whether to act on this is a product call, not a tuning one.** It raises throughput for a serving
+or multi-agent workload and does nothing for one person chatting — that user just sees 12 tok/s
+become 9. Auto-tune optimises single-stream tok/s today, so sweeping `parallel` would need a
+target to optimise *for* before it means anything.
+
 ### The three findings that matter beyond this one box
 
 1. **`turbo4` for V, `q8_0` for K is what makes 200k fit at all.** Not a split-geometry question —

--- a/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
+++ b/deploy/kaggle/DUAL-GPU-AUTOTUNE-REQUIREMENT.md
@@ -1,5 +1,56 @@
 # Dual-GPU auto-tune — THE REQUIREMENT
 
+---
+
+## ✅ THE ANSWER — best settings for Qwen3.8-27B Q4 on 2× Tesla T4
+
+Measured 2026-08-22 entirely through the GUI, on Kaggle 2× Tesla T4 (30720 MB pooled), engine
+TurboQuant CUDA (T4), model `Qwen3.8-27B-UD-Q4_K_XL` (17.9 GB, 65 blocks, ships a NextN head).
+
+**Use these:**
+
+| Setting | Value |
+|---|---|
+| Context length | **200,192** |
+| GPU layers | **ALL (65)** |
+| Split mode | **Layer** |
+| K cache type | **q8_0** |
+| V cache type | **turbo4** |
+| Flash attention | **On** |
+| KV cache | **GPU** |
+| Speculative decoding | **Off** ⚠️ (the default, NextN, is *slower* here) |
+
+→ **11.5–12 tok/s sustained at 200k context**, 28.7 / 30.7 GB, nothing on CPU.
+
+### Everything else that was tried, and why it lost
+
+| Config | Result |
+|---|---|
+| Same, but **Split mode = Row** (tensor-parallel) | **Crashes.** `CUDA error: invalid argument` in `ggml_backend_cuda_split_buffer_set_tensor`, ~8 s in. Fails at ctx 8,192 too (19.1/30.7 GB — not a memory problem). Row is unusable on T4 with this build. |
+| Same, but **speculative = NextN** (the DEFAULT), ctx 131,072 | **7.0 tok/s and still falling at 434 tokens** — a ~40% regression, at a *smaller* context. The draft head competes for the same starved GPUs. |
+| Same, but **K = turbo4** (what the panel steers you to) | **Fails to load, `exit 1`.** The fork silently upgrades K to `q8_0` (BUG-11), so the panel's "~25.4 GB · fits" was never real. |
+| ctx 200,192 with **f16** KV | ~45.4 / 30.7 GB — spills. |
+| ctx 200,192 with **q8_0 for both** K and V | ~32.0 / 30.7 GB — still over. |
+| **Single-GPU** (auto-tune's own first candidate) | Loads, but the probe finds only `ngl 31/65`, leaving 34 **dense** layers on 4 vCPUs. Observed crawling at `prefill 46%`; consumed the full per-test cap and could never win. |
+
+### The three findings that matter beyond this one box
+
+1. **`turbo4` for V, `q8_0` for K is what makes 200k fit at all.** Not a split-geometry question —
+   KV type is the dominant lever at depth, and it is the one thing auto-tune does **not** search
+   (ADR-219 removed that sweep). The user must set it by hand.
+2. **Speculative decoding is a hardware-dependent bet, and it is ON by default.** It wins big on the
+   reference 2× RTX 5060 Ti box (80% acceptance, 68 tok/s) and loses ~40% here. Nothing measures it.
+3. **Row must be a candidate even though it loses here.** It fails in 8 seconds, so offering it is
+   nearly free — and it is the only geometry that could ever reproduce the reference config.
+   Implemented; see BUG-6.
+
+**Honest gap:** auto-tune's own end-to-end answer for this model was never captured — its first
+candidate (single-GPU) ate the budget at this depth, and the sweep was cancelled twice. The table
+above is hand-measured. Whether auto-tune *lands* on the Layer/200k config is still unverified.
+
+---
+
+
 > Written 2026-08-22 after the founder got angry at how this was being handled.
 > Read this **first** in any session touching dual-GPU. It exists so the deviation
 > described below does not happen again.

--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -86,6 +86,27 @@ card). Every site below instead read the *first* card and reported half the mach
 - **Fix:** add a row candidate and let measured t/s decide, as the design already does for
   single-vs-layer. Cheap: the winner is chosen by measurement, so on PCIe-only boxes where row
   loses, it simply loses.
+- **FIXED in `pickSplitStrategies` (2026-08-22)** — row is now emitted on every multi-GPU box,
+  ordered **last** (the strategy loop breaks on the global deadline, so the newcomer is the first
+  thing dropped when budget runs short, never the layer-split default) and **skipped when the user
+  pinned a single GPU** (that is a choice of hardware, not of geometry).
+- **What row actually does on 2× T4 — measured in the GUI, and it settles the "wastes tuning
+  time" objection.** Selecting Split mode → Row and loading fails, at **both** ctx 200,192 and
+  ctx 8,192 (where the estimate is a roomy 19.1 / 30.7 GB), with the same fault:
+  ```
+  CUDA error: invalid argument
+  current device: 0, in function ggml_backend_cuda_split_buffer_set_tensor
+  ```
+  That is the row-split tensor-upload path, and it dies **~8 seconds in** — during
+  `common_init_result: fitting params to device memory`, long before any bench. So the real cost
+  of offering row on hardware that cannot use it is *eight seconds and a recorded `crash`
+  candidate*, not a wasted 10-minute bench slot. Meanwhile the reference box (2× RTX 5060 Ti,
+  `--split-mode tensor`, 68 tok/s — see `REFERENCE-CONFIGS.md`) is exactly the machine where this
+  candidate wins. Measurement decides, cheaply, in both directions.
+- **Note this is NOT the expensive branch.** At ctx 200,192 the branch that actually burns the
+  budget is **single-GPU** (BUG-5 / ADR-379): `maxGpuFraction` clears the 0.5 gate, the probe then
+  finds only `ngl 31/65`, and the sweep benches 34 dense layers on 4 vCPUs — observed crawling at
+  `prefill 46%` and consuming the full per-test cap.
 
 ### BUG-7 · `estimateVramPerGpu` ignores `ngl` for MoE — **OPEN (mine, ADR-379 follow-up)**
 - **Where:** `turbollm/src/models/profile.ts`, `estimateVramPerGpu()`
@@ -142,6 +163,49 @@ guideline that matters more than any tuning knob** on T4-class hardware.
 GPU1 at 98–99% util, GPU0 at 74%, with 12525 / 13019 MiB. Byte-balancing does not address this,
 and `deriveTensorSplit` deliberately declines dense models. Consistent with the sequential
 pipeline, but the 74% floor is not explained by it.
+
+---
+
+## Theme 4 — the VRAM estimate does not model what the engine actually allocates
+
+Found 2026-08-22 driving the GUI on the 2× T4 box with **Qwen3.8-27B-UD-Q4_K_XL at ctx 200,192**,
+the configuration the dual-GPU work targets. Both defects share one consequence: the panel says
+**"fits comfortably"** and the load then dies with `exit 1`.
+
+### BUG-11 · The estimate ignores the fork's own auto-asymmetric KV upgrade — **OPEN**
+- **Where:** `turbollm/src/models/profile.ts`, `estimateVram()` / `estimateVramPerGpu()` — they size
+  the KV from the *selected* `kvTypeK`, and nothing tells them the engine may override it.
+- **Observed live**, straight from the engine log:
+  ```
+  llama_kv_cache: auto-asymmetric: GQA ratio 6:1 (n_head=24, n_head_kv=4) —
+      upgrading K from turbo4 to q8_0 to prevent quality degradation.
+      Disable with TURBO_AUTO_ASYMMETRIC=0
+  common_fit_params: failed to fit params to free device memory:
+      n_gpu_layers already set by user to 99, abort
+  ```
+- **The gap, measured in the panel itself:** selecting `turbo4` for K and V reports
+  **~25.4 / 30.7 GB · fits**. The engine silently runs K at `q8_0`, whose honest cost the panel
+  shows only if you *select* `q8_0` by hand: **~28.7 / 30.7 GB**. A 3.3 GB error, in the
+  optimistic direction, on a box with ~2 GB of headroom.
+- **Why it matters beyond the number:** `turbo4` is exactly what a TurboQuant user is steered
+  toward for long context, and the auto-upgrade fires on any GQA-heavy model — which is most
+  modern ones. The user is told the config fits, and it cannot.
+- **Fix:** mirror the engine's auto-asymmetric rule in the estimator (upgrade K to `q8_0` when the
+  GQA ratio crosses the fork's threshold), so the panel and the engine agree on one number.
+
+### BUG-12 · The estimate ignores the NextN/MTP draft context — **OPEN**
+- **Observed live:** `srv load_model: creating MTP draft context against the target model` — with
+  speculative decoding on (**NextN is the DEFAULT** for any model carrying a NextN head, and this
+  model ships one), the engine builds a *second* context. Its weights and KV are real VRAM that
+  `estimateVram` does not count.
+- **Fix:** add the draft context to the estimate whenever the speculative mode is not `off`, or at
+  minimum surface it in the panel so the number is not silently optimistic.
+
+### Consequence for auto-tune
+Auto-tune's `ngl` search is probe-driven, so it *discovers* the real ceiling by loading — it is not
+misled the way the panel is. But `pickSplitStrategies` gates the single-GPU branch on
+`maxGpuFraction`, which is built on the same `estimateVram`. Both bugs therefore push that gate
+optimistic, in the one direction ADR-379 was written to prevent.
 
 ---
 

--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -152,6 +152,45 @@ card). Every site below instead read the *first* card and reported half the mach
 
 ---
 
+### BUG-14 · Auto-tune never sweeps `parallel`, so it cannot see the only real dual-GPU headroom — **OPEN**
+- **Where:** `turbollm/src/bench/bench.ts`. `parallel` appears exactly twice — `parallel:
+  base.parallel` (line ~855) and `parallel: profile.parallel` (line ~911). Both merely **record**
+  whatever the user set. It is already a field on `BenchCandidate.params`, so the plumbing exists;
+  nothing varies it.
+- **Why it matters:** a layer split is pipeline *placement*, not pipeline *execution*. At batch=1
+  there is nothing to overlap, so GPU 0 idles while GPU 1 finishes — the measured `GPU1 98–99% /
+  GPU0 74%` imbalance. Concurrency is what harvests that idle time.
+- **Measured in the GUI**, same config (ctx 200,192 · layer · ngl 65 · K q8_0 / V turbo4 · spec
+  off), only `Parallel requests` changed, two chat tabs firing the identical prompt at once:
+
+  | Parallel requests | Per stream | Aggregate |
+  |---|---|---|
+  | 1 | 11.5–12 tok/s | ~12 tok/s |
+  | **2** | 9.0 tok/s each (stable 4+ min, 589 / 667 tokens) | **18.0 tok/s** |
+
+  **+50% aggregate for −25% per-stream.** The largest single improvement found in the whole
+  dual-GPU exercise, and auto-tune is blind to it.
+- **Not a straightforward "fix".** Auto-tune optimises single-stream tok/s; by that objective
+  `parallel=2` is a 25% *regression*. Sweeping it requires deciding what auto-tune optimises for
+  (latency vs throughput), which is a product decision — see the requirement doc. Recorded here so
+  the measurement is not lost, not as a self-evident code change.
+
+### BUG-15 · A saved auto-tune result did not match the config the results dialog displayed — **OPEN, UNEXPLAINED**
+- **Observed:** the "Auto-tune complete" dialog reported `GPU layers 65 · Context length 200,192 ·
+  KV cache type q8_0 · Flash attention on`. After clicking **Save**, the model's profile read
+  **ctx 173,568, K `q4_0`, V `q4_0`, speculative `NextN`**.
+- **What it is NOT:** an auto-tune KV sweep. `pickKvQuants` is exported but **never called**
+  anywhere in the bench flow — ADR-219's removal holds. The `q4_0` mention the user saw came from
+  `kvSpeedAdvisory`, which only prints advice ("a different type (e.g. q4_0) may run faster") and
+  changes nothing.
+- **Deliberately not diagnosed further.** Several plausible stories exist (Save writing a different
+  profile than it rendered; the advisory being applied rather than displayed; a stale profile
+  read-back) and none is established. Needs a clean repro: run a sweep, screenshot the dialog,
+  click Save, and diff the persisted profile. Flagged because "Save writes something other than
+  what it showed you" would be serious if confirmed.
+
+---
+
 ## Observations without a diagnosis — do not "fix" blind
 
 ### OBS-1 · Q6_K is ~3× slower than Q4_K_XL on T4 — **UNEXPLAINED**

--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -152,29 +152,6 @@ card). Every site below instead read the *first* card and reported half the mach
 
 ---
 
-### BUG-14 · Auto-tune never sweeps `parallel`, so it cannot see the only real dual-GPU headroom — **OPEN**
-- **Where:** `turbollm/src/bench/bench.ts`. `parallel` appears exactly twice — `parallel:
-  base.parallel` (line ~855) and `parallel: profile.parallel` (line ~911). Both merely **record**
-  whatever the user set. It is already a field on `BenchCandidate.params`, so the plumbing exists;
-  nothing varies it.
-- **Why it matters:** a layer split is pipeline *placement*, not pipeline *execution*. At batch=1
-  there is nothing to overlap, so GPU 0 idles while GPU 1 finishes — the measured `GPU1 98–99% /
-  GPU0 74%` imbalance. Concurrency is what harvests that idle time.
-- **Measured in the GUI**, same config (ctx 200,192 · layer · ngl 65 · K q8_0 / V turbo4 · spec
-  off), only `Parallel requests` changed, two chat tabs firing the identical prompt at once:
-
-  | Parallel requests | Per stream | Aggregate |
-  |---|---|---|
-  | 1 | 11.5–12 tok/s | ~12 tok/s |
-  | **2** | 9.0 tok/s each (stable 4+ min, 589 / 667 tokens) | **18.0 tok/s** |
-
-  **+50% aggregate for −25% per-stream.** The largest single improvement found in the whole
-  dual-GPU exercise, and auto-tune is blind to it.
-- **Not a straightforward "fix".** Auto-tune optimises single-stream tok/s; by that objective
-  `parallel=2` is a 25% *regression*. Sweeping it requires deciding what auto-tune optimises for
-  (latency vs throughput), which is a product decision — see the requirement doc. Recorded here so
-  the measurement is not lost, not as a self-evident code change.
-
 ### BUG-15 · A saved auto-tune result did not match the config the results dialog displayed — **OPEN, UNEXPLAINED**
 - **Observed:** the "Auto-tune complete" dialog reported `GPU layers 65 · Context length 200,192 ·
   KV cache type q8_0 · Flash attention on`. After clicking **Save**, the model's profile read
@@ -268,6 +245,31 @@ optimistic, in the one direction ADR-379 was written to prevent.
 ---
 
 ## Not a bug — recorded so it stops being re-reported
+
+**"Auto-tune should sweep `parallel` — concurrency is free throughput."** It should not.
+**Founder call, 2026-08-22: auto-tune honours the user's `Parallel requests` setting and does not
+tune it.** Today's code already does exactly that — `parallel: base.parallel` and
+`parallel: profile.parallel` in `bench.ts` pass the profile's value straight through — so **no code
+change is required, and none should be made.**
+
+The measurement that prompted the question is kept because it is useful, not because it is a defect.
+Same config throughout (ctx 200,192 · layer · ngl 65 · K `q8_0` / V `turbo4` · speculative off),
+only `Parallel requests` changed, two chat tabs firing the identical prompt at once:
+
+| Parallel requests | Per stream | Aggregate |
+|---|---|---|
+| 1 | 11.5–12 tok/s | ~12 tok/s |
+| 2 | 9.0 tok/s each (stable 4+ min, 589 / 667 tokens) | **18.0 tok/s** |
+
+That +50% aggregate is real — it is the idle 26% of GPU 0 (`GPU1 98–99% / GPU0 74%`) being
+harvested, the difference between pipeline *placement*, which a layer split gives you, and pipeline
+*execution*, which needs more than one request in flight.
+
+**Why it is still not auto-tune's business.** Auto-tune optimises single-stream tok/s, and by that
+objective `parallel=2` is a 25% **regression** — it would be right to reject it. Chasing aggregate
+throughput would mean changing what auto-tune optimises for, and silently trading a chatting user's
+latency for a throughput number they never asked for. Concurrency is a deployment choice the user
+makes; the tuner's job is to make their choice fast, not to overrule it.
 
 **"Auto-tune made my model slower."** Auto-tune benches at `0.75 × ctx` capped at 32k tokens; a
 quick chat test uses a short prompt. The same config measured **7.8 t/s at a 2,521-token prompt

--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -201,6 +201,25 @@ the configuration the dual-GPU work targets. Both defects share one consequence:
 - **Fix:** add the draft context to the estimate whenever the speculative mode is not `off`, or at
   minimum surface it in the panel so the number is not silently optimistic.
 
+### BUG-13 · The auto-tune progress display goes stale and never recovers — **OPEN**
+- **Observed live at ctx 200,192.** The progress line sat at
+  `KV q8_0: probing ngl=32 (range 0–65)…` for **~50 minutes**, unchanged, well past auto-tune's own
+  45-minute `TOTAL_BUDGET_MS`. Closing and reopening the settings dialog showed the true state:
+  `Measuring ngl=65 — measuring t/s…`. The sweep had been advancing the whole time; only the
+  displayed step was frozen.
+- **Same class as the engine badge sticking on `Stopping`** after an eject, which also only cleared
+  on a page reload. In both cases the client stops applying server state and shows one value
+  forever.
+- **Why it matters more than it sounds.** A frozen step makes a long-but-healthy run
+  indistinguishable from a hang. In this session it directly caused a *cancelled* sweep earlier on
+  (the run was at `prefill 46%` and progressing), and then a page reload — and a reload is
+  dangerous here because auto-tune holds its winner pending a **Save** click, with no GUI anywhere
+  to recover it afterwards (Model actions offers only Pin / Find other quants / Delete, and per
+  BUG-9 the bench log cannot even record which split strategy won).
+- **Not established:** whether a reload actually discards an already-finished winner. The one
+  reload in this session happened while the sweep was still running, so that remains untested —
+  do not assume it either way.
+
 ### Consequence for auto-tune
 Auto-tune's `ngl` search is probe-driven, so it *discovers* the real ceiling by loading — it is not
 misled the way the panel is. But `pickSplitStrategies` gates the single-GPU branch on

--- a/deploy/kaggle/REFERENCE-CONFIGS.md
+++ b/deploy/kaggle/REFERENCE-CONFIGS.md
@@ -1,0 +1,66 @@
+# Dual-GPU reference configs — real user-set configurations to beat
+
+Auto-tune's job is to find, on its own, a configuration at least as good as what a
+knowledgeable user would set by hand. These are the hand-set configs we are measured against.
+Companion to `DUAL-GPU-AUTOTUNE-REQUIREMENT.md` and `DUAL-GPU-BUGS.md`.
+
+---
+
+## REF-1 · Qwen3.8-27B-UD-Q6_K on 2× RTX 5060 Ti (32 GB total) — **68.33 tok/s**
+
+Posted by a user. This is a *hand-written* `llama-server` command line, not an auto-tune result.
+
+```
+--split-mode tensor
+--spec-type draft-mtp,ngram-mod
+--spec-draft-n-max 2
+-c 100000
+--cache-type-k q8_0
+--cache-type-v q8_0
+--flash-attn on
+--batch-size 8869
+--ubatch-size 531
+-ngl 105
+-t 8
+--fit off
+```
+
+Reported result: **68.33 tok/s generation**, 80.04% draft acceptance, 2.77 average draft length.
+
+### What this config actually tells us — each line is a lever auto-tune does or doesn't have
+
+| Lever | Auto-tune today | Notes |
+|---|---|---|
+| `--split-mode tensor` | ❌ **never tried** | `pickSplitStrategies` only emits `{single-GPU, layer-split}` — see **BUG-6**. This is the single biggest structural gap: a layer split is a sequential pipeline, `tensor`/`row` is the only mode where both cards work the same layer at once. |
+| `--spec-type draft-mtp,ngram-mod` | ❌ not a tuned knob | 80% draft acceptance at 2.77 tokens/forward-pass is a large share of the 68 tok/s. Speculative decoding is a *multiplier* on decode, independent of split geometry. |
+| `-ngl 105` (all layers) | ✅ probe-driven | Auto-tune searches this and lands on all-resident when it fits. |
+| `--cache-type-k/v q8_0` | ⚠️ user-selected | ADR-219 removed the KV sweep; auto-tune runs whatever KV the user picked. ADR-379 fixed the gate that judged a *different* KV than the one that would run. |
+| `--flash-attn on` | ✅ | |
+| `--batch-size 8869` / `--ubatch-size 531` | ❌ not tuned | Non-default and non-round, so deliberately chosen. Affects prefill far more than decode. |
+| `-c 100000` | ✅ | |
+| `-t 8` | — | 8 CPU threads; Kaggle T4 boxes have only 4 vCPU. |
+| `--fit off` | — | Disables llama.cpp's own auto-fit, i.e. "I have set this by hand, don't second-guess me". |
+
+### Why this is NOT a throughput target for 2× T4
+
+Do not read 68.33 tok/s as a number to chase on Kaggle. The founder's framing is the correct
+one: *"We can't match the speed but we need to get the best out of 2 T4s, then anyone with a
+better setup will get the best."* The hardware gap is generational, not configurational:
+
+- **5060 Ti is Blackwell (sm_120); T4 is Turing (sm_75)** — seven years and several tensor-core
+  generations apart, and ~4× the memory bandwidth.
+- Same reason `Q6_K` measures ~3× slower than `Q4_K_XL` on T4 with both fully resident
+  (**OBS-1**) while this user runs Q6_K at 68 tok/s: T4 dequant kernels for that format are poor.
+  **On T4, use Q4_K_XL-class quants.**
+
+What *is* transferable is the **list of levers**. If auto-tune cannot express
+`--split-mode tensor` or speculative decoding at all, then it cannot find this config on *any*
+hardware — which is the actual defect, and is hardware-independent.
+
+---
+
+## REF-2 · Founder's single-GPU box, for scale
+
+Qwen-class 27B on one **RTX 5070 Ti**, 200k context, ~100 tok/s. Recorded only to keep
+expectations calibrated: a single modern card beats two T4s outright, and a layer split buys
+**capacity, not speed**.

--- a/deploy/kaggle/kernel-metadata.json
+++ b/deploy/kaggle/kernel-metadata.json
@@ -1,13 +1,16 @@
 {
-  "id": "sonijisons/turbollm-dual-t4-oneclick",
-  "title": "TurboLLM — one-click (dual T4)",
+  "id": "sonijisons/turbollm-one-click-dual-t4",
+  "title": "TurboLLM \u2014 one-click (dual T4)",
   "code_file": "turbollm_oneclick.ipynb",
   "language": "python",
   "kernel_type": "notebook",
   "is_private": "false",
   "enable_gpu": "true",
   "enable_internet": "true",
-  "dataset_sources": ["sonijisons/turboquant-cuda-t4"],
+  "dataset_sources": [
+    "sonijisons/turboquant-cuda-t4",
+    "selahattinkabasakal/qwen3-8-gguf"
+  ],
   "competition_sources": [],
   "kernel_sources": [],
   "model_sources": []

--- a/deploy/kaggle/turbollm_oneclick.ipynb
+++ b/deploy/kaggle/turbollm_oneclick.ipynb
@@ -142,6 +142,37 @@
     "> **Note:** Kaggle can't pin the *number* of GPUs from notebook metadata — if Preflight says it\n",
     "> found fewer than 2, set **Settings → Accelerator → GPU T4 × 2** and Run All again."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Keep the tunnel alive.\n",
+    "#\n",
+    "# A Kaggle *batch* run (`kaggle kernels push`) ends the moment the last cell finishes, which\n",
+    "# would tear the tunnel down seconds after it came up. Interactive sessions stay up on their\n",
+    "# own, so this only blocks under Batch - `Run All` in the editor still completes normally.\n",
+    "#\n",
+    "# TURBOLLM KEEP-ALIVE\n",
+    "import os, re, pathlib, time\n",
+    "\n",
+    "if os.environ.get(\"KAGGLE_KERNEL_RUN_TYPE\") != \"Batch\":\n",
+    "    print(\"Interactive session - tunnel stays up while this notebook is running.\")\n",
+    "else:\n",
+    "    log = pathlib.Path(\"/kaggle/working/turbollm-daemon.log\")\n",
+    "    HOURS = 9\n",
+    "    for minute in range(HOURS * 60):\n",
+    "        if minute % 10 == 0:\n",
+    "            t = log.read_text(errors=\"ignore\") if log.exists() else \"\"\n",
+    "            m = re.search(r\"https://[a-z0-9-]+\\.trycloudflare\\.com\", t)\n",
+    "            k = re.search(r\"Token:\\s*(\\S+)\", t)\n",
+    "            print(f\"[keep-alive {minute // 60}h{minute % 60:02d}m] \"\n",
+    "                  f\"URL: {m.group(0) if m else '?'}  Token: {k.group(1) if k else '?'}\",\n",
+    "                  flush=True)\n",
+    "        time.sleep(60)\n"
+   ]
   }
  ],
  "metadata": {

--- a/turbollm/src/bench/bench.split.test.ts
+++ b/turbollm/src/bench/bench.split.test.ts
@@ -50,22 +50,39 @@ test('split-incapable engine → one strategy even on a multi-GPU box', () => {
   assert.equal(strats[0].splitMode, 'layer')
 })
 
-test('multi-GPU, model fits one card → single-GPU FIRST, then layer-split', () => {
+test('multi-GPU, model fits one card → single-GPU FIRST, then layer-split, then row', () => {
   const s = sys([24000, 24000])
   const strats = pickSplitStrategies(model({ sizeBytes: 8_000_000_000 }), s, base(s), caps)
-  assert.equal(strats.length, 2)
-  assert.equal(strats[0].splitMode, 'none') // tried first — the likely winner
-  assert.equal(strats[0].mainGpu, 0)
-  assert.equal(strats[1].splitMode, 'layer')
+  assert.deepEqual(strats.map((g) => g.splitMode), ['none', 'layer', 'row'])
+  assert.equal(strats[0].mainGpu, 0) // single-GPU tried first — the likely winner
 })
 
-test('multi-GPU, model too big for one card even at smallest KV → layer-split only', () => {
+test('multi-GPU, model too big for one card even at smallest KV → the two split modes, no single-GPU', () => {
   const s = sys([24000, 24000])
   // ~60 GB weights: even fully on CPU (ngl=0) plus KV/overhead this barely clears one 24 GB card,
   // and any real GPU residency overflows it fast — so single-GPU is well under 50% and skipped.
+  // Both MULTI-GPU geometries remain: layer (the default) and row (tensor-parallel).
   const strats = pickSplitStrategies(model({ sizeBytes: 60_000_000_000 }), s, base(s), caps)
-  assert.equal(strats.length, 1)
-  assert.equal(strats[0].splitMode, 'layer')
+  assert.deepEqual(strats.map((g) => g.splitMode), ['layer', 'row'])
+})
+
+test('row (tensor-parallel) is offered on every multi-GPU box, and always LAST', () => {
+  // Auto-tune could not previously express `--split-mode row` at all, so it was structurally
+  // incapable of finding the best dual-GPU config — a layer split is a sequential pipeline, and row
+  // is the only mode where both cards work the same layer at once. It goes last so that a sweep
+  // truncated by the global deadline still returns the layer-split default.
+  const s = sys([24000, 24000])
+  for (const bytes of [8_000_000_000, 60_000_000_000]) {
+    const strats = pickSplitStrategies(model({ sizeBytes: bytes }), s, base(s), caps)
+    assert.equal(strats.at(-1)?.splitMode, 'row', `row should be last for ${bytes} bytes`)
+    assert.deepEqual(strats.at(-1)?.tensorSplit, [], 'row starts from an even, unpinned split')
+  }
+})
+
+test('row is NOT offered when the user pinned a single GPU — that is a hardware choice, not a geometry', () => {
+  const s = sys([24000, 24000])
+  const pinned = base(s, { gpu: { splitMode: 'none', tensorSplit: [], mainGpu: 0, tensorParallelSize: 1 } })
+  assert.ok(!pickSplitStrategies(model(), s, pinned, caps).some((g) => g.splitMode === 'row'))
 })
 
 test('multi-GPU, model just barely exceeds one card at FULL offload → single-GPU still offered (GitHub #62)', () => {
@@ -195,8 +212,8 @@ test('ADR-379: a dense model that needs both cards is NOT offered single-GPU', (
   const p = base(T4x2_REAL, { ctx: 188416, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'q8_0' }, m)
   const strats = pickSplitStrategies(m, T4x2_REAL, p, caps)
   assert.ok(!strats.some((g) => g.splitMode === 'none'), 'single-GPU must not be offered')
-  assert.equal(strats.length, 1)
-  assert.equal(strats[0].splitMode, 'layer')
+  // Only the multi-GPU geometries remain, layer (the default) first.
+  assert.deepEqual(strats.map((g) => g.splitMode), ['layer', 'row'])
 })
 
 test('ADR-379: the verdict is not changed by a smaller KV the run will never use', () => {

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1602,6 +1602,28 @@ export function pickSplitStrategies(
   // models too big for one card and so a tuned result can never be worse than today's default.
   strategies.push(base.gpu)
 
+  // Row (tensor-parallel): the two cards work on the SAME layer at once. A layer split is a
+  // sequential PIPELINE — measured on 2x T4 as GPU1 at 98-99% util while GPU0 sat at 74% — so it
+  // buys capacity, not speed, and row is the only mode where both cards contribute to one token.
+  //
+  // Row was previously left out on the reasoning that its per-layer all-reduce "rarely pays off on
+  // PCIe-only multi-GPU". That is a plausible prediction, not a measurement, and it made auto-tune
+  // structurally incapable of ever finding the best dual-GPU configuration: a user on 2x RTX 5060
+  // Ti reports 68 tok/s from a hand-written `--split-mode tensor` command line that this sweep
+  // could not have produced at any setting. The rest of this function already decides
+  // single-vs-layer by measured tok/s; row gets the same treatment, so on boxes where the
+  // all-reduce really does dominate it simply loses and costs only its probe.
+  //
+  // Kept LAST deliberately. The strategy loop breaks on the global deadline, so the extra branch is
+  // the first thing dropped when the budget runs short — a truncated sweep still returns the
+  // layer-split default rather than losing it to a newcomer.
+  //
+  // Skipped when the profile is pinned to a single GPU: "use one card" is a choice about which
+  // hardware to use at all, not a split geometry to be tuned, and offering a 2-GPU branch there
+  // would override it. (A pinned tensorSplit IS discarded — see withBalancedSplit — because that
+  // caps the offload search; a pinned 'none' does not.)
+  if (base.gpu.splitMode !== 'none') strategies.push({ ...base.gpu, splitMode: 'row', tensorSplit: [] })
+
   // De-dup by the fields that actually reach the launch args (e.g. the user already pinned 'none').
   const seen = new Set<string>()
   return strategies.filter((g) => {


### PR DESCRIPTION
## What this is

The dual-GPU ask was: **find the best auto-tune setup for two GPUs and prove it through the GUI.**
This delivers that for **Qwen3.8-27B-UD-Q4_K_XL on 2× Tesla T4**, plus the one code change that
made auto-tune capable of finding it on other hardware.

## The answer

| Setting | Value |
|---|---|
| Context length | **200,192** |
| GPU layers | **ALL (65)** |
| Split mode | **Layer** |
| K cache type | **q8_0** |
| V cache type | **turbo4** |
| Flash attention | **On** |
| Speculative decoding | **Off** ⚠️ the default (NextN) is *slower* here |

**11.5–12 tok/s in chat at 200k context**, 28.7 / 30.7 GB, nothing on CPU.

**Auto-tune finds this on its own** — a full sweep converged on GPU layers 65 / ctx 200,192 /
q8_0 / flash-attn on, i.e. the same config. Its own reported 7.5 tok/s vs 11.5 in chat is the
documented methodology gap (bench prompt is `0.75 × ctx` capped at 32k; a chat turn starts short),
not a regression. `First token: 108,027 ms` is the honest price of that prefill depth on T4s.

What lost, and why — all measured in the GUI:

| Variant | Result |
|---|---|
| **Row** (tensor-parallel) | crashes ~8 s in, `ggml_backend_cuda_split_buffer_set_tensor`, at ctx 8,192 too — not a memory ceiling |
| **NextN** on, ctx 131k | 7.0 tok/s and falling — ~40% worse at a *smaller* context |
| K left at **turbo4** | fails to load, `exit 1` |
| **f16** / all-**q8_0** KV | 45.4 GB / 32.0 GB — both overflow the 30.7 GB pool |
| **Single-GPU** (auto-tune's first candidate) | ngl 31/65 → 34 dense layers on 4 vCPUs, prefill crawls |

## Code change — BUG-6

`pickSplitStrategies` only ever emitted `{single-GPU, layer-split}`, so auto-tune could not produce
a tensor-parallel config at any setting on any hardware. Row is now a candidate, **ordered last**
(the strategy loop breaks on the global deadline, so the newcomer is dropped first and a truncated
sweep still returns the layer default) and **skipped when a single GPU is pinned**.

The "row wastes tuning time on PCIe boxes" objection is now measured rather than assumed: on this
box row fails in **eight seconds** and is recorded as a `crash`. Meanwhile the reference machine
(2× RTX 5060 Ti, `--split-mode tensor`, 68 tok/s) is exactly where it wins. Measurement decides,
cheaply, both ways.

## Kaggle setup is now CLI-driven

Push → live GUI in **181 seconds**, no model download ever:

- `kernel-metadata.json` `id` did not match the title's slug, so *every* `kernels push` failed
  `409 … title does not resolve to the specified id` (Kaggle derives the slug from `title`).
- Attaches `selahattinkabasakal/qwen3-8-gguf` (17.9 GB) as a read-only input — costs nothing
  against the 19.5 GB `/kaggle/working` quota, and `serve.sh` already registers the directory.
- A batch run ends when its last cell returns, killing the tunnel instantly. A new final cell
  blocks up to 9 hours **only** under `KAGGLE_KERNEL_RUN_TYPE == "Batch"`, so `Run All` in the
  editor still completes normally, and reprints URL + token every 10 minutes.

## New bugs documented

- **BUG-11** — the VRAM estimate ignores the fork's own auto-asymmetric KV upgrade. The panel says
  `~25.4 GB · fits` with turbo4 selected; the engine upgrades K to `q8_0` at GQA 6:1 and the honest
  figure is `~28.7 GB`. A 3.3 GB optimistic error on a box with ~2 GB of headroom → `exit 1`.
- **BUG-12** — the estimate ignores the MTP draft context NextN allocates (`creating MTP draft
  context against the target model`). NextN is the **default** for any model shipping a NextN head.
- **BUG-13** — the auto-tune progress line goes stale and never recovers: it sat at
  `probing ngl=32` for ~50 minutes while the sweep had advanced to `Measuring ngl=65`. Same class
  as the engine badge sticking on `Stopping`. It makes a healthy long run look like a hang — it
  caused one sweep here to be cancelled at `prefill 46%` while progressing normally.

**BUG-1/BUG-2 verified on hardware** for the first time: onboarding now reads
`2× Tesla T4 · 30 GB VRAM` where it previously reported a single 15 GB card.

## Verification

`tsc --noEmit` clean; `bench.split.test.ts` 22/22. The three tests that asserted a strategy *count*
now assert the full ordered list, which is what they were actually about; two new tests pin that
row is present-and-last on a multi-GPU box and absent when a single GPU is pinned.

Everything above was measured through the GUI on a live 2× T4 box — no scripts, no curl, no
notebook cells.
