### PR TITLE
feat(engines): branch selector dropdown for all build-from-source engines

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -25,6 +25,7 @@ import {
   backendDir,
   deleteAllBackendBuilds,
   installedBackendBuild,
+  githubHeaders,
   latestReleaseTag,
   provisionBackend,
   provisionTurboquant,
@@ -44,7 +45,7 @@ import { ensureKoboldcpp, koboldcppBinPath, koboldcppDir } from '../engines/kobo
 import { ensureLlamafile, llamafileBinPath, llamafileDir } from '../engines/llamafile'
 import { catalogForPlatform, catalogEngine } from '../engines/catalog'
 import { checkBuildPrereqs } from '../engines/build-prereqs'
-import { runBuild, runPrereqInstall, buildDirName, chooseEngineName, sameRepo, sourceBuildBinary, sourceBuildDirOf } from '../engines/build-runner'
+import { runBuild, runPrereqInstall, buildDirName, chooseEngineName, normRepoUrl, sameRepo, sourceBuildBinary, sourceBuildDirOf } from '../engines/build-runner'
 import { provisionCuda } from '../engines/cuda-provision'
 import { detectHardware } from '../engines/hardware'
 import { recommendEngines } from '../engines/recommend'
@@ -500,9 +501,12 @@ export function registerApi(app: Hono, d: Deps): void {
   // Engine catalog (ADR-044): the hardcoded, browsable list of installable
   // engines for this platform. Per-entry `installed` is disk-based (files exist);
   // `enabled` is registry-based (a registered engine entry exists for this kind).
+  // Optional `branch` query param — when provided, source-built matching is scoped to
+  // that branch so each branch gets its own installed/enabled state on the card.
   app.get('/api/v1/engines/catalog', (c) => {
     const regEngines = d.registry.list().engines
     const enginesRoot = join(d.store.dir(), 'engines')
+    const branchParam = (c.req.query('branch') ?? '').trim() || undefined
     const items = catalogForPlatform().map((e) => {
       let installed: boolean | undefined
       let enabled: boolean | undefined
@@ -540,23 +544,29 @@ export function registerApi(app: Hono, d: Deps): void {
       // requiring the SAME commit + patch, a plain unpatched llama.cpp build would falsely read
       // as "solar-open2 already installed" and hand out a binary with no solar_open2 support at
       // all. Entries with no commit/patch pin (sourceCommit/patchUrl both '') still match each
-      // other exactly as before.
+      // other exactly as before — UNLESS a branch is requested, in which case we scope the
+      // match to that branch so each branch gets its own installed/enabled state.
       // Skip entirely for `excludeFromSourceMatch` entries (ADR-388) — the backend-picker
       // `llama.cpp` card's installed state comes from LlamaCppBackendRows, not this. Without the
       // guard, a manually source-built plain `ggml-org/llama.cpp` (no commit/patch — the same
       // identity this card matches with) got its registry id silently claimed here, hiding it
       // from BOTH the custom-engine card list AND this card's own UI (which never reads
       // `sourceEngineId`) — founder-reported: "now it is only visible for selection in dropdown".
+      // An entry is "branch-capable" when it has no pinned commit or patch — the user can
+      // build any branch, so the match should be scoped to the requested branch.
+      const isBranchCapable = !e.sourceCommit && !e.patchUrl
+      const matchBranch = isBranchCapable ? (branchParam ?? '') : undefined
       const srcEng = e.excludeFromSourceMatch
         ? undefined
         : regEngines.find(
             (x) =>
               sameRepo(x.sourceRepo, e.homepage) &&
               (x.sourceCommit ?? '') === (e.sourceCommit ?? '') &&
-              (x.sourcePatchUrl ?? '') === (e.patchUrl ?? ''),
+              (x.sourcePatchUrl ?? '') === (e.patchUrl ?? '') &&
+              (x.sourceBranch ?? '') === (matchBranch ?? ''),
           )
       let sourceBinPath: string | undefined = srcEng?.binPath
-      if (!srcEng && !e.excludeFromSourceMatch) sourceBinPath = sourceBuildBinary(enginesRoot, e.homepage, undefined, e.sourceCommit) ?? undefined
+      if (!srcEng && !e.excludeFromSourceMatch) sourceBinPath = sourceBuildBinary(enginesRoot, e.homepage, matchBranch, e.sourceCommit) ?? undefined
       const sourceBuilt = !!srcEng || !!sourceBinPath
       if (srcEng) {
         installed = true
@@ -596,6 +606,46 @@ export function registerApi(app: Hono, d: Deps): void {
   app.get('/api/v1/build/prereqs', async (c) =>
     c.json(await checkBuildPrereqs(d.store.snapshot().build.toolchainDirs)),
   )
+
+  // Fetch branch list for a GitHub repo (ADR branch selector). Accepts either a full HTTPS
+  // URL or an `owner/repo` identifier — normalises via normRepoUrl so both shapes work.
+  // Supports `limit` (default 50, max 100) and `offset` for pagination. Returns total count
+  // plus the page slice, with the default branch sorted first within the page.
+  app.get('/api/v1/build/git-branches', async (c) => {
+    const raw = (c.req.query('repo') ?? '').trim()
+    if (!raw) return err(c, 400, 'invalid_input', 'repo is required.')
+    const repo = normRepoUrl(raw)
+    if (!repo) return err(c, 400, 'invalid_input', 'repo must be a valid GitHub repo identifier.')
+    const limit = Math.min(parseInt(c.req.query('limit') ?? '50', 10) || 50, 100)
+    const offset = Math.max(parseInt(c.req.query('offset') ?? '0', 10) || 0, 0)
+    try {
+      // GitHub's branches API doesn't expose total count directly, so we fetch 100 (max per page)
+      // and use that as the total. The caller paginates client-side.
+      const res = await fetch(`https://api.github.com/repos/${repo}/branches?per_page=100`, {
+        headers: githubHeaders(),
+      })
+      if (!res.ok) throw new Error(`GitHub API returned HTTP ${res.status}`)
+      const data = (await res.json()) as { name: string }[]
+      // Try to detect the default branch from the repo metadata (second request).
+      let defaultBranch = ''
+      try {
+        const info = await fetch(`https://api.github.com/repos/${repo}`, {
+          headers: githubHeaders(),
+        })
+        if (info.ok) {
+          const j = await info.json() as { default_branch?: string }
+          defaultBranch = j.default_branch ?? ''
+        }
+      } catch { /* best-effort — caller falls back to 'main' */ }
+      const names = data.map((b) => b.name)
+      const sorted = defaultBranch ? [defaultBranch, ...names.filter((n) => n !== defaultBranch)] : names
+      const total = names.length
+      const page = sorted.slice(offset, offset + limit)
+      return c.json({ total, branches: page })
+    } catch (e) {
+      return err(c, 503, 'offline', `Could not fetch branches for ${repo}: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  })
 
   // 1-click compile-from-source (ADR-100, Windows/Linux + CUDA, or macOS + Metal). Clones the
   // repo, runs cmake, compiles llama-server, then registers + activates the built binary.

--- a/turbollm/src/engines/catalog.ts
+++ b/turbollm/src/engines/catalog.ts
@@ -221,6 +221,39 @@ const ALL: CatalogEngine[] = [
     ],
   },
   {
+    // General-purpose build-from-source entry for official llama.cpp — cross-platform,
+    // branch-aware. Unlike llama.cpp-cuda-linux (Linux-only CUDA) and llama.cpp-android-source
+    // (Termux-only CPU), this works on every desktop OS and lets the user pick any branch.
+    // Each branch builds into its own directory and registers as a separate engine
+    // (e.g. Llama-main, Llama-my-feature). The main llama.cpp entry above handles the
+    // prebuilt download path; this is the source-build complement.
+    id: 'llama.cpp-source',
+    name: 'llama.cpp (Build from Source)',
+    kind: 'llama-server',
+    description:
+      'Official llama.cpp, compiled from source on your machine. Pick any branch — each becomes its own engine.',
+    provision: 'github-release',
+    homepage: 'https://github.com/ggml-org/llama.cpp',
+    repo: 'ggml-org/llama.cpp',
+    platforms: ['win32', 'darwin', 'linux'],
+    support: 'experimental',
+    installEndpoint: '',
+    note:
+      'No prebuilt binary. Select a branch below and TurboLLM clones + compiles it for you. '
+      + 'Each branch you build becomes a separate engine (e.g. Llama-main, Llama-my-feature).',
+    variants: [
+      {
+        id: 'llama.cpp-source-branch',
+        label: 'Build from source',
+        repo: 'ggml-org/llama.cpp',
+        requires: {},
+        stability: 'experimental',
+        speed: 'baseline',
+        hasPrebuilt: false,
+      },
+    ],
+  },
+  {
     id: 'vllm',
     name: 'vLLM',
     kind: 'vllm',

--- a/turbollm/src/engines/download.ts
+++ b/turbollm/src/engines/download.ts
@@ -14,6 +14,19 @@ import type { GpuVendor } from '../sysinfo/sysinfo'
 
 const execFileP = promisify(execFile)
 
+/** Build standard GitHub API headers, injecting a `GITHUB_TOKEN` env var if present
+ *  so authenticated requests get 5,000 req/hour instead of the 60/hour unauthenticated
+ *  limit. Callers spread the result into their fetch() headers object. */
+export function githubHeaders(extra?: Record<string, string>): Record<string, string> {
+  const base: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'turbollm',
+  }
+  const token = process.env.GITHUB_TOKEN?.trim()
+  if (token) base['Authorization'] = `Bearer ${token}`
+  return { ...base, ...extra }
+}
+
 /**
  * Remove the com.apple.quarantine extended attribute that macOS sets on any
  * file downloaded from the internet. Without this, Gatekeeper silently blocks
@@ -468,7 +481,7 @@ export interface GithubRelease {
 export async function latestGithubRelease(repo: string, signal?: AbortSignal): Promise<GithubRelease> {
   const apiUrl = `https://api.github.com/repos/${repo}/releases/latest`
   const res = await fetch(apiUrl, {
-    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'turbollm' },
+    headers: githubHeaders(),
     signal,
   })
   if (!res.ok) throw new Error(`could not query ${repo} releases: HTTP ${res.status}`)
@@ -490,7 +503,7 @@ export async function latestReleaseTag(repo: string, signal?: AbortSignal): Prom
 export async function latestCommitSha(repo: string, branch = '', signal?: AbortSignal): Promise<string> {
   const ref = branch.trim() ? encodeURIComponent(branch.trim()) : 'HEAD'
   const res = await fetch(`https://api.github.com/repos/${repo}/commits/${ref}`, {
-    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'turbollm' },
+    headers: githubHeaders(),
     signal,
   })
   if (!res.ok) throw new Error(`could not query ${repo} commits: HTTP ${res.status}`)
@@ -517,7 +530,7 @@ export async function turboquantAssetUrl(
 ): Promise<string | null> {
   if (platform === 'win32') return null // no usable self-contained Windows prebuilt
   const res = await fetch(`https://api.github.com/repos/${repo}/releases?per_page=100`, {
-    headers: { Accept: 'application/vnd.github+json', 'User-Agent': 'turbollm' },
+    headers: githubHeaders(),
     signal,
   })
   if (!res.ok) throw new Error(`could not query ${repo} releases: HTTP ${res.status}`)

--- a/turbollm/src/engines/registry.custom-source.test.ts
+++ b/turbollm/src/engines/registry.custom-source.test.ts
@@ -114,6 +114,31 @@ test('recordCustomSource: survives being re-loaded from disk (real persistence, 
   assert.equal(reg2.customSources()[0].name, 'My Fork')
 })
 
+test('two engines from the same repo but different branches are both discoverable', () => {
+  const { reg, store } = freshRegistry()
+  // Seed two engines built from the same repo but different branches — mirrors what the
+  // build endpoint does after a successful compile (registry.add + activate).
+  store.update((c) => {
+    c.engines.push(
+      { id: 'e1', name: 'Llama-main', binPath: '/build/main/llama-server', kind: 'llama-server',
+        version: '1.0', capabilities: { kvTypes: [], flags: [] }, addedAt: new Date().toISOString(),
+        sourceRepo: 'https://github.com/ggml-org/llama.cpp', sourceBranch: 'main' },
+      { id: 'e2', name: 'Llama-my-feature', binPath: '/build/my-feature/llama-server', kind: 'llama-server',
+        version: '1.0', capabilities: { kvTypes: [], flags: [] }, addedAt: new Date().toISOString(),
+        sourceRepo: 'https://github.com/ggml-org/llama.cpp', sourceBranch: 'my-feature' },
+    )
+  })
+  const list = reg.list()
+  assert.equal(list.engines.length, 2)
+  // Both names survive — they are distinct engines, not a replace-in-place.
+  const names = list.engines.map((e) => e.name).sort()
+  assert.deepEqual(names, ['Llama-main', 'Llama-my-feature'])
+  // Both sourceBranch values are preserved.
+  const byBranch = Object.fromEntries(list.engines.map((e) => [e.sourceBranch ?? '', e.name]))
+  assert.equal(byBranch['main'], 'Llama-main')
+  assert.equal(byBranch['my-feature'], 'Llama-my-feature')
+})
+
 test('the whole point: Disable (registry.remove) does NOT erase the recorded custom source', () => {
   const { reg, store } = freshRegistry()
   reg.recordCustomSource({ name: 'My Fork', binPath: '/build/my-fork/llama-server', kind: 'llama-server', sourceRepo: 'https://github.com/user/fork', sourceBranch: 'main' })

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -292,6 +292,19 @@ export function installPrereq(tool: 'git' | 'cmake' | 'cuda' | 'gcc'): Promise<{
   return request('/api/v1/build/install-prereq', { method: 'POST', json: { tool } })
 }
 
+/** Fetch a paginated slice of branch names for a GitHub repo. Returns total count plus the
+ *  current page, with the default branch sorted first. Used by the build-from-source branch
+ *  dropdown. */
+export function getGitBranches(
+  repo: string,
+  options?: { limit?: number; offset?: number },
+): Promise<{ total: number; branches: string[] }> {
+  const params = new URLSearchParams({ repo: encodeURIComponent(repo) })
+  if (options?.limit) params.set('limit', String(options.limit))
+  if (options?.offset) params.set('offset', String(options.offset))
+  return request<{ total: number; branches: string[] }>(`/api/v1/build/git-branches?${params}`)
+}
+
 export function installVllm(): Promise<{ accepted: true; engine: 'vllm' }> {
   return request('/api/v1/engines/vllm', { method: 'POST', json: {} })
 }

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -18,6 +18,7 @@ import {
   getConnect,
   getEngineBackends,
   getGitBranch,
+  getGitBranches,
   getHwStats,
   getModelDetail,
   getModelDirs,
@@ -365,6 +366,33 @@ export function useBuild() {
     }),
     /** Call when a build settles (done/error) to pull the new engine into the lists. */
     refresh,
+  }
+}
+
+/** Branch list for a GitHub repo, used by the build-from-source branch dropdown. Disabled
+ *  by default — only enabled when a branch-capable catalog card is rendered.
+ *  Returns total count and the first page of branches (default: 50). */
+export function useGitBranches(repo: string | undefined, enabled = false): UseQueryResult<{ total: number; branches: string[] }> {
+  return useQuery({
+    queryKey: ['git-branches', repo],
+    queryFn: () => getGitBranches(repo!),
+    enabled: enabled && !!repo,
+    staleTime: 10 * 60 * 1000,
+    retry: false,
+  })
+}
+
+/** Load the next page of branches for a repo. Used by the branch dropdown's "Show more" button. */
+export function useLoadMoreBranches() {
+  const qc = useQueryClient()
+  return async (repo: string, offset: number): Promise<{ total: number; branches: string[] }> => {
+    const result = await getGitBranches(repo, { limit: 50, offset })
+    // Append the new page to the existing query data.
+    void qc.setQueryData(['git-branches', repo], (old: { total: number; branches: string[] } | undefined) => {
+      if (!old) return result
+      return { total: result.total, branches: [...old.branches, ...result.branches] }
+    })
+    return result
   }
 }
 

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -427,6 +427,9 @@ export type CatalogEngine = {
   sourceBranch?: string
   /** Path to the built binary (used to Enable a built-but-disabled source engine). */
   sourceBinPath?: string
+  /** Installable variants (one per hardware path). Optional — llama.cpp derives its
+   *  variants at call time; other engines list them inline or leave undefined. */
+  variants?: EngineVariant[]
 }
 
 export type EngineCatalog = {

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -12,7 +12,9 @@ import {
   Flame,
   Gauge,
   Gem,
+  GitBranch,
   Layers,
+  Search,
   Loader2,
   Minus,
   MoreHorizontal,
@@ -34,6 +36,8 @@ import {
   useEngineRecommendation,
   useEngineUpdates,
   useEngines,
+  useGitBranches,
+  useLoadMoreBranches,
   useStatus,
   useSysInfo,
   useUpdatePolicyMutation,
@@ -402,6 +406,16 @@ function hardwareLabel(fit: EngineFit): string {
 const OS_SHORT: Record<string, string> = { win32: 'Win', linux: 'Linux', darwin: 'Mac' }
 function osLabel(platforms: string[]): string {
   return platforms.map((p) => OS_SHORT[p] ?? p).join(' · ')
+}
+
+/** Default engine name for a fresh build-from-source run. Official llama.cpp repos
+ *  get the `Llama-<Branch>` convention; forks get `<EngineName>-<Branch>`. */
+function defaultBuildName(catalog: CatalogEngine | undefined, branch: string): string {
+  const b = (branch || 'main').trim()
+  const officialLlama = ['llama.cpp', 'llama.cpp-cuda-linux', 'llama.cpp-android-source', 'llama.cpp-source'].includes(
+    catalog?.id ?? '',
+  )
+  return officialLlama ? `Llama-${b}` : `${catalog?.name ?? 'engine'}-${b}`
 }
 
 /**
@@ -951,6 +965,7 @@ function EngineGallery({
               onUpdate={doUpdate}
               onDelete={requestDelete}
               onSetPolicy={setPolicy}
+              onRefetchCatalog={() => void catalogQ.refetch()}
             />
           )
         })}
@@ -1054,6 +1069,7 @@ function EngineCard({
   onUpdate,
   onDelete,
   onSetPolicy,
+  onRefetchCatalog: _onRefetchCatalog,
 }: {
   fit: EngineFit
   catalog: CatalogEngine | undefined
@@ -1069,6 +1085,7 @@ function EngineCard({
   onUpdate: (e: CatalogEngine) => void
   onDelete: (e: CatalogEngine) => void
   onSetPolicy: (e: CatalogEngine, policy: UpdatePolicy) => void
+  onRefetchCatalog: () => void
 }) {
   const e = fit.engine
   const meta = metaFor(e.id)
@@ -1076,14 +1093,40 @@ function EngineCard({
   const [guideOpen, setGuideOpen] = useState(false)
   const [rebuildOpen, setRebuildOpen] = useState(false)
   const [buildsOpen, setBuildsOpen] = useState(false)
+  // Branch selected by the user for build-from-source entries. Default: main.
+  const [selectedBranch, setSelectedBranch] = useState('main')
   const isLlama = e.id === 'llama.cpp'
   const sourceBuilt = !!catalog?.sourceBuilt
   const incompatible = fit.compatible.length === 0
-  const buildYourself = !incompatible && fit.compatible.every((v) => !v.hasPrebuilt)
+  // Branch-capable: has a hasPrebuilt:false variant AND no pinned commit/patch.
+  const isBranchCapable = !catalog?.sourceCommit && !catalog?.patchUrl
+  const buildYourself = !incompatible && isBranchCapable && catalog?.variants?.some((v) => !v.hasPrebuilt)
   const isInstalled = !!catalog?.installed
   const isEnabled = !!catalog?.enabled
   const isDisabled = isInstalled && !isEnabled
   const compat = compatFor(fit)
+  // Fetch branch list in background for branch-capable entries; falls back to ['main'] on failure.
+  const branchesQ = useGitBranches(catalog?.homepage, buildYourself)
+  const loadMore = useLoadMoreBranches()
+  // Pagination + search state for the branch dropdown.
+  const [searchQuery, setSearchQuery] = useState('')
+  const allBranches = branchesQ.data?.branches ?? ['main']
+  const totalBranches = branchesQ.data?.total ?? allBranches.length
+  const hasMore = allBranches.length < totalBranches
+  const branchError = branchesQ.error
+  const isRateLimited =
+    branchError != null &&
+    typeof branchError === 'object' &&
+    'status' in branchError &&
+    (branchError as { status?: number }).status === 403
+  const filtered = useMemo(
+    () =>
+      searchQuery
+        ? allBranches.filter((b) => b.toLowerCase().includes(searchQuery.toLowerCase()))
+        : allBranches,
+    [allBranches, searchQuery],
+  )
+  const buildName = defaultBuildName(catalog, selectedBranch)
 
   return (
     <div className="flex flex-col rounded-xl border border-border bg-panel p-4">
@@ -1144,6 +1187,91 @@ function EngineCard({
               ))}
             </ul>
           </div>
+        </div>
+      )}
+
+      {/* Branch selector for build-from-source entries */}
+      {isBranchCapable && buildYourself && (
+        <div className="mt-3 flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <GitBranch size={13} className="shrink-0 text-muted" />
+            <span className="text-[12px] text-muted shrink-0">Branch:</span>
+            <div className="relative flex-1">
+              <select
+                value={selectedBranch}
+                onChange={(e) => {
+                  setSelectedBranch(e.target.value)
+                  void _onRefetchCatalog()
+                }}
+                className="w-full rounded-md border border-border bg-panel-2 pl-2 pr-7 py-1 text-[12px] text-ink outline-none focus:border-accent font-mono appearance-none"
+                disabled={branchesQ.isLoading}
+              >
+                {branchesQ.isLoading ? (
+                  <option value="main" disabled>
+                    Loading branches…
+                  </option>
+                ) : filtered.length === 0 ? (
+                  <option value="main" disabled>
+                    No matching branches
+                  </option>
+                ) : (
+                  filtered.map((b) => (
+                    <option key={b} value={b}>
+                      {b}
+                    </option>
+                  ))
+                )}
+              </select>
+              <ChevronDown
+                size={13}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted pointer-events-none"
+              />
+            </div>
+          </div>
+          {/* Error state — GitHub rate limit or network failure */}
+          {isRateLimited && (
+            <p className="pl-9 text-[11px] text-warning">
+              GitHub API rate-limited. Set{' '}
+              <code className="rounded bg-panel-2 px-1">GITHUB_TOKEN</code> in the daemon env to
+              raise the limit from 60 → 5,000 req/hour.
+            </p>
+          )}
+          {/* Search filter + load more — shown only when there are many branches */}
+          {allBranches.length > 5 && !isRateLimited && (
+            <div className="flex items-center gap-2 pl-9">
+              <div className="relative flex-1">
+                <Search
+                  size={13}
+                  className="absolute left-2 top-1/2 -translate-y-1/2 text-muted pointer-events-none"
+                />
+                <input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder={`Search ${totalBranches} branches…`}
+                  className="w-full rounded-md border border-border bg-panel-2 pl-7 pr-2 py-1 text-[12px] text-ink outline-none focus:border-accent"
+                />
+              </div>
+              <span className="text-[11px] text-muted shrink-0">
+                {filtered.length === totalBranches
+                  ? `${totalBranches} branches`
+                  : `${filtered.length} of ${totalBranches}`}
+              </span>
+              {hasMore && (
+                <button
+                  onClick={async () => {
+                    const nextOffset = allBranches.length
+                    void loadMore(catalog!.homepage!, nextOffset)
+                  }}
+                  disabled={branchesQ.isLoading}
+                  className="rounded-md border border-border bg-panel-2 px-2 py-0.5 text-[11px] text-muted hover:text-ink disabled:opacity-50 shrink-0"
+                >
+                  {branchesQ.isLoading
+                    ? 'Loading…'
+                    : `Show more (${totalBranches - allBranches.length} left)`}
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -1230,7 +1358,7 @@ function EngineCard({
                   open={rebuildOpen}
                   onOpenChange={setRebuildOpen}
                   repoUrl={catalog.homepage}
-                  branch={catalog.sourceBranch || undefined}
+                  branch={selectedBranch || undefined}
                   commit={catalog.sourceCommit}
                   patchUrl={catalog.patchUrl}
                   patchSha256={catalog.patchSha256}
@@ -1253,10 +1381,11 @@ function EngineCard({
                 open={guideOpen}
                 onOpenChange={setGuideOpen}
                 repoUrl={catalog.homepage}
+                branch={selectedBranch || undefined}
                 commit={catalog.sourceCommit}
                 patchUrl={catalog.patchUrl}
                 patchSha256={catalog.patchSha256}
-                engineName={e.name}
+                engineName={buildName}
               />
             </>
           ) : (


### PR DESCRIPTION
## What

Add a universal branch selector to the engine catalog for any build-from-source entry (hasPrebuilt:false, no pinned commit/patch). Users can pick any branch and each build becomes a separate engine (e.g. Llama-main, Llama-my-feature).

## Backend

- New `GET /api/v1/build/git-branches` endpoint with `limit`/`offset` pagination
- `GITHUB_TOKEN` env var support — raises limit from 60 → 5,000 req/hour
- Branch-aware catalog matching: `?branch=X` scopes registry lookup + disk scan
- Default branch sorted first in response

## Frontend

- `<select>` dropdown replaces free-text input
- Search bar filters branches client-side (shown when >5 branches)
- **Show more** button loads next 50 branches from GitHub
- Rate-limit error message with `GITHUB_TOKEN` hint
- `defaultBuildName` helper: `Llama-<branch>` for official repos, `<Engine>-<branch>` for forks

## Excluded

Entries pinned to a specific commit/patch (e.g. solar-open2) are automatically excluded from the branch selector.

## Files changed

- `turbollm/src/api/routes.ts` — new endpoint + githubHeaders
- `turbollm/src/engines/catalog.ts` — llama.cpp-source entry
- `turbollm/src/engines/download.ts` — githubHeaders() helper
- `turbollm/src/engines/registry.custom-source.test.ts` — new test
- `turbollm/web/src/lib/api.ts` — getGitBranches with pagination
- `turbollm/web/src/lib/queries.ts` — useGitBranches + useLoadMoreBranches
- `turbollm/web/src/lib/types.ts` — variants field on CatalogEngine
- `turbollm/web/src/screens/EnginesScreen.tsx` — dropdown UI + search + load more