### PR TITLE
fix(engines): branch selector only showed main in dropdown

### DIFF
--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -607,25 +607,28 @@ export function registerApi(app: Hono, d: Deps): void {
     c.json(await checkBuildPrereqs(d.store.snapshot().build.toolchainDirs)),
   )
 
-  // Fetch branch list for a GitHub repo (ADR branch selector). Accepts either a full HTTPS
-  // URL or an `owner/repo` identifier — normalises via normRepoUrl so both shapes work.
-  // Supports `limit` (default 50, max 100) and `offset` for pagination. Returns total count
-  // plus the page slice, with the default branch sorted first within the page.
+  // Fetch the full branch list for a GitHub repo (ADR branch selector). Accepts either a full
+  // HTTPS URL or an `owner/repo` identifier — normalises via normRepoUrl so both shapes work.
+  // Returns every branch (GitHub paginated, 100/page) with the default branch sorted first;
+  // the caller does its own client-side search filtering over the full list.
   app.get('/api/v1/build/git-branches', async (c) => {
     const raw = (c.req.query('repo') ?? '').trim()
     if (!raw) return err(c, 400, 'invalid_input', 'repo is required.')
     const repo = normRepoUrl(raw)
     if (!repo) return err(c, 400, 'invalid_input', 'repo must be a valid GitHub repo identifier.')
-    const limit = Math.min(parseInt(c.req.query('limit') ?? '50', 10) || 50, 100)
-    const offset = Math.max(parseInt(c.req.query('offset') ?? '0', 10) || 0, 0)
     try {
-      // GitHub's branches API doesn't expose total count directly, so we fetch 100 (max per page)
-      // and use that as the total. The caller paginates client-side.
-      const res = await fetch(`https://api.github.com/repos/${repo}/branches?per_page=100`, {
-        headers: githubHeaders(),
-      })
-      if (!res.ok) throw new Error(`GitHub API returned HTTP ${res.status}`)
-      const data = (await res.json()) as { name: string }[]
+      const names: string[] = []
+      // GitHub caps per_page at 100; walk pages until one comes back short (the last page) or
+      // a generous cap is hit (protects against an unbounded loop against a huge/malicious repo).
+      for (let page = 1; page <= 20; page++) {
+        const res = await fetch(`https://api.github.com/repos/${repo}/branches?per_page=100&page=${page}`, {
+          headers: githubHeaders(),
+        })
+        if (!res.ok) throw new Error(`GitHub API returned HTTP ${res.status}`)
+        const data = (await res.json()) as { name: string }[]
+        names.push(...data.map((b) => b.name))
+        if (data.length < 100) break
+      }
       // Try to detect the default branch from the repo metadata (second request).
       let defaultBranch = ''
       try {
@@ -637,11 +640,8 @@ export function registerApi(app: Hono, d: Deps): void {
           defaultBranch = j.default_branch ?? ''
         }
       } catch { /* best-effort — caller falls back to 'main' */ }
-      const names = data.map((b) => b.name)
       const sorted = defaultBranch ? [defaultBranch, ...names.filter((n) => n !== defaultBranch)] : names
-      const total = names.length
-      const page = sorted.slice(offset, offset + limit)
-      return c.json({ total, branches: page })
+      return c.json({ total: sorted.length, branches: sorted })
     } catch (e) {
       return err(c, 503, 'offline', `Could not fetch branches for ${repo}: ${e instanceof Error ? e.message : String(e)}`)
     }

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -292,16 +292,11 @@ export function installPrereq(tool: 'git' | 'cmake' | 'cuda' | 'gcc'): Promise<{
   return request('/api/v1/build/install-prereq', { method: 'POST', json: { tool } })
 }
 
-/** Fetch a paginated slice of branch names for a GitHub repo. Returns total count plus the
- *  current page, with the default branch sorted first. Used by the build-from-source branch
- *  dropdown. */
-export function getGitBranches(
-  repo: string,
-  options?: { limit?: number; offset?: number },
-): Promise<{ total: number; branches: string[] }> {
-  const params = new URLSearchParams({ repo: encodeURIComponent(repo) })
-  if (options?.limit) params.set('limit', String(options.limit))
-  if (options?.offset) params.set('offset', String(options.offset))
+/** Fetch every branch name for a GitHub repo, with the default branch sorted first. Used by
+ *  the build-from-source branch dropdown, which does its own client-side search filtering
+ *  over the full list. */
+export function getGitBranches(repo: string): Promise<{ total: number; branches: string[] }> {
+  const params = new URLSearchParams({ repo })
   return request<{ total: number; branches: string[] }>(`/api/v1/build/git-branches?${params}`)
 }
 

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -369,9 +369,9 @@ export function useBuild() {
   }
 }
 
-/** Branch list for a GitHub repo, used by the build-from-source branch dropdown. Disabled
- *  by default — only enabled when a branch-capable catalog card is rendered.
- *  Returns total count and the first page of branches (default: 50). */
+/** Full branch list for a GitHub repo, used by the build-from-source branch dropdown. Disabled
+ *  by default — only enabled when a branch-capable catalog card is rendered. The caller does
+ *  its own client-side search filtering over the returned list. */
 export function useGitBranches(repo: string | undefined, enabled = false): UseQueryResult<{ total: number; branches: string[] }> {
   return useQuery({
     queryKey: ['git-branches', repo],
@@ -380,20 +380,6 @@ export function useGitBranches(repo: string | undefined, enabled = false): UseQu
     staleTime: 10 * 60 * 1000,
     retry: false,
   })
-}
-
-/** Load the next page of branches for a repo. Used by the branch dropdown's "Show more" button. */
-export function useLoadMoreBranches() {
-  const qc = useQueryClient()
-  return async (repo: string, offset: number): Promise<{ total: number; branches: string[] }> => {
-    const result = await getGitBranches(repo, { limit: 50, offset })
-    // Append the new page to the existing query data.
-    void qc.setQueryData(['git-branches', repo], (old: { total: number; branches: string[] } | undefined) => {
-      if (!old) return result
-      return { total: result.total, branches: [...old.branches, ...result.branches] }
-    })
-    return result
-  }
 }
 
 export function useBackendInstall() {

--- a/turbollm/web/src/screens/EnginesScreen.tsx
+++ b/turbollm/web/src/screens/EnginesScreen.tsx
@@ -37,7 +37,6 @@ import {
   useEngineUpdates,
   useEngines,
   useGitBranches,
-  useLoadMoreBranches,
   useStatus,
   useSysInfo,
   useUpdatePolicyMutation,
@@ -1105,14 +1104,12 @@ function EngineCard({
   const isEnabled = !!catalog?.enabled
   const isDisabled = isInstalled && !isEnabled
   const compat = compatFor(fit)
-  // Fetch branch list in background for branch-capable entries; falls back to ['main'] on failure.
+  // Fetch the full branch list in background for branch-capable entries; falls back to
+  // ['main'] on failure. Search below filters this list client-side.
   const branchesQ = useGitBranches(catalog?.homepage, buildYourself)
-  const loadMore = useLoadMoreBranches()
-  // Pagination + search state for the branch dropdown.
   const [searchQuery, setSearchQuery] = useState('')
   const allBranches = branchesQ.data?.branches ?? ['main']
   const totalBranches = branchesQ.data?.total ?? allBranches.length
-  const hasMore = allBranches.length < totalBranches
   const branchError = branchesQ.error
   const isRateLimited =
     branchError != null &&
@@ -1256,20 +1253,6 @@ function EngineCard({
                   ? `${totalBranches} branches`
                   : `${filtered.length} of ${totalBranches}`}
               </span>
-              {hasMore && (
-                <button
-                  onClick={async () => {
-                    const nextOffset = allBranches.length
-                    void loadMore(catalog!.homepage!, nextOffset)
-                  }}
-                  disabled={branchesQ.isLoading}
-                  className="rounded-md border border-border bg-panel-2 px-2 py-0.5 text-[11px] text-muted hover:text-ink disabled:opacity-50 shrink-0"
-                >
-                  {branchesQ.isLoading
-                    ? 'Loading…'
-                    : `Show more (${totalBranches - allBranches.length} left)`}
-                </button>
-              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Fixed a double-encoding bug in `getGitBranches` (frontend called `encodeURIComponent` before handing the value to `URLSearchParams`, which encodes again) that made every GitHub API branch lookup 404, silently falling back to showing only `main` in the build-from-source dropdown.
- The backend's `/api/v1/build/git-branches` endpoint only fetched GitHub's first page (100 branches max) and reported that as the total, so repos with more branches (llama.cpp has 770) could never be fully listed, and the "load more" button just re-fetched the same page.
- Backend now walks all of GitHub's paginated pages (capped at 2000 branches) and returns the complete list in one response; frontend does simple client-side search filtering over the full list instead of paginated "load more".

## Test plan
- [x] Built the daemon + web bundle from `main` and ran it in Docker on port 6997 (isolated from the live 6996 daemon)
- [x] Verified `/api/v1/build/git-branches?repo=ggml-org%2Fllama.cpp` returns all 770 branches with `master` sorted first (was previously capped at 100, or 404ing entirely before the encoding fix)
- [x] Manually retested the engine catalogue's branch dropdown + search in-browser against the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)