### PR TITLE
chore(release): v1.12.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ Thumbs.db
 # Local backups of a physical test device's TurboLLM data (adb-pulled tarball),
 # made before a signature-mismatch reinstall wipes it. Multi-GB, device-specific, never for git.
 /.tllm-device-backup/
+
+# Sibling app repos checked out alongside this one — never part of this repo
+/TurboLLM Android/
+/TurboLLM-Android-Llama/

--- a/README.md
+++ b/README.md
@@ -628,7 +628,8 @@ Use `--config <file>` to point at an alternate config (its directory becomes the
 
   </details>
 
-- **Windows, macOS, or Linux.**
+- **Windows, macOS, or Linux** for `npx turbollm`. A native **Android app** also exists, with a
+  bundled Vulkan-accelerated engine — currently in closed/open testing, see turbollm.dev.
 - A GPU is recommended but **not required** — a CPU build is provisioned as a fallback.
 - On Windows, the first time the auto-downloaded `llama-server` runs, SmartScreen/Defender may
   prompt (it's an upstream binary). Allow it once.

--- a/turbollm/CHANGELOG.md
+++ b/turbollm/CHANGELOG.md
@@ -99,6 +99,10 @@ published version on npm has a matching `vX.Y.Z` tag in git.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [1.12.5] - 2026-09-08
+
 ### Added
 
 - **A new Monitor tab** puts the live engine log and system hardware stats on one always-visible
@@ -106,6 +110,14 @@ published version on npm has a matching `vX.Y.Z` tag in git.
   stats only living in Settings → System. The top half auto-tracks the running engine's log with
   a toggle to pause auto-scroll and review earlier output; the bottom half is the same live
   CPU/RAM/GPU gauges and sparklines Settings → System already shows.
+- **TurboLLM now runs as a native Android app.** The daemon ships inside the APK with a bundled
+  Vulkan-accelerated `llama-server` engine, so a phone can load and run a model with no separate
+  install step. The UI adapts for a phone: Engines, Discover, and Chat are simplified to the
+  screens that make sense on-device, model recommendations are filtered to what the device can
+  actually hold, a fresh install starts new chats on a lightweight agent with thinking off (to
+  fit a tighter memory/compute budget), and hardware Back, safe-area insets, and touch gestures
+  (like swiping between Engines pages) behave the way an Android app is expected to. GPU
+  detection now correctly reports the phone's real Vulkan GPU instead of "CPU-only."
 
 ### Fixed
 
@@ -117,6 +129,25 @@ published version on npm has a matching `vX.Y.Z` tag in git.
   standard OpenAI `"high"` would 500 the whole turn. TurboLLM's gateway now translates and
   validates it directly, so it works no matter which engine build is installed, and `"high"`
   is mapped to Qwen3.8's own `"xhigh"` instead of erroring.
+- **The download button for a gated Hugging Face repo stayed disabled even with a valid token
+  configured** (#198). Gating actually has two independent halves — the license accepted on
+  huggingface.co, and a token saved in Settings → Models & loading — but only the token half is
+  visible to this screen, and the dialog was blocking on gated-ness alone regardless of it. A
+  configured token now lets the download through, and Hugging Face's own response (401/403) is
+  the authority on whether the license was actually accepted; the gated-repo notice now also
+  shows on the safetensors (MLX/vLLM) download path, which previously gave no explanation at all.
+
+### Discord
+
+- TurboLLM now runs as a native Android app — the daemon and a Vulkan-accelerated engine ship
+  inside the APK, so you can load and chat with a model right on your phone.
+- The Android app adapts to your device: simplified screens, model picks filtered to what your
+  phone can actually run, and a lighter default setup so chats stay fast on limited hardware.
+- A new Monitor tab shows the live engine log and hardware stats (CPU/RAM/GPU) together on one
+  screen instead of hunting through a drawer or Settings.
+- Fixed: a gated Hugging Face model's download button now works once you've added a token in
+  Settings, instead of staying greyed out regardless; and `reasoning_effort` from third-party
+  tools like opencode/LiteLLM now actually takes effect.
 
 ## [1.12.4] - 2026-09-05
 

--- a/turbollm/README.md
+++ b/turbollm/README.md
@@ -628,7 +628,8 @@ Use `--config <file>` to point at an alternate config (its directory becomes the
 
   </details>
 
-- **Windows, macOS, or Linux.**
+- **Windows, macOS, or Linux** for `npx turbollm`. A native **Android app** also exists, with a
+  bundled Vulkan-accelerated engine — currently in closed/open testing, see turbollm.dev.
 - A GPU is recommended but **not required** — a CPU build is provisioned as a fallback.
 - On Windows, the first time the auto-downloaded `llama-server` runs, SmartScreen/Defender may
   prompt (it's an upstream binary). Allow it once.

--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbollm",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "TurboLLM — local LLM platform: run any inference engine auto-tuned to your GPU, with a web UI and OpenAI/Anthropic-compatible API. Point Claude Code at your own machine in one command.",
   "license": "FSL-1.1-ALv2",
   "author": "Mohit Soni",

--- a/turbollm/web/src/lib/personas.ts
+++ b/turbollm/web/src/lib/personas.ts
@@ -216,6 +216,10 @@ const TURBOLLM_KNOWLEDGE =
   '**BeeLlama.cpp** (Windows / Linux / macOS — GGUF):\n' +
   'llama.cpp fork adding variance-normalized KV-cache quantization (KVarN: `kvarn2`…`kvarn8`, set via `--cache-type-k`/`-v`), a KV precision tail, and adaptive DFlash speculative decoding. Build-from-source only. The KVarN types show up directly in the KV cache type dropdown (auto-discovered from the build\'s own --help output) but aren\'t in the auto-tune sweep yet — pick one manually.\n\n' +
 
+  '## Monitor\n\n' +
+  'Nav tab (rail order: Workspace, Models, Engines, Monitor, Customize, Usage, Developer, Settings) that puts the live engine log and system hardware stats on one always-visible, split screen — no more opening the Engines drawer or jumping to Settings → System to see them. Top half: the same log/auto-scroll behavior as the Engines diagnostics drawer (shows the last-loaded engine\'s log even after it stopped, gated on an engine being selected, not necessarily running). Bottom half: the same live CPU/RAM/GPU gauges and sparklines as Settings → System — same component, same data, so the two screens can never disagree.\n\n' +
+  '## Android app\n\n' +
+  'TurboLLM also ships as a native Android app (separate from `npx turbollm`) — the daemon runs inside the APK with a bundled Vulkan-accelerated engine for on-device GPU inference, no separate install step. The UI is the same shared codebase, adapted for a phone: Engines/Discover/Chat simplified, Code and Agents management hidden (desktop-only), model recommendations filtered to what the device can actually hold, and hardware Back / safe-area / swipe gestures behave like a native app. A fresh install starts on a lightweight default agent with thinking off, tuned for phone-class memory/compute.\n\n' +
   '## Gateway\n\n' +
   'TurboLLM at `http://localhost:6996` exposes:\n' +
   '- **OpenAI-compatible**: `POST /v1/chat/completions`, `GET /v1/models`, `POST /v1/embeddings`\n' +


### PR DESCRIPTION
## Summary
Patch release, per founder call — despite genuinely new capabilities (Android app, Monitor tab), this ships as 1.12.4 → 1.12.5.

### Added
- Monitor tab (issue #211): live engine log + system hardware stats on one always-visible split screen.
- TurboLLM now runs as a native Android app: daemon ships inside the APK with a bundled Vulkan-accelerated engine, UI adapted for phone use.

### Fixed
- `reasoning_effort` from external OpenAI-compatible clients (opencode, LiteLLM, etc.) now actually takes effect instead of silently doing nothing or 500ing on `"high"`.
- Gated Hugging Face downloads now work with a valid token configured (#198), instead of staying disabled regardless.

## Release-prep in this PR
- `turbollm/package.json` 1.12.4 → 1.12.5
- `turbollm/CHANGELOG.md` — `[Unreleased]` moved into a dated `[1.12.5]` section + Discord subsection
- `turbollm/README.md` Requirements section notes the Android app; root `README.md` re-mirrored
- `turbollm/web/src/lib/personas.ts` (TurboLLM Expert persona) — added Monitor + Android app sections, web bundle rebuilt

## Note on scope
This release consolidates ~50 commits already merged to `main` (the `feature/apps` branch — Android daemon support + desktop installer groundwork — landed outside the normal release-branch flow). The changelog above was compiled by diffing every commit since `v1.12.4` against RELEASE.md's hard rule (a bug introduced AND fixed in the same unreleased cycle never appears in the changelog) — Android-only bugfixes on Android-only code new this cycle are folded into the one Added entry rather than itemized; telemetry-internal and desktop-wrapper/signup-worker commits are excluded as out of scope for this package's user-facing changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)