### PR TITLE
fix(engines): DFlash/NextN speculative decoding for ik_llama.cpp

### DIFF
--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -364,7 +364,7 @@ const ALL: CatalogEngine[] = [
     name: 'ik_llama.cpp',
     kind: 'llama-server',
     description:
-      'A llama.cpp fork (ikawrakow) with CPU/GPU performance work and extra quant types. Ships llama-server but publishes no prebuilt binaries — build it, then add your own engine.',
+      'A llama.cpp fork (ikawrakow) with CPU/GPU performance work, extra quant types, and adaptive DFlash speculative decoding. Ships llama-server but publishes no prebuilt binaries — build it, then add your own engine.',
     provision: 'github-release',
     homepage: 'https://github.com/ikawrakow/ik_llama.cpp',
     repo: 'ikawrakow/ik_llama.cpp',

--- a/turbollm/src/engines/probe.test.ts
+++ b/turbollm/src/engines/probe.test.ts
@@ -1,7 +1,7 @@
 // Capability-flag extraction from --help output (GitHub #43 regression).
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { extractFlags, detectKvTypes, parseEnumList, classifyFlag } from './probe'
+import { extractFlags, detectKvTypes, parseEnumList, classifyFlag, extractSpecTypeValues } from './probe'
 
 test('captures a normally-documented flag', () => {
   const help = `--cache-type-k TYPE     KV cache data type for K\n--parallel N            number of parallel sequences\n`
@@ -214,4 +214,46 @@ test('classifyFlag: a bare boolean flag at true end-of-line (zero trailing space
   const help = `--no-mmproj\nsome other line\n`
   const info = classifyFlag('--no-mmproj', help)
   assert.equal(info.kind, 'boolean')
+})
+
+// ---- extractSpecTypeValues: DFlash never showed up as an option for ik_llama.cpp because its
+// --help prints the --spec-type enum on its own continuation line ("types: none, draft,
+// dflash, ...") instead of directly after the flag like mainline/beellama/TurboQuant do — the
+// old regex only matched the latter form. Fixtures below are the real --help text from each
+// engine, captured live. ---------------------------------------------------------------------
+
+test('extractSpecTypeValues: mainline/beellama/TurboQuant comma list directly after the flag', () => {
+  const help =
+    `--spec-type none,draft-simple,draft-eagle3,draft-mtp,draft-dflash,draft-dspark,ngram-simple,ngram-map-k,ngram-map-k4v,ngram-mod,ngram-cache\n` +
+    `                                        comma-separated list of types of speculative decoding to use (default:\n` +
+    `                                        none)\n`
+  const values = extractSpecTypeValues(help)
+  assert.ok(values.includes('draft-dflash'))
+  assert.ok(values.includes('draft-mtp'))
+  assert.ok(!values.includes('speculative'), 'must not pick up words from the trailing description prose')
+})
+
+test('extractSpecTypeValues: bracket/pipe form (TurboQuant-style)', () => {
+  const help = `--spec-type [none|draft|nextn]         which speculative decoding mode to use\n`
+  assert.deepEqual(extractSpecTypeValues(help).sort(), ['draft', 'nextn', 'none'])
+})
+
+test('extractSpecTypeValues: ik_llama.cpp\'s real --help — enum on its own "types:" continuation line', () => {
+  const help =
+    `  --spec-type SPEC[:k=v,...]      canonical speculative stage entry; repeat for a supported two-stage chain.\n` +
+    `                                  types: none, draft, dflash, dspark, mtp, ngram-cache, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, suffix\n` +
+    `                                  examples: --spec-type mtp:n_max=1,p_min=0.0\n` +
+    `                                            --model-draft draft.gguf --spec-type dflash:n_max=4\n` +
+    `                                            --spec-type ngram-mod:n_max=64,n_min=2,ngram_size_n=8 --spec-type mtp:n_max=1,p_min=0.0\n` +
+    `                                            --spec-type "suffix:n_max=16,n_min=2,suffix_min_match_len=5,suffix_max_depth=64,suffix_corpus='/tmp/spec,type-corpus.json'"\n`
+  const values = extractSpecTypeValues(help)
+  assert.deepEqual(
+    values.sort(),
+    ['dflash', 'draft', 'dspark', 'mtp', 'ngram-cache', 'ngram-map-k', 'ngram-map-k4v', 'ngram-mod', 'ngram-simple', 'none', 'suffix'],
+  )
+})
+
+test('extractSpecTypeValues: an unrelated "types of X" mention elsewhere does not false-positive', () => {
+  const help = `some flag         does something with types of widgets, not speculative decoding\n`
+  assert.deepEqual(extractSpecTypeValues(help), [])
 })

--- a/turbollm/src/engines/probe.ts
+++ b/turbollm/src/engines/probe.ts
@@ -120,22 +120,7 @@ export async function probe(bin: string): Promise<ProbeResult> {
   const kvTypes = detectKvTypes(h.out, flags.includes('--cache-type-k'))
   const flagInfo = flags.map((f) => classifyFlag(f, h.out))
 
-  // Capture the accepted `--spec-type` enum values (e.g. `none,draft-mtp,nextn`)
-  // as `spec-type:<value>` pseudo-flags. The enum differs by engine — official
-  // llama.cpp has no `nextn`, the TurboQuant fork does — so speculative-decoding
-  // arg emission must check the VALUE is accepted, not just that the flag exists.
-  // The enum's printed form differs by engine: official llama.cpp lists it
-  // comma-separated (`none,draft-mtp,...`), the TurboQuant fork bracket/pipe
-  // (`[none|draft|nextn|...]`). Match only the actual enum (a bracket group, or a
-  // multi-value comma/pipe list) — never the prose mentions like `--spec-type mtp,
-  // or ...` — and union the values across all such occurrences.
-  const ENUM_RE = /--spec-type\s+(\[[^\]\n]+\]|[a-z][a-z0-9_-]*(?:[,|][a-z0-9_-]+)+)/gi
-  for (const m2 of h.out.matchAll(ENUM_RE)) {
-    for (const v of m2[1].replace(/[[\]]/g, '').split(/[,|]/)) {
-      const t = v.trim()
-      if (t) flags.push(`spec-type:${t}`)
-    }
-  }
+  for (const t of extractSpecTypeValues(h.out)) flags.push(`spec-type:${t}`)
 
   return { version, capabilities: { kvTypes, flags: [...new Set(flags)].sort(), flagInfo } }
 }
@@ -206,6 +191,39 @@ export function detectKvTypes(helpText: string, hasCacheTypeFlag: boolean): stri
     for (const extra of cacheTypeK.enumValues ?? []) if (!kvTypes.includes(extra)) kvTypes.push(extra)
   }
   return kvTypes
+}
+
+/** Capture the accepted `--spec-type` enum values (e.g. `none,draft-mtp,nextn`) as plain
+ *  value strings (the caller prefixes them `spec-type:<value>`). The enum differs by engine
+ *  — official llama.cpp has no `nextn`, the TurboQuant fork does — so speculative-decoding
+ *  arg emission must check the VALUE is accepted, not just that the flag exists.
+ *  The enum's printed form differs by engine:
+ *   - official llama.cpp/beellama/TurboQuant list it comma-separated directly after the flag
+ *     (`none,draft-mtp,...`), or bracket/pipe (`[none|draft|nextn|...]`);
+ *   - ik_llama.cpp prints only a placeholder after the flag (`SPEC[:k=v,...]`) and puts the
+ *     real enum on its OWN continuation line a bit further down (`types: none, draft,
+ *     dflash, ...`) — confirmed against its real --help output. Scoped to shortly after each
+ *     `--spec-type` occurrence so an unrelated "types:" mention elsewhere in the help text
+ *     can't leak in.
+ *  Never matches prose mentions like `--spec-type mtp, or ...` — only an actual value list —
+ *  and unions values across every occurrence found. */
+export function extractSpecTypeValues(helpText: string): string[] {
+  const values = new Set<string>()
+  const ENUM_RE = /--spec-type\s+(\[[^\]\n]+\]|[a-z][a-z0-9_-]*(?:[,|][a-z0-9_-]+)+)/gi
+  for (const m of helpText.matchAll(ENUM_RE)) {
+    for (const v of m[1].replace(/[[\]]/g, '').split(/[,|]/)) {
+      const t = v.trim()
+      if (t) values.add(t)
+    }
+  }
+  const TYPES_LINE_RE = /--spec-type\b[\s\S]{0,400}?\r?\n[ \t]*types:\s*([a-z0-9_][a-z0-9_, -]*)/gi
+  for (const m of helpText.matchAll(TYPES_LINE_RE)) {
+    for (const v of m[1].split(',')) {
+      const t = v.trim()
+      if (t) values.add(t)
+    }
+  }
+  return [...values]
 }
 
 /** Parses a comma/pipe-separated list of accepted values out of a flag's own help block.

--- a/turbollm/src/models/profile.gen.test.ts
+++ b/turbollm/src/models/profile.gen.test.ts
@@ -328,6 +328,19 @@ test('dflash mode is gated on the engine accepting spec-type:draft-dflash', () =
   assert.ok(!args.includes('--spec-draft-model'), '--spec-draft-model must not be passed when the engine lacks draft-dflash support')
 })
 
+// Regression: ik_llama.cpp genuinely supports DFlash but names things differently — it has
+// no --spec-draft-model alias (only --model-draft) and its --spec-type enum value is the
+// bare `dflash`, not mainline's `draft-dflash`. Confirmed live against the fork's real
+// --help output; dflash silently never fired for it before this fix (GitHub report).
+test('dflash mode works on ik_llama.cpp\'s naming (--model-draft, bare "dflash" value)', () => {
+  const ikLlamaCaps = { kvTypes: [], flags: ['--spec-type', '--model-draft', 'spec-type:dflash', 'spec-type:draft', 'spec-type:none'] }
+  const p = { ...base(), speculative: 'dflash' as const, draftModelPath: '/models/draft-dflash.gguf' }
+  const args = profileToArgs(p, model(), ikLlamaCaps)
+  assert.equal(args[args.indexOf('--spec-type') + 1], 'dflash')
+  assert.equal(args[args.indexOf('--model-draft') + 1], '/models/draft-dflash.gguf')
+  assert.ok(!args.includes('--spec-draft-model'), 'must not emit a flag ik_llama.cpp does not have')
+})
+
 // Regression: the draft window is a property of the speculation mechanism itself
 // (llama.cpp's shared verify loop), not specific to how the draft is produced — it must
 // apply to 'mtp' and 'nextn' modes too, not only the external-draft-model 'draft' mode
@@ -370,6 +383,19 @@ test('nextn mode on the TurboQuant fork (spec-type:nextn) still includes --model
   const args = profileToArgs(p, m, capFork)
   assert.equal(args[args.indexOf('--spec-type') + 1], 'nextn')
   assert.equal(args[args.indexOf('--model-draft') + 1], m.path)
+})
+
+// Regression: ik_llama.cpp has no `nextn`/`draft-mtp` value — it calls the same
+// self-contained built-in-head mechanism `mtp` (confirmed against its real --help:
+// `--spec-type mtp:n_max=1,p_min=0.0`, no --model-draft in the example). Same
+// no-model-draft semantics as mainline's draft-mtp, just a different value string —
+// nextn silently never fired for it before this fix.
+test('nextn mode on ik_llama.cpp (spec-type:mtp) omits --model-draft, like mainline draft-mtp', () => {
+  const capIkLlama = { kvTypes: [], flags: ['--spec-type', '--model-draft', 'spec-type:mtp', 'spec-type:dflash'] }
+  const p = { ...base(), speculative: 'nextn' as const }
+  const args = profileToArgs(p, model({ nextnLayers: 1 }), capIkLlama)
+  assert.equal(args[args.indexOf('--spec-type') + 1], 'mtp')
+  assert.ok(!args.includes('--model-draft'), '--model-draft must not be passed for ik_llama.cpp\'s self-contained mtp stage')
 })
 
 test('off mode emits no draft-max/draft-min flags', () => {

--- a/turbollm/src/models/profile.ts
+++ b/turbollm/src/models/profile.ts
@@ -784,10 +784,15 @@ export function profileToArgs(
     // model (24GB → 59GB) for a 54% SLOWER generation, with no error printed —
     // a silent, severe regression (GitHub VRAM report). The TurboQuant fork's own
     // `nextn` spec-type value is a different codebase that DOES want --model-draft
-    // pointing at the same file (verified when this branch was first written) —
-    // only mainline's draft-mtp is exempted here.
-    const nextnVal = ['nextn', 'draft-mtp'].find((v) => specAccepts(v))
-    if (nextnVal === 'draft-mtp') {
+    // pointing at the same file (verified when this branch was first written).
+    // ik_llama.cpp has no `nextn`/`draft-mtp` value at all — it calls the same
+    // self-contained built-in-head mechanism `mtp` (confirmed against its real
+    // --help: `--spec-type mtp:n_max=1,p_min=0.0`, no --model-draft in the
+    // example, unlike its `dflash` stage which does take one) — same
+    // no-model-draft semantics as mainline's draft-mtp, just a different value
+    // string. Only `nextn` (the TurboQuant-style value) wants --model-draft.
+    const nextnVal = ['nextn', 'draft-mtp', 'mtp'].find((v) => specAccepts(v))
+    if (nextnVal === 'draft-mtp' || nextnVal === 'mtp') {
       a.push('--spec-type', nextnVal)
       specActive = true
     } else if (nextnVal === 'nextn' && has('--model-draft')) {
@@ -798,20 +803,22 @@ export function profileToArgs(
     if (specType) a.push('--spec-type', 'draft')
     a.push('--model-draft', p.draftModelPath)
     specActive = true
-  } else if (
-    p.speculative === 'dflash' &&
-    p.draftModelPath &&
-    specType &&
-    specAccepts('draft-dflash') &&
-    has('--spec-draft-model')
-  ) {
+  } else if (p.speculative === 'dflash' && p.draftModelPath && specType) {
     // DFlash: adaptive speculative decoding with a separate draft GGUF (same
     // --spec-draft-model flag as 'draft' mode's --model-draft — llama.cpp aliases
     // them). --spec-dm-controller defaults to 'profit' (the adaptive controller)
     // when omitted, so no extra flag is needed to get the adaptive behavior.
-    a.push('--spec-type', 'draft-dflash')
-    a.push('--spec-draft-model', p.draftModelPath)
-    specActive = true
+    // Naming varies by fork: mainline/beellama/TurboQuant alias --spec-draft-model to
+    // --model-draft and use the enum value `draft-dflash`; ik_llama.cpp only has
+    // --model-draft (no --spec-draft-model alias) and its own bare `dflash` value —
+    // accept either name/value pair rather than hardcode mainline's.
+    const dflashVal = ['draft-dflash', 'dflash'].find((v) => specAccepts(v))
+    const draftFlag = has('--spec-draft-model') ? '--spec-draft-model' : has('--model-draft') ? '--model-draft' : null
+    if (dflashVal && draftFlag) {
+      a.push('--spec-type', dflashVal)
+      a.push(draftFlag, p.draftModelPath)
+      specActive = true
+    }
   }
   // Draft window (GitHub #35): how many tokens the draft head proposes per step before
   // the main model verifies them, and the minimum before verification kicks in. This is

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -210,7 +210,7 @@ const TURBOLLM_KNOWLEDGE =
   '**llamafile** (Windows / Linux / macOS — GGUF):\n' +
   'GGUF model bundled into a single self-contained executable. Very easy distribution. Launch flag is `--no-webui` (not `--nobrowser`). Full gateway passthrough verified.\n\n' +
   '**ik_llama.cpp** (Linux / macOS — GGUF):\n' +
-  'Drop-in fork with additional quantization optimizations. No universal prebuilt — build from source, then register via "Add your own engine."\n\n' +
+  'Drop-in fork with additional quantization optimizations and adaptive DFlash speculative decoding. No universal prebuilt — build from source, then register via "Add your own engine."\n\n' +
   '**Prism** (Windows / Linux / macOS — GGUF):\n' +
   'llama.cpp fork tuned for 1-2 bit ternary/Bonsai models. Build-from-source only (guided walkthrough) — no one-click install, even though upstream publishes prebuilts.\n\n' +
   '**BeeLlama.cpp** (Windows / Linux / macOS — GGUF):\n' +

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -219,6 +219,7 @@ const ENGINE_META: Record<string, EngineMeta> = {
       'SOTA low-bit IQK / Trellis quants',
       'Best-in-class CPU + hybrid MoE speed',
       'Strong DeepSeek MLA / FlashMLA performance',
+      'Adaptive DFlash speculative decoding',
       'Same llama-server + GGUF flow',
     ],
     cons: ['No prebuilts — build from source', 'CPU + CUDA only (no ROCm/Metal)', 'Some quant types are fork-only'],

--- a/turbollm/web/src/screens/models/ModelDetailDialog.tsx
+++ b/turbollm/web/src/screens/models/ModelDetailDialog.tsx
@@ -359,20 +359,29 @@ export function ModelDetailDialog({
   const specOptions: Array<LoadProfile['speculative']> = ['off']
   if (hasFlag('--spec-type') && hasFlag('--mtp-head') && modelSupportsMtp) specOptions.push('mtp')
   // NextN = the model's built-in head as a self-draft. The fork's spec-type is
-  // `nextn`; mainline llama.cpp's equivalent is `draft-mtp` — accept either.
+  // `nextn`; mainline llama.cpp's equivalent is `draft-mtp`; ik_llama.cpp calls the
+  // same self-contained mechanism `mtp` (confirmed against its real --help) — accept any.
   if (
     hasFlag('--spec-type') &&
     hasFlag('--model-draft') &&
     modelSupportsNextn &&
-    (specAccepts('nextn') || specAccepts('draft-mtp'))
+    (specAccepts('nextn') || specAccepts('draft-mtp') || specAccepts('mtp'))
   )
     specOptions.push('nextn')
   if (hasFlag('--model-draft')) specOptions.push('draft')
   // DFlash = adaptive speculative decoding with a separate draft GGUF, same as `draft`
   // but with its own --spec-type value. Not fork-specific — mainline llama.cpp and every
   // fork we've probed exposes it, so (like `draft`) it's gated on engine capability only,
-  // never on model arch.
-  if (hasFlag('--spec-type') && hasFlag('--spec-draft-model') && specAccepts('draft-dflash')) specOptions.push('dflash')
+  // never on model arch. Naming varies by fork: mainline/beellama/TurboQuant alias
+  // --spec-draft-model to --model-draft and use the enum value `draft-dflash`; ik_llama.cpp
+  // only has --model-draft (no --spec-draft-model alias) and its own bare `dflash` value —
+  // accept either name/value pair rather than hardcode mainline's.
+  if (
+    hasFlag('--spec-type') &&
+    (hasFlag('--spec-draft-model') || hasFlag('--model-draft')) &&
+    (specAccepts('draft-dflash') || specAccepts('dflash'))
+  )
+    specOptions.push('dflash')
 
   const fit = useMemo(() => {
     if (!detail || !draft) return null


### PR DESCRIPTION
## Summary
- ik_llama.cpp genuinely supports both DFlash and NextN-equivalent (`mtp`) speculative decoding, but the app never surfaced them for it:
  - `probe.ts` didn't parse its `--help` format — the `--spec-type` enum prints on its own `types: ...` continuation line, not directly after the flag like other forks
  - the UI gating and launch-arg emission assumed mainline's flag/value naming (`--spec-draft-model` + `draft-dflash`, `nextn`/`draft-mtp`) instead of this fork's own (`--model-draft` + bare `dflash`/`mtp` values)
- Also brings `ik_llama.cpp`'s catalog/persona/Engines-screen copy to parity with `beellama.cpp`'s existing DFlash mention (previously undocumented despite genuinely shipping the feature)

## Test plan
- [x] New regression tests for `extractSpecTypeValues` (probe.test.ts) using real `--help` text captured from `ik_llama.cpp`, mainline, and TurboQuant
- [x] New regression tests in `profile.gen.test.ts` for DFlash and NextN arg emission on ik_llama.cpp's naming
- [x] Full suite: 3564/3568 pass (4 pre-existing skips), 0 failures
- [x] Verified live: re-probed a real installed `ik_llama.cpp` build, confirmed `spec-type:dflash` and `spec-type:mtp` now captured
- [x] Verified via the engine's own log that a NextN load allocates one extra lightweight MTP draft context, not a second copy of the model weights (no RAM-doubling regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)