### PR TITLE
chore: ignore the local worktree node_modules junction helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ Thumbs.db
 # Local-only agent/tooling scratch dirs — not product source
 /.agents/
 /wrapper/
+# Worktree node_modules junction helper (Windows-only dev convenience)
+/scripts/link-node-modules.ps1


### PR DESCRIPTION
One-line .gitignore addition: `/scripts/link-node-modules.ps1`.

That script is a Windows-only dev convenience — it points each git worktree's
`node_modules` at the main checkout's via a directory junction, because this
repo's dependency set is ~990 MB / ~109,000 files per checkout and we run
several worktrees at once. It is machine workflow, not product source, so it
stays local alongside `.claude/` and `.agents/` rather than shipping in the
public repo.

No runtime impact: the file is a developer helper under `scripts/`, untouched
by build, test, or the daemon.