### PR TITLE
Code over Turbo Link (ADR-382/385) + dense-split probe gate (ADR-384)

### DIFF
--- a/deploy/kaggle/DUAL-GPU-BUGS.md
+++ b/deploy/kaggle/DUAL-GPU-BUGS.md
@@ -70,6 +70,7 @@ card). Every site below instead read the *first* card and reported half the mach
   True ceiling `ngl 28/65 = 0.43`, below the 0.5 gate; measured against `turbo4` it cleared it.
 - **Fix:** judge on `base.kvTypeK`. Threshold deliberately left at 0.5 — raising it for dense
   was tried and reverted because it also rejected GitHub #62 at ~0.72.
+- **Follow-up:** that last sentence turned out to be wrong on both halves — see **BUG-16**.
 
 ### BUG-6 · Auto-tune never tries row / tensor-parallel split — **OPEN, likely the biggest miss**
 - **Where:** `turbollm/src/bench/bench.ts`, `pickSplitStrategies()` — only ever generates
@@ -276,3 +277,27 @@ quick chat test uses a short prompt. The same config measured **7.8 t/s at a 2,5
 and 6.26 t/s at 32k**. Two points on one curve, not a regression. The auto-tune/chat gap measured
 on-design is **70%**, of which ~19 points is methodology (engine-internal `predicted_per_second`
 vs wall-clock streaming), ~10 points run-to-run, and only **4%** the daemon's proxy hop.
+
+### BUG-16 · The single-GPU gate still opened at mid depth, with half a dense model on CPU — **FIXED (ADR-384)**
+- **Where:** `turbollm/src/bench/bench.ts`, `pickSplitStrategies()` — the same gate as BUG-5.
+- **Was:** BUG-5 closed the *deep* end (ctx 188k+ computes 0.000, correctly skipped) but left a
+  band open in the middle. BUG-6's fix notes saw the symptom without naming it: *"the branch that
+  actually burns budget is single-GPU — it clears the 0.5 gate, probes down to `ngl 31/65`, then
+  benches 34 dense layers on four vCPUs."*
+- **Measured**, real Qwen3.8-27B UD-Q4_K_XL (dense, 65 blocks, 17.9 GB, `headCountKv` 4,
+  `headDim` 256) on 2x15360 MiB — model metadata pulled live off the box, fractions computed with
+  the real `estimateVram`:
+  ```
+  ctx   8192  q8_0 -> 0.708  (19/65 on CPU)  offered -> still offered   <- GitHub #62's shape
+  ctx  16384  f16  -> 0.523  (31/65 on CPU)  offered -> NOW SKIPPED
+  ctx  32768  q8_0 -> 0.523  (31/65 on CPU)  offered -> NOW SKIPPED
+  ctx 188416  q8_0 -> 0.000  (65/65 on CPU)  skipped (BUG-5)
+  ```
+- **Fix:** the bar is now `0.6` for **dense** and stays `0.5` for **MoE**
+  (`MIN_SINGLE_GPU_FRACTION_DENSE` / `..._MOE`). A dense layer is read on every token; an
+  offloaded MoE expert only when the router picks it — a MoE at 0.550 is pinned as still offered.
+- **Why BUG-5's "raising it broke #62" no longer holds:** #62's own fixture computes **0.875**,
+  not the ~0.72 estimated at the time, and every fixture `pickSplitStrategies` is pinned against
+  sits at >= 0.875 or <= 0.344 — the 0.5-0.6 band was empty of intended behaviour.
+- **Not fixed by this:** the branch is still entered on an estimate, and "auto-tune is correct;
+  it is merely slow" still stands at deep context.

--- a/turbollm/src/api/link-admin-routes.ts
+++ b/turbollm/src/api/link-admin-routes.ts
@@ -243,6 +243,40 @@ export function registerLinkAdminRoutes(
     return c.json({ models: d.remoteCatalog?.models() ?? [] })
   })
 
+  // ── Which machine this install is POINTED AT (ADR-382) ──────────────────────────────────
+  //
+  // The selection used to live in the web app's UI store alone, which meant a different
+  // process could not see it: `turbollm launch pi` with no --model auto-loaded a LOCAL model
+  // while the UI showed a linked machine selected, then spent 180 s failing to load it
+  // (founder-reported, 2026-08-23). Persisting it here makes one selection true for every
+  // surface — this browser, another device's browser, and the CLI.
+  //
+  // Validated on write, not on read: an id that names no online link with that model is
+  // refused NOW, with the router's own message, rather than being stored and silently
+  // failing at the user's first prompt. Reads still re-resolve (a link can go offline
+  // afterwards), so a stale value degrades to the local path instead of breaking.
+  app.put('/api/v1/links/selected-model', async (c) => {
+    const denied = gate(c, MANAGE)
+    if (denied) return denied
+    const body = await c.req.json().catch(() => null) as { model?: string | null } | null
+    const wanted = (body?.model ?? '').trim()
+    if (!wanted) {
+      // Clearing is always allowed — it is how the user comes back to their own machine, and
+      // it must work even when the link they were using has since disappeared.
+      d.store.update((cfg) => { cfg.selectedRemoteModel = '' })
+      return c.json({ ok: true, selectedRemoteModel: '' })
+    }
+    const route = d.modelRouter?.resolveRemoteTarget?.(wanted)
+    if (!route) {
+      return c.json({ error: { code: 'not_remote', message: `'${wanted}' does not name a model on a linked machine.` } }, 400)
+    }
+    if ('status' in route) {
+      return c.json({ error: { code: 'remote_unavailable', message: route.message } }, 503)
+    }
+    d.store.update((cfg) => { cfg.selectedRemoteModel = wanted })
+    return c.json({ ok: true, selectedRemoteModel: wanted })
+  })
+
   // ── Peer side: add / edit / remove a link.
   app.post('/api/v1/links', async (c) => {
     const denied = gate(c, MANAGE)

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -129,6 +129,11 @@ export function registerApi(app: Hono, d: Deps): void {
       // Last model the user loaded (config-tracked) — lets `turbollm launch` auto-load the
       // true last-used model instead of guessing the first library entry (F-034).
       lastLoaded: d.store.snapshot().lastLoaded,
+      // Turbo Link (ADR-382): the linked-machine model this install is pointed at, or '' for
+      // local. On /status because every surface reads it here — the web app hydrates its picker
+      // from it, and `turbollm launch <cli>` (which has no access to browser state) uses it
+      // instead of auto-loading a local model the user did not ask for.
+      selectedRemoteModel: d.store.snapshot().selectedRemoteModel ?? '',
       engineStats: core.engineStats,
       liveGeneration: core.liveGeneration,
       // Auto-tune runner state (spec 09 §1): real progress while a sweep runs, then

--- a/turbollm/src/bench/bench.split.test.ts
+++ b/turbollm/src/bench/bench.split.test.ts
@@ -232,12 +232,57 @@ test('ADR-379: a dense model that comfortably fits one card still gets single-GP
   assert.equal(strats[0].splitMode, 'none', 'tried first -- the likely winner')
 })
 
-test('ADR-379: the 0.5 threshold is untouched, so GitHub #62 still gets its shot', () => {
-  // Guards against fixing the gate by raising the bar, which was tried and reverted: it
-  // rejected the reported 0.43 case but also rejected #62 at ~0.72, which must still be
-  // offered. The KV type is what separates them, not the threshold.
+test('ADR-379: GitHub #62 still gets its shot after ADR-384 raised the DENSE bar', () => {
+  // Originally guarded the flat 0.5 bar. ADR-384 raised the bar for DENSE models only, so what
+  // this now pins is that #62 clears the higher one too — it computes 0.875 (4 of 32 blocks on
+  // CPU), nowhere near the 0.5–0.6 band ADR-384 closes. Note ADR-379 estimated this case at
+  // ~0.72; the fixture actually computes 0.875. The KV type (ADR-379) still separates #62 from
+  // the 0.43 case; the bar is what separates it from the half-on-CPU case.
   const m = model({ sizeBytes: 15_000_000_000, blockCount: 32, nativeCtx: 8192 })
   const s16 = sys([16000, 16000])
   const strats = pickSplitStrategies(m, s16, base(s16, { ctx: 8192 }, m), caps)
   assert.equal(strats[0].splitMode, 'none')
+})
+
+// ---- ADR-384: a dense model may not be tried single-GPU with half its layers on CPU --------
+// Ground truth pulled live off the Kaggle 2x T4 box: Qwen3.8-27B UD-Q4_K_XL, dense, 65 blocks,
+// 17,923,394,624 bytes, headCountKv 4, headDim 256, nativeCtx 262144.
+//
+// ADR-379 fixed the KV type the gate judges with, which correctly closed the deep end (ctx 188k+
+// computes 0.000). It left a band open in the middle: at ctx 32768/q8_0 the gate computes 0.523,
+// clears the flat 0.5 bar, and opens a single-GPU branch that parks 31 of 65 DENSE layers on the
+// CPU. Every one of those layers is touched on every token, so it cannot beat a layer-split that
+// holds the whole model — it just costs a bench slot (up to the 10-minute timeout) to prove it.
+// This is the band ADR-381 saw as "the branch that actually burns budget is single-GPU".
+
+const QWEN38_REAL = {
+  sizeBytes: 17_923_394_624, arch: 'qwen35', quant: 'Q4_K_XL', nativeCtx: 262144,
+  blockCount: 65, headCountKv: 4, headDim: 256, moe: false, nextnLayers: 1,
+} as Partial<ModelEntry>
+
+test('ADR-384: a dense model with ~half its layers on CPU is NOT offered single-GPU', () => {
+  const m = model(QWEN38_REAL)
+  const p = base(T4x2_REAL, { ctx: 32768, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'q8_0' }, m)
+  const strats = pickSplitStrategies(m, T4x2_REAL, p, caps)
+  assert.ok(!strats.some((g) => g.splitMode === 'none'), 'single-GPU must not be offered at 0.523')
+})
+
+test('ADR-384: the same model at a shallower ctx keeps its single-GPU shot', () => {
+  // ctx 8192 computes 0.708 — only 19 of 65 blocks on CPU. This is the shape GitHub #62 is about,
+  // and it must survive the higher bar, so the fix cannot just be "skip whenever it needs CPU".
+  const m = model(QWEN38_REAL)
+  const p = base(T4x2_REAL, { ctx: 8192, ngl: 99, kvTypeK: 'q8_0', kvTypeV: 'q8_0' }, m)
+  assert.equal(pickSplitStrategies(m, T4x2_REAL, p, caps)[0].splitMode, 'none')
+})
+
+test('ADR-384: MoE is untouched — partial residency is cheap when experts are idle', () => {
+  // 20 GB MoE at ctx 8192 computes 0.550 — inside the band the dense bar now rejects. It must
+  // still be offered: an offloaded expert is only read when the router picks it, so half a MoE
+  // on CPU is nothing like half a dense model on CPU. The bar is dense-only for that reason.
+  const m = model({ sizeBytes: 20_000_000_000, blockCount: 40, moe: true, expertCount: 128, arch: 'qwen3moe' })
+  const p = base(T4x2_REAL, { ctx: 8192, ngl: 99 }, m)
+  assert.ok(
+    pickSplitStrategies(m, T4x2_REAL, p, caps).some((g) => g.splitMode === 'none'),
+    'MoE single-GPU must still be offered inside the 0.5–0.6 band',
+  )
 })

--- a/turbollm/src/bench/bench.ts
+++ b/turbollm/src/bench/bench.ts
@@ -1556,6 +1556,13 @@ export function overHeadroom(vramAbsMb: number | null, budgetMb: number, headroo
  *  second. Single-GPU is tried first because, when the model fits one card, it beats any split (a
  *  layer-split is a sequential cross-GPU pipeline + per-token PCIe activation copies), so a
  *  budget-truncated run still measured the likely winner. */
+/** Smallest GPU-resident fraction that makes a single-GPU branch worth a bench slot (ADR-384).
+ *  Split by architecture because CPU residency costs the two shapes very differently: every dense
+ *  layer is read on every token, while an offloaded MoE expert is read only when the router picks
+ *  it. See the reasoning in {@link pickSplitStrategies}. */
+const MIN_SINGLE_GPU_FRACTION_MOE = 0.5
+const MIN_SINGLE_GPU_FRACTION_DENSE = 0.6
+
 export function pickSplitStrategies(
   entry: ModelEntry,
   sys: SysInfo,
@@ -1583,10 +1590,28 @@ export function pickSplitStrategies(
   // CPU wouldn't end up doing the majority of the work — below that, the summed multi-GPU pool
   // (kept as today's fallback either way) is the sounder bet.
   //
-  // The 0.5 threshold is deliberately UNCHANGED. Raising it for dense models (partial residency
-  // hurts far more when every parameter is active) was tried and reverted: the KV fix below
-  // already rejects the reported failure at 0.43, while GitHub #62's "just missed the card" case
-  // computes ~0.72 and must still be offered. A higher bar fixed nothing extra and broke #62.
+  // The bar is 0.5 for MoE and 0.6 for DENSE (ADR-384). ADR-379 recorded the dense bar as
+  // deliberately unchanged, on the grounds that raising it "fixed nothing extra and broke #62".
+  // That was true of the evidence available then and is no longer true: the KV fix below closes
+  // the DEEP end (ctx 188k+ computes 0.000, correctly skipped) but leaves a band open in the
+  // middle. Measured on the real 2x T4 box with the real model — Qwen3.8-27B UD-Q4_K_XL, dense,
+  // 65 blocks — ctx 32768 at the user's q8_0 computes 0.523: it clears 0.5 and opens a branch
+  // that parks 31 of 65 DENSE layers on four vCPUs. A dense layer is touched on EVERY token, so
+  // that branch cannot beat a layer-split holding the whole model; it only costs a bench slot
+  // (up to the 10-minute timeout) to establish what the arithmetic already knew. ADR-381's
+  // "the branch that actually burns budget is single-GPU" is this band.
+  //
+  // Why 0.6, and why dense-only:
+  //   - It separates the two measured cases with margin on both sides — rejects 0.523, keeps the
+  //     same model at ctx 8192 (0.708, only 19 of 65 blocks on CPU), which is #62's shape.
+  //   - Every fixture this function is pinned against sits at >= 0.875 or <= 0.344, so the
+  //     0.5-0.6 band was empty of intended behavior. GitHub #62's own fixture computes 0.875,
+  //     not the ~0.72 ADR-379 estimated.
+  //   - Erring low is deliberate. Wrongly OFFERING costs one bench slot; wrongly SKIPPING costs
+  //     the better configuration and reproduces #62, which is the worse failure. So the bar sits
+  //     nearer the case it must reject than the case it must keep.
+  //   - MoE keeps 0.5: an offloaded expert is only read when the router selects it, so half a MoE
+  //     on CPU is nothing like half a dense model on CPU. A MoE at 0.550 is still offered.
   //
   // Judged with the KV type that will ACTUALLY be used (ADR-379). This used to judge with the
   // smallest KV the engine offers, justified by "the inner KV sweep can pick it to fit" — but
@@ -1596,7 +1621,9 @@ export function pickSplitStrategies(
   // the doomed branch was opened anyway — six probes and a 10-minute bench TIMEOUT before falling
   // through to the layer-split that was right from the start.
   const singleFrac = maxGpuFraction(entry, sys, { ...base, gpu: single })
-  if (singleFrac >= 0.5) strategies.push(single)
+  if (singleFrac >= (entry.moe ? MIN_SINGLE_GPU_FRACTION_MOE : MIN_SINGLE_GPU_FRACTION_DENSE)) {
+    strategies.push(single)
+  }
 
   // The profile's current split (default: layer across all GPUs) — always kept, as the fallback for
   // models too big for one card and so a tuned result can never be worse than today's default.

--- a/turbollm/src/cli-launch.remote.test.ts
+++ b/turbollm/src/cli-launch.remote.test.ts
@@ -54,14 +54,16 @@ function makeFetch(
   gatewayIds: string[],
   hits: Hits,
   engineState: 'running' | 'idle' = 'idle',
+  /** ADR-382: what the UI has this install pointed at, as /status reports it. */
+  selectedRemoteModel = '',
 ): typeof fetch {
   const fn = async (input: string | URL | globalThis.Request): Promise<Response> => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
 
     if (url.includes('/api/v1/status')) {
       const body = engineState === 'running'
-        ? { engine: { state: 'running' }, model: { key: LOCAL[0].key, name: LOCAL[0].name } }
-        : { engine: { state: 'idle' }, model: null }
+        ? { engine: { state: 'running' }, model: { key: LOCAL[0].key, name: LOCAL[0].name }, selectedRemoteModel }
+        : { engine: { state: 'idle' }, model: null, selectedRemoteModel }
       return { ok: true, status: 200, json: async () => body } as Response
     }
     if (url.includes('/api/v1/models')) {
@@ -149,6 +151,72 @@ test('a LOCAL key containing a slash still resolves locally, unchanged', async (
     assert.equal(code, 0)
     assert.equal(calls[0].env['ANTHROPIC_MODEL'], 'unsloth/Qwen3-GGUF')
     assert.equal(hits.engineStart, 0, 'already loaded — no reload')
+  } finally {
+    out.restore()
+  }
+})
+
+// ── ADR-382: no --model, but the UI has this install pointed at a linked machine ─────────
+//
+// The founder-reported symptom, verbatim: `turbollm launch pi` printed
+// "Auto-loading model qwen3.8-27b…", gave up after 180 s, and crashed — while the UI showed a
+// cloud model selected and ready. The selection lived only in the browser, so this process
+// never saw it. It is daemon state now (/status's selectedRemoteModel), and these tests fail
+// if the CLI ever goes back to guessing a local model instead of reading it.
+
+test('no --model: the daemon-side remote selection is used, and NOTHING is loaded locally', async () => {
+  const { calls, fn } = makeSpawn()
+  const hits: Hits = { engineStart: 0, gatewayModels: 0 }
+  const out = silenceOutput()
+  try {
+    const code = await launchCli(
+      'claude', 6996, [], fn,
+      undefined,
+      makeFetch(['qwen3-8b', 'workstation/Qwen3-35B'], hits, 'idle', 'workstation/Qwen3-35B'),
+    )
+    assert.equal(code, 0)
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], 'workstation/Qwen3-35B')
+    // THE bug: this used to be 1 — a 180-second local load nobody asked for.
+    assert.equal(hits.engineStart, 0, 'a remote selection must never trigger a local auto-load')
+  } finally {
+    out.restore()
+  }
+})
+
+test('the remote selection wins over a model that happens to be loaded locally', async () => {
+  // It is an explicit user choice; reusing whatever this box has running would silently ignore
+  // it, which is the same class of bug as auto-loading something else.
+  const { calls, fn } = makeSpawn()
+  const hits: Hits = { engineStart: 0, gatewayModels: 0 }
+  const out = silenceOutput()
+  try {
+    const code = await launchCli(
+      'claude', 6996, [], fn,
+      undefined,
+      makeFetch(['qwen3-8b', 'workstation/Qwen3-35B'], hits, 'running', 'workstation/Qwen3-35B'),
+    )
+    assert.equal(code, 0)
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], 'workstation/Qwen3-35B')
+    assert.equal(hits.engineStart, 0)
+  } finally {
+    out.restore()
+  }
+})
+
+test('a STALE selection (its machine went offline) falls back to the local path', async () => {
+  // Re-validated against what the gateway advertises RIGHT NOW rather than trusted from
+  // config — otherwise a link that dropped would pin the CLI to a machine that cannot answer.
+  const { calls, fn } = makeSpawn()
+  const hits: Hits = { engineStart: 0, gatewayModels: 0 }
+  const out = silenceOutput()
+  try {
+    const code = await launchCli(
+      'claude', 6996, [], fn,
+      undefined,
+      makeFetch(['qwen3-8b'], hits, 'running', 'workstation/Qwen3-35B'),
+    )
+    assert.equal(code, 0)
+    assert.equal(calls[0].env['ANTHROPIC_MODEL'], 'qwen3-8b', 'falls back to the loaded local model')
   } finally {
     out.restore()
   }

--- a/turbollm/src/cli-launch.ts
+++ b/turbollm/src/cli-launch.ts
@@ -206,6 +206,10 @@ interface DaemonStatus {
   engine?: { state?: string; parallelSlots?: number }
   model?: { name?: string; key?: string; ctx?: number } | null
   lastLoaded?: { modelKey?: string } | null
+  /** Turbo Link (ADR-382): the qualified `<machine>/<model>` id the user pointed this install
+   *  at in the UI, or '' / absent for 'this machine'. Daemon state, so this process can see a
+   *  choice made in a browser. */
+  selectedRemoteModel?: string
 }
 
 // Claude Code CLI's own documented range for CLAUDE_CODE_AUTO_COMPACT_WINDOW (env-vars docs,
@@ -1288,6 +1292,17 @@ export async function launchCli(
       const refreshed = await fetchStatus(base, _fetch)
       if (refreshed) status = refreshed
     }
+  } else if (status?.selectedRemoteModel && (await fetchGatewayModelIds(base, _fetch)).includes(status.selectedRemoteModel)) {
+    // No --model, but the user has pointed this install at a linked machine's model (ADR-382).
+    // That choice wins over BOTH auto-loading a local model and reusing whatever happens to be
+    // running here: it is an explicit selection, and the founder-reported symptom was exactly
+    // this branch not existing — the UI showed a linked machine while this process spent 180 s
+    // failing to auto-load a local 27B nobody had asked for.
+    //
+    // Re-checked against the gateway's OWN advertised ids rather than trusted from config, so a
+    // link that went offline since the pick simply falls through to the local path below
+    // instead of pinning the CLI to a machine that cannot answer.
+    remoteModel = status.selectedRemoteModel
   } else if (!alreadyRunning) {
     // No --model and no model loaded: auto-load the last-used / first available model.
     const models = await fetchModels(base, _fetch)
@@ -1342,7 +1357,14 @@ export async function launchCli(
   // case no cap is set and the CLI keeps its own default, rather than inventing a limit of 1.
   const parallelSlots = status.engine?.parallelSlots
 
-  const modelNote = modelKey ? `model: ${model}` : `using loaded model: ${model}`
+  // "loaded" would be a lie for a model that is up on ANOTHER machine and was never loaded
+  // here — and it is precisely the case the user needs the banner to confirm, since nothing
+  // else on this box will show it.
+  const modelNote = modelKey
+    ? `model: ${model}`
+    : remoteModel
+      ? `using selected remote model: ${model}`
+      : `using loaded model: ${model}`
   process.stdout.write(`▸ Launching ${spec.label} → TurboLLM  (${modelNote}, ${base})\n`)
 
   // The whole library, for the harnesses whose model picker can only offer what we write into their

--- a/turbollm/src/code/code-routes.ts
+++ b/turbollm/src/code/code-routes.ts
@@ -34,7 +34,10 @@ import { agentsMdPresence } from './persona'
 import type { CodeMode } from './persona'
 import { sessionAuth } from './session-auth'
 
-type S = 200 | 201 | 202 | 400 | 404 | 409 | 500
+// 503 is Turbo Link's (ADR-376): a linked machine that went offline between the picker
+// listing it and this turn being submitted. Deliberately not 409 — nothing about THIS
+// machine's state is wrong, and the fix is on the other box.
+type S = 200 | 201 | 202 | 400 | 404 | 409 | 500 | 503
 function err(c: Context, s: S, code: string, msg: string) { return c.json({ error: { code, message: msg } }, s) }
 async function body<T>(c: Context): Promise<T> { try { return await c.req.json() as T } catch { return {} as T } }
 
@@ -483,13 +486,22 @@ export function registerCodeRoutes(app: Hono, d: Deps, codeRuns?: CodeRunManager
     if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
     if (runs.isActive(id)) return err(c, 409, 'run_active', 'Stop or wait for the current run before compacting.')
     if (run.clearedUpToMessageId) return err(c, 409, 'session_cleared', 'Resume this session before compacting — compacting a cleared session would lose the hidden history.')
-    const ms = d.manager.status()
-    if (ms.state !== 'running' || !ms.model) return err(c, 409, 'model_not_loaded', 'Load a model first.')
-    const b = await body<{ instructions?: string }>(c)
+    const b = await body<{ instructions?: string; model?: string }>(c)
+    // Same Turbo Link branch as the turn route: a session whose history was generated on a
+    // linked machine is compacted BY that machine, so this machine's engine state is not what
+    // decides whether compaction can run.
+    const requestedModel = (b.model ?? '').trim() || undefined
+    const remoteRoute = requestedModel ? d.modelRouter.resolveRemoteTarget(requestedModel) : undefined
+    if (remoteRoute && 'status' in remoteRoute) return err(c, 503, 'remote_unavailable', remoteRoute.message)
+    if (!remoteRoute) {
+      const ms = d.manager.status()
+      if (ms.state !== 'running' || !ms.model) return err(c, 409, 'model_not_loaded', 'Load a model first.')
+    }
     try {
       const result = await compactCodeSession({
         d, convId: run.convId, sessionId: id, repoRoot: agentCwd(run),
         customInstructions: b.instructions?.trim() || undefined,
+        model: requestedModel,
       })
       return c.json({ ok: true, ...result })
     } catch (e) {
@@ -784,7 +796,7 @@ export function registerCodeRoutes(app: Hono, d: Deps, codeRuns?: CodeRunManager
   // that is how a follow-up submitted mid-run survives a disconnect and still fires in order.
   app.post('/api/v1/code/sessions/:id/messages', async (c) => {
     const id = c.req.param('id')
-    const b = await body<{ content?: string; promptOverride?: string; contextFiles?: string[]; thinkingBudget?: number; reasoningEffort?: string; kind?: string }>(c)
+    const b = await body<{ content?: string; promptOverride?: string; contextFiles?: string[]; thinkingBudget?: number; reasoningEffort?: string; kind?: string; model?: string }>(c)
     // How to deliver this message when a run is already active (Phase 1, ADR-246): 'steer'
     // redirects the CURRENTLY ACTIVE turn, 'followUp' queues a fresh turn behind it. Anything
     // else — including the field being omitted by the not-yet-updated frontend — defaults to
@@ -797,12 +809,23 @@ export function registerCodeRoutes(app: Hono, d: Deps, codeRuns?: CodeRunManager
     if (!conv) return err(c, 404, 'not_found', 'Session conversation not found.')
     if (!run.repoRoot) return err(c, 400, 'invalid_input', 'Session has no repo root.')
 
-    // Fail fast with a clear message if there is no engine to run against right now. (A turn
+    // Fail fast with a clear message if there is nothing to run against right now. (A turn
     // that queues while a model is loaded but is then unloaded before it runs fails cleanly
     // inside the run instead — see code-run-manager.ts's turn executor.)
-    const ms = d.manager.status()
-    if (ms.state !== 'running' || !ms.model) return err(c, 409, 'model_not_loaded', 'Load a model first.')
-    if (!d.manager.target()) return err(c, 409, 'model_not_loaded', 'Engine not running.')
+    //
+    // Turbo Link (ADR-376): a turn pointed at a linked machine must NOT be judged by this
+    // machine's engine — the whole point is a box with no GPU of its own driving one that has
+    // it, where 'Load a model first' would refuse the only configuration the feature exists to
+    // serve. `resolveRemoteTarget` is the router's own resolution (never an `includes('/')`
+    // test), so a local key carrying its own slash still takes the local path below.
+    const requestedModel = (b.model ?? '').trim() || undefined
+    const remoteRoute = requestedModel ? d.modelRouter.resolveRemoteTarget(requestedModel) : undefined
+    if (remoteRoute && 'status' in remoteRoute) return err(c, 503, 'remote_unavailable', remoteRoute.message)
+    if (!remoteRoute) {
+      const ms = d.manager.status()
+      if (ms.state !== 'running' || !ms.model) return err(c, 409, 'model_not_loaded', 'Load a model first.')
+      if (!d.manager.target()) return err(c, 409, 'model_not_loaded', 'Engine not running.')
+    }
 
     // The task for this turn: an explicit message body wins; otherwise the last user message
     // (the seeded task on the first run).
@@ -835,7 +858,7 @@ export function registerCodeRoutes(app: Hono, d: Deps, codeRuns?: CodeRunManager
     // commits silently did nothing while the repo went dirty. (The site fixed first was /compact —
     // a different one.) Caught by the pre-release review gate, which is why worktrees were cut
     // from v1.9.6 rather than shipped half-wired.
-    const enqueueParams = { convId: run.convId, repoRoot: agentCwd(run), task, userMsgId, thinkingBudget: b.thinkingBudget, reasoningEffort: parseReasoningEffort(b.reasoningEffort) }
+    const enqueueParams = { convId: run.convId, repoRoot: agentCwd(run), task, userMsgId, thinkingBudget: b.thinkingBudget, reasoningEffort: parseReasoningEffort(b.reasoningEffort), model: requestedModel }
     if (kind === 'steer') {
       const { steered, queued } = await runs.steer(id, enqueueParams)
       return c.json({ ok: true, queued, steered, userMessageId: userMsgId }, 202)

--- a/turbollm/src/code/code-run-manager.ts
+++ b/turbollm/src/code/code-run-manager.ts
@@ -103,6 +103,11 @@ interface PendingTurn {
   /** What the caller requested for this message — recorded even for a queued entry so the UI can
    *  distinguish a steer that fell back to the queue from a plain follow-up (see SteerKind). */
   kind: SteerKind
+  /** Turbo Link (ADR-376): the qualified `<machine>/<model>` id this turn should generate on,
+   *  or undefined for this machine's loaded model. Captured PER TURN (not per session) for the
+   *  same reason chat sends it per message: the picker can move between turns, and a queued
+   *  turn must run on the machine it was submitted for. */
+  model?: string
 }
 
 interface ActiveTurn {
@@ -202,10 +207,10 @@ export class CodeRunManager {
    *
    * `queued` is true when the turn had to wait (a run was already active), false when it started.
    */
-  enqueue(sessionId: string, params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number; reasoningEffort?: ReasoningEffort; kind?: SteerKind }): { queued: boolean } {
+  enqueue(sessionId: string, params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number; reasoningEffort?: ReasoningEffort; kind?: SteerKind; model?: string }): { queued: boolean } {
     const s = this.ensure(sessionId, params.convId, params.repoRoot)
     const willQueue = s.active !== null
-    s.queue.push({ task: params.task, userMsgId: params.userMsgId, thinkingBudget: params.thinkingBudget ?? -1, reasoningEffort: params.reasoningEffort, kind: params.kind ?? 'followUp' })
+    s.queue.push({ task: params.task, userMsgId: params.userMsgId, thinkingBudget: params.thinkingBudget ?? -1, reasoningEffort: params.reasoningEffort, kind: params.kind ?? 'followUp', model: params.model })
     this.emitQueue(sessionId)
     void this.pump(sessionId)
     return { queued: willQueue }
@@ -227,7 +232,7 @@ export class CodeRunManager {
    */
   async steer(
     sessionId: string,
-    params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number; reasoningEffort?: ReasoningEffort },
+    params: { convId: string; repoRoot: string; task: string; userMsgId: string; thinkingBudget?: number; reasoningEffort?: ReasoningEffort; model?: string },
   ): Promise<{ steered: boolean; queued: boolean }> {
     const active = this.sessions.get(sessionId)?.active
     if (active?.steer) {
@@ -360,8 +365,10 @@ export class CodeRunManager {
     }
 
     try {
-      const ms = this.d.manager.status()
-      const model = ms.model
+      // What this turn's stats are LABELLED with. For a Turbo Link turn the local engine did not
+      // run the tokens, so the local loaded model (often none at all) is the wrong answer — the
+      // qualified id the turn was submitted for is the honest one.
+      const statsModelKey = turn.model ?? this.d.manager.status().model?.key
       // START mode is read fresh from the conversation (runCodeSession re-reads it per tool call
       // for the live ask-gate switch); a run that starts with no model loaded fails cleanly below.
       const mode = (this.d.db.getConversation(s.convId)?.agentMode ?? 'auto') as CodeMode
@@ -375,6 +382,7 @@ export class CodeRunManager {
         thinkingBudget: turn.thinkingBudget,
         reasoningEffort: turn.reasoningEffort,
         task: turn.task,
+        model: turn.model,
         signal: ac.signal,
         sink,
         // Publish/withdraw the live turn's steer handle so steer() can inject into THIS turn.
@@ -399,7 +407,7 @@ export class CodeRunManager {
         toolCalls,
         timeline,
         stats: {
-          ctxUsed: ctxStats.ctxUsed, ctxMax: ctxStats.ctxMax, model: model?.key, aborted: result.aborted,
+          ctxUsed: ctxStats.ctxUsed, ctxMax: ctxStats.ctxMax, model: statsModelKey, aborted: result.aborted,
           // Real per-turn token/timing stats (foldTurnUsage, code-session.ts) — omitted by
           // runCodeSession (not zeroed) when the engine returned no usable usage at all.
           promptTokens: result.promptTokens, genTokens: result.genTokens, cachedTokens: result.cachedTokens,

--- a/turbollm/src/code/code-session.ts
+++ b/turbollm/src/code/code-session.ts
@@ -34,10 +34,10 @@ import { createRobustBashOperations } from './robust-bash'
 import type { TextContent, ToolCall as PiToolCall, Usage } from '@earendil-works/pi-ai'
 import type { Deps } from '../deps'
 import type { Message as DbMessage } from '../chat/db'
-import { engineModelAlias } from '../engines/compat'
 import type { ReasoningEffort } from '../chat/reasoning-effort'
 import { SkillStore, type Skill } from '../agents/skills'
 import { isContainedFromRoot } from './containment'
+import { resolveCodeUpstream } from './code-upstream'
 import { buildAppendPrompt, toolsForMode, type CodeMode } from './persona'
 import {
   LOOP_ABORT_AFTER,
@@ -308,6 +308,11 @@ export interface RunCodeParams {
   reasoningEffort: ReasoningEffort | undefined
   /** The user's task text (first prompt of the run). */
   task: string
+  /** Turbo Link (ADR-376): the qualified `<machine>/<model>` id the Code picker selected,
+   *  or absent for "this machine's loaded model" — every pre-Turbo-Link caller. Resolved by
+   *  `resolveCodeUpstream`, which treats a non-matching id (including a local key carrying
+   *  its own slash) as local. */
+  model?: string
   /** Fires when the HTTP request is aborted / the run is stopped. */
   signal: AbortSignal
   sink: CodeSseSink
@@ -622,21 +627,23 @@ export function pickPrefillProgress(slots: unknown): PrefillProgress | null {
 export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResult> {
   const { d, convId, sessionId, repoRoot, mode, thinkingBudget, reasoningEffort, task: rawTask, signal, sink } = params
 
-  const ms = d.manager.status()
-  if (ms.state !== 'running' || !ms.model) throw new Error('model_not_loaded')
-  const target = d.manager.target()
-  if (!target) throw new Error('model_not_loaded')
-
-  // The model id the engine expects: an engine may expose an alias (e.g. vLLM) instead of
-  // TurboLLM's model key — mirror exactly how chat-routes resolves it.
-  const engineKind = d.registry.active()?.kind ?? ''
-  const modelId = engineModelAlias(engineKind, d.manager.currentOpts()?.modelPath) ?? ms.model.key
-  // REAL context window from the loaded model (plan §3, point 3) — never a hardcoded 32768.
-  const contextWindow = ms.model.ctx > 0 ? ms.model.ctx : 8192
-  // Captured once here (rather than re-read as `ms.model.name` at each registration site)
-  // because TS's null-narrowing of `ms.model` from the guard above doesn't reliably propagate
-  // into runSkillSubSession's nested function declaration below.
-  const modelDisplayName = ms.model.name || 'Local Model'
+  // Local engine or linked host — resolved ONCE for the whole turn, including every
+  // sub-session it spawns (delegate_task, invoke_skill), so a delegated sub-agent can never
+  // silently land on a different machine than its parent. Throws 'model_not_loaded' exactly
+  // where the two local guards used to; see resolveCodeUpstream.
+  // Captured here because the tool executors below shadow `params` with their own arguments.
+  const requestedModel = params.model
+  const upstream = resolveCodeUpstream(d, requestedModel)
+  // `''` for a remote turn. The ONLY consumer left is the llama.cpp /slots prefill poller,
+  // which is a local-engine endpoint and is simply not started when the tokens are being
+  // generated somewhere else.
+  const target = upstream.target
+  const modelId = upstream.modelId
+  const contextWindow = upstream.contextWindow
+  // Captured once here (rather than re-read at each registration site) because TS's
+  // null-narrowing of the loaded model doesn't reliably propagate into runSkillSubSession's
+  // nested function declaration below.
+  const modelDisplayName = upstream.modelName
 
   // The FULL shared SkillStore — the main prompt only ever sees names+descriptions of these
   // (persona.ts's skillCatalogBlock); invoke_skill (registered below) looks a specific one up
@@ -695,9 +702,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
 
   // Register TurboLLM's own local gateway as a custom OpenAI-completions provider (plan §3a).
   modelRegistry.registerProvider('local', {
-    baseUrl: `${target}/v1`,
-    apiKey: 'agent-key',
-    authHeader: true,
+    ...upstream.provider,
     api: 'openai-completions',
     models: [
       {
@@ -782,9 +787,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     const skillAuth = AuthStorage.inMemory()
     const skillRegistry = ModelRegistry.inMemory(skillAuth)
     skillRegistry.registerProvider('local', {
-      baseUrl: `${target}/v1`,
-      apiKey: 'agent-key',
-      authHeader: true,
+      ...upstream.provider,
       api: 'openai-completions',
       models: [{
         id: modelId,
@@ -808,7 +811,10 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
         releaseSkillGate()
         // Stays 'bg' — this is background sub-work, not the turn the user is watching — but takes
         // the same queue ceiling, so a long holder ahead of it isn't reported as a failure.
-        if (d.gate) skillHeldGate = await d.gate.acquire('bg', { signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
+        // Not on a remote turn: the gate serializes THIS machine's single engine slot, and a
+        // run generating on a linked host occupies none of it — holding it would block local
+        // chat for the length of a borrowed-GPU run for no reason.
+        if (d.gate && !upstream.remote) skillHeldGate = await d.gate.acquire('bg', { signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
         // Same stale-ceiling strip as the outer session's own hook above — this sub-session
         // declares the identical PI_MAX_OUTPUT_TOKENS and would otherwise forward it verbatim too.
         const payload = { ...(event.payload as Record<string, unknown>) }
@@ -952,9 +958,7 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
     const subAuth = AuthStorage.inMemory()
     const subRegistry = ModelRegistry.inMemory(subAuth)
     subRegistry.registerProvider('local', {
-      baseUrl: `${target}/v1`,
-      apiKey: 'agent-key',
-      authHeader: true,
+      ...upstream.provider,
       api: 'openai-completions',
       models: [{
         id: modelId,
@@ -989,7 +993,8 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
         // 'bg' priority + subAc.signal: foreground Chat preempts, and a parent Stop / timeout gives
         // up a queued wait instead of hanging (see gate.ts). The parent isn't holding the gate here
         // (it released before executing this tool), so this acquire can't deadlock against it.
-        if (d.gate) subHeldGate = await d.gate.acquire('bg', { signal: subAc.signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
+        // See the skill sub-session's note: no local engine slot is consumed by a remote turn.
+        if (d.gate && !upstream.remote) subHeldGate = await d.gate.acquire('bg', { signal: subAc.signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
         const payload = { ...(event.payload as Record<string, unknown>) }
         delete payload.max_tokens
         delete payload.max_completion_tokens
@@ -1193,10 +1198,14 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
       // user's own Code turn could hit `gate_acquire_timeout` and surface as a silent abort while
       // background traffic proceeded. 'fg' puts it ahead of every queued 'bg' waiter, and the
       // matching timeout stops a legitimately-long generation ahead of it from failing it.
-      if (d.gate) heldGate = await d.gate.acquire('fg', { signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
+      // Skipped entirely for a remote turn — see the sub-session note above. Chat and Code on
+      // this machine stay fully available while a linked host does the work.
+      if (d.gate && !upstream.remote) heldGate = await d.gate.acquire('fg', { signal, timeoutMs: GATE_QUEUE_TIMEOUT_MS })
       // Gate acquired, request is about to go out — begin polling /slots for prefill progress for
       // THIS round (stopped on first token / completion / response end / abort). Best-effort.
-      startPrefillPoll()
+      // /slots is llama.cpp's own local endpoint — there is nothing to poll when the prompt is
+      // being processed on another machine, and `target` is deliberately '' there.
+      if (!upstream.remote) startPrefillPoll()
       roundStartedAt = Date.now()
       roundFirstTokenAt = undefined
       const payload = { ...(event.payload as Record<string, unknown>) }
@@ -1569,7 +1578,9 @@ export async function runCodeSession(params: RunCodeParams): Promise<RunCodeResu
         const q = (params.question ?? '').trim()
         if (!q) return { content: [{ type: 'text', text: 'lookback_history: `question` must be non-empty.' }], details: {} }
         try {
-          const { answer } = await lookbackPreCompactionHistory({ d, convId, sessionId, repoRoot, question: q, signal })
+          // Same machine as the turn that asked — a lookback answered by a different model
+          // than the session is running on would read as the agent contradicting itself.
+          const { answer } = await lookbackPreCompactionHistory({ d, convId, sessionId, repoRoot, question: q, signal, model: requestedModel })
           return { content: [{ type: 'text', text: answer }], details: {} }
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e)
@@ -1984,6 +1995,8 @@ export interface CompactCodeParams {
   convId: string
   sessionId: string
   repoRoot: string
+  /** Turbo Link (ADR-376): the qualified id this session is pointed at, if any. */
+  model?: string
   /** Optional focus for the summary, mirrors pi's own `/compact [instructions]`. */
   customInstructions?: string
 }
@@ -2016,13 +2029,12 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
   // as it was" contract.
   if (d.db.getAgentRun(sessionId)?.clearedUpToMessageId) throw new Error('session_cleared')
 
-  const ms = d.manager.status()
-  if (ms.state !== 'running' || !ms.model) throw new Error('model_not_loaded')
-  const target = d.manager.target()
-  if (!target) throw new Error('model_not_loaded')
-  const engineKind = d.registry.active()?.kind ?? ''
-  const modelId = engineModelAlias(engineKind, d.manager.currentOpts()?.modelPath) ?? ms.model.key
-  const contextWindow = ms.model.ctx > 0 ? ms.model.ctx : 8192
+  // Same local-or-linked-host resolution the main turn does — a session compacting (or
+  // looking back over) history it generated on another machine must summarize it with THAT
+  // machine's model, not with whatever happens to be loaded here.
+  const upstream = resolveCodeUpstream(d, params.model)
+  const modelId = upstream.modelId
+  const contextWindow = upstream.contextWindow
 
   const { summaryText, messages: effectiveMessages } = resolveEffectiveHistory(d, convId, sessionId)
   if (effectiveMessages.length === 0) throw new Error('nothing_to_compact')
@@ -2032,13 +2044,11 @@ export async function compactCodeSession(params: CompactCodeParams): Promise<Com
   const authStorage = AuthStorage.inMemory()
   const modelRegistry = ModelRegistry.inMemory(authStorage)
   modelRegistry.registerProvider('local', {
-    baseUrl: `${target}/v1`,
-    apiKey: 'agent-key',
-    authHeader: true,
+    ...upstream.provider,
     api: 'openai-completions',
     models: [{
       id: modelId,
-      name: ms.model.name || 'Local Model',
+      name: upstream.modelName,
       reasoning: false,
       input: ['text'],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -2142,6 +2152,8 @@ export interface LookbackParams {
   sessionId: string
   repoRoot: string
   question: string
+  /** Turbo Link (ADR-376): the qualified id this session is pointed at, if any. */
+  model?: string
   signal?: AbortSignal
 }
 
@@ -2167,13 +2179,12 @@ export async function lookbackPreCompactionHistory(params: LookbackParams): Prom
   const run = d.db.getAgentRun(sessionId)
   if (!run?.compactionUpToMessageId) throw new Error('nothing_compacted')
 
-  const ms = d.manager.status()
-  if (ms.state !== 'running' || !ms.model) throw new Error('model_not_loaded')
-  const target = d.manager.target()
-  if (!target) throw new Error('model_not_loaded')
-  const engineKind = d.registry.active()?.kind ?? ''
-  const modelId = engineModelAlias(engineKind, d.manager.currentOpts()?.modelPath) ?? ms.model.key
-  const contextWindow = ms.model.ctx > 0 ? ms.model.ctx : 8192
+  // Same local-or-linked-host resolution the main turn does — a session compacting (or
+  // looking back over) history it generated on another machine must summarize it with THAT
+  // machine's model, not with whatever happens to be loaded here.
+  const upstream = resolveCodeUpstream(d, params.model)
+  const modelId = upstream.modelId
+  const contextWindow = upstream.contextWindow
 
   // Everything up to and including the cut, from the FULL (never-deactivated-by-compaction) DB
   // history — compaction only ever moves this cursor, it never deletes rows, so this is genuinely
@@ -2186,13 +2197,11 @@ export async function lookbackPreCompactionHistory(params: LookbackParams): Prom
   const authStorage = AuthStorage.inMemory()
   const modelRegistry = ModelRegistry.inMemory(authStorage)
   modelRegistry.registerProvider('local', {
-    baseUrl: `${target}/v1`,
-    apiKey: 'agent-key',
-    authHeader: true,
+    ...upstream.provider,
     api: 'openai-completions',
     models: [{
       id: modelId,
-      name: ms.model.name || 'Local Model',
+      name: upstream.modelName,
       reasoning: false,
       input: ['text'],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/turbollm/src/code/code-upstream.test.ts
+++ b/turbollm/src/code/code-upstream.test.ts
@@ -1,0 +1,98 @@
+// Code against a Turbo Link host (ADR-376) — where a Code turn is generated.
+//
+// Code shipped hard-wired to `d.manager.target()`, so the properties that matter most here
+// are the NEGATIVE ones: with the local engine stopped, a remote turn must still resolve,
+// and it must never present the link token as the host's bearer credential. Every remote
+// case below therefore runs with NO local engine at all — if one of them starts passing
+// only when a model is loaded locally, Code has gone secretly local again.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { resolveCodeUpstream } from './code-upstream.js'
+import type { Deps } from '../deps.js'
+
+const REMOTE = {
+  linkId: 'lnk1',
+  baseUrl: 'https://rig.trycloudflare.com',
+  token: 'tllm-hostsecret',
+  modelKey: 'qwen3-35b',
+}
+
+/** `localRunning: false` is the configuration Turbo Link exists to serve — a machine with no
+ *  GPU of its own driving one that has it. */
+function mkDeps(opts: { localRunning?: boolean; route?: unknown } = {}): Deps {
+  return {
+    manager: {
+      status: () => (opts.localRunning
+        ? { state: 'running', model: { key: 'local-model', name: 'Local Model', ctx: 16384 } }
+        : { state: 'stopped', model: null }),
+      target: () => (opts.localRunning ? 'http://127.0.0.1:8080' : ''),
+      currentOpts: () => ({ modelPath: '/models/local.gguf' }),
+    },
+    registry: { active: () => ({ kind: 'llama-server' }) },
+    modelRouter: { resolveRemoteTarget: () => opts.route },
+    remoteCatalog: { modelOn: () => ({ key: REMOTE.modelKey, name: 'Qwen3 35B', nativeCtx: 131072 }) },
+  } as unknown as Deps
+}
+
+test('a remote id resolves with the local engine stopped', () => {
+  const d = mkDeps({ localRunning: false, route: { target: REMOTE.baseUrl, remote: REMOTE } })
+  const up = resolveCodeUpstream(d, 'rig/qwen3-35b')
+
+  assert.equal(up.remote?.linkId, 'lnk1')
+  // The host's UNQUALIFIED key: a `<machine>/` prefix names no machine over there and would
+  // fall back to whatever it happens to have loaded.
+  assert.equal(up.modelId, REMOTE.modelKey)
+  assert.equal(up.modelName, 'Qwen3 35B')
+  assert.equal(up.contextWindow, 131072)
+  assert.equal(up.provider.baseUrl, `${REMOTE.baseUrl}/v1`)
+  // Nothing may build a local engine URL for a turn running elsewhere.
+  assert.equal(up.target, '')
+})
+
+test('the link token travels as X-TurboLLM-Auth, never as the host bearer', () => {
+  const d = mkDeps({ localRunning: false, route: { target: REMOTE.baseUrl, remote: REMOTE } })
+  const up = resolveCodeUpstream(d, 'rig/qwen3-35b')
+
+  assert.equal(up.provider.headers?.['X-TurboLLM-Auth'], REMOTE.token)
+  // `Authorization` on the host is its own API-key credential — a different secret with
+  // different scope. pi adds it only when authHeader is on, so this flag is the whole guard.
+  assert.equal(up.provider.authHeader, false)
+})
+
+test('an offline link fails by name and never degrades to the local model', () => {
+  const d = mkDeps({
+    localRunning: true,
+    route: { status: 503, message: "'rig' is not connected (unreachable). Reconnect it in Settings → Turbo Link." },
+  })
+  assert.throws(
+    () => resolveCodeUpstream(d, 'rig/qwen3-35b'),
+    // Not 'model_not_loaded' — the local model IS loaded here, and silently running an
+    // agentic turn on it instead is worse than refusing.
+    /rig.*not connected/,
+  )
+})
+
+test('no requested model is the unchanged local path', () => {
+  const d = mkDeps({ localRunning: true })
+  const up = resolveCodeUpstream(d)
+
+  assert.equal(up.remote, undefined)
+  assert.equal(up.provider.baseUrl, 'http://127.0.0.1:8080/v1')
+  assert.equal(up.provider.apiKey, 'agent-key')
+  assert.equal(up.provider.authHeader, true)
+  assert.equal(up.contextWindow, 16384)
+})
+
+test('no requested model and no local engine still throws model_not_loaded', () => {
+  assert.throws(() => resolveCodeUpstream(mkDeps({ localRunning: false })), /model_not_loaded/)
+})
+
+test('a local key containing a slash is NOT treated as remote', () => {
+  // The router returns undefined for an id naming no linked machine — which is exactly how
+  // `unsloth/Qwen3-GGUF` keeps loading locally instead of 503ing forever.
+  const d = mkDeps({ localRunning: true, route: undefined })
+  const up = resolveCodeUpstream(d, 'unsloth/Qwen3-GGUF')
+
+  assert.equal(up.remote, undefined)
+  assert.equal(up.provider.baseUrl, 'http://127.0.0.1:8080/v1')
+})

--- a/turbollm/src/code/code-upstream.ts
+++ b/turbollm/src/code/code-upstream.ts
@@ -1,0 +1,100 @@
+// Where a Code turn is actually generated — the local engine, or a linked host (ADR-376).
+//
+// Code shipped with exactly one answer: `d.manager.target()`, the llama-server process on
+// THIS machine, hard-wired into five pi provider registrations. So a Turbo Link install
+// could chat with a linked machine's model but could not code with it, and the Code
+// screen's picker didn't even list the remote rows — the one place a borrowed GPU is worth
+// the most (a long agentic run) was the one place it wasn't offered.
+//
+// Nothing here is a second implementation of "is this id remote?". The decision is
+// `resolveChatUpstream` — which is itself `ModelRouter.resolveRemoteTarget`, the same
+// resolution the gateway routes on — so a LOCAL model key that happens to contain a slash
+// (`unsloth/Qwen3-GGUF`) keeps resolving locally here for free, and a link that goes
+// offline produces the same named, actionable message chat already gives. Three findings in
+// Turbo Link came from two implementations of one idea drifting apart; this is deliberately
+// a thin adapter over the existing one.
+//
+// What it adds is the pi-specific half: pi talks to a provider, not to a URL, so the auth
+// differs by destination. The local engine takes the static `agent-key` bearer it has
+// always taken; a linked host authenticates the SAME way every other link request does —
+// `X-TurboLLM-Auth`, via pi's `headers` passthrough — and deliberately NOT as a bearer
+// token, which is the host's own API-key credential and means something different there.
+import { resolveChatUpstream } from '../chat/chat-upstream'
+import type { RemoteTarget } from '../link/link-proxy'
+import type { Deps } from '../deps'
+
+/** The parts of a pi `registerProvider` config that differ by destination. Spread into each
+ *  registration site so the five of them cannot drift apart. */
+export interface CodePiProvider {
+  baseUrl: string
+  apiKey: string
+  authHeader: boolean
+  headers?: Record<string, string>
+}
+
+export interface CodeUpstream {
+  /** The `model` id to declare to pi. Local: the engine's alias (vLLM exposes one) or the
+   *  loaded key. Remote: the host's UNQUALIFIED key — a `<machine>/` prefix names no machine
+   *  over there and would silently fall back to whatever the host has loaded. */
+  modelId: string
+  /** Display name, for pi's model metadata and the turn's own stats label. */
+  modelName: string
+  contextWindow: number
+  /** Set only for a linked host. Its presence is the "this machine did not run the tokens"
+   *  test — the local engine gate and the llama.cpp `/slots` prefill poller both branch on
+   *  it, because neither has anything to do with a run happening on another box. */
+  remote?: RemoteTarget
+  /** Local engine base URL, `''` when remote. Nothing may build a URL from it unchecked. */
+  target: string
+  provider: CodePiProvider
+}
+
+/** Same fallback the Code path has always used when a loaded model reports no context. */
+const FALLBACK_CTX = 8192
+
+/**
+ * Resolve where THIS Code turn generates, or throw.
+ *
+ * `requestedModel` is the id the picker sent. Empty/absent — every pre-Turbo-Link client,
+ * and every ordinary local session — takes the unchanged local path, including its two
+ * `model_not_loaded` guards.
+ *
+ * Throws `Error('model_not_loaded')` for the local case (the string the Code routes and
+ * run manager already branch on), and for a remote one the router's own sentence, which
+ * names the machine and the fix ("'rig' is not connected (unreachable). Reconnect it in
+ * Settings → Turbo Link."). A remote failure NEVER degrades to a local model: silently
+ * running an agentic turn — one that edits files and runs commands — on a different model
+ * than the user picked is worse than refusing.
+ */
+export function resolveCodeUpstream(d: Deps, requestedModel?: string): CodeUpstream {
+  const res = resolveChatUpstream(d, requestedModel)
+  if (!res.ok) throw new Error(res.code === 'model_not_loaded' ? 'model_not_loaded' : res.message)
+  const u = res.upstream
+  const contextWindow = u.ctxMax > 0 ? u.ctxMax : FALLBACK_CTX
+  if (u.remote) {
+    return {
+      modelId: u.modelField,
+      modelName: u.modelName || 'Remote Model',
+      contextWindow,
+      remote: u.remote,
+      target: '',
+      provider: {
+        baseUrl: `${u.remote.baseUrl}/v1`,
+        apiKey: u.remote.token,
+        // The link token travels as X-TurboLLM-Auth (linkHeaders, link-proxy.ts) and NOT as
+        // a bearer: `Authorization` on the host is its own API-key credential, a different
+        // secret with different scope, and presenting a link token there would either be
+        // rejected or — worse — accepted as something it is not.
+        authHeader: false,
+        headers: { 'X-TurboLLM-Auth': u.remote.token },
+      },
+    }
+  }
+  return {
+    modelId: u.modelField,
+    modelName: u.modelName || 'Local Model',
+    contextWindow,
+    target: u.target,
+    provider: { baseUrl: `${u.target}/v1`, apiKey: 'agent-key', authHeader: true },
+  }
+}

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -478,6 +478,19 @@ export interface Config {
    *  Absent in pre-this-feature configs → normalize seeds the default. */
   vramHeadroomMb: number
   lastLoaded: LastLoaded
+  /** Turbo Link (ADR-382): the qualified `<machine>/<model>` id the user last pointed this
+   *  install at, or '' for 'this machine's own engine'.
+   *
+   *  DAEMON-side deliberately, right next to lastLoaded, and for the same reason: the browser
+   *  is not the only surface that has to know. It first lived in the web app's UI store, which
+   *  made `turbollm launch <cli>` (a different process entirely) auto-load a LOCAL model while
+   *  the UI showed a linked machine selected — founder-reported, 2026-08-23. A selection every
+   *  surface must agree on is daemon state, not view state.
+   *
+   *  Never trusted blindly on read: a link that is offline (or no longer advertises that model)
+   *  resolves to nothing through ModelRouter, so a stale value degrades to the local path
+   *  rather than failing every request. */
+  selectedRemoteModel: string
   autoLoadOnStart: boolean
   hf: HF
   modelDefaults: ModelDefaults
@@ -630,6 +643,7 @@ export function defaultConfig(): Config {
     benchResults: {},
     vramHeadroomMb: VRAM_HEADROOM_DEFAULT_MB,
     lastLoaded: { modelKey: '', engineId: '' },
+    selectedRemoteModel: '',
     autoLoadOnStart: false,
     hf: { token: '' },
     modelDefaults: { ctx: 8192, ngl: 99, imageMaxTokens: 0, maxTokens: 0 },
@@ -795,6 +809,9 @@ function normalize(c: Config): void {
   // (treat absent as defaults; never throw on an old file).
   c.modelDefaults = { ...d.modelDefaults, ...(c.modelDefaults ?? {}) }
   c.lastLoaded = { ...d.lastLoaded, ...(c.lastLoaded ?? {}) }
+  // Absent in every config written before ADR-382 → '' (no remote selection), which is exactly
+  // the pre-Turbo-Link behaviour.
+  if (typeof c.selectedRemoteModel !== 'string') c.selectedRemoteModel = ''
   c.apiKeys ??= []
   c.links ??= []
   c.engines ??= []

--- a/turbollm/web/src/App.tsx
+++ b/turbollm/web/src/App.tsx
@@ -12,6 +12,7 @@ import { Shell } from './components/Shell'
 import { UnreachableOverlay } from './components/UnreachableOverlay'
 import { AuthGate } from './components/AuthGate'
 import { useStatus, useSettings, useDownloads } from './lib/queries'
+import { useUiStore } from './stores/ui'
 import { useOnboardingState } from './lib/onboarding-queries'
 import { ApiError, setAuthToken } from './lib/api'
 import { subscribeCodeAuthNeeded, isCodeAuthNeeded } from './lib/auth-signal'
@@ -124,6 +125,17 @@ function useResumeOnboardingAfterDiscoverDownload(shouldOnboard: boolean) {
 
 export function App() {
   const statusQ = useStatus()
+  // Turbo Link (ADR-382): the daemon owns which machine this install is pointed at, so mirror
+  // its value into the UI store on every status poll. Mounted HERE, once for the app's lifetime,
+  // because the screens that read the selection unmount on navigation — hydrating in one of them
+  // would make the value depend on which screen you happened to open first. The store ignores
+  // this while a pick of its own is in flight.
+  const syncRemoteModelId = useUiStore((s) => s.syncRemoteModelId)
+  const daemonRemoteModel = statusQ.data?.selectedRemoteModel
+  useEffect(() => {
+    if (daemonRemoteModel === undefined) return // older daemon / not loaded yet — leave the cache alone
+    syncRemoteModelId(daemonRemoteModel || null)
+  }, [daemonRemoteModel, syncRemoteModelId])
   const qc = useQueryClient()
   const onboardingQ = useOnboardingState()
   const shouldOnboard =

--- a/turbollm/web/src/lib/code-api.ts
+++ b/turbollm/web/src/lib/code-api.ts
@@ -152,8 +152,8 @@ export function updateCodeSessionTitle(id: string, title: string): Promise<{ ok:
  *  future turns replay the summary instead of every raw message. Blocked (409) while a run is
  *  active. Rejects with code 'nothing_to_compact' (400) when history is already short enough
  *  that pi found nothing worth summarizing. */
-export function compactCodeSession(id: string, instructions?: string): Promise<{ ok: true; summary: string; upToMessageId: string; tokensBefore: number }> {
-  return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/compact`, { method: 'POST', json: { instructions } })
+export function compactCodeSession(id: string, instructions?: string, model?: string): Promise<{ ok: true; summary: string; upToMessageId: string; tokensBefore: number }> {
+  return req(`/api/v1/code/sessions/${encodeURIComponent(id)}/compact`, { method: 'POST', json: { instructions, model } })
 }
 
 /** Start (or queue) a turn. Returns immediately — the run is owned by the daemon, NOT by this
@@ -178,6 +178,9 @@ export async function startCodeRun(
   contextFiles?: string[],
   kind?: SteerKind,
   reasoningEffort?: ReasoningEffort,
+  /** Turbo Link: the qualified `<machine>/<model>` id, when this session is pointed at another
+   *  machine. Omitted for an ordinary local session. */
+  model?: string,
 ): Promise<CodeSendMessageResponse> {
   const body: CodeSendMessageBody = {
     content: content || undefined,
@@ -186,6 +189,7 @@ export async function startCodeRun(
     thinkingBudget: thinkingBudget !== undefined && thinkingBudget !== -1 ? thinkingBudget : undefined,
     reasoningEffort: reasoningEffort !== undefined && reasoningEffort !== DEFAULT_REASONING_EFFORT ? reasoningEffort : undefined,
     kind,
+    model: model || undefined,
   }
   return req(`/api/v1/code/sessions/${encodeURIComponent(sessionId)}/messages`, { method: 'POST', json: body })
 }

--- a/turbollm/web/src/lib/code-types.ts
+++ b/turbollm/web/src/lib/code-types.ts
@@ -135,6 +135,10 @@ export interface CodeSendMessageBody {
   /** Delivery mode when a run is already active — 'steer' redirects the live turn, 'followUp'
    *  (default) queues behind it. Omitted = 'followUp'. */
   kind?: SteerKind
+  /** Turbo Link (ADR-376): the qualified `<machine>/<model>` id this turn should generate on.
+   *  Sent ONLY when the picker selected a model on another machine; absent means 'whatever this
+   *  machine has loaded', which is every ordinary session. */
+  model?: string
 }
 
 /** POST .../messages response (202). `steered` is true ONLY when a 'steer' actually injected into

--- a/turbollm/web/src/lib/link-api.ts
+++ b/turbollm/web/src/lib/link-api.ts
@@ -297,3 +297,14 @@ export function cancelRemoteDownload(id: LinkRecordId, downloadId: string): Prom
     { method: 'DELETE' },
   )
 }
+
+/** Point this install at a linked machine's model, or clear it (`null`) to come back to this
+ *  machine. Persisted DAEMON-side (ADR-382): the selection has to be visible to surfaces that
+ *  are not this browser — above all `turbollm launch <cli>`, a separate process that was
+ *  auto-loading a local model while the UI showed a linked machine selected.
+ *
+ *  Rejects an id that names no ONLINE link advertising that model (400/503 with the router's
+ *  own message), so a bad pick fails here rather than at the user's first prompt. */
+export function setSelectedRemoteModel(model: string | null): Promise<{ ok: true; selectedRemoteModel: string }> {
+  return request('/api/v1/links/selected-model', { method: 'PUT', json: { model } })
+}

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -156,6 +156,11 @@ export type Status = {
    *  every status poll. Survives a FAILED load — `model` above is null then — which is
    *  what makes a one-click retry of the thing that just broke possible at all. */
   lastLoaded?: string
+  /** Turbo Link (ADR-382): the qualified `<machine>/<model>` id this INSTALL is pointed at,
+   *  or '' for this machine's own engine. Daemon-side so every surface agrees — this browser,
+   *  another device's browser, and `turbollm launch <cli>`, which has no access to any of
+   *  them. Absent from an older daemon, which is read as ''. */
+  selectedRemoteModel?: string
   engineStats?: EngineStats | null
   liveGeneration?: LiveGeneration | null
   bench: BenchState

--- a/turbollm/web/src/screens/ChatScreen.tsx
+++ b/turbollm/web/src/screens/ChatScreen.tsx
@@ -283,9 +283,13 @@ export function ChatScreen({ embedded, convIdOverride }: { embedded?: boolean; c
    *  in-flight generation in every conversation before it does anything else, and then
    *  either 409s or loads a completely different local model.
    *
-   *  Component state, so it resets on reload — the daemon holds no per-conversation model
-   *  and inventing one here would be a schema decision this fix has no mandate for. */
-  const [remoteModelId, setRemoteModelId] = useState<string | null>(null)
+   *  Held in the UI store, NOT in `useState`: every screen is lazily routed and unmounts
+   *  on navigation, so component state made the pick silently revert to the local model as
+   *  soon as the user visited another screen and came back. Still not per-conversation —
+   *  the daemon holds no per-conversation model and inventing one would be a schema
+   *  decision this has no mandate for — but it now outlives the screen (and a reload). */
+  const remoteModelId = useUiStore((s) => s.remoteModelId)
+  const setRemoteModelId = useUiStore((s) => s.setRemoteModelId)
   const remoteChoice = remoteModelId
     ? findRemoteChoice(remoteModelId, linksQ.data ?? [], remoteModelsQ.data ?? [])
     : undefined

--- a/turbollm/web/src/screens/code/CodeComposer.tsx
+++ b/turbollm/web/src/screens/code/CodeComposer.tsx
@@ -15,6 +15,8 @@ import { ReasoningEffortSelect, type ReasoningEffort } from '../../components/Re
 import { toast } from '../../components/ui/sonner'
 import { browseFs, track } from '../../lib/api'
 import type { ModelEntry } from '../../lib/types'
+import type { LinkRecord } from '../../lib/link-api'
+import type { RemoteModelRow } from '../../lib/remote-models'
 import { cn } from '../../lib/utils'
 import { CodeStatsFooter } from './CodeStatsFooter'
 import { ContextUsageRing } from './ContextUsageRing'
@@ -188,6 +190,11 @@ export interface CodeComposerProps {
   onModeChange: (m: AgentMode) => void
 
   models: ModelEntry[]
+  /** Turbo Link (ADR-376): linked machines and the models they advertise, passed straight to
+   *  ModelLoadMenu. Empty arrays on every install with no links — the picker then renders flat,
+   *  exactly as it did before Turbo Link existed. */
+  links?: LinkRecord[]
+  remoteModels?: RemoteModelRow[]
   loadedKey: string | null
   loadedName: string | null
   modelPending: boolean
@@ -271,7 +278,7 @@ export interface CodeComposerProps {
 export function CodeComposer({
   inputRef, value, onValueChange, onSubmit, placeholder, textareaDisabled,
   repo, repoRoot, repoBranch, mode, onModeChange,
-  models, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
+  models, links, remoteModels, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
   ctxUsed, ctxMax, live, onStop, sendDisabled,
   onAddContext, contextFiles, onRemoveContextFile, hintText, statusText, slashCommands = [],
   thinkingBudget, onThinkingBudgetChange, reasoningEffort, onReasoningEffortChange, onImagesChange, lastPromptTokens, lastGenTokens,
@@ -829,6 +836,8 @@ export function CodeComposer({
           )}
           <ModelLoadMenu
             models={models}
+            links={links}
+            remoteModels={remoteModels}
             loadedKey={loadedKey}
             loadedName={loadedName}
             pending={modelPending}

--- a/turbollm/web/src/screens/code/CodeHomeScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeHomeScreen.tsx
@@ -9,6 +9,9 @@ import { useIsDesktop } from '../../lib/useIsDesktop'
 import { cn, formatDiff } from '../../lib/utils'
 import { ApiError, track } from '../../lib/api'
 import { useGitBranch, useModelActions, useModels, useStatus } from '../../lib/queries'
+import { useLinks, useRemoteModels } from '../../lib/link-queries'
+import { findRemoteChoice, selectModel } from '../../lib/remote-models'
+import { useUiStore } from '../../stores/ui'
 import { createCodeSession } from '../../lib/code-api'
 import { useCodeStats } from '../../lib/code-queries'
 import { useWorkspaceSidebarOpen } from '../../lib/workspace-sidebar'
@@ -158,13 +161,31 @@ export function CodeHomeScreen() {
     engineState === 'stopping'
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
 
+  // Turbo Link (ADR-376): a session can be STARTED against a linked machine's model, which is
+  // the case a laptop with no GPU of its own cares about most. Shared with Chat and the session
+  // screen via the UI store, so the machine you picked stays picked across screens.
+  const linksQ = useLinks()
+  const remoteModelsQ = useRemoteModels()
+  const remoteModelId = useUiStore((s) => s.remoteModelId)
+  const setRemoteModelId = useUiStore((s) => s.setRemoteModelId)
+  const remoteChoice = remoteModelId
+    ? findRemoteChoice(remoteModelId, linksQ.data ?? [], remoteModelsQ.data ?? [])
+    : undefined
+  const activeRemoteId = remoteChoice?.id ?? null
+
   const handleLoadModel = (key: string) => {
+    // A remote id names another machine — a routing choice, never a local engine load.
+    const choice = selectModel(key, linksQ.data ?? [], remoteModelsQ.data ?? [])
+    if (choice.kind === 'remote') { setRemoteModelId(choice.id); return }
+    setRemoteModelId(null)
     modelActions.load.mutate(
-      { key },
+      { key: choice.key },
       { onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not load model.') },
     )
   }
   const handleEject = () => {
+    // Pointed at another machine, Eject means stop using it — not kill this box's engine.
+    if (activeRemoteId) { setRemoteModelId(null); return }
     modelActions.eject.mutate(undefined, {
       onError: (e) => toast.error(e instanceof ApiError ? e.message : 'Could not eject model.'),
     })
@@ -270,14 +291,16 @@ export function CodeHomeScreen() {
       return
     }
     if (!repoPath) { toast.error('Choose a repository first.'); return }
-    if (!engineReady || !model) { toast.error('Load a model first.'); return }
+    // A remote model is already up on the other machine — there is nothing to load here, so the
+    // local engine's state must not gate starting the session.
+    if (!activeRemoteId && (!engineReady || !model)) { toast.error('Load a model first.'); return }
 
     setSubmitting(true)
     try {
       const { sessionId } = await createCodeSession({
         repoRoot: repoPath,
         repoBranch: repoBranch || undefined,
-        modelKey: model.key,
+        modelKey: activeRemoteId ?? model?.key,
         mode: mode.id,
         task,
         useWorktree,
@@ -461,8 +484,10 @@ export function CodeHomeScreen() {
           mode={mode}
           onModeChange={setMode}
           models={allModels}
-          loadedKey={model?.key ?? null}
-          loadedName={model?.name ?? null}
+          links={linksQ.data ?? []}
+          remoteModels={remoteModelsQ.data ?? []}
+          loadedKey={activeRemoteId ?? model?.key ?? null}
+          loadedName={remoteChoice ? `${remoteChoice.name} — ${remoteChoice.machine}` : (model?.name ?? null)}
           modelPending={modelBusy}
           ejecting={modelActions.eject.isPending}
           onLoadModel={handleLoadModel}
@@ -474,7 +499,7 @@ export function CodeHomeScreen() {
           onModelSettings={(key) => setSettingsKey(key)}
           ctxUsed={0}
           ctxMax={model?.ctx ?? 0}
-          sendDisabled={!input.trim() || !repoPath || !engineReady || submitting}
+          sendDisabled={!input.trim() || !repoPath || (!engineReady && !activeRemoteId) || submitting}
           onAddContext={() => setContextBrowserOpen(true)}
           contextFiles={contextFiles}
           onRemoveContextFile={(p) => setContextFiles((cf) => cf.filter((x) => x !== p))}

--- a/turbollm/web/src/screens/code/CodeSessionScreen.tsx
+++ b/turbollm/web/src/screens/code/CodeSessionScreen.tsx
@@ -5,6 +5,9 @@ import { ArrowDown, Diff, Download, Eraser, FolderOpen, GitBranch, MoreHorizonta
 import { ApiError, track } from '../../lib/api'
 import { skillKeys, fetchSkills } from '../../lib/agent-api'
 import { useModelActions, useModels, useStatus } from '../../lib/queries'
+import { useLinks, useRemoteModels } from '../../lib/link-queries'
+import { findRemoteChoice, selectModel } from '../../lib/remote-models'
+import { useUiStore } from '../../stores/ui'
 import { compactCodeSession, execShellCommand, revertCodeSession, sendCodeQueuedTurnNow, startCodeRun, steerOutcomeMessage, stopCodeSession } from '../../lib/code-api'
 import type { CodeAgent, QueuedTurn, ShellRun, SteerKind } from '../../lib/code-types'
 import {
@@ -178,6 +181,22 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
     modelActions.eject.isPending ||
     engineState === 'starting' ||
     engineState === 'stopping'
+  // Turbo Link (ADR-376): models on linked machines, offered here exactly as they are in Chat.
+  // A long agentic run is where borrowing another box's GPU is worth the most, so Code listing
+  // only local models was the odd one out. Both queries fail soft — an install with no links
+  // renders precisely as before.
+  const linksQ = useLinks()
+  const remoteModelsQ = useRemoteModels()
+  // Shared with Chat (stores/ui.ts): the machine you picked is the machine you picked, whichever
+  // screen you picked it on. It also has to outlive this screen, which unmounts on navigation.
+  const remoteModelId = useUiStore((s) => s.remoteModelId)
+  const setRemoteModelId = useUiStore((s) => s.setRemoteModelId)
+  const remoteChoice = remoteModelId
+    ? findRemoteChoice(remoteModelId, linksQ.data ?? [], remoteModelsQ.data ?? [])
+    : undefined
+  // A selection whose machine went offline silently stops being one — same rule the catalog
+  // enforces server-side, and the turn route re-checks it anyway (503, by name).
+  const activeRemoteId = remoteChoice?.id ?? null
   const [settingsKey, setSettingsKey] = useState<string | null>(null)
   const [gitDialogOpen, setGitDialogOpen] = useState(false)
   // A non-'turbollm' agent (config.ts's code.defaultAgent, snapshotted onto the session at
@@ -204,6 +223,23 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
   // user had mistyped it by hand.
   const terminalViewRef = useRef<TerminalViewHandle>(null)
   const handleLoadModel = (key: string) => {
+    // Turbo Link: a remote row's id names ANOTHER machine and must never reach the local engine
+    // loader, which aborts every in-flight generation before it even looks the key up. Selecting
+    // one is a routing choice — nothing is loaded here, because it is already up over there.
+    // `selectModel` is the same unit-tested branch ChatScreen uses (lib/remote-models.ts).
+    const choice = selectModel(key, linksQ.data ?? [], remoteModelsQ.data ?? [])
+    if (choice.kind === 'remote') {
+      setRemoteModelId(choice.id)
+      if (isTerminalSession) {
+        // A terminal harness picks its model from inside its own TUI against the gateway's
+        // advertised ids; switching a LIVE one to a linked machine is a separate piece of work
+        // (each harness's own /model command), so say so rather than silently doing nothing.
+        toast.info(`Pointed at ${choice.machine}. New Code sessions use it; this terminal keeps its own model.`)
+      }
+      return
+    }
+    // Picking a local model is also how the user comes BACK from a remote machine.
+    setRemoteModelId(null)
     modelActions.load.mutate(
       { key },
       {
@@ -236,6 +272,9 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
     )
   }
   const handleEject = () => {
+    // Pointed at another machine, "Eject" means "stop using it" — this machine's engine is not
+    // what is serving these turns, and stopping it would be a surprising side effect.
+    if (activeRemoteId) { setRemoteModelId(null); return }
     // Ejecting kills the whole engine — stop this session's own daemon-owned run first (so it
     // doesn't fail mid-engine-call), mirroring ChatScreen's handleEject aborting live chat gen.
     if (effectiveSessionId) void stopCodeSession(effectiveSessionId).catch(() => {})
@@ -456,7 +495,7 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
       // new session — the state update from that effect hasn't applied yet, so the closure here
       // would still hold the PREVIOUS session's value. readThinkingBudget is a synchronous
       // localStorage read, immune to that ordering race.
-      void startCodeRun(effectiveSessionId, '', readThinkingBudget(effectiveSessionId), undefined, undefined, undefined, readReasoningEffort(effectiveSessionId))
+      void startCodeRun(effectiveSessionId, '', readThinkingBudget(effectiveSessionId), undefined, undefined, undefined, readReasoningEffort(effectiveSessionId), activeRemoteId ?? undefined)
         .then(() => { void qc.invalidateQueries({ queryKey: codeKeys.detail(effectiveSessionId) }); clientRef.current?.connect() })
         .catch((e) => { autoStartedRef.current = null; toast.error(e instanceof ApiError ? e.message : 'Could not start the run.') })
     }
@@ -519,7 +558,7 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
     setInput('')
     setManualCompacting(true)
     try {
-      const result = await compactCodeSession(effectiveSessionId, instructions)
+      const result = await compactCodeSession(effectiveSessionId, instructions, activeRemoteId ?? undefined)
       void qc.invalidateQueries({ queryKey: codeKeys.detail(effectiveSessionId) })
       toast.success(`Compacted — ${result.tokensBefore.toLocaleString()} tokens of history summarized.`)
     } catch (e) {
@@ -658,7 +697,7 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
     // run. Either way it's owned server-side, so a queued follow-up survives a disconnect. The
     // open stream reflects the result (a new `queue` frame, or the turn going live when it runs).
     try {
-      const res = await startCodeRun(effectiveSessionId, text, thinkingBudget, promptOverride, filesToSend, kind, reasoningEffort)
+      const res = await startCodeRun(effectiveSessionId, text, thinkingBudget, promptOverride, filesToSend, kind, reasoningEffort, activeRemoteId ?? undefined)
       // `steered` reports whether a steer actually injected into the live turn vs. was queued —
       // confirm the real outcome. followUp needs no toast: its queued card already shows inline.
       if (kind === 'steer') toast.success(steerOutcomeMessage(res.steered))
@@ -922,8 +961,10 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
             <TerminalToolbar
               agent={session.codeAgent}
               models={allModels}
-              loadedKey={model?.key ?? null}
-              loadedName={model?.name ?? null}
+              links={linksQ.data ?? []}
+              remoteModels={remoteModelsQ.data ?? []}
+              loadedKey={activeRemoteId ?? model?.key ?? null}
+              loadedName={remoteChoice ? `${remoteChoice.name} — ${remoteChoice.machine}` : (model?.name ?? null)}
               modelPending={modelBusy}
               ejecting={modelActions.eject.isPending}
               onLoadModel={handleLoadModel}
@@ -1055,8 +1096,10 @@ export function CodeSessionScreen({ embedded, sessionIdOverride }: { embedded?: 
                 mode={modeInfo}
                 onModeChange={handleModeChange}
                 models={allModels}
-                loadedKey={model?.key ?? null}
-                loadedName={model?.name ?? null}
+                links={linksQ.data ?? []}
+                remoteModels={remoteModelsQ.data ?? []}
+                loadedKey={activeRemoteId ?? model?.key ?? null}
+                loadedName={remoteChoice ? `${remoteChoice.name} — ${remoteChoice.machine}` : (model?.name ?? null)}
                 modelPending={modelBusy}
                 ejecting={modelActions.eject.isPending}
                 onLoadModel={handleLoadModel}

--- a/turbollm/web/src/screens/code/TerminalToolbar.tsx
+++ b/turbollm/web/src/screens/code/TerminalToolbar.tsx
@@ -29,12 +29,19 @@ import { ThinkingBudgetSlider } from '../../components/ThinkingBudgetSlider'
 import { ReasoningEffortSelect, type ReasoningEffort } from '../../components/ReasoningEffortSelect'
 import { CodeStatsFooter } from './CodeStatsFooter'
 import type { ModelEntry } from '../../lib/types'
+import type { LinkRecord } from '../../lib/link-api'
+import type { RemoteModelRow } from '../../lib/remote-models'
 
 export interface TerminalToolbarProps {
   /** The CLI driving this session (`session.codeAgent` — 'claude', 'pi', 'opencode'). */
   agent: string
 
   models: ModelEntry[]
+  /** Turbo Link (ADR-376): linked machines and the models they advertise, passed straight to
+   *  ModelLoadMenu. Empty arrays on every install with no links — the picker then renders flat,
+   *  exactly as it did before Turbo Link existed. */
+  links?: LinkRecord[]
+  remoteModels?: RemoteModelRow[]
   loadedKey: string | null
   loadedName: string | null
   modelPending: boolean
@@ -62,7 +69,7 @@ export interface TerminalToolbarProps {
 }
 
 export function TerminalToolbar({
-  agent, models, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
+  agent, models, links, remoteModels, loadedKey, loadedName, modelPending, ejecting, onLoadModel, onEjectModel, onModelSettings,
   ctxUsed, ctxMax, thinkingBudget, onThinkingBudgetChange, reasoningEffort, onReasoningEffortChange,
   lastPromptTokens, lastGenTokens, lastPromptTps, lastGenTps,
 }: TerminalToolbarProps) {
@@ -86,6 +93,8 @@ export function TerminalToolbar({
         )}
         <ModelLoadMenu
           models={models}
+          links={links}
+          remoteModels={remoteModels}
           loadedKey={loadedKey}
           loadedName={loadedName}
           pending={modelPending}

--- a/turbollm/web/src/stores/ui.remote-model.test.ts
+++ b/turbollm/web/src/stores/ui.remote-model.test.ts
@@ -1,0 +1,81 @@
+// Turbo Link (ADR-376/382): which machine this install is pointed at.
+//
+// Two founder-reported bugs are pinned here, and they are different bugs:
+//
+//  1. The pick must OUTLIVE the chat screen. It was ChatScreen `useState`, and every screen is
+//     lazily routed — navigating away unmounted it, so coming back showed the local model as if
+//     nothing had been chosen. The store is precisely the thing that does not unmount.
+//  2. The pick must reach surfaces that are NOT this browser. `turbollm launch pi` auto-loaded a
+//     local model — and spent 180 s failing to — while the UI showed a linked machine selected,
+//     because the selection lived only in browser state. It is daemon state now, so a write that
+//     never reaches the daemon is the whole failure, not a detail.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const setSelectedRemoteModel = vi.fn<(id: string | null) => Promise<unknown>>()
+vi.mock('../lib/link-api', () => ({ setSelectedRemoteModel: (id: string | null) => setSelectedRemoteModel(id) }))
+const toastError = vi.fn()
+vi.mock('../components/ui/sonner', () => ({ toast: { error: (m: string) => toastError(m) } }))
+
+const { useUiStore } = await import('./ui')
+
+describe('ui store: remote model selection', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setSelectedRemoteModel.mockReset()
+    setSelectedRemoteModel.mockResolvedValue({ ok: true })
+    toastError.mockReset()
+    useUiStore.setState({ remoteModelId: null })
+  })
+
+  it('survives a screen unmount — the value lives in the store, not the screen', () => {
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    expect(useUiStore.getState().remoteModelId).toBe('rig/Qwen3-35B')
+  })
+
+  it('persists the pick to the DAEMON, not just this tab', () => {
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    // This is what `turbollm launch <cli>` reads. Without it the CLI auto-loads a local model.
+    expect(setSelectedRemoteModel).toHaveBeenCalledWith('rig/Qwen3-35B')
+  })
+
+  it('caches to localStorage so the picker is not blank on first paint', () => {
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    expect(localStorage.getItem('tllm.remoteModelId')).toBe('rig/Qwen3-35B')
+  })
+
+  it('clears both the daemon and the cache when the user goes back to a local model', () => {
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    useUiStore.getState().setRemoteModelId(null)
+    expect(useUiStore.getState().remoteModelId).toBeNull()
+    expect(setSelectedRemoteModel).toHaveBeenLastCalledWith(null)
+    // Removed, not stored as the string "null" — which would read back as a model id named
+    // `null` and resolve to nothing forever.
+    expect(localStorage.getItem('tllm.remoteModelId')).toBeNull()
+  })
+
+  it('reverts and explains when the daemon refuses the pick', async () => {
+    setSelectedRemoteModel.mockRejectedValue(new Error("'rig' is not connected (unreachable)."))
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalled())
+    // A refused pick left showing as selected would 503 on every later turn.
+    expect(useUiStore.getState().remoteModelId).toBeNull()
+    expect(localStorage.getItem('tllm.remoteModelId')).toBeNull()
+  })
+
+  it('adopts the daemon value on a status poll (a pick made on another device)', () => {
+    useUiStore.getState().syncRemoteModelId('rig/Qwen3-35B')
+    expect(useUiStore.getState().remoteModelId).toBe('rig/Qwen3-35B')
+    // Sync is not a user action — it must not write back, or two tabs would ping-pong.
+    expect(setSelectedRemoteModel).not.toHaveBeenCalled()
+  })
+
+  it('a status poll racing a fresh pick does NOT snap the picker back', async () => {
+    let release: (v: unknown) => void = () => {}
+    setSelectedRemoteModel.mockReturnValue(new Promise((r) => { release = r }))
+    useUiStore.getState().setRemoteModelId('rig/Qwen3-35B')
+    // The daemon hasn't seen the new pick yet, so its poll still reports the old value.
+    useUiStore.getState().syncRemoteModelId(null)
+    expect(useUiStore.getState().remoteModelId).toBe('rig/Qwen3-35B')
+    release({ ok: true })
+  })
+})

--- a/turbollm/web/src/stores/ui.ts
+++ b/turbollm/web/src/stores/ui.ts
@@ -1,4 +1,7 @@
 import { create } from 'zustand'
+import { ApiError } from '../lib/api'
+import { setSelectedRemoteModel } from '../lib/link-api'
+import { toast } from '../components/ui/sonner'
 
 export type Theme = 'system' | 'light' | 'dark'
 
@@ -54,7 +57,49 @@ type UiState = {
    *  Launch Expert button in Settings). ChatScreen consumes and clears it. */
   pendingConversationId: string | null
   setPendingConversationId: (id: string | null) => void
+  /** Turbo Link (ADR-376): the qualified `<machine>/<model>` id chat is pointed at, or
+   *  null for "this machine's loaded model".
+   *
+   *  Store state rather than ChatScreen state, because every screen is lazily routed and
+   *  therefore UNMOUNTS on navigation: held in `useState` the pick silently reverted to
+   *  the local model the moment the user visited Models, Code or Settings and came back —
+   *  with the picker showing the local model as if nothing had been chosen. A local
+   *  selection is an engine load the daemon remembers on its own; a remote one is pure
+   *  routing state nothing else persists, so it has to live somewhere that outlives the
+   *  screen.
+   *
+   *  The DAEMON owns the real value (ADR-382, config `selectedRemoteModel`); this is a
+   *  mirror of it. It has to be daemon-side because the browser is not the only surface
+   *  that reads it — `turbollm launch <cli>` is a separate process, and while this lived
+   *  only here it auto-loaded a LOCAL model while the UI showed a linked machine selected.
+   *  localStorage stays as a first-paint cache so the picker isn't blank for one poll.
+   *
+   *  Staleness is safe by construction: every consumer resolves the id through
+   *  `findRemoteChoice`, which yields nothing unless that link is online AND still
+   *  advertises that model — an id whose machine went away is simply ignored. */
+  remoteModelId: string | null
+  /** Optimistic: sets locally, then persists to the daemon. */
+  setRemoteModelId: (id: string | null) => void
+  /** Adopt the daemon's value (status poll). Ignored while a write of ours is in flight, so
+   *  a poll that raced a fresh pick cannot snap the picker back to the old machine. */
+  syncRemoteModelId: (id: string | null) => void
 }
+
+const REMOTE_MODEL_KEY = 'tllm.remoteModelId'
+
+function readStoredRemoteModelId(): string | null {
+  return localStorage.getItem(REMOTE_MODEL_KEY) || null
+}
+
+function cacheRemoteModelId(id: string | null): void {
+  if (id) localStorage.setItem(REMOTE_MODEL_KEY, id)
+  else localStorage.removeItem(REMOTE_MODEL_KEY)
+}
+
+/** How many of our own writes are in flight. A status poll that lands while one is means the
+ *  daemon has not seen the new pick yet, and adopting its answer would visibly snap the picker
+ *  back to the previous machine. */
+let pendingWrites = 0
 
 export const useUiStore = create<UiState>((set) => ({
   theme: readStoredTheme(),
@@ -73,4 +118,28 @@ export const useUiStore = create<UiState>((set) => ({
   setLogPanelOpen: (logPanelOpen) => set({ logPanelOpen }),
   pendingConversationId: null,
   setPendingConversationId: (pendingConversationId) => set({ pendingConversationId }),
+  remoteModelId: readStoredRemoteModelId(),
+  setRemoteModelId: (remoteModelId) => {
+    cacheRemoteModelId(remoteModelId)
+    set({ remoteModelId })
+    // Persist to the daemon — the surface that actually has to agree with this is the CLI,
+    // not this tab. Counted so an in-flight write wins over any status poll that lands
+    // mid-flight (see syncRemoteModelId).
+    pendingWrites++
+    void setSelectedRemoteModel(remoteModelId)
+      .catch((e) => {
+        // A pick the daemon refused (the link went offline between listing and clicking) must
+        // not sit in the UI looking selected — every later turn would 503. Revert and say why.
+        cacheRemoteModelId(null)
+        set({ remoteModelId: null })
+        toast.error(e instanceof ApiError ? e.message : 'Could not switch to that machine.')
+      })
+      .finally(() => { pendingWrites-- })
+  },
+  syncRemoteModelId: (remoteModelId) => {
+    if (pendingWrites > 0) return
+    if (useUiStore.getState().remoteModelId === remoteModelId) return
+    cacheRemoteModelId(remoteModelId)
+    set({ remoteModelId })
+  },
 }))


### PR DESCRIPTION
## What

Two pieces of work on this branch:

**1. bench: a dense model with half its layers on CPU is not worth a single-GPU probe (ADR-384)**
- `pickSplitStrategies` gains a dense-model gate: probing a single GPU with a dense model that needs a CPU split is not worth it; the strategy is skipped with a reason.
- 3 new `bench.split.test.ts` cases; ADR-379 threshold-guard test renamed/corrected; BUG-16 added to `deploy/kaggle/DUAL-GPU-BUGS.md`.

**2. Code sessions run on a linked machine's model; the remote pick is daemon state (ADR-382, ADR-385)**
- New `code-upstream.ts`: resolves where a Code turn is generated (local engine or linked host) as a thin adapter over the chat-side resolution — one implementation of 'is this id remote?', never a second. Local takes the static agent-key bearer; a linked host authenticates via `X-TurboLLM-Auth`.
- `runCodeSession` resolves the upstream ONCE per turn, including every sub-session it spawns (`delegate_task`, `invoke_skill`), so a delegated sub-agent can never silently land on a different machine than its parent. Remote turns skip the local engine gate — they consume no local slot.
- The Code picker lists linked machines' models; the qualified `<machine>/<model>` id flows through routes → run manager → session.
- The pick moves out of ChatScreen `useState` into the UI store (it outlives navigation and reload), and the store becomes a mirror of **daemon** state (`config.selectedRemoteModel`, exposed on `/status`, written via `PUT /api/v1/links/selected-model` validated on write).
- `turbollm launch <cli>` honours the selection over BOTH local fallbacks, re-validated against the gateway's advertised ids so a stale pick degrades to the local path; the launch banner reads 'using selected remote model'.

Both ADRs are already recorded in `docs/decisions/decision-log.md` on main; this PR is their implementation.

## Verification

- `npm run typecheck` (daemon) — clean
- `cd turbollm/web && npx tsc --noEmit` — clean
- `npm test` — 3,432/3,436 pass, 0 fail (4 skipped)
- `cd turbollm/web && npm test` — 689/689 pass (incl. 6 new `resolveCodeUpstream` cases that run with the local engine STOPPED, 3 new `cli-launch` remote cases, 7 store cases)

**Not yet verified:** a real remote Code turn end to end — needs two live machines, the same two-machine verification ADR-376 §10 already gates graduation on.

## Notes

- No daemon restart required to review or merge this PR.
- `docs/CHANGELOG.md` entry to be added at release time per repo convention.