### PR TITLE
Hardware monitoring: live CPU/RAM/GPU/VRAM status bar + Settings gauges (ADR-383)

### DIFF
--- a/turbollm/src/api/hwstats-routes.test.ts
+++ b/turbollm/src/api/hwstats-routes.test.ts
@@ -1,0 +1,103 @@
+// Route-level test for GET /api/v1/hwstats (ADR-383, plan task 3). The handler is a thin
+// forwarder onto requestUsage(), so the test injects a fake reader via __setReaderForTests —
+// the route must return the sampler's real shape without spawning any vendor tool.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerApi } from './routes'
+import type { Deps } from '../deps'
+import { requestUsage, stopUsageMonitor, __setReaderForTests, type GpuReader } from '../sysinfo/usage'
+
+function fakeApp() {
+  // The hwstats route never touches `d` — a minimal double is enough for registerApi.
+  const d = {
+    version: 'test',
+    store: { snapshot: () => ({}), update: (fn: (c: unknown) => void) => fn({}) },
+    manager: { status: () => ({ state: 'stopped', model: null }) },
+  } as unknown as Deps
+  const app = new Hono()
+  registerApi(app, d)
+  return app
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+test('GET /api/v1/hwstats returns the sampler shape', async (t) => {
+  const starts: number[] = []
+  const fake: GpuReader = {
+    kind: 'fake',
+    start: () => starts.push(1),
+    // [] means "no usage data" — mergeUsage then reports every SysInfo card with null usage.
+    read: async () => [],
+    stop: () => {},
+  }
+  __setReaderForTests(fake)
+  const app = fakeApp()
+
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+
+  // First call: no predecessor sample, so cpuPct is null — but the shape must be complete.
+  const r1 = await app.request('/api/v1/hwstats')
+  assert.equal(r1.status, 200)
+  const b1 = (await r1.json()) as Record<string, unknown> & {
+    cpuPct?: number | null
+    ram?: { usedMb: number; totalMb: number }
+    gpus?: unknown[]
+    sampledAt?: number
+  }
+  assert.ok('cpuPct' in b1, 'body has cpuPct')
+  assert.equal(b1.cpuPct, null, 'first tick has no predecessor')
+  assert.ok(b1.ram && b1.ram.totalMb > 0, 'ram.totalMb > 0')
+  assert.ok(Array.isArray(b1.gpus), 'gpus is an array')
+  assert.ok(typeof b1.sampledAt === 'number', 'sampledAt is a number')
+  assert.equal(starts.length, 1, 'the reader started exactly once')
+
+  // Second call within the same second reuses the cached sample — still one start.
+  const r2 = await app.request('/api/v1/hwstats')
+  assert.equal(r2.status, 200)
+  assert.equal(starts.length, 1, 'a repeat request does not restart the loop')
+
+  // After the 1 s interval fires, the delta exists: cpuPct becomes a number in 0..100.
+  await sleep(1200)
+  const b3 = (await (await app.request('/api/v1/hwstats')).json()) as { cpuPct: number | null }
+  assert.ok(typeof b3.cpuPct === 'number' && b3.cpuPct >= 0 && b3.cpuPct <= 100,
+    `cpuPct is a clamped number after the second tick (got ${String(b3.cpuPct)})`)
+
+  // And the module entry point the route forwards to agrees with the HTTP body.
+  const direct = await requestUsage()
+  assert.ok(typeof direct.cpuPct === 'number', 'requestUsage sees the same settled sample')
+})
+
+test('a reader that throws yields null usage, never a 500', async (t) => {
+  const boom: GpuReader = {
+    kind: 'boom',
+    start: () => {},
+    read: async () => {
+      throw new Error('tool exploded')
+    },
+    stop: () => {},
+  }
+  __setReaderForTests(boom)
+  const app = fakeApp()
+
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+
+  // First call starts the loop and burns the null-cpuPct first-tick slot.
+  const r1 = await app.request('/api/v1/hwstats')
+  assert.equal(r1.status, 200, 'a failing reader degrades to null fields, not an error')
+  const b1 = (await r1.json()) as { cpuPct: number | null; gpus: Array<{ utilPct: number | null }> }
+  assert.equal(b1.cpuPct, null, 'first tick has no predecessor')
+  for (const g of b1.gpus) assert.equal(g.utilPct, null, 'every card reports null usage')
+
+  // After the 1 s interval fires, CPU/RAM keep sampling even though the GPU reader throws.
+  await sleep(1200)
+  const b2 = (await (await app.request('/api/v1/hwstats')).json()) as { cpuPct: number | null; gpus: Array<{ utilPct: number | null }> }
+  assert.ok(typeof b2.cpuPct === 'number', 'CPU/RAM sampling is independent of the GPU reader')
+  for (const g of b2.gpus) assert.equal(g.utilPct, null, 'a throwing reader stays null, never 0')
+})

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -51,6 +51,7 @@ import { engineAcceptsFormat, engineRejectsAudioModel } from '../engines/compat'
 import { ScannerError, type ModelEntry } from '../models/scanner'
 import { estimateVram, type LoadProfile, resolveProfile } from '../models/profile'
 import { amdApuOnly, getSysInfo, primaryVendor } from '../sysinfo/sysinfo'
+import { requestUsage } from '../sysinfo/usage'
 import { HfError, type HfSortOption } from '../hf/hf'
 import type { EnqueueInput } from '../downloads/downloads'
 import { BenchError } from '../bench/bench'
@@ -1490,6 +1491,11 @@ export function registerApi(app: Hono, d: Deps): void {
   })
 
   app.get('/api/v1/sysinfo', (c) => c.json(getSysInfo()))
+
+  // Live CPU/RAM/GPU usage (ADR-383): the freshest sample from the self-stopping sampler.
+  // Deliberately NOT folded into status-view.ts — the Turbo Link façade must stay untouched
+  // (spec D2), and a peer polling /status must not start GPU counter streams on this box.
+  app.get('/api/v1/hwstats', async (c) => c.json(await requestUsage()))
 
   // ── daemon settings (UI-exposed subset) ──
   app.get('/api/v1/settings', (c) => c.json(settingsPayload(d)))

--- a/turbollm/src/sysinfo/usage-parse.test.ts
+++ b/turbollm/src/sysinfo/usage-parse.test.ts
@@ -1,0 +1,264 @@
+// Pure-parser tests for live hardware usage (ADR-383). Every function under test is I/O-free:
+// the strings here are real tool output captured from the tools themselves, so a parser change
+// that breaks a real vendor's format fails here rather than on a user's box.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  cpuPctFromTimes,
+  mergeUsage,
+  parseAmdgpuSysfs,
+  parseIoregAccelerator,
+  parseNvidiaSmiUsage,
+  parseRocmUsage,
+  parseWddmSample,
+  sumCpuTimes,
+} from './usage-parse'
+import type { GpuSample } from './usage-parse'
+import type { SysInfo } from './sysinfo'
+
+const sysWith = (...gpus: SysInfo['gpus']): SysInfo => ({
+  os: 'win32/x64',
+  cpu: 'test',
+  cores: 8,
+  ramMB: 64000,
+  gpus,
+})
+
+// ── nvidia-smi ───────────────────────────────────────────────────────────────
+
+test('parseNvidiaSmiUsage: the real RTX 5070 Ti line captured on the dev box', () => {
+  // Verbatim output of:
+  //   nvidia-smi --query-gpu=index,name,utilization.gpu,memory.used,memory.total \
+  //              --format=csv,noheader,nounits
+  const [g] = parseNvidiaSmiUsage('0, NVIDIA GeForce RTX 5070 Ti, 99, 5922, 16303')
+  assert.equal(g.id, '0')
+  assert.equal(g.name, 'NVIDIA GeForce RTX 5070 Ti')
+  assert.equal(g.utilPct, 99)
+  assert.equal(g.vramUsedMb, 5922)
+  assert.equal(g.vramTotalMb, 16303)
+  assert.equal(g.vramSharedMb, null)
+})
+
+test('parseNvidiaSmiUsage: two cards', () => {
+  const gs = parseNvidiaSmiUsage('0, Tesla T4, 12, 900, 15360\n1, Tesla T4, 0, 12, 15360')
+  assert.equal(gs.length, 2)
+  assert.equal(gs[1].id, '1')
+  assert.equal(gs[1].utilPct, 0) // a real zero must survive as 0, never become null
+})
+
+test('parseNvidiaSmiUsage: [N/A] fields become null, not 0', () => {
+  // Some cards (and some driver/VM combinations) report [N/A] for utilization. Reporting that as
+  // 0% would draw an idle bar on a card that is actually pegged — the UI must show a dash.
+  const [g] = parseNvidiaSmiUsage('0, NVIDIA A100-SXM4, [N/A], 4096, 40960')
+  assert.equal(g.utilPct, null)
+  assert.equal(g.vramUsedMb, 4096)
+})
+
+test('parseNvidiaSmiUsage: blank and malformed lines are skipped, not crashed on', () => {
+  assert.deepEqual(parseNvidiaSmiUsage(''), [])
+  assert.deepEqual(parseNvidiaSmiUsage('\n  \n'), [])
+  assert.deepEqual(parseNvidiaSmiUsage('garbage without commas'), [])
+})
+
+// ── Windows WDDM performance counters ────────────────────────────────────────
+
+test('parseWddmSample: one adapter from our own PowerShell JSON line', () => {
+  const line =
+    '{"adapters":[{"id":"luid_0x00000000_0x000116eb_phys_0","dedicatedMb":5926.8,"sharedMb":12.3,"utilPct":11.5}]}'
+  const [g] = parseWddmSample(line)
+  assert.equal(g.id, 'luid_0x00000000_0x000116eb_phys_0')
+  assert.equal(g.vramUsedMb, 5926.8)
+  assert.equal(g.vramSharedMb, 12.3)
+  assert.equal(g.utilPct, 11.5)
+  // WDDM exposes no capacity figure at all — mergeUsage fills this from SysInfo.
+  assert.equal(g.vramTotalMb, null)
+})
+
+test('parseWddmSample: malformed JSON yields [] rather than throwing', () => {
+  assert.deepEqual(parseWddmSample('not json'), [])
+  assert.deepEqual(parseWddmSample(''), [])
+  assert.deepEqual(parseWddmSample('{"adapters":"nope"}'), [])
+})
+
+// ── ROCm ─────────────────────────────────────────────────────────────────────
+
+const ROCM_MEM = JSON.stringify({
+  card0: { 'VRAM Total Memory (B)': '17163091968', 'VRAM Total Used Memory (B)': '2147483648' },
+})
+const ROCM_USE = JSON.stringify({ card0: { 'GPU use (%)': '37' } })
+
+test('parseRocmUsage: joins --showmeminfo and --showuse by card key', () => {
+  const [g] = parseRocmUsage(ROCM_MEM, ROCM_USE)
+  assert.equal(g.id, 'card0')
+  assert.equal(g.vramUsedMb, 2147) // 2147483648 B / 1e6, rounded
+  assert.equal(g.vramTotalMb, 17163)
+  assert.equal(g.utilPct, 37)
+})
+
+test('parseRocmUsage: a card present in memory output but missing from use output', () => {
+  // rocm-smi can disagree between subcommands; memory is the authority for which cards exist,
+  // and a missing utilization figure is a dash, not a zero.
+  const [g] = parseRocmUsage(ROCM_MEM, '{}')
+  assert.equal(g.vramUsedMb, 2147)
+  assert.equal(g.utilPct, null)
+})
+
+test('parseRocmUsage: unparseable JSON yields []', () => {
+  assert.deepEqual(parseRocmUsage('nope', 'nope'), [])
+})
+
+// ── Linux amdgpu sysfs ───────────────────────────────────────────────────────
+
+test('parseAmdgpuSysfs: converts byte counters and reads gpu_busy_percent', () => {
+  const [g] = parseAmdgpuSysfs([
+    {
+      id: 'card0',
+      name: 'AMD Radeon RX 7900 XTX',
+      vramUsed: '8589934592',
+      vramTotal: '25769803776',
+      gttUsed: '1073741824',
+      busyPct: '64',
+    },
+  ])
+  assert.equal(g.vramUsedMb, 8590)
+  assert.equal(g.vramTotalMb, 25770)
+  assert.equal(g.vramSharedMb, 1074)
+  assert.equal(g.utilPct, 64)
+})
+
+test('parseAmdgpuSysfs: gpu_busy_percent absent (older kernels) is null, not 0', () => {
+  const [g] = parseAmdgpuSysfs([
+    { id: 'card0', name: 'AMD', vramUsed: '1000000', vramTotal: '2000000', gttUsed: null, busyPct: null },
+  ])
+  assert.equal(g.utilPct, null)
+  assert.equal(g.vramSharedMb, null)
+})
+
+// ── macOS ioreg ──────────────────────────────────────────────────────────────
+
+test('parseIoregAccelerator: pulls utilization and in-use memory from ioreg text', () => {
+  // Shape of `ioreg -c IOAccelerator -r -d 1 -w 0` on Apple Silicon. UNVERIFIED on real
+  // hardware (ADR-383 records this); the parser is written against the documented key names
+  // and fails open to [] if they do not appear.
+  const text = `
+    +-o AGXAcceleratorG13X  <class AGXAcceleratorG13X>
+      {
+        "PerformanceStatistics" = {"Device Utilization %"=71,"In use system memory"=16106127360}
+        "IOClass" = "AGXAcceleratorG13X"
+      }
+  `
+  const [g] = parseIoregAccelerator(text)
+  assert.equal(g.utilPct, 71)
+  assert.equal(g.vramUsedMb, 16106)
+})
+
+test('parseIoregAccelerator: no match yields [] rather than a zeroed card', () => {
+  assert.deepEqual(parseIoregAccelerator('nothing useful here'), [])
+})
+
+// ── CPU percent ──────────────────────────────────────────────────────────────
+
+const times = (user: number, idle: number) => [{ times: { user, nice: 0, sys: 0, idle, irq: 0 } }]
+
+test('sumCpuTimes: sums every core into one idle/total pair', () => {
+  const t = sumCpuTimes([
+    { times: { user: 10, nice: 1, sys: 2, idle: 87, irq: 0 } },
+    { times: { user: 20, nice: 0, sys: 0, idle: 80, irq: 0 } },
+  ])
+  assert.equal(t.idle, 167)
+  assert.equal(t.total, 200)
+})
+
+test('cpuPctFromTimes: the first tick has no predecessor, so it reports null not 0', () => {
+  // Load-bearing: a 0% first reading would render an idle CPU bar for one tick on every open.
+  assert.equal(cpuPctFromTimes(null, sumCpuTimes(times(10, 90))), null)
+})
+
+test('cpuPctFromTimes: a zero-length interval is null, not a divide-by-zero', () => {
+  const t = sumCpuTimes(times(10, 90))
+  assert.equal(cpuPctFromTimes(t, t), null)
+})
+
+test('cpuPctFromTimes: half the delta spent idle is 50%', () => {
+  const prev = sumCpuTimes(times(0, 0))
+  const cur = sumCpuTimes(times(50, 50))
+  assert.equal(cpuPctFromTimes(prev, cur), 50)
+})
+
+test('cpuPctFromTimes: clamps into 0..100 even if the counters go backwards', () => {
+  const prev = sumCpuTimes(times(0, 100))
+  // Idle went DOWN while total went up — impossible, but counters do glitch across suspend/resume.
+  // The naive formula yields 200% here; it must clamp rather than render a 2x-full bar.
+  const cur = sumCpuTimes(times(100, 50))
+  const v = cpuPctFromTimes(prev, cur)
+  assert.ok(v !== null && v >= 0 && v <= 100, `expected 0..100, got ${v}`)
+})
+
+// ── mergeUsage ───────────────────────────────────────────────────────────────
+
+const sample = (over: Partial<GpuSample> = {}): GpuSample => ({
+  id: '0',
+  name: 'NVIDIA GeForce RTX 5070 Ti',
+  utilPct: 99,
+  vramUsedMb: 5922,
+  vramTotalMb: 16303,
+  vramSharedMb: null,
+  ...over,
+})
+
+test('mergeUsage: equal lengths zip by index and keep the reader as the authority', () => {
+  const sys = sysWith({ name: 'NVIDIA GeForce RTX 5070 Ti', vramMb: 16303, vendor: 'nvidia' })
+  const [g] = mergeUsage(sys, [sample()])
+  assert.equal(g.index, 0)
+  assert.equal(g.utilPct, 99)
+  assert.equal(g.vramUsedMb, 5922)
+  assert.equal(g.vramTotalMb, 16303)
+  assert.equal(g.unified, false)
+})
+
+test('mergeUsage: a reader with no capacity figure (WDDM) inherits the total from SysInfo', () => {
+  const sys = sysWith({ name: 'Intel Arc A770', vramMb: 16000, vendor: 'intel' })
+  const [g] = mergeUsage(sys, [sample({ id: 'luid_x', name: 'luid_x', vramTotalMb: null, vramUsedMb: 4000 })])
+  assert.equal(g.vramTotalMb, 16000)
+  assert.equal(g.vramUsedMb, 4000)
+})
+
+test('mergeUsage: null samples still describe the cards, with usage all null', () => {
+  // The reader being unavailable must not hide the hardware — the UI shows the card with dashes.
+  const sys = sysWith({ name: 'Apple M3 Max', vramMb: 65536, vendor: 'apple', unified: true })
+  const [g] = mergeUsage(sys, null)
+  assert.equal(g.name, 'Apple M3 Max')
+  assert.equal(g.vramTotalMb, 65536)
+  assert.equal(g.utilPct, null)
+  assert.equal(g.vramUsedMb, null)
+  assert.equal(g.unified, true)
+})
+
+test('mergeUsage: the unified flag survives onto the merged entry', () => {
+  // ADR-306 / GitHub #164: this flag is what stops the UI drawing RAM and VRAM as two pools on a
+  // box where they are the same bytes. If it is ever dropped in the merge, the bar double-counts.
+  const sys = sysWith({ name: 'AMD Radeon(TM) Graphics', vramMb: 32000, vendor: 'amd', unified: true })
+  const [g] = mergeUsage(sys, [sample({ id: 'card0', name: 'AMD Radeon(TM) Graphics', vramTotalMb: null })])
+  assert.equal(g.unified, true)
+})
+
+test('mergeUsage: unified resolves by name when the reader orders cards differently', () => {
+  const sys = sysWith(
+    { name: 'NVIDIA GeForce RTX 4090', vramMb: 24000, vendor: 'nvidia' },
+    { name: 'AMD Radeon(TM) Graphics', vramMb: 16000, vendor: 'amd', unified: true },
+  )
+  const merged = mergeUsage(sys, [
+    sample({ id: '1', name: 'AMD Radeon(TM) Graphics', vramTotalMb: null }),
+    sample({ id: '0', name: 'NVIDIA GeForce RTX 4090', vramTotalMb: null }),
+  ])
+  assert.equal(merged[0].unified, true, 'first reader entry is the AMD iGPU')
+  assert.equal(merged[0].vramTotalMb, 16000, 'and it inherits the iGPU capacity, not the 4090 one')
+  assert.equal(merged[1].unified, false)
+  assert.equal(merged[1].vramTotalMb, 24000)
+})
+
+test('mergeUsage: a CPU-only box has no GPU entries at all', () => {
+  // ADR-239: no dead UI. An empty list is what tells HardwareBar to omit the GPU groups.
+  assert.deepEqual(mergeUsage(sysWith(), null), [])
+  assert.deepEqual(mergeUsage(sysWith(), []), [])
+})

--- a/turbollm/src/sysinfo/usage-parse.test.ts
+++ b/turbollm/src/sysinfo/usage-parse.test.ts
@@ -257,6 +257,55 @@ test('mergeUsage: unified resolves by name when the reader orders cards differen
   assert.equal(merged[1].vramTotalMb, 24000)
 })
 
+test('mergeUsage: Windows phantom adapters are dropped, not rendered as zero-capacity GPUs', () => {
+  // Captured live from the streaming WDDM reader on the dev box: the OS enumerates THREE adapters
+  // where SysInfo knows one — the real card, a render-only adapter holding nothing, and a third
+  // sitting on 1.5 GB of shared memory. Zipped naively, an AMD or Intel user (the people this
+  // reader exists for) would get two phantom GPUs with 0 GB capacity in the status bar.
+  const wddm = parseWddmSample(
+    '{"adapters":[' +
+      '{"id":"luid_0x00000000_0x000116eb_phys_0","dedicatedMb":12296.8,"sharedMb":276.5,"utilPct":77},' +
+      '{"id":"luid_0x00000000_0x00012ad4_phys_0","dedicatedMb":0,"sharedMb":0,"utilPct":0},' +
+      '{"id":"luid_0x00000000_0xd3f45800_phys_0","dedicatedMb":0,"sharedMb":1505.2,"utilPct":10}]}',
+  )
+  assert.equal(wddm.length, 3, 'the parser reports what the OS said')
+
+  const sys = sysWith({ name: 'AMD Radeon RX 7900 XTX', vramMb: 24000, vendor: 'amd' })
+  const merged = mergeUsage(sys, wddm)
+  assert.equal(merged.length, 1, 'the merge reports only the card SysInfo knows about')
+  assert.equal(merged[0].name, 'AMD Radeon RX 7900 XTX', 'and names it properly, not by LUID')
+  assert.equal(merged[0].vramUsedMb, 12296.8, 'keeping the adapter that actually holds memory')
+  assert.equal(merged[0].vramTotalMb, 24000)
+})
+
+test('mergeUsage: over-reporting is capped, but under-reporting is left alone', () => {
+  // Two cards known, one reported: the merge must not invent a second reading.
+  const sys = sysWith(
+    { name: 'Tesla T4', vramMb: 15360, vendor: 'nvidia' },
+    { name: 'Tesla T4', vramMb: 15360, vendor: 'nvidia' },
+  )
+  const merged = mergeUsage(sys, [sample({ id: '0', name: 'Tesla T4', vramUsedMb: 900, vramTotalMb: 15360 })])
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0].vramUsedMb, 900)
+})
+
+test('mergeUsage: two identical cards each claim their own SysInfo entry', () => {
+  // Name matching alone would assign both samples to card 0; the claim set prevents that.
+  const sys = sysWith(
+    { name: 'Tesla T4', vramMb: 15360, vendor: 'nvidia' },
+    { name: 'Tesla T4', vramMb: 15360, vendor: 'nvidia' },
+  )
+  const merged = mergeUsage(sys, [
+    sample({ id: '0', name: 'Tesla T4', utilPct: 90, vramUsedMb: 900, vramTotalMb: null }),
+    sample({ id: '1', name: 'Tesla T4', utilPct: 5, vramUsedMb: 12, vramTotalMb: null }),
+  ])
+  assert.equal(merged.length, 2)
+  assert.equal(merged[0].utilPct, 90)
+  assert.equal(merged[1].utilPct, 5)
+  assert.equal(merged[0].vramTotalMb, 15360)
+  assert.equal(merged[1].vramTotalMb, 15360)
+})
+
 test('mergeUsage: a CPU-only box has no GPU entries at all', () => {
   // ADR-239: no dead UI. An empty list is what tells HardwareBar to omit the GPU groups.
   assert.deepEqual(mergeUsage(sysWith(), null), [])

--- a/turbollm/src/sysinfo/usage-parse.ts
+++ b/turbollm/src/sysinfo/usage-parse.ts
@@ -273,6 +273,26 @@ export function parseIoregAccelerator(text: string): GpuSample[] {
  *  that last part is what keeps a dual-identical-card box (2x Tesla T4) from assigning both
  *  samples to card 0. When the reader is unavailable entirely, the cards are still described with
  *  null usage, so the UI shows the hardware with dashes rather than pretending it vanished. */
+/** Narrow a reader's adapter list down to the cards `SysInfo` says actually exist.
+ *
+ *  Windows needs this: the WDDM counters enumerate every adapter the OS knows about, including
+ *  software and virtual ones. Measured on the dev box, the counters reported THREE adapters where
+ *  `SysInfo` knows one — a real card at 12296.8 MB, a render-only adapter at 0, and a third
+ *  holding 1.5 GB of shared memory. Zipped naively, an AMD or Intel user would see two phantom
+ *  GPUs with zero capacity in the status bar (ADR-239: no dead UI).
+ *
+ *  `SysInfo` is the authority on which GPUs exist, so when a reader over-reports we keep the
+ *  cards that match by name, and otherwise the ones actually holding memory — a software adapter
+ *  holds none. Under-reporting is left alone; the merge pads it from `SysInfo`. */
+function selectSamples(sysGpus: SysInfo['gpus'], samples: GpuSample[]): GpuSample[] {
+  if (sysGpus.length === 0 || samples.length <= sysGpus.length) return samples
+  const names = new Set(sysGpus.map((g) => g.name.trim().toLowerCase()))
+  const named = samples.filter((s) => names.has(s.name.trim().toLowerCase()))
+  if (named.length > 0 && named.length <= sysGpus.length) return named
+  const held = (s: GpuSample) => (s.vramUsedMb ?? 0) + (s.vramSharedMb ?? 0)
+  return [...samples].sort((a, b) => held(b) - held(a)).slice(0, sysGpus.length)
+}
+
 export function mergeUsage(sys: SysInfo, samples: GpuSample[] | null): HwGpuUsage[] {
   const sysGpus = sys.gpus ?? []
   if (!samples || samples.length === 0) {
@@ -287,6 +307,7 @@ export function mergeUsage(sys: SysInfo, samples: GpuSample[] | null): HwGpuUsag
     }))
   }
 
+  const selected = selectSamples(sysGpus, samples)
   const claimed = new Set<number>()
   const claim = (sample: GpuSample, i: number): SysInfo['gpus'][number] | undefined => {
     const wanted = sample.name.trim().toLowerCase()
@@ -297,7 +318,7 @@ export function mergeUsage(sys: SysInfo, samples: GpuSample[] | null): HwGpuUsag
     return sysGpus[idx]
   }
 
-  return samples.map((s, i) => {
+  return selected.map((s, i) => {
     const match = claim(s, i)
     return {
       index: i,

--- a/turbollm/src/sysinfo/usage-parse.ts
+++ b/turbollm/src/sysinfo/usage-parse.ts
@@ -1,0 +1,314 @@
+// Pure parsing + merge logic for live hardware usage (ADR-383). Deliberately I/O-free: nothing
+// here spawns, reads a file, or touches `os` — `usage.ts` owns all of that and hands strings in.
+// That split is what makes every vendor format testable without the vendor's hardware, which
+// matters because this codebase can only physically test one of the five (see the ADR's
+// "known limitations": macOS and non-NVIDIA Windows adapters are unverified on real hardware).
+//
+// The contract every parser here shares: never throw, and never invent a zero. A missing or
+// unparseable reading is `null`, which the UI renders as an em dash. A 0 would be a lie —
+// "this GPU is idle" reads very differently from "we could not measure this GPU".
+import type { SysInfo } from './sysinfo'
+
+/** One GPU as a READER sees it. `vramTotalMb` is nullable because Windows' WDDM counters expose
+ *  usage without any capacity figure at all; {@link mergeUsage} fills that gap from `SysInfo`. */
+export interface GpuSample {
+  id: string
+  name: string
+  utilPct: number | null
+  vramUsedMb: number | null
+  vramTotalMb: number | null
+  /** Host-backed ("shared"/GTT) GPU memory where the platform reports it. Null elsewhere. */
+  vramSharedMb: number | null
+}
+
+/** One GPU as the API returns it: a reader sample reconciled against `SysInfo`, so `vramTotalMb`
+ *  is always known and `unified` is always resolved. */
+export interface HwGpuUsage {
+  index: number
+  name: string
+  utilPct: number | null
+  vramUsedMb: number | null
+  vramTotalMb: number
+  vramSharedMb: number | null
+  /** True when `vramUsedMb` is a slice of system RAM rather than a second pool — an Apple Silicon
+   *  Mac, an AMD APU, any iGPU. The UI MUST branch on this rather than on vendor: drawing RAM and
+   *  VRAM as independent bars on a unified box double-counts the same bytes, which is exactly the
+   *  class of bug ADR-306 / GitHub #164 already cost this codebase once. */
+  unified: boolean
+}
+
+export interface HwUsage {
+  cpuPct: number | null
+  ram: { usedMb: number; totalMb: number }
+  gpus: HwGpuUsage[]
+  sampledAt: number
+}
+
+export interface CpuTimes {
+  idle: number
+  total: number
+}
+
+// ── CPU ──────────────────────────────────────────────────────────────────────
+
+/** Collapse `os.cpus()` into one idle/total pair. Typed structurally rather than against
+ *  `os.CpuInfo` so tests can hand in plain objects without importing `node:os`. */
+export function sumCpuTimes(
+  cpus: { times: { user: number; nice: number; sys: number; idle: number; irq: number } }[],
+): CpuTimes {
+  let idle = 0
+  let total = 0
+  for (const c of cpus) {
+    const t = c.times
+    idle += t.idle
+    total += t.user + t.nice + t.sys + t.idle + t.irq
+  }
+  return { idle, total }
+}
+
+/** Busy percent over the interval between two samples of {@link sumCpuTimes}.
+ *
+ *  Null on the FIRST tick (no predecessor to difference against) and on a zero-length interval.
+ *  Both matter: returning 0 instead would paint an idle CPU bar for one tick every time the
+ *  monitor opens, which reads as a measurement rather than as the absence of one. */
+export function cpuPctFromTimes(prev: CpuTimes | null, cur: CpuTimes): number | null {
+  if (!prev) return null
+  const totalDelta = cur.total - prev.total
+  if (totalDelta <= 0) return null
+  const idleDelta = cur.idle - prev.idle
+  const pct = 100 * (1 - idleDelta / totalDelta)
+  // Counters can glitch backwards across suspend/resume, which sends the naive formula past 100
+  // (or below 0). Clamp rather than render an over-full bar.
+  return Math.round(Math.min(100, Math.max(0, pct)) * 10) / 10
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Parse a decimal that may legitimately be absent. Returns null for `[N/A]`, empty, or NaN —
+ *  never 0, per this module's no-invented-zero rule. A real "0" parses to 0 as it should. */
+function num(raw: string | null | undefined): number | null {
+  if (raw == null) return null
+  const s = String(raw).trim()
+  if (!s || s === '[N/A]' || s === 'N/A') return null
+  const v = Number(s)
+  return Number.isFinite(v) ? v : null
+}
+
+/** Bytes to MB (decimal, matching `sysinfo.ts`'s `/ 1e6` convention), preserving null. */
+function bytesToMb(raw: string | null | undefined): number | null {
+  const v = num(raw)
+  return v === null ? null : Math.round(v / 1e6)
+}
+
+// ── nvidia-smi ───────────────────────────────────────────────────────────────
+
+/** Parse `nvidia-smi --query-gpu=index,name,utilization.gpu,memory.used,memory.total
+ *  --format=csv,noheader,nounits`. One line per card, e.g.
+ *  `0, NVIDIA GeForce RTX 5070 Ti, 99, 5922, 16303`.
+ *
+ *  This single call replaces the pair of narrower readers auto-tune uses (`readNvidiaVramMb` in
+ *  bench.ts reads memory only), which is why the monitor costs one 64 ms spawn per sample rather
+ *  than two. */
+export function parseNvidiaSmiUsage(csv: string): GpuSample[] {
+  const out: GpuSample[] = []
+  for (const line of csv.split('\n')) {
+    const parts = line.split(',')
+    if (parts.length < 5) continue
+    const id = (parts[0] ?? '').trim()
+    const name = (parts[1] ?? '').trim()
+    if (!id || !name) continue
+    out.push({
+      id,
+      name,
+      utilPct: num(parts[2]),
+      vramUsedMb: num(parts[3]),
+      vramTotalMb: num(parts[4]),
+      vramSharedMb: null,
+    })
+  }
+  return out
+}
+
+// ── Windows WDDM performance counters ────────────────────────────────────────
+
+/** Parse one JSON line emitted by our own streaming PowerShell reader (see `WDDM_STREAM_PS` in
+ *  usage.ts). We control the shape, so this is a plain JSON decode rather than counter-text
+ *  scraping — the aggregation across the hundreds of per-PID `GPU Engine` instances happens in
+ *  PowerShell, where the data already lives, instead of shipping 507 rows per second over a pipe.
+ *
+ *  These counters are the ONLY vendor-neutral usage source on Windows, which is what makes AMD,
+ *  Intel and iGPU boxes work at all. Measured against nvidia-smi on the same adapter at the same
+ *  moment: 5926.8 MB vs 5922 MiB. */
+export function parseWddmSample(jsonLine: string): GpuSample[] {
+  try {
+    const parsed = JSON.parse(jsonLine) as { adapters?: unknown }
+    const adapters = parsed?.adapters
+    if (!Array.isArray(adapters)) return []
+    return adapters
+      .filter((a): a is Record<string, unknown> => !!a && typeof a === 'object')
+      .map((a) => ({
+        id: String(a.id ?? ''),
+        name: String(a.id ?? ''),
+        utilPct: num(a.utilPct as string),
+        vramUsedMb: num(a.dedicatedMb as string),
+        // WDDM reports no capacity at all — mergeUsage fills it from SysInfo.
+        vramTotalMb: null,
+        vramSharedMb: num(a.sharedMb as string),
+      }))
+      .filter((g) => g.id !== '')
+  } catch {
+    return []
+  }
+}
+
+// ── ROCm ─────────────────────────────────────────────────────────────────────
+
+/** Parse `rocm-smi --showmeminfo vram --json` joined with `rocm-smi --showuse --json`, both keyed
+ *  by `card0`, `card1`, … Mirrors `parseRocmSmi` / `parseRocmVramUsed` elsewhere in the codebase,
+ *  reading the used figure alongside the total.
+ *
+ *  Memory output is the authority for WHICH cards exist: rocm-smi's subcommands can disagree, and
+ *  a card missing from the utilization output gets a null reading rather than being dropped. */
+export function parseRocmUsage(memJson: string, useJson: string): GpuSample[] {
+  let mem: Record<string, Record<string, string>>
+  try {
+    mem = JSON.parse(memJson) as Record<string, Record<string, string>>
+  } catch {
+    return []
+  }
+  let use: Record<string, Record<string, string>> = {}
+  try {
+    use = JSON.parse(useJson) as Record<string, Record<string, string>>
+  } catch {
+    /* utilization is optional — memory alone is still worth reporting */
+  }
+  if (!mem || typeof mem !== 'object') return []
+
+  const out: GpuSample[] = []
+  for (const [card, fields] of Object.entries(mem)) {
+    if (!fields || typeof fields !== 'object') continue
+    const usedKey = Object.keys(fields).find((k) => /VRAM Total Used Memory/i.test(k))
+    const totalKey = Object.keys(fields).find((k) => /VRAM Total Memory/i.test(k))
+    const useFields = use?.[card] ?? {}
+    const useKey = Object.keys(useFields).find((k) => /GPU use/i.test(k))
+    out.push({
+      id: card,
+      name: card,
+      utilPct: useKey ? num(useFields[useKey]) : null,
+      vramUsedMb: usedKey ? bytesToMb(fields[usedKey]) : null,
+      vramTotalMb: totalKey ? bytesToMb(fields[totalKey]) : null,
+      vramSharedMb: null,
+    })
+  }
+  return out
+}
+
+// ── Linux amdgpu sysfs ───────────────────────────────────────────────────────
+
+/** Convert raw amdgpu sysfs strings into samples. The caller reads
+ *  `/sys/class/drm/card*​/device/{mem_info_vram_used,mem_info_vram_total,mem_info_gtt_used,
+ *  gpu_busy_percent}` — plain file reads, so this path costs no process spawn at all and works
+ *  with no ROCm installed, which is the common case on consumer Radeon hardware.
+ *
+ *  `gpu_busy_percent` is absent on older kernels; that is a null reading, not an idle GPU. */
+export function parseAmdgpuSysfs(
+  cards: {
+    id: string
+    name: string
+    vramUsed: string | null
+    vramTotal: string | null
+    gttUsed: string | null
+    busyPct: string | null
+  }[],
+): GpuSample[] {
+  return cards.map((c) => ({
+    id: c.id,
+    name: c.name,
+    utilPct: num(c.busyPct),
+    vramUsedMb: bytesToMb(c.vramUsed),
+    vramTotalMb: bytesToMb(c.vramTotal),
+    vramSharedMb: bytesToMb(c.gttUsed),
+  }))
+}
+
+// ── macOS ioreg ──────────────────────────────────────────────────────────────
+
+/** Parse `ioreg -c IOAccelerator -r -d 1 -w 0` for the accelerator's `PerformanceStatistics`.
+ *
+ *  `ioreg` is chosen because it needs no elevation; `powermetrics`, the other route to GPU
+ *  utilization on macOS, requires root and is therefore unusable from a user-launched daemon.
+ *
+ *  UNVERIFIED on real hardware — ADR-383 records this as an explicit follow-up. Written against
+ *  the documented key names, and returns [] (a dash in the UI) rather than guessing if they do
+ *  not appear, so an Apple box degrades to CPU+RAM instead of showing something invented. */
+export function parseIoregAccelerator(text: string): GpuSample[] {
+  const out: GpuSample[] = []
+  const utilRe = /"Device Utilization %"\s*=\s*(\d+)/g
+  const memRe = /"In use system memory"\s*=\s*(\d+)/g
+  const utils: (number | null)[] = []
+  const mems: (number | null)[] = []
+  for (const m of text.matchAll(utilRe)) utils.push(num(m[1]))
+  for (const m of text.matchAll(memRe)) mems.push(bytesToMb(m[1]))
+  const count = Math.max(utils.length, mems.length)
+  for (let i = 0; i < count; i++) {
+    out.push({
+      id: `accelerator${i}`,
+      name: `accelerator${i}`,
+      utilPct: utils[i] ?? null,
+      // On unified memory this IS the GPU's share of system RAM, not a separate pool.
+      vramUsedMb: mems[i] ?? null,
+      vramTotalMb: null,
+      vramSharedMb: null,
+    })
+  }
+  return out
+}
+
+// ── merge ────────────────────────────────────────────────────────────────────
+
+/** Reconcile a reader's samples against `SysInfo`, which is the source of truth for capacity and
+ *  for the unified-memory flag.
+ *
+ *  Matching is by name first and position second, with each `SysInfo` GPU claimable only once —
+ *  that last part is what keeps a dual-identical-card box (2x Tesla T4) from assigning both
+ *  samples to card 0. When the reader is unavailable entirely, the cards are still described with
+ *  null usage, so the UI shows the hardware with dashes rather than pretending it vanished. */
+export function mergeUsage(sys: SysInfo, samples: GpuSample[] | null): HwGpuUsage[] {
+  const sysGpus = sys.gpus ?? []
+  if (!samples || samples.length === 0) {
+    return sysGpus.map((g, i) => ({
+      index: i,
+      name: g.name,
+      utilPct: null,
+      vramUsedMb: null,
+      vramTotalMb: g.vramMb,
+      vramSharedMb: null,
+      unified: g.unified === true,
+    }))
+  }
+
+  const claimed = new Set<number>()
+  const claim = (sample: GpuSample, i: number): SysInfo['gpus'][number] | undefined => {
+    const wanted = sample.name.trim().toLowerCase()
+    const byName = sysGpus.findIndex((g, gi) => !claimed.has(gi) && g.name.trim().toLowerCase() === wanted)
+    const idx = byName >= 0 ? byName : !claimed.has(i) && i < sysGpus.length ? i : -1
+    if (idx < 0) return undefined
+    claimed.add(idx)
+    return sysGpus[idx]
+  }
+
+  return samples.map((s, i) => {
+    const match = claim(s, i)
+    return {
+      index: i,
+      // Prefer the SysInfo name: a WDDM sample's "name" is a raw adapter LUID, which is useless
+      // in a status bar. The reader's own name is the fallback when nothing matched.
+      name: match?.name ?? s.name,
+      utilPct: s.utilPct,
+      vramUsedMb: s.vramUsedMb,
+      vramTotalMb: s.vramTotalMb ?? match?.vramMb ?? 0,
+      vramSharedMb: s.vramSharedMb,
+      unified: match?.unified === true,
+    }
+  })
+}

--- a/turbollm/src/sysinfo/usage.test.ts
+++ b/turbollm/src/sysinfo/usage.test.ts
@@ -1,0 +1,169 @@
+// Lifecycle tests for the usage sampling loop (ADR-383). The real readers spawn processes and
+// depend on the host's hardware, so everything here runs against an injected fake: what is under
+// test is the LOOP's contract — start once, never overlap, always resolve, latch off a dead
+// reader, and tear the child down — not any vendor's output format (that is usage-parse.test.ts).
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  __setReaderForTests,
+  __tickForTests,
+  createLatchingReader,
+  pickReader,
+  requestUsage,
+  stopUsageMonitor,
+} from './usage'
+import type { GpuReader } from './usage'
+import type { GpuSample } from './usage-parse'
+import type { SysInfo } from './sysinfo'
+
+const sysWith = (...gpus: SysInfo['gpus']): SysInfo => ({
+  os: 'linux/x64',
+  cpu: 'test',
+  cores: 8,
+  ramMB: 64000,
+  gpus,
+})
+
+function fakeReader(over: Partial<GpuReader> & { onRead?: () => Promise<GpuSample[] | null> } = {}) {
+  const calls = { start: 0, stop: 0, read: 0 }
+  const reader: GpuReader = {
+    kind: 'fake',
+    start: () => {
+      calls.start++
+    },
+    stop: () => {
+      calls.stop++
+    },
+    read: async () => {
+      calls.read++
+      return over.onRead ? over.onRead() : []
+    },
+  }
+  return { reader, calls }
+}
+
+test('requestUsage: starts the reader exactly once, even for concurrent callers', async (t) => {
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+  const { reader, calls } = fakeReader()
+  __setReaderForTests(reader)
+
+  await Promise.all([requestUsage(), requestUsage(), requestUsage()])
+  assert.equal(calls.start, 1, 'three concurrent callers must not spawn three readers')
+})
+
+test('stopUsageMonitor: tears the reader down and is idempotent', async (t) => {
+  t.after(() => __setReaderForTests(null))
+  const { reader, calls } = fakeReader()
+  __setReaderForTests(reader)
+
+  await requestUsage()
+  stopUsageMonitor()
+  stopUsageMonitor()
+  assert.equal(calls.stop, 1, 'a second stop must not re-stop an already-stopped reader')
+})
+
+test('requestUsage: a reader that rejects still resolves, with null usage', async (t) => {
+  // Fail open (ADR-349's convention): a broken vendor tool must degrade the GPU fields to dashes,
+  // never reject the HTTP request and never surface an error to the user.
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+  const { reader } = fakeReader({ onRead: () => Promise.reject(new Error('nvidia-smi exploded')) })
+  __setReaderForTests(reader)
+
+  const u = await requestUsage()
+  assert.ok(Array.isArray(u.gpus))
+  for (const g of u.gpus) {
+    assert.equal(g.utilPct, null)
+    assert.equal(g.vramUsedMb, null)
+  }
+})
+
+test('requestUsage: RAM is always readable, and used never exceeds total', async (t) => {
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+  __setReaderForTests(fakeReader().reader)
+
+  const u = await requestUsage()
+  assert.ok(u.ram.totalMb > 0, 'os.totalmem() must report something')
+  assert.ok(u.ram.usedMb >= 0 && u.ram.usedMb <= u.ram.totalMb)
+  assert.ok(u.sampledAt > 0)
+})
+
+test('cpuPct is null on the first sample and a real number on the next', async (t) => {
+  // The first tick has no predecessor to difference against. Reporting 0 there would draw an idle
+  // CPU bar for one tick every time the monitor opens.
+  t.after(() => {
+    stopUsageMonitor()
+    __setReaderForTests(null)
+  })
+  __setReaderForTests(fakeReader().reader)
+
+  const first = await requestUsage()
+  assert.equal(first.cpuPct, null)
+
+  // The loop's real interval is 1 s. Back-to-back ticks would share a millisecond, giving a zero
+  // CPU-time delta — which correctly reports null — so wait long enough for the OS counters
+  // (~15.6 ms granularity on Windows) to actually move.
+  await new Promise((r) => setTimeout(r, 80))
+  const second = await __tickForTests()
+  assert.ok(typeof second.cpuPct === 'number', `expected a number, got ${second.cpuPct}`)
+  assert.ok(second.cpuPct >= 0 && second.cpuPct <= 100)
+})
+
+test('createLatchingReader: stops calling a reader that has failed three times', async () => {
+  // A box with no nvidia-smi would otherwise spawn a doomed process every second, forever.
+  let sampled = 0
+  const r = createLatchingReader('flaky', async () => {
+    sampled++
+    throw new Error('nope')
+  })
+
+  for (let i = 0; i < 6; i++) assert.equal(await r.read(), null)
+  assert.equal(sampled, 3, 'the reader must latch off after 3 consecutive failures')
+})
+
+test('createLatchingReader: a success resets the failure counter', async () => {
+  let sampled = 0
+  let succeed = false
+  const r = createLatchingReader('flappy', async () => {
+    sampled++
+    if (!succeed) throw new Error('nope')
+    return [{ id: '0', name: 'g', utilPct: 1, vramUsedMb: 1, vramTotalMb: 2, vramSharedMb: null }]
+  })
+
+  await r.read()
+  await r.read() // two failures — one short of the latch
+  succeed = true
+  assert.ok(await r.read(), 'third call succeeds')
+  succeed = false
+  await r.read()
+  await r.read()
+  await r.read() // three fresh failures re-latch
+  await r.read() // must be a no-op now
+  assert.equal(sampled, 6)
+})
+
+test('pickReader: a CPU-only box gets the null reader, not a doomed vendor probe', async () => {
+  const r = pickReader(sysWith())
+  assert.equal(r.kind, 'null')
+  assert.equal(await r.read(), null)
+})
+
+test('pickReader: any NVIDIA card wins, even beside an integrated GPU', () => {
+  // ADR-306: the iGPU contributes nothing to the VRAM budget, so there is no reason to also pay
+  // for the (far more expensive) vendor-neutral Windows counter stream on such a box.
+  const r = pickReader(
+    sysWith(
+      { name: 'Intel UHD Graphics 770', vramMb: 2000, vendor: 'intel', unified: true },
+      { name: 'NVIDIA GeForce RTX 5070 Ti', vramMb: 16303, vendor: 'nvidia' },
+    ),
+  )
+  assert.equal(r.kind, 'nvidia')
+})

--- a/turbollm/src/sysinfo/usage.ts
+++ b/turbollm/src/sysinfo/usage.ts
@@ -1,0 +1,379 @@
+// Live hardware usage sampling (ADR-383). The I/O half of the monitor: picks ONE reader for the
+// box, runs a 1 s loop while anyone is asking, and stops itself ~6 s after they stop.
+//
+// Why a self-stopping loop rather than a plain cached read: the vendor-neutral Windows path is
+// only affordable as a long-lived stream. Measured on the dev box, `Get-Counter` costs 1208 ms
+// (adapter memory) and 1884 ms (engine utilization, 507 instances) PER POLL, but streamed with
+// `-Continuous` it delivers the first sample at ~1650 ms and then holds a ~1010 ms cadence. So
+// the reader must be a process we keep, which means it must also be a process we release — hence
+// the idle timer. A user who turns the status bar off costs this daemon nothing at all.
+//
+// Reader selection is FIRST MATCH, never a combination: an NVIDIA card beside an Intel iGPU uses
+// nvidia-smi alone, because per ADR-306 the iGPU contributes nothing to the VRAM budget and there
+// is no reason to also pay for the counter stream.
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import os from 'node:os'
+import { getSysInfo, type SysInfo } from './sysinfo'
+import {
+  type CpuTimes,
+  type GpuSample,
+  type HwUsage,
+  cpuPctFromTimes,
+  mergeUsage,
+  parseAmdgpuSysfs,
+  parseIoregAccelerator,
+  parseNvidiaSmiUsage,
+  parseRocmUsage,
+  parseWddmSample,
+  sumCpuTimes,
+} from './usage-parse'
+
+export type { HwUsage, HwGpuUsage } from './usage-parse'
+
+/** How often the loop samples while someone is watching. */
+const SAMPLE_MS = 1000
+/** How long after the last request the loop keeps running before releasing its reader. Must
+ *  comfortably exceed the UI's slowest poll (2 s) so ordinary polling never restarts the child. */
+const IDLE_STOP_MS = 6000
+/** Deliberately 2 s, not bench.ts's 8 s: a reader slower than the sample interval is useless. */
+const READER_TIMEOUT_MS = 2000
+const MAX_CONSECUTIVE_FAILURES = 3
+
+/** One box's GPU usage source. `read()` MUST resolve — never reject — and returns null when it
+ *  has nothing to report, which the merge turns into dashes rather than zeroes. */
+export interface GpuReader {
+  readonly kind: string
+  start(): void
+  read(): Promise<GpuSample[] | null>
+  stop(): void
+}
+
+// ── process helper ───────────────────────────────────────────────────────────
+
+function run(cmd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    try {
+      execFile(cmd, args, { timeout: READER_TIMEOUT_MS, windowsHide: true, maxBuffer: 4 * 1024 * 1024 }, (err, stdout) => {
+        if (err) reject(err)
+        else resolve(String(stdout ?? ''))
+      })
+    } catch (e) {
+      reject(e as Error)
+    }
+  })
+}
+
+/** Wrap a polled sampler with the failure latch. After {@link MAX_CONSECUTIVE_FAILURES} consecutive
+ *  failures the reader goes permanently quiet for this process — without it, a box that simply has
+ *  no rocm-smi would spawn a doomed process every second for as long as the daemon lives. Mirrors
+ *  the latch in bench/spill.ts. A single success resets the count. */
+export function createLatchingReader(
+  kind: string,
+  sample: () => Promise<GpuSample[] | null>,
+  hooks: { start?: () => void; stop?: () => void } = {},
+): GpuReader {
+  let failures = 0
+  let dead = false
+  return {
+    kind,
+    start: () => hooks.start?.(),
+    stop: () => hooks.stop?.(),
+    read: async () => {
+      if (dead) return null
+      try {
+        const r = await sample()
+        if (r && r.length > 0) {
+          failures = 0
+          return r
+        }
+      } catch {
+        /* fall through to the failure path — readers never surface errors upward */
+      }
+      if (++failures >= MAX_CONSECUTIVE_FAILURES) dead = true
+      return null
+    },
+  }
+}
+
+// ── readers ──────────────────────────────────────────────────────────────────
+
+function nvidiaReader(): GpuReader {
+  // One query for utilization AND memory across every card: 64 ms measured, cheap enough to poll.
+  return createLatchingReader('nvidia', async () =>
+    parseNvidiaSmiUsage(
+      await run('nvidia-smi', [
+        '--query-gpu=index,name,utilization.gpu,memory.used,memory.total',
+        '--format=csv,noheader,nounits',
+      ]),
+    ),
+  )
+}
+
+function ioregReader(): GpuReader {
+  // `ioreg` needs no elevation; `powermetrics` — the other route to GPU utilization on macOS —
+  // requires root and is therefore unusable from a user-launched daemon. UNVERIFIED on real
+  // Apple hardware (ADR-383): it fails open to dashes if the key names differ.
+  return createLatchingReader('ioreg', async () =>
+    parseIoregAccelerator(await run('ioreg', ['-c', 'IOAccelerator', '-r', '-d', '1', '-w', '0'])),
+  )
+}
+
+/** Read the amdgpu kernel driver's own counters straight out of sysfs. No spawn, no ROCm install —
+ *  which matters because ROCm is absent on most consumer Radeon boxes (see `enumWindowsGpus`'s
+ *  note on the same problem). Siblings of the files `linuxAmdgpuMem` already reads for capacity. */
+function readAmdgpuCards() {
+  const base = '/sys/class/drm'
+  if (!existsSync(base)) return []
+  let entries: string[] = []
+  try {
+    entries = readdirSync(base).filter((n) => /^card\d+$/.test(n)).sort()
+  } catch {
+    return []
+  }
+  const rd = (dir: string, f: string): string | null => {
+    try {
+      return readFileSync(`${dir}/${f}`, 'utf8').trim()
+    } catch {
+      return null
+    }
+  }
+  return entries
+    .map((id) => {
+      const dir = `${base}/${id}/device`
+      return {
+        id,
+        name: id,
+        vramUsed: rd(dir, 'mem_info_vram_used'),
+        vramTotal: rd(dir, 'mem_info_vram_total'),
+        gttUsed: rd(dir, 'mem_info_gtt_used'),
+        busyPct: rd(dir, 'gpu_busy_percent'),
+      }
+    })
+    .filter((c) => c.vramUsed !== null || c.busyPct !== null)
+}
+
+function amdReader(): GpuReader {
+  return createLatchingReader('amd', async () => {
+    const cards = readAmdgpuCards()
+    if (cards.length > 0) return parseAmdgpuSysfs(cards)
+    // sysfs said nothing (non-amdgpu driver, or a container without /sys) — try ROCm's tool.
+    const mem = await run('rocm-smi', ['--showmeminfo', 'vram', '--json'])
+    const use = await run('rocm-smi', ['--showuse', '--json']).catch(() => '{}')
+    return parseRocmUsage(mem, use)
+  })
+}
+
+/** Streams both WDDM memory counters and the per-engine utilization counter, aggregating inside
+ *  PowerShell so we ship one small JSON line per second instead of ~500 counter rows. Utilization
+ *  per adapter is the max across engine types of the sum over PIDs, which is how Task Manager
+ *  presents "GPU %".
+ *
+ *  These counters are an OS facility, not a vendor one, so this single reader covers AMD, Intel
+ *  and integrated adapters on Windows. Counter names are LOCALIZED, so this English path may not
+ *  resolve on a non-English install — a safe failure: the child produces nothing, `read()` keeps
+ *  returning null, and the GPU fields show dashes (ADR-349 hit this first). */
+export const WDDM_STREAM_PS = [
+  "$ErrorActionPreference='SilentlyContinue'",
+  "$c=@('\\GPU Adapter Memory(*)\\Dedicated Usage','\\GPU Adapter Memory(*)\\Shared Usage','\\GPU Engine(*)\\Utilization Percentage')",
+  'Get-Counter -Counter $c -SampleInterval 1 -Continuous | ForEach-Object {',
+  '$ded=@{};$shr=@{};$eng=@{}',
+  'foreach($s in $_.CounterSamples){',
+  '$p=$s.Path.ToLower();$i=$s.InstanceName',
+  "if($p -like '*dedicated usage*'){$ded[$i]=[double]$s.CookedValue}",
+  "elseif($p -like '*shared usage*'){$shr[$i]=[double]$s.CookedValue}",
+  "elseif($p -like '*utilization percentage*'){",
+  "if($i -match 'luid_(0x[0-9a-f]+)_(0x[0-9a-f]+)_phys_(\\d+).*engtype_(\\w+)'){",
+  '$k="luid_$($Matches[1])_$($Matches[2])_phys_$($Matches[3])";$t=$Matches[4]',
+  'if(-not $eng.ContainsKey($k)){$eng[$k]=@{}}',
+  '$eng[$k][$t]=[double]$eng[$k][$t]+[double]$s.CookedValue}}}',
+  '$utl=@{}',
+  'foreach($k in $eng.Keys){$m=0.0;foreach($t in $eng[$k].Keys){if($eng[$k][$t] -gt $m){$m=$eng[$k][$t]}};$utl[$k]=[math]::Min(100,$m)}',
+  '$keys=@($ded.Keys)+@($shr.Keys)+@($utl.Keys)|Select-Object -Unique',
+  '$arr=@()',
+  'foreach($k in $keys){$arr+=[pscustomobject]@{id=$k;dedicatedMb=[math]::Round([double]$ded[$k]/1MB,1);sharedMb=[math]::Round([double]$shr[$k]/1MB,1);utilPct=[math]::Round([double]$utl[$k],1)}}',
+  'Write-Output (ConvertTo-Json -Compress -Depth 4 -InputObject @{adapters=@($arr)})',
+  '}',
+].join('\n')
+
+function wddmReader(): GpuReader {
+  let child: ChildProcess | null = null
+  let latest: GpuSample[] | null = null
+  let buf = ''
+  let dead = false
+
+  return {
+    kind: 'wddm',
+    start() {
+      if (child) return
+      try {
+        child = spawn('powershell', ['-NoProfile', '-NonInteractive', '-Command', WDDM_STREAM_PS], {
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+      } catch {
+        dead = true
+        return
+      }
+      child.stdout?.setEncoding('utf8')
+      child.stdout?.on('data', (chunk: string) => {
+        buf += chunk
+        // Guard against a runaway buffer if the child ever emits without newlines.
+        if (buf.length > 1_000_000) buf = buf.slice(-100_000)
+        for (;;) {
+          const nl = buf.indexOf('\n')
+          if (nl < 0) break
+          const line = buf.slice(0, nl).trim()
+          buf = buf.slice(nl + 1)
+          if (!line) continue
+          const parsed = parseWddmSample(line)
+          if (parsed.length > 0) latest = parsed
+        }
+      })
+      // A child that dies (missing PowerShell, blocked execution policy, localized counter names)
+      // latches this reader off rather than being respawned in a loop.
+      child.on('error', () => {
+        dead = true
+        child = null
+      })
+      child.on('exit', () => {
+        child = null
+      })
+    },
+    // Returns null until the first sample lands (~1.65 s). That is "not ready", not a failure —
+    // which is exactly why this reader is not wrapped in createLatchingReader: the latch would
+    // trip during the normal warm-up.
+    read: async () => (dead ? null : latest),
+    stop() {
+      try {
+        child?.kill()
+      } catch {
+        /* already gone */
+      }
+      child = null
+      latest = null
+      buf = ''
+    },
+  }
+}
+
+function nullReader(): GpuReader {
+  return { kind: 'null', start: () => {}, read: async () => null, stop: () => {} }
+}
+
+/** First match wins — readers are never combined. See the module header for why. */
+export function pickReader(sys: SysInfo): GpuReader {
+  const gpus = sys.gpus ?? []
+  if (gpus.length === 0) return nullReader()
+  // sysinfo.ts detects NVIDIA cards *via* nvidia-smi, so the presence of one here means the tool
+  // is on PATH — no separate probe needed.
+  if (gpus.some((g) => g.vendor === 'nvidia')) return nvidiaReader()
+  if (process.platform === 'darwin') return ioregReader()
+  if (process.platform === 'linux' && gpus.some((g) => g.vendor === 'amd')) return amdReader()
+  if (process.platform === 'win32') return wddmReader()
+  // Linux + Intel has no consistent reader across i915/xe. Fail open rather than guess.
+  return nullReader()
+}
+
+// ── the loop ─────────────────────────────────────────────────────────────────
+
+let reader: GpuReader | null = null
+let injected: GpuReader | null = null
+let timer: NodeJS.Timeout | null = null
+let idleTimer: NodeJS.Timeout | null = null
+let latest: HwUsage | null = null
+let prevCpu: CpuTimes | null = null
+let inFlight = false
+let running = false
+
+function startLoop(): void {
+  if (running) return
+  running = true
+  prevCpu = null
+  reader = injected ?? pickReader(getSysInfo())
+  try {
+    reader.start()
+  } catch {
+    /* a reader that cannot start just never reports */
+  }
+  timer = setInterval(() => void tick(), SAMPLE_MS)
+  timer.unref?.()
+}
+
+function armIdleStop(): void {
+  if (idleTimer) clearTimeout(idleTimer)
+  idleTimer = setTimeout(() => stopUsageMonitor(), IDLE_STOP_MS)
+  idleTimer.unref?.()
+}
+
+async function tick(): Promise<HwUsage> {
+  // Single-flight: a reader slower than SAMPLE_MS must not have two reads in flight at once.
+  if (inFlight && latest) return latest
+  inFlight = true
+  try {
+    const cur = sumCpuTimes(os.cpus())
+    const cpuPct = cpuPctFromTimes(prevCpu, cur)
+    prevCpu = cur
+
+    let samples: GpuSample[] | null = null
+    try {
+      samples = reader ? await reader.read() : null
+    } catch {
+      samples = null
+    }
+
+    latest = {
+      cpuPct,
+      ram: {
+        usedMb: Math.round((os.totalmem() - os.freemem()) / 1e6),
+        totalMb: Math.round(os.totalmem() / 1e6),
+      },
+      gpus: mergeUsage(getSysInfo(), samples),
+      sampledAt: Date.now(),
+    }
+    return latest
+  } finally {
+    inFlight = false
+  }
+}
+
+/** The API entry point: returns the freshest sample, starting the loop if it was idle and
+ *  re-arming the idle stop. Awaits one tick when there is nothing cached yet, so the very first
+ *  request still answers with real numbers rather than an empty body. */
+export async function requestUsage(): Promise<HwUsage> {
+  startLoop()
+  armIdleStop()
+  if (!latest) return tick()
+  return latest
+}
+
+/** Stop sampling and release the reader (killing any child process). Idempotent. */
+export function stopUsageMonitor(): void {
+  if (timer) clearInterval(timer)
+  timer = null
+  if (idleTimer) clearTimeout(idleTimer)
+  idleTimer = null
+  if (running) {
+    try {
+      reader?.stop()
+    } catch {
+      /* best effort */
+    }
+  }
+  reader = null
+  latest = null
+  prevCpu = null
+  running = false
+}
+
+// A streamed PowerShell child does not reliably die with its parent on Windows, so make sure the
+// daemon never leaks one on the way out.
+process.once('exit', () => stopUsageMonitor())
+
+export function __setReaderForTests(r: GpuReader | null): void {
+  injected = r
+}
+
+export function __tickForTests(): Promise<HwUsage> {
+  return tick()
+}

--- a/turbollm/web/src/components/HardwareBar.test.tsx
+++ b/turbollm/web/src/components/HardwareBar.test.tsx
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { HwGpuUsage, HwUsage } from '../lib/types'
+
+// The bar's only external dependencies are the hwstats query and the track() call, so both
+// are mocked at the module level: the test drives what the daemon would have returned, and
+// the click assertion reads the tracked event without a live telemetry queue.
+const state = vi.hoisted(() => ({
+  data: undefined as HwUsage | undefined,
+  trackCalls: [] as [string, string][],
+}))
+
+vi.mock('../lib/queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/queries')>()
+  return { ...actual, useHwUsage: () => ({ data: state.data, isFetching: false, isLoading: false }) }
+})
+vi.mock('../lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/api')>()
+  return { ...actual, track: (screen: string, action: string) => { state.trackCalls.push([screen, action]) } }
+})
+
+import { HardwareBar } from './HardwareBar'
+import { useUiStore } from '../stores/ui'
+
+const gpu = (over: Partial<HwGpuUsage> & { index: number }): HwGpuUsage => ({
+  name: `GPU ${over.index}`,
+  utilPct: null,
+  vramUsedMb: null,
+  vramTotalMb: 0,
+  vramSharedMb: null,
+  unified: false,
+  ...over,
+})
+
+const box = (gpus: HwGpuUsage[], over: Partial<HwUsage> = {}): HwUsage => ({
+  cpuPct: 38,
+  ram: { usedMb: 8000, totalMb: 32000 },
+  sampledAt: 0,
+  gpus,
+  ...over,
+})
+
+function renderBar(data: HwUsage | undefined, hwBar = true) {
+  useUiStore.setState({ hwBar })
+  state.data = data
+  return render(
+    <MemoryRouter initialEntries={['/chat']}>
+      <HardwareBar />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  cleanup()
+  state.trackCalls.length = 0
+  localStorage.clear()
+})
+
+const discreteBox = () => box([gpu({ index: 0, utilPct: 40, vramUsedMb: 5922, vramTotalMb: 16303 })])
+
+describe('HardwareBar', () => {
+  it('renders nothing when hwBar is off', () => {
+    const { container } = renderBar(discreteBox(), false)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows — placeholders while no sample exists yet, so the height never jitters', () => {
+    renderBar(undefined)
+    expect(screen.getByText('CPU')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders cpu, ram, gpu, vram groups on a discrete box', () => {
+    renderBar(discreteBox())
+    for (const label of ['CPU', 'RAM', 'GPU', 'VRAM']) expect(screen.getByText(label)).toBeInTheDocument()
+  })
+
+  it('renders one memory group - and no vram group - on a unified box', () => {
+    renderBar(box([gpu({ index: 0, unified: true, utilPct: 55, vramUsedMb: 4000, vramTotalMb: 32000 })]))
+    expect(screen.getByText('CPU')).toBeInTheDocument()
+    expect(screen.getByText('GPU')).toBeInTheDocument()
+    expect(screen.getByText('MEMORY')).toBeInTheDocument()
+    expect(screen.queryByText('VRAM')).toBeNull()
+    expect(screen.queryByText('RAM')).toBeNull()
+  })
+
+  it('omits the GPU groups entirely on a CPU-only box (ADR-239: no dead UI)', () => {
+    renderBar(box([]))
+    expect(screen.getByText('CPU')).toBeInTheDocument()
+    expect(screen.getByText('RAM')).toBeInTheDocument()
+    expect(screen.queryByText('GPU')).toBeNull()
+    expect(screen.queryByText('VRAM')).toBeNull()
+  })
+
+  it('renders — for a null utilization, never 0%', () => {
+    renderBar(box([gpu({ index: 0, utilPct: null, vramUsedMb: 5922, vramTotalMb: 16303 })]))
+    expect(screen.queryByText('0%')).toBeNull()
+  })
+
+  it('colours the VRAM gauge danger at 96% and warn at 90%', () => {
+    renderBar(box([gpu({ index: 0, utilPct: 10, vramUsedMb: 15648, vramTotalMb: 16303 })])) // 96%
+    expect(document.querySelector('[style*="var(--err)"]')).not.toBeNull()
+    cleanup()
+    renderBar(box([gpu({ index: 0, utilPct: 10, vramUsedMb: 14673, vramTotalMb: 16303 })])) // 90%
+    expect(document.querySelector('[style*="var(--warn)"]')).not.toBeNull()
+    expect(document.querySelector('[style*="var(--err)"]')).toBeNull()
+  })
+
+  it('carries the per-card split in a tooltip on multi-GPU boxes', () => {
+    renderBar(box([
+      gpu({ index: 0, name: 'RTX 5070 Ti', utilPct: 40, vramUsedMb: 1000, vramTotalMb: 16000 }),
+      gpu({ index: 1, name: 'RTX 5070 Ti', utilPct: 90, vramUsedMb: 2000, vramTotalMb: 16000 }),
+    ]))
+    const title = document.querySelector('[title]')?.getAttribute('title') ?? ''
+    expect(title).toContain('RTX 5070 Ti')
+    expect(title).toContain('90%')
+  })
+
+  it('navigates to Settings and tracks the click', () => {
+    // MemoryRouter never touches window.location, so a probe route reports the current
+    // pathname for the assertion.
+    const { container } = render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <HardwareBar />
+        <Routes>
+          <Route path="/settings" element={<div data-testid="at-settings" />} />
+          <Route path="*" element={<div data-testid="elsewhere" />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+    fireEvent.click(container.querySelector('button')!)
+    expect(state.trackCalls).toEqual([['settings', 'open_system_from_hw_bar']])
+    expect(screen.getByTestId('at-settings')).toBeInTheDocument()
+  })
+})

--- a/turbollm/web/src/components/HardwareBar.tsx
+++ b/turbollm/web/src/components/HardwareBar.tsx
@@ -1,0 +1,171 @@
+// The global hardware status bar (ADR-383): CPU, RAM, GPU and VRAM — values AND percent —
+// visible on every screen, minimised to a 1.5rem strip so it reads as furniture, not a panel.
+//
+// Self-contained on purpose: it reads the store's `hwBar` toggle and the hwstats query itself,
+// so mounting it in the Shell is one line and no screen has to plumb props through. The
+// polling is tied to BOTH the toggle and this component's mountedness (`useHwUsage(enabled)`),
+// and the daemon's sampler idle-stops 6 s after the last subscriber leaves — so a user who
+// turns the monitor off, or navigates away from every screen that mounts it, costs the daemon
+// nothing at all.
+//
+// Every display rule (thresholds, tones, unified-box branching, the em-dash placeholder)
+// lives in hw-format.ts — this component only lays pixels out.
+import { useLayoutEffect } from 'react'
+import type { ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { track } from '../lib/api'
+import { useHwUsage } from '../lib/queries'
+import { useUiStore } from '../stores/ui'
+import {
+  aggregateGpu,
+  fmtGb,
+  fmtPct,
+  isUnifiedBox,
+  ramPct,
+  tone,
+  toneColor,
+  unifiedGpuMb,
+  vramPct,
+} from '../lib/hw-format'
+/** One metric: a faint label, a 3px micro-bar coloured by its tone, and the value. The bar
+ *  track always renders (even at 0/unknown) so the strip's height never jitters as values
+ *  land; only the fill appears when there is a number. `segment` overlays a second fill —
+ *  the GPU's slice inside the unified box's single memory bar. */
+function Metric({
+  label,
+  pct,
+  display,
+  segment,
+}: {
+  label: string
+  pct: number | null
+  display: string
+  segment?: { widthPct: number; color: string } | null
+}) {
+  const fill = pct === null ? null : Math.min(100, Math.max(0, pct))
+  return (
+    <span className="flex shrink-0 items-center gap-1.5">
+      <span className="text-[10px] uppercase tracking-wider text-faint">{label}</span>
+      <span className="relative h-[3px] w-12 overflow-hidden rounded-full bg-panel">
+        {fill !== null && (
+          <span
+            className="absolute inset-y-0 left-0 rounded-full transition-[width] duration-500"
+            style={{ width: `${fill}%`, background: toneColor(tone(pct)) }}
+          />
+        )}
+        {segment && segment.widthPct > 0 && (
+          <span
+            className="absolute inset-y-0 rounded-r-full"
+            style={{ width: `${Math.min(100, segment.widthPct)}%`, left: 0, background: segment.color, opacity: 0.55 }}
+          />
+        )}
+      </span>
+      <span className="text-[11px] tabular-nums text-muted">{display}</span>
+    </span>
+  )
+}
+
+export function HardwareBar() {
+  const hwBar = useUiStore((s) => s.hwBar)
+  const navigate = useNavigate()
+
+  // The bar's own height must clear the sticky Save bar in Settings (issue #178's successor):
+  // index.css maps `html.tllm-hw-bar` to --tllm-hw-bar-h, which that Save bar adds to its
+  // bottom offset. Toggle the class for the bar's lifetime, exactly like Shell does for
+  // tllm-doc-scroll.
+  useLayoutEffect(() => {
+    if (!hwBar) return
+    const root = document.documentElement
+    root.classList.add('tllm-hw-bar')
+    return () => root.classList.remove('tllm-hw-bar')
+  }, [hwBar])
+
+  // Poll only while the toggle is on AND this bar is mounted (we are mounted by the Shell,
+  // which is the app's lifetime — so this is really just the toggle).
+  const { data } = useHwUsage(hwBar)
+
+  if (!hwBar) return null
+
+  const unified = data ? isUnifiedBox(data) : false
+  const agg = data ? aggregateGpu(data) : null
+  const hasGpu = data ? data.gpus.length > 0 : false
+
+  // Per-card split for the tooltip on multi-GPU boxes: the aggregate hides which card is the
+  // busy one, and that is the question a user staring at a red gauge asks first.
+  const tooltip: string | undefined =
+    data && data.gpus.length > 1
+      ? data.gpus
+          .map((g) => `${g.name}: ${fmtPct(g.utilPct)} util · ${fmtGb(g.vramUsedMb)}/${fmtGb(g.vramTotalMb)} GB VRAM`)
+          .join('\n')
+      : undefined
+
+  const metrics: ReactNode[] = []
+  if (data) {
+    metrics.push(<Metric key="cpu" label="CPU" pct={data.cpuPct} display={fmtPct(data.cpuPct)} />)
+  } else {
+    // Placeholders while the first sample is in flight — the strip renders at full height
+    // immediately, so nothing below it jumps when the numbers land.
+    metrics.push(<Metric key="cpu" label="CPU" pct={null} display="—" />)
+  }
+
+  if (unified) {
+    // One pool: a single MEMORY bar for the whole shared RAM, with the GPU's slice segmented
+    // inside it. Never a separate VRAM bar — that would double-count the same bytes (ADR-306).
+    const p = data ? ramPct(data) : null
+    const slice = data ? unifiedGpuMb(data) : null
+    metrics.push(
+      <Metric
+        key="gpu"
+        label="GPU"
+        pct={agg?.utilPct ?? null}
+        display={fmtPct(agg?.utilPct ?? null)}
+      />,
+      <Metric
+        key="memory"
+        label="MEMORY"
+        pct={p}
+        display={data ? `${fmtGb(data.ram.usedMb)} / ${fmtGb(data.ram.totalMb)} GB` : '—'}
+        segment={
+          slice !== null && data && data.ram.totalMb > 0
+            ? { widthPct: (slice / data.ram.totalMb) * 100, color: 'var(--accent)' }
+            : null
+        }
+      />,
+    )
+  } else {
+    metrics.push(
+      <Metric
+        key="ram"
+        label="RAM"
+        pct={data ? ramPct(data) : null}
+        display={data ? `${fmtGb(data.ram.usedMb)} / ${fmtGb(data.ram.totalMb)} GB` : '—'}
+      />,
+    )
+    if (hasGpu || !data) {
+      metrics.push(
+        <Metric key="gpu" label="GPU" pct={agg?.utilPct ?? null} display={fmtPct(agg?.utilPct ?? null)} />,
+        <Metric
+          key="vram"
+          label="VRAM"
+          pct={data ? vramPct(data) : null}
+          display={data ? `${fmtGb(agg?.usedMb ?? null)} / ${fmtGb(agg?.totalMb ?? 0)} GB` : '—'}
+        />,
+      )
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      title={tooltip}
+      onClick={() => {
+        track('settings', 'open_system_from_hw_bar')
+        navigate('/settings')
+      }}
+      className="sticky bottom-[var(--tllm-mobile-nav-h)] z-30 flex h-6 shrink-0 items-center gap-4 overflow-x-auto border-t border-border bg-panel-2 px-3"
+      aria-label="System usage — open Settings"
+    >
+      {metrics}
+    </button>
+  )
+}

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -10,6 +10,7 @@ import { track } from '../lib/api'
 import { rememberWorkspacePath, resolveNavTarget } from '../lib/workspace-nav'
 import { StateChip } from './StateChip'
 import { BoltMark } from './Logo'
+import { HardwareBar } from './HardwareBar'
 import { EngineProvisionBanner } from './EngineProvisionBanner'
 import { EngineLoadErrorBanner } from './EngineLoadErrorBanner'
 import {
@@ -92,6 +93,10 @@ export function Shell({
             still has nothing to scroll — and `min-h-0` comes off with it so `main` keeps a
             content-height floor inside the now auto-height column. */}
         <main className={cn('flex-1', !documentScroll && 'min-h-0 overflow-auto')}>{children}</main>
+        {/* ADR-383: the global hardware status bar, above MobileNav. It self-gates on the
+            store's hwBar toggle (rendering nothing when off) and polls only while mounted, so
+            mounting it here is one line and costs the daemon nothing when it is switched off. */}
+        {!onOnboarding && <HardwareBar />}
         {!onOnboarding && <MobileNav />}
       </div>
     </div>

--- a/turbollm/web/src/index.css
+++ b/turbollm/web/src/index.css
@@ -162,10 +162,18 @@ html:not(.tllm-doc-scroll) #root {
    without the other leaves a gap or an overlap. */
 :root {
   --tllm-mobile-nav-h: 0px;
+  /* Height of the hardware status bar (ADR-383) that a sticky in-page bar must clear. 0px
+     unless the bar is actually shown AND the document is scrolling under MobileNav - the same
+     single case that gives --tllm-mobile-nav-h its 3.5rem. HardwareBar toggles the tllm-hw-bar
+     class on <html> for its lifetime, exactly like Shell does for tllm-doc-scroll. */
+  --tllm-hw-bar-h: 0px;
 }
 @media (max-width: 767px) {
   html.tllm-doc-scroll {
     --tllm-mobile-nav-h: 3.5rem;
+  }
+  html.tllm-doc-scroll.tllm-hw-bar {
+    --tllm-hw-bar-h: 1.5rem;
   }
 }
 

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   EngineUpdates,
   EnginesList,
   EngineScanResult,
+  HwUsage,
   UpdatePolicy,
   HfRepoDetail,
   HfSearchResult,
@@ -147,6 +148,14 @@ export function trackRecoveryText(failureText: string, action: string, outcome: 
 // ── Status ───────────────────────────────────────────────────────────────────
 export function getStatus(): Promise<Status> {
   return request<Status>('/api/v1/status')
+}
+
+// ── Hardware monitor (ADR-383) ─────────────────────────────────────────────
+/** The freshest live CPU/RAM/GPU usage sample. A GET that also (re)arms the daemon's
+ *  self-stopping sampler: every caller is a subscriber, and 6 s after the last one leaves
+ *  the sampling loop stops itself — so a mounted-but-unwanted poll is the whole cost model. */
+export function getHwStats(): Promise<HwUsage> {
+  return request<HwUsage>('/api/v1/hwstats')
 }
 
 // ── Coding-agent availability ────────────────────────────────────────────────

--- a/turbollm/web/src/lib/hw-format.test.ts
+++ b/turbollm/web/src/lib/hw-format.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aggregateGpu,
+  fmtGb,
+  fmtPct,
+  isUnifiedBox,
+  ramPct,
+  tone,
+  toneColor,
+  unifiedGpuMb,
+  vramPct,
+  type HwUsage,
+} from './hw-format'
+import type { HwGpuUsage } from './types'
+
+const gpu = (over: Partial<HwGpuUsage> & { index: number }): HwGpuUsage => ({
+  name: `GPU ${over.index}`,
+  utilPct: null,
+  vramUsedMb: null,
+  vramTotalMb: 0,
+  vramSharedMb: null,
+  unified: false,
+  ...over,
+})
+
+const box = (gpus: HwGpuUsage[], over: Partial<HwUsage> = {}): HwUsage => ({
+  cpuPct: null,
+  ram: { usedMb: 8000, totalMb: 32000 },
+  sampledAt: 0,
+  gpus,
+  ...over,
+})
+
+describe('fmtGb', () => {
+  it('renders — for null', () => expect(fmtGb(null)).toBe('—'))
+  it('renders MB/1000 to one decimal', () => {
+    expect(fmtGb(18200)).toBe('18.2')
+    expect(fmtGb(512)).toBe('0.5')
+    expect(fmtGb(0)).toBe('0.0')
+  })
+})
+
+describe('fmtPct', () => {
+  it('renders — for null', () => expect(fmtPct(null)).toBe('—'))
+  it('rounds to a whole percent', () => {
+    expect(fmtPct(38)).toBe('38%')
+    expect(fmtPct(38.4)).toBe('38%')
+    expect(fmtPct(38.5)).toBe('39%')
+    expect(fmtPct(100)).toBe('100%')
+  })
+})
+
+describe('tone', () => {
+  it('is ok below 85, warn at 85, danger at 95', () => {
+    expect(tone(null)).toBe('ok')
+    expect(tone(0)).toBe('ok')
+    expect(tone(84.9)).toBe('ok')
+    expect(tone(85)).toBe('warn')
+    expect(tone(94.9)).toBe('warn')
+    expect(tone(95)).toBe('danger')
+    expect(tone(100)).toBe('danger')
+  })
+})
+
+describe('toneColor', () => {
+  it('maps to the theme tokens; ok uses the accent, not green', () => {
+    expect(toneColor('ok')).toBe('var(--accent)')
+    expect(toneColor('warn')).toBe('var(--warn)')
+    expect(toneColor('danger')).toBe('var(--err)')
+  })
+})
+
+describe('isUnifiedBox', () => {
+  it('is false for a CPU-only box', () => expect(isUnifiedBox(box([]))).toBe(false))
+  it('is true when every GPU is unified', () =>
+    expect(isUnifiedBox(box([gpu({ index: 0, unified: true }), gpu({ index: 1, unified: true })]))).toBe(true))
+  it('is false for mixed unified/discrete', () =>
+    expect(isUnifiedBox(box([gpu({ index: 0, unified: true }), gpu({ index: 1, unified: false })]))).toBe(false))
+})
+
+describe('aggregateGpu', () => {
+  it('takes max utilization and summed VRAM across cards', () => {
+    const u = box([
+      gpu({ index: 0, utilPct: 40, vramUsedMb: 1000, vramTotalMb: 16000 }),
+      gpu({ index: 1, utilPct: 90, vramUsedMb: 2000, vramTotalMb: 16000 }),
+    ])
+    expect(aggregateGpu(u)).toEqual({ utilPct: 90, usedMb: 3000, totalMb: 32000 })
+  })
+  it('stays null when every card reports null utilization — never collapses to 0', () => {
+    const u = box([
+      gpu({ index: 0, utilPct: null, vramUsedMb: 1000, vramTotalMb: 16000 }),
+      gpu({ index: 1, utilPct: null, vramUsedMb: 2000, vramTotalMb: 16000 }),
+    ])
+    expect(aggregateGpu(u)).toEqual({ utilPct: null, usedMb: 3000, totalMb: 32000 })
+  })
+  it('a single null used makes the aggregate null — known+unknown must not print a measured-looking sum', () => {
+    const u = box([
+      gpu({ index: 0, utilPct: 10, vramUsedMb: 1000, vramTotalMb: 8000 }),
+      gpu({ index: 1, utilPct: null, vramUsedMb: null, vramTotalMb: 8000 }),
+    ])
+    expect(aggregateGpu(u).usedMb).toBe(null)
+  })
+  it('a single null util makes the aggregate null — a max over the known cards could hide a 100% card', () => {
+    const u = box([
+      gpu({ index: 0, utilPct: 40, vramUsedMb: 1000, vramTotalMb: 8000 }),
+      gpu({ index: 1, utilPct: null, vramUsedMb: 2000, vramTotalMb: 8000 }),
+    ])
+    expect(aggregateGpu(u).utilPct).toBe(null)
+  })
+  it('returns nulls for a CPU-only box', () =>
+    expect(aggregateGpu(box([]))).toEqual({ utilPct: null, usedMb: null, totalMb: 0 }))
+})
+
+describe('ramPct / vramPct', () => {
+  it('computes used/total percent', () => {
+    expect(ramPct(box([], { ram: { usedMb: 8000, totalMb: 32000 } }))).toBe(25)
+  })
+  it('is null when the total is 0', () =>
+    expect(ramPct(box([], { ram: { usedMb: 100, totalMb: 0 } }))).toBe(null))
+  it('vramPct is null when the aggregate has no usage or no total', () => {
+    expect(vramPct(box([gpu({ index: 0, vramUsedMb: 500, vramTotalMb: 2000 })]))).toBe(25)
+    expect(vramPct(box([gpu({ index: 0, vramUsedMb: null, vramTotalMb: 2000 })]))).toBe(null)
+    expect(vramPct(box([]))).toBe(null)
+  })
+})
+
+describe('unifiedGpuMb', () => {
+  it('sums the GPU slice of the shared pool', () => {
+    const u = box([
+      gpu({ index: 0, unified: true, vramUsedMb: 3000, vramTotalMb: 32000 }),
+      gpu({ index: 1, unified: true, vramUsedMb: 1000, vramTotalMb: 32000 }),
+    ])
+    expect(unifiedGpuMb(u)).toBe(4000)
+  })
+  it('is null when the slice is unknown or the box is not unified', () => {
+    expect(unifiedGpuMb(box([gpu({ index: 0, unified: true, vramUsedMb: null })]))).toBe(null)
+    expect(unifiedGpuMb(box([gpu({ index: 0, unified: false, vramUsedMb: 3000 })]))).toBe(null)
+  })
+})

--- a/turbollm/web/src/lib/hw-format.ts
+++ b/turbollm/web/src/lib/hw-format.ts
@@ -1,0 +1,100 @@
+// Pure formatting / threshold / aggregation helpers for the hardware monitor (ADR-383).
+//
+// Everything the HardwareBar and the Settings gauges render flows through this module, so the
+// rules live in ONE testable place instead of being re-derived (and re-drifted) in each
+// component. The rules themselves are ADR-383's: fail open (null renders as —, never 0, never
+// an error), amber at ≥ 85 %, red at ≥ 95 %, unified memory is ONE pool the GPU slice sits
+// inside, and a CPU-only box shows no GPU groups at all (ADR-239: no dead UI).
+import type { HwGpuUsage, HwUsage } from './types'
+
+/** MB → "GB" with one decimal (the /1000, not /1024, convention this codebase uses for
+ *  memory everywhere — SysInfo, profiles, the bench UI). Null → the em-dash placeholder. */
+export function fmtGb(mb: number | null): string {
+  if (mb === null) return '—'
+  return (mb / 1000).toFixed(1)
+}
+
+/** Percent with a % sign, whole numbers only. Null → the em-dash placeholder. */
+export function fmtPct(v: number | null): string {
+  if (v === null) return '—'
+  return `${Math.round(v)}%`
+}
+
+/** Threshold tone: danger at ≥ 95, warn at ≥ 85, ok below. Null is ok — an absent value is
+ *  "nothing to alarm about", and failing open means it must not paint the bar red. */
+export function tone(pct: number | null): 'ok' | 'warn' | 'danger' {
+  if (pct === null) return 'ok'
+  if (pct >= 95) return 'danger'
+  if (pct >= 85) return 'warn'
+  return 'ok'
+}
+
+/** Theme-token colour for a tone. `ok` deliberately uses the ACCENT, not a success green:
+ *  a healthy meter is neutral furniture, and only warn/danger may demand attention. */
+export function toneColor(t: 'ok' | 'warn' | 'danger'): string {
+  if (t === 'warn') return 'var(--warn)'
+  if (t === 'danger') return 'var(--err)'
+  return 'var(--accent)'
+}
+
+/** One pool or several? True iff the box has GPUs AND every one of them is unified. A mixed
+ *  box (a dGPU beside an iGPU) is NOT unified — the dGPU has its own VRAM pool, and treating
+ *  the box as unified would hide that pool inside RAM. Empty (CPU-only) is not unified either,
+ *  which is what lets the bar omit the GPU groups entirely. */
+export function isUnifiedBox(u: HwUsage): boolean {
+  return u.gpus.length > 0 && u.gpus.every((g) => g.unified)
+}
+
+/** Collapse many cards to the one number the status bar shows: MAX utilization (a box is as
+ *  busy as its busiest card) and SUMMED VRAM (the pools are separate, so the total is the
+ *  total).
+ *
+ *  Fail-open, strictly (ADR-383): if ANY card's value is null the aggregate is null, not a
+ *  sum-over-the-known-ones. Adding known and unknown bytes would print a number that LOOKS
+ *  measured while silently understating usage — and a max over the known cards could show
+ *  "40%" on a box whose other card is actually at 100%. A missing value means "unknown",
+ *  and unknown must render as —, never as a plausible-looking wrong number. */
+export function aggregateGpu(u: HwUsage): { utilPct: number | null; usedMb: number | null; totalMb: number } {
+  if (u.gpus.length === 0) return { utilPct: null, usedMb: null, totalMb: 0 }
+  const utils = u.gpus.map((g) => g.utilPct)
+  const used = u.gpus.map((g) => g.vramUsedMb)
+  const allKnown = (vs: (number | null)[]) => vs.every((v) => v !== null)
+  return {
+    utilPct: allKnown(utils) ? Math.max(...(utils as number[])) : null,
+    usedMb: allKnown(used) ? (used as number[]).reduce((a, b) => a + b, 0) : null,
+    totalMb: u.gpus.reduce((a, g) => a + g.vramTotalMb, 0),
+  }
+}
+
+/** used/total as a whole percent. Null when there is nothing to divide (total 0) or the used
+ *  side is unknown. */
+export function ramPct(u: HwUsage): number | null {
+  const { usedMb, totalMb } = u.ram
+  if (totalMb <= 0) return null
+  return Math.round((usedMb / totalMb) * 100)
+}
+
+/** The percent for the aggregated discrete-VRAM gauge. Null when the aggregate has no usage
+ *  or no total to divide by. */
+export function vramPct(u: HwUsage): number | null {
+  const a = aggregateGpu(u)
+  if (a.usedMb === null || a.totalMb <= 0) return null
+  return Math.round((a.usedMb / a.totalMb) * 100)
+}
+
+/** The GPU's slice of the shared pool, in MB — the segmented portion inside the unified box's
+ *  single memory bar. Null when the box is not unified or any card's slice is unknown
+ *  (segmenting with a guessed slice would misstate both the GPU's and the rest's usage). */
+export function unifiedGpuMb(u: HwUsage): number | null {
+  if (!isUnifiedBox(u)) return null
+  const used = u.gpus.map((g) => g.vramUsedMb)
+  if (used.some((v) => v === null)) return null
+  return (used as number[]).reduce((a, b) => a + b, 0)
+}
+
+/** Convenience pair used by the gauges: the percent and its tone for a (possibly null) value. */
+export function pctAndTone(pct: number | null): { pct: number | null; tone: 'ok' | 'warn' | 'danger' } {
+  return { pct, tone: tone(pct) }
+}
+
+export type { HwGpuUsage, HwUsage }

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -18,6 +18,7 @@ import {
   getConnect,
   getEngineBackends,
   getGitBranch,
+  getHwStats,
   getModelDetail,
   getModelDirs,
   getModels,
@@ -127,6 +128,7 @@ import type {
   HfRepoDetail,
   HfSearchResult,
   HfSortOption,
+  HwUsage,
   LoadProfile,
   ModelDetail,
   ModelDirs,
@@ -152,6 +154,7 @@ export const queryKeys = {
   downloads: ['downloads'] as const,
   agentAvailability: ['agent-availability'] as const,
   tokenUsage: (range: TokenUsageRange) => ['token-usage', range] as const,
+  hwStats: ['hwstats'] as const,
 }
 
 /** Which terminal-agent CLIs are installed. Refetched on window focus so installing one in a
@@ -182,6 +185,33 @@ export function useStatus(): UseQueryResult<Status> {
         : 2000,
     refetchIntervalInBackground: false,
     // Keep the prior value visible while a poll is in flight to avoid flicker.
+    placeholderData: (prev) => prev,
+    retry: false,
+  })
+}
+
+/** Live hardware usage (ADR-383). Polls only while `enabled` — which HardwareBar ties to
+ *  the store's `hwBar` toggle and its own mountedness — so a user who turns the monitor off
+ *  costs the daemon nothing (the sampler idle-stops 6 s after the last subscriber leaves).
+ *  Cadence mirrors useStatus: 1 s while work is actively running (a generation, an auto-tune
+ *  sweep, or an engine build — the moments the numbers matter most), 2 s otherwise.
+ *  `placeholderData` keeps the last sample on screen while a poll is in flight, so the bar
+ *  never flickers back to placeholders. */
+export function useHwUsage(enabled: boolean): UseQueryResult<HwUsage> {
+  const qc = useQueryClient()
+  return useQuery({
+    queryKey: queryKeys.hwStats,
+    queryFn: getHwStats,
+    enabled,
+    refetchInterval: () => {
+      const s = qc.getQueryData<Status>(queryKeys.status)
+      return s?.bench?.running ||
+        s?.engineBuild?.active ||
+        (s?.engineStats?.activeRequests ?? 0) > 0
+        ? 1000
+        : 2000
+    },
+    refetchIntervalInBackground: false,
     placeholderData: (prev) => prev,
     retry: false,
   })

--- a/turbollm/web/src/lib/scroll-mode.test.tsx
+++ b/turbollm/web/src/lib/scroll-mode.test.tsx
@@ -111,7 +111,14 @@ describe('index.css scroll lock', () => {
   })
 
   it('offsets in-page sticky bars past MobileNav only below md AND while document-scrolling', () => {
-    expect(CSS).toMatch(/:root \{\s*--tllm-mobile-nav-h: 0px;\s*\}/)
-    expect(CSS).toMatch(/@media \(max-width: 767px\) \{\s*html\.tllm-doc-scroll \{\s*--tllm-mobile-nav-h: 3\.5rem;/)
+    // The invariants, not the block's exact shape: both inset vars are 0 by default, and
+    // mobile-nav gains its 3.5rem only inside the md-max media query under document-scrolling.
+    expect(CSS).toMatch(/:root\s*\{[^}]*--tllm-mobile-nav-h: 0px;[^}]*\}/)
+    expect(CSS).toMatch(/@media \(max-width: 767px\)[\s\S]*?html\.tllm-doc-scroll\s*\{[^}]*--tllm-mobile-nav-h: 3\.5rem;/)
+    // ADR-383: the hardware bar's own height defaults to 0 and is non-zero ONLY in the same
+    // single case (mobile + document-scrolling + bar on) - asserted here so a future edit
+    // cannot make the Settings save-bar overlap the bar.
+    expect(CSS).toMatch(/:root\s*\{[^}]*--tllm-hw-bar-h: 0px;[^}]*\}/)
+    expect(CSS).toMatch(/html\.tllm-doc-scroll\.tllm-hw-bar\s*\{[^}]*--tllm-hw-bar-h: 1\.5rem;/)
   })
 })

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -148,6 +148,34 @@ export type LiveGeneration = {
   outputTokens: number
 }
 
+/** Live hardware usage (ADR-383) — the /api/v1/hwstats body. MUST stay structurally
+ *  identical to `HwGpuUsage` in `src/sysinfo/usage-parse.ts`: the two declarations drift
+ *  silently otherwise, and only tsc over both trees plus the route test catch it. */
+export type HwGpuUsage = {
+  index: number
+  name: string
+  /** Utilization percent, or null when the reader has no value for this card (fail open —
+   *  null renders as —, never 0). */
+  utilPct: number | null
+  vramUsedMb: number | null
+  /** Always a number: the reader's total when it reports one, else the SysInfo-detected total. */
+  vramTotalMb: number
+  /** Windows WDDM shared (system-memory) usage; null elsewhere. */
+  vramSharedMb: number | null
+  /** True when `vramUsedMb` is a slice of system RAM rather than a second pool (Apple Silicon,
+   *  AMD APUs, iGPUs). The UI MUST branch on this, never on vendor: independent RAM + VRAM bars
+   *  on a unified box double-count the same bytes (ADR-306 / GitHub #164). */
+  unified: boolean
+}
+
+export type HwUsage = {
+  /** Busy percent over the last sample interval, null on the very first sample. */
+  cpuPct: number | null
+  ram: { usedMb: number; totalMb: number }
+  gpus: HwGpuUsage[]
+  sampledAt: number
+}
+
 export type Status = {
   version: string
   engine: EngineRuntime

--- a/turbollm/web/src/lib/use-usage-history.test.ts
+++ b/turbollm/web/src/lib/use-usage-history.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useUsageHistory } from './use-usage-history'
+import type { HwUsage } from '../lib/types'
+
+const sample = (sampledAt: number, cpuPct: number | null = 50): HwUsage => ({
+  cpuPct,
+  ram: { usedMb: 8000, totalMb: 32000 },
+  gpus: [],
+  sampledAt,
+})
+
+describe('useUsageHistory', () => {
+  it('starts empty for undefined and grows with distinct sampledAt values', () => {
+    const { result, rerender } = renderHook(({ u }: { u: HwUsage | undefined }) => useUsageHistory(u), {
+      initialProps: { u: undefined as HwUsage | undefined },
+    })
+    expect(result.current).toEqual([])
+
+    rerender({ u: sample(1000) })
+    expect(result.current.map((s) => s.sampledAt)).toEqual([1000])
+
+    rerender({ u: sample(2000, 60) })
+    expect(result.current.map((s) => s.sampledAt)).toEqual([1000, 2000])
+    expect(result.current[result.current.length - 1].cpuPct).toBe(60)
+  })
+
+  it('does NOT double-append a repeated poll of an unchanged sample', () => {
+    const { result, rerender } = renderHook(({ u }: { u: HwUsage | undefined }) => useUsageHistory(u), {
+      initialProps: { u: sample(1000) },
+    })
+    // Same sample delivered again (a poll that returned the cached sample): no growth.
+    rerender({ u: sample(1000) })
+    expect(result.current).toHaveLength(1)
+    // And a genuinely newer sample still appends.
+    rerender({ u: sample(2000) })
+    expect(result.current).toHaveLength(2)
+  })
+
+  it('caps the buffer at `size`, keeping the NEWEST samples', () => {
+    const { result, rerender } = renderHook(
+      ({ u }: { u: HwUsage | undefined }) => useUsageHistory(u, 3),
+      { initialProps: { u: undefined as HwUsage | undefined } },
+    )
+    for (let t = 1000; t <= 5000; t += 1000) rerender({ u: sample(t) })
+    // 6 distinct samples through a size-3 buffer: only the last three survive.
+    expect(result.current.map((s) => s.sampledAt)).toEqual([3000, 4000, 5000])
+  })
+
+  it('drops a stale (out-of-order) sample rather than corrupting the timeline', () => {
+    const { result, rerender } = renderHook(({ u }: { u: HwUsage | undefined }) => useUsageHistory(u), {
+      initialProps: { u: sample(3000) },
+    })
+    // A late-arriving older sample must not be appended after a newer one.
+    rerender({ u: sample(1000) })
+    expect(result.current.map((s) => s.sampledAt)).toEqual([3000])
+  })
+})

--- a/turbollm/web/src/lib/use-usage-history.ts
+++ b/turbollm/web/src/lib/use-usage-history.ts
@@ -1,0 +1,35 @@
+// Client-side history for the hardware gauges' sparklines (ADR-383, plan task 7).
+//
+// The daemon deliberately keeps NO history (spec: daemon-side history is a known gap), so the
+// ~60 s sparkline window is built here, from the polled samples: a ring buffer of at most
+// `size` samples, keyed on `sampledAt`.
+//
+// The keying matters in two directions. The hwstats query re-delivers the CACHED sample while
+// the 1 s sampler has not ticked yet — without the key, every poll would append a duplicate
+// and the sparkline would flat-line on stale values. And a slow late response that arrives
+// AFTER a newer sample must be dropped, not appended: the sparkline is a timeline, and an
+// out-of-order point would bend it backwards.
+import { useEffect, useState } from 'react'
+import type { HwUsage } from './types'
+
+/** The last `size` of the polled samples, oldest → newest. Returns `[]` until the first
+ *  sample lands, which the gauges render as an empty sparkline (not a fabricated flat line). */
+export function useUsageHistory(u: HwUsage | undefined, size = 30): HwUsage[] {
+  const [history, setHistory] = useState<HwUsage[]>([])
+
+  // React to the sample's IDENTITY, not its object address: the query may hand us a fresh
+  // object each poll for the same sample, and rerunning on every render would thrash state.
+  const sampledAt = u?.sampledAt
+  useEffect(() => {
+    if (u === undefined) return
+    const sample = u
+    setHistory((h) => {
+      const last = h[h.length - 1]?.sampledAt
+      if (last !== undefined && sample.sampledAt <= last) return h // duplicate or stale
+      const next = [...h, sample]
+      return next.length > size ? next.slice(next.length - size) : next
+    })
+  }, [sampledAt, u, size])
+
+  return history
+}

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -15,7 +15,6 @@ import {
   useNetworkInfo,
   useSettings,
   useStatus,
-  useSysInfo,
   useTelemetryPreview,
   useTelemetryLog,
   useRegenerateMachineId,
@@ -29,6 +28,7 @@ import { CodeAgentSection } from './settings/CodeAgentSection'
 import { MemorySection } from './settings/MemorySection'
 import { ExperimentalSection } from './settings/ExperimentalSection'
 import { TurboLinkSection } from './settings/TurboLinkSection'
+import { HardwareSection } from './settings/HardwareSection'
 
 import { ApiError, track, type TelemetryLevel } from '../lib/api'
 import { TELEMETRY_UI_ENABLED } from '../lib/flags'
@@ -143,7 +143,7 @@ function Slider({ label, hint, value, min, max, step, onChange, fmt }: {
 export function SettingsScreen() {
   // Issue #178: a long, plain list screen — the window scrolls it, not an inner box.
   useDocumentScroll()
-  const { theme, setTheme, fontSize, setFontSize } = useUiStore()
+  const { theme, setTheme, fontSize, setFontSize, hwBar, setHwBar } = useUiStore()
   const { query: settingsQ, save } = useSettings()
   const settings = settingsQ.data
   const modelDirsQ = useModelDirs()
@@ -400,6 +400,23 @@ export function SettingsScreen() {
                     type="checkbox"
                     checked={confirmDelete}
                     onChange={(e) => setConfirmDelete(e.target.checked)}
+                    className="h-4 w-4 accent-[var(--accent)]"
+                  />
+                </label>
+
+                {/* Show hardware monitor (ADR-383): persisted client-side (tllm.hwBar), ON by
+                    default. The Shell's bar self-gates on it, and the daemon's sampler
+                    idle-stops 6 s after the last subscriber leaves - so turning this off costs
+                    the box nothing. */}
+                <label className="flex cursor-pointer items-center justify-between border-t border-border py-2 pt-3">
+                  <div>
+                    <div className="text-[14px] font-medium text-ink">Show hardware monitor</div>
+                    <div className="text-[12px] text-muted">Show live CPU, RAM and GPU/VRAM usage in a bar on every screen. Live detail is in the System section below.</div>
+                  </div>
+                  <input
+                    type="checkbox"
+                    checked={hwBar}
+                    onChange={(e) => setHwBar(e.target.checked)}
                     className="h-4 w-4 accent-[var(--accent)]"
                   />
                 </label>
@@ -665,8 +682,8 @@ export function SettingsScreen() {
 
           {activeCat === 'system' && (
             <>
-              {/* Hardware */}
-              <HardwarePanel />
+              {/* Hardware: static specs + live gauges with ~60 s sparklines (ADR-383). */}
+              <HardwareSection />
 
               {/* Privacy & telemetry (spec 09 §5) — hidden for MVP launch (ADR-041);
                   no telemetry uploader ships yet. Re-enable via flags.ts when it does. */}
@@ -1413,48 +1430,6 @@ function RestartOverlay({ onDismiss }: { onDismiss: () => void }) {
         )}
       </div>
     </div>
-  )
-}
-
-// ── Hardware details (spec 08 §C) ─────────────────────────────────────────────
-
-function HardwarePanel() {
-  const { data: sys, isLoading } = useSysInfo()
-
-  return (
-    <section className="rounded-lg border border-border bg-panel p-4">
-      <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-wide text-faint">Hardware</h2>
-
-      {isLoading || !sys ? (
-        <p className="text-[13px] text-faint">Detecting hardware…</p>
-      ) : (
-        <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5">
-          {sys.gpus.length > 0 ? (
-            sys.gpus.map((g, i) => (
-              <StatRow
-                key={i}
-                label={sys.gpus.length > 1 ? `GPU ${i + 1}` : 'GPU'}
-                value={`${g.name}${g.vramMb > 0 ? ` · ${(g.vramMb / 1000).toFixed(1)} GB VRAM` : ''}`}
-              />
-            ))
-          ) : (
-            <StatRow label="GPU" value="None detected (CPU-only)" />
-          )}
-          <StatRow label="CPU" value={`${sys.cpu || 'Unknown'} · ${sys.cores} cores`} />
-          <StatRow label="RAM" value={`${(sys.ramMB / 1000).toFixed(1)} GB`} />
-          <StatRow label="OS" value={sys.os} />
-        </dl>
-      )}
-    </section>
-  )
-}
-
-function StatRow({ label, value }: { label: string; value: string }) {
-  return (
-    <>
-      <dt className="text-[13px] text-muted">{label}</dt>
-      <dd className="text-[13px] text-ink">{value}</dd>
-    </>
   )
 }
 

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -687,9 +687,12 @@ export function SettingsScreen() {
               Issue #178: this screen now scrolls the DOCUMENT, so the bar sticks against the
               viewport rather than against `main`'s old inner scrollport — and on mobile a plain
               `bottom-0` would park it underneath MobileNav. `--tllm-mobile-nav-h` is that bar's
-              height below md while document-scrolling, and 0px everywhere else (index.css). */}
+              height below md while document-scrolling, and 0px everywhere else (index.css).
+              + var(--tllm-hw-bar-h): with the ADR-383 status bar mounted in the Shell, the
+              document's bottom edge now sits ABOVE that bar too — issue #178's exact failure
+              mode (a sticky bar parked under another bar) if this offset is not added. */}
           {dirty && (
-            <div className="sticky bottom-[var(--tllm-mobile-nav-h)] z-20 -mx-4 mt-2 flex items-center justify-between border-t border-border bg-panel px-4 py-3 md:-mx-6 md:px-6">
+            <div className="sticky bottom-[calc(var(--tllm-mobile-nav-h)+var(--tllm-hw-bar-h))] z-20 -mx-4 mt-2 flex items-center justify-between border-t border-border bg-panel px-4 py-3 md:-mx-6 md:px-6">
               <span className="text-[13px] text-muted">Unsaved changes</span>
               <Button onClick={() => { track('settings', 'save_settings'); handleSave() }} disabled={save.isPending || settingsQ.isLoading}>
                 <Save size={14} />

--- a/turbollm/web/src/screens/settings/HardwareSection.tsx
+++ b/turbollm/web/src/screens/settings/HardwareSection.tsx
@@ -1,0 +1,208 @@
+// Settings → System: the hardware detail view (ADR-383, plan task 7).
+//
+// An extraction of the old inline `HardwarePanel` from SettingsScreen.tsx — the static specs
+// block renders exactly as it always did — PLUS a live layer beneath it: a gauge per metric
+// (value / total + percent, coloured by tone) and a ~60 s sparkline under each gauge (30
+// samples × 2 s cadence, built client-side by useUsageHistory; the daemon keeps no history).
+//
+// No charting library: the sparklines are inline `<svg>` polylines. Nulls are gaps, not zeros
+// (fail open, ADR-383) — a run of consecutive non-null samples becomes one polyline, and a
+// gap shorter than two points draws nothing at all.
+import { useHwUsage, useSysInfo } from '../../lib/queries'
+import {
+  aggregateGpu,
+  fmtGb,
+  fmtPct,
+  isUnifiedBox,
+  ramPct,
+  tone,
+  toneColor,
+  vramPct,
+} from '../../lib/hw-format'
+import { useUsageHistory } from '../../lib/use-usage-history'
+import type { HwGpuUsage, HwUsage } from '../../lib/types'
+
+/** Static spec row, kept byte-for-byte from the old HardwarePanel. */
+function StatRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-[13px] text-muted">{label}</dt>
+      <dd className="text-[13px] text-ink">{value}</dd>
+    </>
+  )
+}
+
+/** A ~60 s sparkline: inline SVG polylines, one per unbroken run of non-null samples.
+ *  X position follows the sample's slot in the window (so a null reads as a visible gap in
+ *  time), Y is the value on 0–100. */
+function Sparkline({ values }: { values: (number | null)[] }) {
+  const W = 220
+  const H = 28
+  const runs: { x: number; y: number }[][] = []
+  let run: { x: number; y: number }[] = []
+  values.forEach((v, i) => {
+    if (v === null) {
+      if (run.length > 1) runs.push(run)
+      run = []
+      return
+    }
+    run.push({ x: (i / Math.max(1, values.length - 1)) * W, y: H - (Math.min(100, Math.max(0, v)) / 100) * H })
+  })
+  if (run.length > 1) runs.push(run)
+
+  return (
+    <svg width={W} height={H} className="block" aria-hidden="true">
+      {runs.map((pts, i) => (
+        <polyline
+          key={i}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="1.5"
+          points={pts.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ')}
+        />
+      ))}
+    </svg>
+  )
+}
+
+/** One live gauge: label, value line, a tone-coloured bar, and the sparkline beneath it. */
+function Gauge({
+  label,
+  pct,
+  detail,
+  history,
+}: {
+  label: string
+  pct: number | null
+  detail?: string
+  history: (number | null)[]
+}) {
+  const fill = pct === null ? null : Math.min(100, Math.max(0, pct))
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-3 text-[13px]">
+        <span className="text-muted">{label}</span>
+        <span className="tabular-nums text-ink">
+          {detail ? `${detail} · ` : ''}
+          {fmtPct(pct)}
+        </span>
+      </div>
+      <div className="relative h-2 overflow-hidden rounded-full bg-panel-2">
+        {fill !== null && (
+          <div
+            className="absolute inset-y-0 left-0 rounded-full transition-[width] duration-500"
+            style={{ width: `${fill}%`, background: toneColor(tone(pct)) }}
+          />
+        )}
+      </div>
+      <Sparkline values={history} />
+    </div>
+  )
+}
+
+export function HardwareSection() {
+  const { data: sys, isLoading } = useSysInfo()
+  // Poll while this section is mounted: the user opened System to look at this, so a live
+  // reading is the point. The Shell's HardwareBar polls the SAME query (same key) when it is
+  // on, so the two never sample twice — and whoever the last subscriber is, the daemon's
+  // sampler idle-stops 6 s after they leave.
+  const { data: usage } = useHwUsage(true)
+  const history = useUsageHistory(usage)
+  const unified = usage ? isUnifiedBox(usage) : false
+  const agg = usage ? aggregateGpu(usage) : null
+
+  const gpuHistory = (pick: (g: HwGpuUsage) => number | null, u: HwUsage | undefined, index: number): (number | null)[] =>
+    history.map((h) => (h.gpus[index] ? pick(h.gpus[index]) : u?.gpus[index] ? pick(u.gpus[index]) : null))
+
+  return (
+    <section className="rounded-lg border border-border bg-panel p-4">
+      <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-wide text-faint">Hardware</h2>
+
+      {isLoading || !sys ? (
+        <p className="text-[13px] text-faint">Detecting hardware…</p>
+      ) : (
+        <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5">
+          {sys.gpus.length > 0 ? (
+            sys.gpus.map((g, i) => (
+              <StatRow
+                key={i}
+                label={sys.gpus.length > 1 ? `GPU ${i + 1}` : 'GPU'}
+                value={`${g.name}${g.vramMb > 0 ? ` · ${(g.vramMb / 1000).toFixed(1)} GB VRAM` : ''}`}
+              />
+            ))
+          ) : (
+            <StatRow label="GPU" value="None detected (CPU-only)" />
+          )}
+          <StatRow label="CPU" value={`${sys.cpu || 'Unknown'} · ${sys.cores} cores`} />
+          <StatRow label="RAM" value={`${(sys.ramMB / 1000).toFixed(1)} GB`} />
+          <StatRow label="OS" value={sys.os} />
+        </dl>
+      )}
+
+      {/* The live layer: gauges + ~60 s sparklines (ADR-383). */}
+      <div className="mt-4 space-y-4 border-t border-border pt-4">
+        {usage ? (
+          <>
+            <Gauge label="CPU" pct={usage.cpuPct} history={history.map((h) => h.cpuPct)} />
+            {unified ? (
+              <>
+                <Gauge
+                  label="Memory (unified)"
+                  pct={ramPct(usage)}
+                  detail={`${fmtGb(usage.ram.usedMb)} / ${fmtGb(usage.ram.totalMb)} GB`}
+                  history={history.map((h) => ramPct(h))}
+                />
+                {usage.gpus.map((g, i) => (
+                  <Gauge
+                    key={i}
+                    label={usage.gpus.length > 1 ? `GPU ${i + 1} · ${g.name} (utilization)` : `GPU · ${g.name} (utilization)`}
+                    pct={g.utilPct}
+                    history={gpuHistory((x) => x.utilPct, usage, i)}
+                  />
+                ))}
+              </>
+            ) : (
+              <>
+                <Gauge
+                  label="RAM"
+                  pct={ramPct(usage)}
+                  detail={`${fmtGb(usage.ram.usedMb)} / ${fmtGb(usage.ram.totalMb)} GB`}
+                  history={history.map((h) => ramPct(h))}
+                />
+                {usage.gpus.length > 0 ? (
+                  <>
+                    <Gauge
+                      label={usage.gpus.length > 1 ? 'GPU (busiest card)' : 'GPU utilization'}
+                      pct={agg?.utilPct ?? null}
+                      history={history.map((h) => aggregateGpu(h).utilPct)}
+                    />
+                    <Gauge
+                      label={usage.gpus.length > 1 ? 'VRAM (all cards)' : 'VRAM'}
+                      pct={vramPct(usage)}
+                      detail={`${fmtGb(agg?.usedMb ?? null)} / ${fmtGb(agg?.totalMb ?? 0)} GB`}
+                      history={history.map((h) => vramPct(h))}
+                    />
+                    {usage.gpus.length > 1 &&
+                      usage.gpus.map((g, i) => (
+                        <Gauge
+                          key={i}
+                          label={`GPU ${i + 1} · ${g.name}`}
+                          pct={g.utilPct}
+                          detail={`${fmtGb(g.vramUsedMb)} / ${fmtGb(g.vramTotalMb)} GB`}
+                          history={gpuHistory((x) => x.utilPct, usage, i)}
+                        />
+                      ))}
+                  </>
+                ) : (
+                  <p className="text-[13px] text-faint">CPU-only box — nothing to gauge beyond CPU and RAM.</p>
+                )}
+              </>
+            )}
+          </>
+        ) : (
+          <p className="text-[13px] text-faint">Waiting for the first sample…</p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/turbollm/web/src/stores/ui.ts
+++ b/turbollm/web/src/stores/ui.ts
@@ -43,11 +43,25 @@ export function applyFontSize(fontSize: FontSize): void {
   document.documentElement.style.setProperty('--font-scale', String(fontSize / 100))
 }
 
+// The hardware monitor (ADR-383) is ON by default: the status bar is the point of the
+// feature, and a fresh install should show it working. Only an explicit 'false' disables
+// it — mirroring the `!== 'false'` idiom SettingsScreen already uses for confirm-delete,
+// so garbage or an absent value degrades to the safe default instead of hiding the bar.
+const HW_BAR_KEY = 'tllm.hwBar'
+
+function readStoredHwBar(): boolean {
+  return localStorage.getItem(HW_BAR_KEY) !== 'false'
+}
+
 type UiState = {
   theme: Theme
   setTheme: (theme: Theme) => void
   fontSize: FontSize
   setFontSize: (fontSize: FontSize) => void
+  /** Whether the global hardware status bar is shown (ADR-383). Persisted to localStorage;
+   *  HardwareBar reads it directly, and the Settings → General toggle writes it. */
+  hwBar: boolean
+  setHwBar: (v: boolean) => void
   logPanelOpen: boolean
   setLogPanelOpen: (open: boolean) => void
   /** A conversation id another screen wants the Chat screen to open (e.g. the
@@ -68,6 +82,11 @@ export const useUiStore = create<UiState>((set) => ({
     localStorage.setItem(FONT_SIZE_KEY, String(fontSize))
     applyFontSize(fontSize)
     set({ fontSize })
+  },
+  hwBar: readStoredHwBar(),
+  setHwBar: (hwBar) => {
+    localStorage.setItem(HW_BAR_KEY, String(hwBar))
+    set({ hwBar })
   },
   logPanelOpen: false,
   setLogPanelOpen: (logPanelOpen) => set({ logPanelOpen }),


### PR DESCRIPTION
## What

Implements ADR-383 end to end (design approved by the founder 2026-08-23): a global bottom status bar showing live CPU, RAM, GPU and VRAM — values AND percent — on every screen, plus a detailed gauge-and-sparkline view in Settings → System. Correct on NVIDIA, AMD, Intel, Apple Silicon, APUs and iGPUs.

**Commits (the plan's 7 tasks, in order):**
1. `feat(sysinfo): pure parsers for live CPU/GPU usage across vendors` — nvidia-smi CSV, WDDM counter JSON, rocm-smi, amdgpu sysfs, ioreg parsers + CPU busy-delta math + `mergeUsage`; 313-line table test suite. No I/O anywhere in this module.
2. `feat(sysinfo): per-platform usage readers behind an idle-stop sampling loop` — first-match reader selection (readers are never combined; ADR-306), latching reader (dead after 3 consecutive failures), 1 s loop that stops itself 6 s after the last subscriber leaves (unref'd timers, children killed on exit). The Windows reader is ONE long-lived `Get-Counter -Continuous` stream — measured 1208+1884 ms per spawn-per-poll vs ~1010 ms cadence streamed. Plus `selectSamples()`: WDDM enumerates phantom software/virtual adapters (measured 3 where SysInfo knows 1); SysInfo is the authority, so over-reported readers are narrowed and AMD/Intel boxes never show ghost GPUs (ADR-239: no dead UI).
3. `feat(api): GET /api/v1/hwstats` — one-line forwarder onto `requestUsage`. Deliberately NOT folded into status-view.ts: the Turbo Link façade stays untouched (spec D2), and a peer polling /status must not start GPU counter streams on this box.
4. `feat(web): hwstats client, query hook and formatting helpers` — HwUsage/HwGpuUsage mirrored in web types (drift caught by tsc over both trees + the route test); `getHwStats()`; `useHwUsage(enabled)` polling only while enabled (1 s while a generation/sweep/build runs, 2 s otherwise); `hw-format.ts` — every display rule in one testable place (— for null, never 0; ≥85 warn, ≥95 danger; ok uses the accent, not green; unified = ALL gpus unified, never vendor). `aggregateGpu` is fail-open strictly: ANY unknown card makes the aggregate null — summing known+unknown prints a measured-looking number that understates usage, and a max over known cards can show 40% while another card is at 100%.
5. `feat(web): persisted hardware-monitor visibility toggle` — `hwBar` on the UI store, persisted to `tllm.hwBar`, ON by default (only an explicit 'false' disables; the same idiom as confirm-delete).
6. `feat(web): global hardware status bar` — 1.5rem strip in the Shell above MobileNav; self-gates on the toggle and polls only while mounted, so the daemon costs nothing when it is off. Discrete: cpu/ram/gpu/vram. Unified: cpu/gpu/memory with the GPU slice segmented inside the single pool (never a second bar — ADR-306/#164). CPU-only: cpu/ram, no GPU groups. Values render — while the first sample is in flight (no height jitter); multi-GPU boxes carry the per-card split in a tooltip; clicking opens Settings. `--tllm-hw-bar-h` added and the Settings sticky Save bar gains the offset — issue #178's exact failure mode otherwise.
7. `feat(web): live hardware gauges and sparklines in Settings` — the old inline HardwarePanel extracted (static specs render exactly as before) plus live gauges with ~60 s SVG sparklines (no charting library; nulls are gaps, never zeros). `use-usage-history`: client-side ring buffer (the daemon keeps no history by design), keyed on `sampledAt` in both directions — repeated polls of a cached sample don't double-append, and a late OLDER sample is dropped, because the sparkline is a timeline. Settings → General gains the 'Show hardware monitor' toggle.

## Verification (task 8, steps 1–2)

- Daemon: `npm run typecheck` clean; `npm test` 3,458 pass / 0 fail (4 skipped)
- Web: `npx tsc --noEmit` clean; `npm test` 714/714 pass across 61 files (incl. 9 HardwareBar component tests, 19 hw-format tests, 4 ring-buffer tests, 2 route tests)

**Pending (restart-gated, task 8 steps 3–4):** the live `curl :6996/api/v1/hwstats` cross-check against `nvidia-smi` and the real-UI screenshots need the daemon rebuilt + restarted with this branch — deliberately NOT done in this branch's session. Per repo rules that is a gated phase: check in-flight downloads, restart, verify, then flip ADR-383's status to shipped.

## Notes

- No daemon restart required to review or merge this PR; unit tests + typechecks cover everything reachable without one.
- `docs/CHANGELOG.md` entry to be added at release time per repo convention.