### PR TITLE
fix(models): gated repos download when an HF token is set

### DIFF
--- a/turbollm/web/src/screens/models/HfRepoDialog.fleet.test.tsx
+++ b/turbollm/web/src/screens/models/HfRepoDialog.fleet.test.tsx
@@ -40,6 +40,10 @@ vi.mock('../../lib/queries', () => ({
   useStatus: () => ({ data: { engine: { kind: 'llamacpp' } } }),
   useDownloadMutations: () => ({ enqueue: { mutate: enqueue, isPending: false, error: null } }),
   useModelActions: () => ({ load: { mutate: vi.fn(), isPending: false } }),
+  // Read only for `hfTokenSet`, which decides the gated block. This fixture's repo is
+  // ungated, so the value is irrelevant here — the gate itself is covered by
+  // HfRepoDialog.gated.test.tsx.
+  useSettings: () => ({ query: { data: { hfTokenSet: false } } }),
 }))
 
 vi.mock('../../lib/api', async (importOriginal) => ({

--- a/turbollm/web/src/screens/models/HfRepoDialog.gated.test.tsx
+++ b/turbollm/web/src/screens/models/HfRepoDialog.gated.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { HfRepoContent } from './HfRepoDialog'
+
+// Issue #198. A gated repo used to disable Download unconditionally — with a valid HF
+// token configured, a set of files the backend had already listed, and a download path
+// that authenticates every request, the button still could not be pressed. The token, not
+// the gate flag, is what makes an attempt pointless: these tests pin the button to it,
+// on both repo shapes (GGUF and safetensors), and pin the notice's copy to the same state
+// so the user is told which half is still on them.
+
+const enqueue = vi.fn()
+
+const state = { gated: true, hfTokenSet: false, safetensors: false }
+
+vi.mock('../../lib/queries', () => ({
+  useHfRepo: () => ({
+    data: {
+      repo: 'owner/gated-repo',
+      gated: state.gated,
+      downloads: 0,
+      likes: 0,
+      license: 'other',
+      safetensors: state.safetensors,
+      card: '',
+      files: state.safetensors
+        ? [{ name: 'model.safetensors', quant: '', sizeBytes: 8e9, sha256: 'abc', mmproj: false, downloaded: false }]
+        : [{ name: 'model-Q4_K_M.gguf', quant: 'Q4_K_M', sizeBytes: 4e9, sha256: 'abc', mmproj: false, downloaded: false }],
+    },
+  }),
+  useSysInfo: () => ({ data: { gpus: [{ vramMb: 16000 }] } }),
+  useStatus: () => ({ data: { engine: { kind: 'llamacpp' } } }),
+  useDownloadMutations: () => ({ enqueue: { mutate: enqueue, isPending: false, error: null } }),
+  useModelActions: () => ({ load: { mutate: vi.fn(), isPending: false } }),
+  useSettings: () => ({ query: { data: { hfTokenSet: state.hfTokenSet } } }),
+}))
+
+// No links: the download target is never a question here, so the plain local button renders.
+vi.mock('../../lib/link-queries', () => ({
+  useLinks: () => ({ data: [] }),
+  useRemoteDownloadActions: () => ({ start: { mutate: vi.fn(), isPending: false } }),
+}))
+
+vi.mock('../../lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/api')>()),
+  track: vi.fn(),
+}))
+
+function renderContent() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <HfRepoContent repo="owner/gated-repo" onClose={vi.fn()} />
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  state.gated = true
+  state.hfTokenSet = false
+  state.safetensors = false
+  enqueue.mockClear()
+})
+
+describe('HfRepoDialog — gated repos', () => {
+  it('downloads a gated repo when a Hugging Face token is configured', async () => {
+    state.hfTokenSet = true
+    renderContent()
+    const btn = await screen.findByRole('button', { name: /download/i })
+    expect(btn).not.toBeDisabled()
+    await userEvent.click(btn)
+    expect(enqueue).toHaveBeenCalledTimes(1)
+    expect(enqueue.mock.calls[0][0]).toMatchObject({ repo: 'owner/gated-repo', rfilename: 'model-Q4_K_M.gguf' })
+  })
+
+  it('blocks a gated repo only while NO token is configured', async () => {
+    renderContent()
+    expect(await screen.findByRole('button', { name: /download/i })).toBeDisabled()
+  })
+
+  it('names the missing half: add a token when there is none…', async () => {
+    renderContent()
+    expect(await screen.findByText(/add a Hugging Face token/i)).toBeTruthy()
+  })
+
+  it('…and accept the license when the token is already there', async () => {
+    state.hfTokenSet = true
+    renderContent()
+    expect(await screen.findByText(/Accept the license/i)).toBeTruthy()
+    expect(screen.queryByText(/add a Hugging Face token/i)).toBeNull()
+  })
+
+  it('applies the same rule to a gated safetensors repo, and explains it there too', async () => {
+    state.safetensors = true
+    state.hfTokenSet = true
+    renderContent()
+    const btn = await screen.findByRole('button', { name: /download model/i })
+    expect(btn).not.toBeDisabled()
+    // The notice used to render only on the GGUF side: a safetensors repo was greyed out
+    // with no explanation at all.
+    expect(screen.getByText(/This is a gated model/i)).toBeTruthy()
+    await userEvent.click(btn)
+    expect(enqueue).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves an ungated repo alone', async () => {
+    state.gated = false
+    renderContent()
+    expect(await screen.findByRole('button', { name: /download/i })).not.toBeDisabled()
+    expect(screen.queryByText(/This is a gated model/i)).toBeNull()
+  })
+})

--- a/turbollm/web/src/screens/models/HfRepoDialog.tsx
+++ b/turbollm/web/src/screens/models/HfRepoDialog.tsx
@@ -17,7 +17,7 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import { ChevronDown, Download, ExternalLink, Lock, Zap } from 'lucide-react'
 import { ApiError, track } from '../../lib/api'
-import { useDownloadMutations, useHfRepo, useModelActions, useStatus, useSysInfo } from '../../lib/queries'
+import { useDownloadMutations, useHfRepo, useModelActions, useSettings, useStatus, useSysInfo } from '../../lib/queries'
 import { useLinks, useRemoteDownloadActions } from '../../lib/link-queries'
 import { DownloadTargetMenu } from '../../components/fleet'
 import { describeRemoteFailure } from '../../lib/remote-failure'
@@ -114,6 +114,9 @@ export function HfRepoContent({
   const [remoteDlError, setRemoteDlError] = useState<string | null>(null)
 
   const statusQ = useStatus()
+  // Only for `hfTokenSet` (see `blockedByGate` below). Host-gated and soft like the reads
+  // above: a browser off-box that can't read settings simply reports "no token".
+  const settingsQ = useSettings()
   const engineKind = statusQ.data?.engine.kind ?? ''
   const detail = detailQ.data
   const vramMb = sysQ.data?.gpus?.[0]?.vramMb
@@ -153,11 +156,16 @@ export function HfRepoContent({
 
   const fit = selectedFile ? fileFit(selectedFile.sizeBytes, vramMb) : 'unknown'
   const gated = detail?.gated ?? false
-  // Gated repos require the user to accept the license + configure an HF token in
-  // Settings → Models (spec 10 §4). The token state isn't exposed to this screen, so
-  // gated repos route through the guided flow and disable the in-dialog download; the
-  // enqueue endpoint is authoritative and returns 401/403 if the token is missing.
-  const blockedByGate = gated
+  // Gated repos require BOTH halves: the license accepted on huggingface.co AND an HF
+  // token in Settings → Models (spec 10 §4; catalog spec "pass-through to HF auth, never
+  // circumvent"). Only the token half is knowable here — `/settings` reports `hfTokenSet`
+  // — and it is the half that makes the attempt pointless, so that alone decides whether
+  // the button is blocked. WITH a token we let the request through and leave the verdict
+  // to the download path, which is authoritative and already types both refusals
+  // (401 `hf_unauthorized` / 403 `hf_gated`, surfaced on the download row). Blocking every
+  // gated repo regardless of token stranded users who had one configured (issue #198).
+  const hfTokenSet = settingsQ.query.data?.hfTokenSet ?? false
+  const blockedByGate = gated && !hfTokenSet
 
   const enqueueError = dlMut.enqueue.error instanceof ApiError ? dlMut.enqueue.error.message : null
 
@@ -258,6 +266,8 @@ export function HfRepoContent({
           detail={detail}
           vramMb={vramMb}
           engineKind={engineKind}
+          hfTokenSet={hfTokenSet}
+          blockedByGate={blockedByGate}
           onDownload={onDownloadSafetensors}
           isPending={dlMut.enqueue.isPending}
         />
@@ -288,18 +298,7 @@ export function HfRepoContent({
           )}
 
           {/* Gated guidance */}
-          {blockedByGate && (
-            <div className="rounded-md border px-3 py-2.5 text-[12px]" style={{ borderColor: 'var(--warn)', background: 'color-mix(in srgb, var(--warn) 10%, transparent)' }}>
-              <p className="text-ink">This is a gated model.</p>
-              <p className="mt-1 text-muted">
-                Accept the license on{' '}
-                <a href={`https://huggingface.co/${detail.repo}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 underline" style={{ color: 'var(--accent)' }}>
-                  huggingface.co <ExternalLink size={11} />
-                </a>
-                , then add a Hugging Face token in Settings → Models.
-              </p>
-            </div>
-          )}
+          {gated && <GatedNotice repo={detail.repo} hfTokenSet={hfTokenSet} />}
 
           {enqueueError && <p className="text-[12px]" style={{ color: 'var(--err)' }}>{enqueueError}</p>}
           {remoteDlError && <p className="text-[12px]" style={{ color: 'var(--err)' }}>{remoteDlError}</p>}
@@ -536,17 +535,49 @@ function ModelCard({ text }: { text: string }) {
   )
 }
 
+/** The gated-repo notice, shared by the GGUF and safetensors bodies. Gating has two
+ *  halves — license accepted on HF, token configured here — so the copy says which one
+ *  is still on the user. With a token set the download is allowed to run (the failure,
+ *  if the license was never accepted, comes back typed from the download path); without
+ *  one there is nothing to try, so the button beside this notice is disabled. */
+function GatedNotice({ repo, hfTokenSet }: { repo: string; hfTokenSet: boolean }) {
+  const hfLink = (
+    <a href={`https://huggingface.co/${repo}`} target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 underline" style={{ color: 'var(--accent)' }}>
+      huggingface.co <ExternalLink size={11} />
+    </a>
+  )
+  return (
+    <div className="rounded-md border px-3 py-2.5 text-[12px]" style={{ borderColor: 'var(--warn)', background: 'color-mix(in srgb, var(--warn) 10%, transparent)' }}>
+      <p className="text-ink">This is a gated model.</p>
+      {hfTokenSet ? (
+        <p className="mt-1 text-muted">
+          Your Hugging Face token will be used. Accept the license on {hfLink} with that same
+          account first — the download fails otherwise.
+        </p>
+      ) : (
+        <p className="mt-1 text-muted">
+          Accept the license on {hfLink}, then add a Hugging Face token in Settings → Models.
+        </p>
+      )}
+    </div>
+  )
+}
+
 /** Body shown for safetensors repos (MLX / vLLM) — no quant selection, whole-directory download. */
 function MlxRepoBody({
   detail,
   vramMb,
   engineKind,
+  hfTokenSet,
+  blockedByGate,
   onDownload,
   isPending,
 }: {
-  detail: { files: { sizeBytes: number }[]; gated: boolean }
+  detail: { repo: string; files: { sizeBytes: number }[]; gated: boolean }
   vramMb: number | undefined
   engineKind: string
+  hfTokenSet: boolean
+  blockedByGate: boolean
   onDownload: () => void
   isPending: boolean
 }) {
@@ -573,7 +604,11 @@ function MlxRepoBody({
         </span>
       </div>
 
-      <Button className="w-full" onClick={() => { track('models', 'download_hf_model'); onDownload() }} disabled={detail.gated || isPending}>
+      {/* Same gated rule as the GGUF body — a safetensors repo used to be blocked with no
+          explanation at all, since the notice only ever rendered on the GGUF side. */}
+      {detail.gated && <GatedNotice repo={detail.repo} hfTokenSet={hfTokenSet} />}
+
+      <Button className="w-full" onClick={() => { track('models', 'download_hf_model'); onDownload() }} disabled={blockedByGate || isPending}>
         <Download size={14} />
         {isPending ? 'Queuing…' : btnLabel}
       </Button>


### PR DESCRIPTION
Fixes #198.

## The bug

The Download button in the HF repo panel was disabled for **every** gated repo, regardless of whether a Hugging Face token was configured. A user with a valid token — looking at a file list the backend had already fetched *with that token* — could never press it.

Three call sites did it: the local GGUF button, the fleet download-target menu, and the safetensors button.

## Why the block wasn't needed

Nothing downstream depended on it. The enqueue/download path authenticates every request and already types both refusals, which the Downloads panel renders on the row:

- `401` → `hf_unauthorized` — "Your Hugging Face token was rejected."
- `403` → `hf_gated` — "This repository is gated — accept its license and add your token."

## The fix

Gating has two halves: the license accepted on huggingface.co, and a token configured in Settings → Models. Only the token half is visible to this screen (`/settings` reports `hfTokenSet`), and it is also the half that makes an attempt pointless — so it alone decides the block now:

- **No token** → still disabled, same guidance as before.
- **Token set** → the request goes through, and Hugging Face is the authority on whether the license was accepted.

This is pass-through to HF auth, not circumvention (`docs/architecture/07-model-catalog.md`, "Gotchas").

Two smaller things came along with it:

- The gated notice now renders for every gated repo, not only blocked ones, with copy that names whichever half is still on the user ("add a token" vs. "accept the license with that account").
- The safetensors body gets the same rule *and* the notice — it used to grey its button out with no explanation at all, since the notice only ever rendered on the GGUF side.

## Verification

New `HfRepoDialog.gated.test.tsx` (6 cases): gated + token downloads and enqueues the right file, gated without a token stays disabled, the notice names the right missing half in each state, the safetensors path follows the same rule and explains itself, and an ungated repo is untouched. Confirmed the two behavioural cases fail against the old `blockedByGate = gated` before passing against the fix.

`npx tsc --noEmit` clean; full web suite green (63 files, 732 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
