### PR TITLE
fix(gateway): translate external clients' reasoning_effort ourselves

### DIFF
--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -99,7 +99,15 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **`reasoning_effort` sent by external OpenAI-compatible clients (opencode, LiteLLM, etc.)
+  could silently do nothing.** Those tools send the standard top-level `reasoning_effort`
+  field, which only takes effect if the underlying llama.cpp engine build happens to translate
+  it itself — an older build ignored it outright, so every effort level rendered identically
+  with no error. TurboLLM's gateway now translates it directly, so it works no matter which
+  engine build is installed. The standard OpenAI value `"high"` is also now accepted and mapped
+  to Qwen3.8's own `"xhigh"`, instead of crashing the request.
 
 ## [1.12.4] - 2026-09-05
 

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -103,11 +103,12 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 - **`reasoning_effort` sent by external OpenAI-compatible clients (opencode, LiteLLM, etc.)
   could silently do nothing.** Those tools send the standard top-level `reasoning_effort`
-  field, which only takes effect if the underlying llama.cpp engine build happens to translate
+  field, which only took effect if the underlying llama.cpp engine build happened to translate
   it itself — an older build ignored it outright, so every effort level rendered identically
-  with no error. TurboLLM's gateway now translates it directly, so it works no matter which
-  engine build is installed. The standard OpenAI value `"high"` is also now accepted and mapped
-  to Qwen3.8's own `"xhigh"`, instead of crashing the request.
+  with no error, and even on a build new enough to forward it, an unsupported value like the
+  standard OpenAI `"high"` would 500 the whole turn. TurboLLM's gateway now translates and
+  validates it directly, so it works no matter which engine build is installed, and `"high"`
+  is mapped to Qwen3.8's own `"xhigh"` instead of erroring.
 
 ## [1.12.4] - 2026-09-05
 

--- a/turbollm/src/chat/reasoning-effort.test.ts
+++ b/turbollm/src/chat/reasoning-effort.test.ts
@@ -26,3 +26,14 @@ test('parseReasoningEffort rejects anything else, including near-misses and non-
     assert.equal(parseReasoningEffort(bad), undefined, `expected undefined for ${JSON.stringify(bad)}`)
   }
 })
+
+test('parseReasoningEffort does not resolve inherited Object.prototype members as an alias', () => {
+  // A plain-object alias lookup (`ALIASES[value]`) would resolve these to inherited
+  // Object.prototype members instead of undefined — a function for most of them, the
+  // prototype object itself for '__proto__' — which a caller then writes straight into
+  // `chat_template_kwargs.reasoning_effort`, crashing the engine's template on a non-string
+  // value. None of these are valid reasoning-effort values; all must come back undefined.
+  for (const key of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString']) {
+    assert.equal(parseReasoningEffort(key), undefined, `expected undefined for prototype key ${JSON.stringify(key)}`)
+  }
+})

--- a/turbollm/src/chat/reasoning-effort.test.ts
+++ b/turbollm/src/chat/reasoning-effort.test.ts
@@ -1,0 +1,28 @@
+// Unit coverage for the one shared client-value parser (see reasoning-effort.ts's own doc
+// comment: every caller from client JSON to an engine request must go through this rather
+// than forwarding a client-supplied string directly, since Qwen3.8's chat template
+// `raise_exception`s on anything outside 'low'/'medium'/'xhigh').
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { parseReasoningEffort } from './reasoning-effort'
+
+test('parseReasoningEffort accepts the four template-native values verbatim', () => {
+  assert.equal(parseReasoningEffort('off'), 'off')
+  assert.equal(parseReasoningEffort('low'), 'low')
+  assert.equal(parseReasoningEffort('medium'), 'medium')
+  assert.equal(parseReasoningEffort('xhigh'), 'xhigh')
+})
+
+test("parseReasoningEffort aliases the OpenAI-standard 'high' to Qwen3.8's 'xhigh' (GitHub #213)", () => {
+  // Generic OpenAI-compatible clients (opencode, LiteLLM, plain SDK scripts) speak the
+  // standard low/medium/high vocabulary — 'high' is not a value the template itself
+  // recognizes (it would raise_exception), so the parser must translate it rather than
+  // reject it outright.
+  assert.equal(parseReasoningEffort('high'), 'xhigh')
+})
+
+test('parseReasoningEffort rejects anything else, including near-misses and non-strings', () => {
+  for (const bad of ['xhigh ', 'Low', 'HIGH', 'ultra', '', null, undefined, 42, {}, ['low']]) {
+    assert.equal(parseReasoningEffort(bad), undefined, `expected undefined for ${JSON.stringify(bad)}`)
+  }
+})

--- a/turbollm/src/chat/reasoning-effort.ts
+++ b/turbollm/src/chat/reasoning-effort.ts
@@ -13,9 +13,19 @@ export type ReasoningEffort = 'off' | 'low' | 'medium' | 'xhigh'
 
 const VALID = new Set<string>(['off', 'low', 'medium', 'xhigh'])
 
-/** Undefined for anything not exactly one of the four supported values (including
- *  absent/undefined/empty-string input) — callers omit the field entirely rather than
- *  risk sending a value the template rejects. */
+// 'high' is the OpenAI-standard `reasoning_effort` enum value (low/medium/high) that generic
+// OpenAI-compatible clients — opencode, LiteLLM, plain SDK scripts — send natively; Qwen3.8's
+// own template only ever recognizes the literal string 'xhigh' and `raise_exception`s on
+// anything else (GitHub #213: a client-side 'high' variant otherwise 500s the whole turn, or
+// silently never applies on an engine build old enough to forward it raw). Aliased here, in
+// the one shared parser, so every caller gets it for free rather than each reimplementing it.
+const ALIASES: Record<string, ReasoningEffort> = { high: 'xhigh' }
+
+/** Undefined for anything not exactly one of the four supported values or the 'high' alias
+ *  (including absent/undefined/empty-string input) — callers omit the field entirely rather
+ *  than risk sending a value the template rejects. */
 export function parseReasoningEffort(value: unknown): ReasoningEffort | undefined {
-  return typeof value === 'string' && VALID.has(value) ? (value as ReasoningEffort) : undefined
+  if (typeof value !== 'string') return undefined
+  if (VALID.has(value)) return value as ReasoningEffort
+  return ALIASES[value]
 }

--- a/turbollm/src/chat/reasoning-effort.ts
+++ b/turbollm/src/chat/reasoning-effort.ts
@@ -19,7 +19,12 @@ const VALID = new Set<string>(['off', 'low', 'medium', 'xhigh'])
 // anything else (GitHub #213: a client-side 'high' variant otherwise 500s the whole turn, or
 // silently never applies on an engine build old enough to forward it raw). Aliased here, in
 // the one shared parser, so every caller gets it for free rather than each reimplementing it.
-const ALIASES: Record<string, ReasoningEffort> = { high: 'xhigh' }
+// A `Map`, not a plain object: a plain-object lookup (`ALIASES[value]`) resolves inherited
+// `Object.prototype` members for a key like 'constructor' or '__proto__', handing back a
+// function or `Object.prototype` itself instead of `undefined` — which this parser's callers
+// then write straight into `chat_template_kwargs.reasoning_effort`, the exact `raise_exception`
+// this function exists to prevent. A `Map` has no prototype-chain lookup, so no key can do that.
+const ALIASES = new Map<string, ReasoningEffort>([['high', 'xhigh']])
 
 /** Undefined for anything not exactly one of the four supported values or the 'high' alias
  *  (including absent/undefined/empty-string input) — callers omit the field entirely rather
@@ -27,5 +32,5 @@ const ALIASES: Record<string, ReasoningEffort> = { high: 'xhigh' }
 export function parseReasoningEffort(value: unknown): ReasoningEffort | undefined {
   if (typeof value !== 'string') return undefined
   if (VALID.has(value)) return value as ReasoningEffort
-  return ALIASES[value]
+  return ALIASES.get(value)
 }

--- a/turbollm/src/gateway/gateway.reasoning-effort.test.ts
+++ b/turbollm/src/gateway/gateway.reasoning-effort.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { Hono } from 'hono'
 import { registerGateway } from './gateway'
+import { sessionAuth } from '../code/session-auth'
 import type { Deps } from '../deps'
 
 const LIBRARY = [{ key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' }]
@@ -45,16 +46,20 @@ function captureOutboundFetch(): { calls: Array<{ url: string; body: Record<stri
   return { calls, restore: () => { globalThis.fetch = original } }
 }
 
-async function postChat(app: Hono, body: Record<string, unknown>) {
+async function postChatAs(app: Hono, token: string, body: Record<string, unknown>) {
   const capture = captureOutboundFetch()
   try {
     await app.request('/v1/chat/completions', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer turbollm-local' },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], stream: false, ...body }),
     })
   } finally { capture.restore() }
   return capture.calls[0]?.body
+}
+
+function postChat(app: Hono, body: Record<string, unknown>) {
+  return postChatAs(app, 'turbollm-local', body)
 }
 
 test('a client-supplied reasoning_effort is translated into chat_template_kwargs, not forwarded raw', async () => {
@@ -111,4 +116,47 @@ test('a caller-supplied chat_template_kwargs is preserved alongside the translat
   const kwargs = outbound?.chat_template_kwargs as Record<string, unknown>
   assert.equal(kwargs.reasoning_effort, 'medium')
   assert.equal(kwargs.some_other_flag, true)
+})
+
+// A Code-session client (launched via TurboLLM's own `turbollm launch`) carries a
+// session-scoped token AND may send its own top-level `reasoning_effort` on the same turn.
+// The persisted session override must win cleanly — not just be added alongside whatever the
+// client-value translation already wrote to chat_template_kwargs/thinking_budget_tokens.
+test("a Code-session override to a real effort clears a client-sent 'off' cleanly (no stale enable_thinking/thinking_budget_tokens)", async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const token = sessionAuth.mint('sess-conflict-a')
+  sessionAuth.setReasoningEffort('sess-conflict-a', 'low')
+
+  const outbound = await postChatAs(app, token, { reasoning_effort: 'off' })
+
+  const kwargs = outbound?.chat_template_kwargs as Record<string, unknown> | undefined
+  assert.equal(kwargs?.reasoning_effort, 'low', "the session's override must win")
+  assert.equal(kwargs?.enable_thinking, undefined, "no stale enable_thinking:false left over from the client's 'off'")
+  assert.equal(outbound?.thinking_budget_tokens, undefined, "no stale thinking_budget_tokens:0 left over from the client's 'off'")
+})
+
+test("a Code-session override to 'off' clears a client-sent real effort cleanly (no stale reasoning_effort)", async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const token = sessionAuth.mint('sess-conflict-b')
+  sessionAuth.setReasoningEffort('sess-conflict-b', 'off')
+
+  const outbound = await postChatAs(app, token, { reasoning_effort: 'medium' })
+
+  const kwargs = outbound?.chat_template_kwargs as Record<string, unknown> | undefined
+  assert.equal(kwargs?.enable_thinking, false, "the session's 'off' override must win")
+  assert.equal(outbound?.thinking_budget_tokens, 0)
+  assert.equal(kwargs?.reasoning_effort, undefined, "no stale reasoning_effort:'medium' left over from the client's value")
+})
+
+test('a Code session with no reasoning-effort override set still gets the client value translated', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const token = sessionAuth.mint('sess-no-effort-override')
+  // No setReasoningEffort call — the client's own value should flow through untouched.
+
+  const outbound = await postChatAs(app, token, { reasoning_effort: 'low' })
+
+  assert.equal((outbound?.chat_template_kwargs as Record<string, unknown>)?.reasoning_effort, 'low')
 })

--- a/turbollm/src/gateway/gateway.reasoning-effort.test.ts
+++ b/turbollm/src/gateway/gateway.reasoning-effort.test.ts
@@ -160,3 +160,26 @@ test('a Code session with no reasoning-effort override set still gets the client
 
   assert.equal((outbound?.chat_template_kwargs as Record<string, unknown>)?.reasoning_effort, 'low')
 })
+
+test('a prototype-chain key never reaches the engine as a non-string reasoning_effort', async () => {
+  // ALIASES[value] on a plain object would resolve '__proto__' to Object.prototype itself,
+  // which then lands in chat_template_kwargs.reasoning_effort as a JSON object — exactly the
+  // raise_exception-triggering shape this whole feature exists to keep away from the engine.
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: '__proto__' })
+
+  assert.equal(outbound?.reasoning_effort, undefined)
+  assert.equal(outbound?.chat_template_kwargs, undefined)
+})
+
+test('a non-string reasoning_effort (e.g. an explicit null from an SDK wrapper) is still deleted, not forwarded raw', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+
+  const nullBody = await postChat(app, { reasoning_effort: null })
+  assert.equal(nullBody && 'reasoning_effort' in nullBody, false)
+
+  const numberBody = await postChat(app, { reasoning_effort: 5 })
+  assert.equal(numberBody && 'reasoning_effort' in numberBody, false)
+})

--- a/turbollm/src/gateway/gateway.reasoning-effort.test.ts
+++ b/turbollm/src/gateway/gateway.reasoning-effort.test.ts
@@ -1,0 +1,114 @@
+// Regression coverage for GitHub #213: a plain OpenAI-protocol client (opencode via
+// `@ai-sdk/openai-compatible`, LiteLLM, or any script hitting /v1/chat/completions directly,
+// with no TurboLLM Code-session token at all) sends the OpenAI-standard top-level
+// `reasoning_effort` field. Before this fix that field passed straight through to the engine
+// untouched, so whether it did anything depended entirely on the vendored llama.cpp build's
+// own (version-dependent) support for it — on an older build every variant silently rendered
+// identically. gateway.ts now translates it itself, through the same validated parser
+// reasoning-effort.ts's own doc comment requires every caller to use.
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerGateway } from './gateway'
+import type { Deps } from '../deps'
+
+const LIBRARY = [{ key: 'qwen3-8b|Q4|123', name: 'Qwen3 8B' }]
+
+function fakeDeps(): Deps {
+  return {
+    scanner: { list: () => ({ models: LIBRARY, scanning: false, lastScanAt: '' }) },
+    modelRouter: { route: async () => ({ target: 'http://engine.invalid.local:1' }) },
+    store: { snapshot: () => ({ modelDefaults: { maxTokens: 0 }, gateway: { autoSwap: false } }) },
+    manager: {
+      status: () => ({ state: 'running', model: { name: 'Qwen3 8B', key: 'qwen3-8b|Q4|123' } }),
+      target: () => 'http://engine.invalid.local:1',
+      currentOpts: () => null,
+      generationStart: () => {},
+      generationEnd: () => {},
+    },
+    registry: { active: () => ({ kind: 'llama.cpp' }) },
+    db: { recordApiUsage: () => {} },
+  } as unknown as Deps
+}
+
+/** Captures the single outbound fetch call's body without needing a real/valid engine —
+ *  the handler's response after that point is irrelevant to what this test checks. */
+function captureOutboundFetch(): { calls: Array<{ url: string; body: Record<string, unknown> | null }>; restore: () => void } {
+  const original = globalThis.fetch
+  const calls: Array<{ url: string; body: Record<string, unknown> | null }> = []
+  globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    let body: Record<string, unknown> | null = null
+    try { body = init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null } catch { body = null }
+    calls.push({ url: String(url), body })
+    return new Response(null, { status: 500 })
+  }) as typeof fetch
+  return { calls, restore: () => { globalThis.fetch = original } }
+}
+
+async function postChat(app: Hono, body: Record<string, unknown>) {
+  const capture = captureOutboundFetch()
+  try {
+    await app.request('/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer turbollm-local' },
+      body: JSON.stringify({ model: 'qwen3-8b|Q4|123', messages: [], stream: false, ...body }),
+    })
+  } finally { capture.restore() }
+  return capture.calls[0]?.body
+}
+
+test('a client-supplied reasoning_effort is translated into chat_template_kwargs, not forwarded raw', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: 'low' })
+
+  assert.equal(outbound?.reasoning_effort, undefined, 'the raw top-level key must not reach the engine')
+  assert.deepEqual((outbound?.chat_template_kwargs as Record<string, unknown>)?.reasoning_effort, 'low')
+})
+
+test("the OpenAI-standard 'high' is aliased to Qwen3.8's 'xhigh' rather than forwarded raw (would raise_exception)", async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: 'high' })
+
+  assert.equal((outbound?.chat_template_kwargs as Record<string, unknown>)?.reasoning_effort, 'xhigh')
+})
+
+test("reasoning_effort: 'off' collapses onto enable_thinking/thinking_budget_tokens, same as the Code-session override", async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: 'off' })
+
+  assert.equal(outbound?.thinking_budget_tokens, 0)
+  assert.equal((outbound?.chat_template_kwargs as Record<string, unknown>)?.enable_thinking, false)
+  assert.equal((outbound?.chat_template_kwargs as Record<string, unknown> | undefined)?.reasoning_effort, undefined)
+})
+
+test('an unsupported reasoning_effort value is dropped rather than forwarded to the engine', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: 'ultra-mega' })
+
+  assert.equal(outbound?.reasoning_effort, undefined)
+  assert.equal(outbound?.chat_template_kwargs, undefined)
+})
+
+test('no reasoning_effort field at all is a no-op — the request is otherwise unmodified', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, {})
+
+  assert.equal(outbound?.reasoning_effort, undefined)
+  assert.equal(outbound?.chat_template_kwargs, undefined)
+  assert.equal(outbound?.thinking_budget_tokens, undefined)
+})
+
+test('a caller-supplied chat_template_kwargs is preserved alongside the translated reasoning_effort', async () => {
+  const app = new Hono()
+  registerGateway(app, fakeDeps())
+  const outbound = await postChat(app, { reasoning_effort: 'medium', chat_template_kwargs: { some_other_flag: true } })
+
+  const kwargs = outbound?.chat_template_kwargs as Record<string, unknown>
+  assert.equal(kwargs.reasoning_effort, 'medium')
+  assert.equal(kwargs.some_other_flag, true)
+})

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -13,6 +13,7 @@ import { noteLocalActivity } from '../link/host-idle'
 import { linkHeaders, proxyStream } from '../link/link-proxy'
 import { formatRemoteId } from '../link/model-id'
 import { sessionAuth } from '../code/session-auth'
+import { parseReasoningEffort } from '../chat/reasoning-effort'
 import { classifyHarness } from '../telemetry/classify'
 import { mapToOpenAI, mapFromOpenAI, streamToAnthropic, messageStartEvent, pingWhilePending, DEFAULT_PING_INTERVAL_MS, type AnthropicRequest, type StreamToolCall } from './anthropic'
 import { analyzeTurn, applyAgentGuidance } from './agent-guidance'
@@ -832,10 +833,36 @@ export async function gatewayV1Handler(c: Context, d: Deps, opts: GatewayV1Optio
         const alias = engineModelAlias(d.registry.active()?.kind ?? '', d.manager.currentOpts()?.modelPath)
         if (alias) parsedBody.model = alias
       }
+      // A plain OpenAI-protocol client (opencode/LiteLLM/any `@ai-sdk/openai-compatible`
+      // caller — GitHub #213) sends the OpenAI-standard top-level `reasoning_effort` field,
+      // not TurboLLM's own `chat_template_kwargs.reasoning_effort` shape. Recent llama.cpp
+      // builds forward that field into chat_template_kwargs themselves, but relying on the
+      // vendored engine's own version-dependent compat shim means an older build silently
+      // drops the unrecognized top-level key — every variant then renders identically,
+      // since the template's own `reasoning_effort|default('xhigh')` wins every time with no
+      // visible error. Translated here instead, through the same validated parser the
+      // session-token override below uses, so it works regardless of engine version and a
+      // bad/unsupported value (or the standard OpenAI 'high', aliased to Qwen3.8's 'xhigh')
+      // is handled once rather than left for the engine's `raise_exception` to hit. The raw
+      // key is always deleted: forwarding it too would either duplicate what's now in
+      // chat_template_kwargs or, if invalid, still reach a modern engine unsanitized.
+      if (parsedBody && typeof parsedBody.reasoning_effort === 'string') {
+        const clientEffort = parseReasoningEffort(parsedBody.reasoning_effort)
+        delete parsedBody.reasoning_effort
+        if (clientEffort === 'off') {
+          parsedBody.thinking_budget_tokens = 0
+          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), enable_thinking: false }
+        } else if (clientEffort !== undefined) {
+          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), reasoning_effort: clientEffort }
+        }
+      }
       // Terminal-agent thinking-budget override (ADR-284) — OpenAI-protocol clients (pi/
       // opencode via this passthrough) reach the same `thinking_budget_tokens` field the
       // engine sampler reads directly (no Anthropic-shaped `thinking` object to translate,
-      // unlike /v1/messages above). Same session-scoped-token gate as that handler.
+      // unlike /v1/messages above). Same session-scoped-token gate as that handler. Runs
+      // AFTER the client-supplied translation above so a deliberate, persistent Code-session
+      // override still wins over whatever the CLI itself sent on this turn — same precedence
+      // the thinking-budget override next to it already has.
       if (parsedBody && chatCodeSessionId) {
         const override = sessionAuth.getThinkingBudgetForToken(chatToken)
         if (override !== null) {

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -840,44 +840,54 @@ export async function gatewayV1Handler(c: Context, d: Deps, opts: GatewayV1Optio
       // vendored engine's own version-dependent compat shim means an older build silently
       // drops the unrecognized top-level key — every variant then renders identically,
       // since the template's own `reasoning_effort|default('xhigh')` wins every time with no
-      // visible error. Translated here instead, through the same validated parser the
+      // visible error. Parsed here instead, through the same validated parser the
       // session-token override below uses, so it works regardless of engine version and a
       // bad/unsupported value (or the standard OpenAI 'high', aliased to Qwen3.8's 'xhigh')
       // is handled once rather than left for the engine's `raise_exception` to hit. The raw
-      // key is always deleted: forwarding it too would either duplicate what's now in
-      // chat_template_kwargs or, if invalid, still reach a modern engine unsanitized.
+      // key is always deleted: forwarding it too would either duplicate what's below or, if
+      // invalid, still reach a modern engine unsanitized. Not applied to `chat_template_kwargs`
+      // yet — a Code-session override, if set, replaces it below — so the two sources are
+      // resolved to a single effective value before either ever touches the outbound body.
+      let effort: ReturnType<typeof parseReasoningEffort> = undefined
       if (parsedBody && typeof parsedBody.reasoning_effort === 'string') {
-        const clientEffort = parseReasoningEffort(parsedBody.reasoning_effort)
+        effort = parseReasoningEffort(parsedBody.reasoning_effort)
         delete parsedBody.reasoning_effort
-        if (clientEffort === 'off') {
-          parsedBody.thinking_budget_tokens = 0
-          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), enable_thinking: false }
-        } else if (clientEffort !== undefined) {
-          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), reasoning_effort: clientEffort }
-        }
       }
       // Terminal-agent thinking-budget override (ADR-284) — OpenAI-protocol clients (pi/
       // opencode via this passthrough) reach the same `thinking_budget_tokens` field the
       // engine sampler reads directly (no Anthropic-shaped `thinking` object to translate,
-      // unlike /v1/messages above). Same session-scoped-token gate as that handler. Runs
-      // AFTER the client-supplied translation above so a deliberate, persistent Code-session
-      // override still wins over whatever the CLI itself sent on this turn — same precedence
-      // the thinking-budget override next to it already has.
+      // unlike /v1/messages above). Same session-scoped-token gate as that handler.
       if (parsedBody && chatCodeSessionId) {
         const override = sessionAuth.getThinkingBudgetForToken(chatToken)
         if (override !== null) {
           if (override > 0) parsedBody.thinking_budget_tokens = override
           else delete parsedBody.thinking_budget_tokens
         }
-        // Same override mechanism, for reasoning_effort — see session-auth.ts. 'off'
-        // collapses onto enable_thinking/thinking_budget_tokens (reasoning-effort.ts).
+        // Same override mechanism, for reasoning_effort — see session-auth.ts. A deliberate,
+        // persistent Code-session override replaces whatever the client itself sent on this
+        // turn (including the plain-client value parsed above), same precedence the
+        // thinking-budget override above already has.
         const effortOverride = sessionAuth.getReasoningEffortForToken(chatToken)
-        if (effortOverride === 'off') {
+        if (effortOverride !== null) effort = effortOverride
+      }
+      // Applied exactly once, from whichever of the two sources above won, so a client value
+      // and a session override that disagree (e.g. client sends 'off' but the session's own
+      // override is 'low') can never leave a stale `enable_thinking`/`reasoning_effort` key
+      // behind from a discarded intermediate write — every prior key this pair can set is
+      // cleared before the winning one is applied. 'off' collapses onto
+      // enable_thinking/thinking_budget_tokens (reasoning-effort.ts) since it isn't itself a
+      // template value.
+      if (parsedBody && effort !== undefined) {
+        const kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}) }
+        delete kwargs.enable_thinking
+        delete kwargs.reasoning_effort
+        if (effort === 'off') {
           parsedBody.thinking_budget_tokens = 0
-          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), enable_thinking: false }
-        } else if (effortOverride !== null) {
-          parsedBody.chat_template_kwargs = { ...(parsedBody.chat_template_kwargs as Record<string, unknown> ?? {}), reasoning_effort: effortOverride }
+          kwargs.enable_thinking = false
+        } else {
+          kwargs.reasoning_effort = effort
         }
+        parsedBody.chat_template_kwargs = kwargs
       }
       // Apply the scaffolding computed above. Standing rules go on the system message (stable
       // for the whole session → the engine's reusable prompt prefix is unaffected after turn

--- a/turbollm/src/gateway/gateway.ts
+++ b/turbollm/src/gateway/gateway.ts
@@ -849,7 +849,12 @@ export async function gatewayV1Handler(c: Context, d: Deps, opts: GatewayV1Optio
       // yet — a Code-session override, if set, replaces it below — so the two sources are
       // resolved to a single effective value before either ever touches the outbound body.
       let effort: ReturnType<typeof parseReasoningEffort> = undefined
-      if (parsedBody && typeof parsedBody.reasoning_effort === 'string') {
+      if (parsedBody && 'reasoning_effort' in parsedBody) {
+        // `parseReasoningEffort` already returns undefined for a non-string (e.g. a
+        // LiteLLM-style explicit `null` for an unset optional), so the delete below must not
+        // be gated on the value's type too — the key still has to go either way for "always
+        // deleted" above to be true, or a non-string value skips this parser entirely and
+        // reaches the engine exactly as raw as an unvalidated one would.
         effort = parseReasoningEffort(parsedBody.reasoning_effort)
         delete parsedBody.reasoning_effort
       }


### PR DESCRIPTION
## Summary

Fixes #213 — an external OpenAI-compatible client (opencode via `@ai-sdk/openai-compatible`, LiteLLM, or any similar tool) sends the OpenAI-standard **top-level** `reasoning_effort` field on `/v1/chat/completions`, not TurboLLM's own `chat_template_kwargs.reasoning_effort` shape.

Previously that field passed straight through to the engine untouched, so whether it did anything at all depended entirely on the vendored llama.cpp build's own (version-dependent) support for forwarding it — an older build silently drops the unrecognized top-level key, so every reasoning-effort variant (`low`/`medium`/`high`/`xhigh`) rendered identically with no visible error, matching the reported symptom exactly.

### Changes

- `turbollm/src/gateway/gateway.ts`: the `/v1/chat/completions` passthrough now parses a client-supplied `reasoning_effort`, resolves it against a Code-session's own persisted override (the override wins if set), and applies the result in a **single write** — into `chat_template_kwargs.reasoning_effort`, or `enable_thinking:false` + `thinking_budget_tokens:0` for `"off"`. Resolving both sources to one value before writing (rather than two independent writes) avoids leaving a stale key behind when they disagree — an earlier version of this PR had exactly that bug, caught in review and fixed with a regression test.
- `turbollm/src/chat/reasoning-effort.ts`: `parseReasoningEffort` now also accepts the standard OpenAI value `"high"`, aliasing it to Qwen3.8's own `"xhigh"`. The alias table is a `Map` (not a plain object) so a key like `"constructor"` or `"__proto__"` can't resolve to an inherited `Object.prototype` member instead of `undefined` — also caught in review, since that would have handed the engine a non-string value in the one field its template raise_exceptions on.
- The raw top-level `reasoning_effort` key is always deleted from the outbound body regardless of its type (not just when it's a string), so an explicit `null` or a stray number from an SDK wrapper can't reach the engine unsanitized either.

### Test plan

- [x] `turbollm/src/chat/reasoning-effort.test.ts` (new) — parser unit tests: the four template values, the `"high"` alias, rejection of bad values, and rejection of `Object.prototype`-key inputs.
- [x] `turbollm/src/gateway/gateway.reasoning-effort.test.ts` (new) — end-to-end coverage of the `/v1/chat/completions` translation: plain client values, the `"high"` alias, `"off"`, invalid/absent values, a preserved caller-supplied `chat_template_kwargs`, both directions of a client-value-vs-session-override conflict, a prototype-chain key, and a non-string value.
- [x] Full backend suite: `npm test` — 3592 passed, 0 failed, 4 pre-existing skips.
- [x] `npm run typecheck` — clean.
- [x] Reviewed independently (opus) against the real checked-out branch, including probing the running handler with adversarial inputs — findings from that pass are folded into the commits above; two narrower non-blocking follow-ups (unifying precedence with the session's separate thinking-budget override, and aliasing the rest of OpenAI's `reasoning_effort` enum) are tracked separately rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)