### PR TITLE
fix(engines): Add-via-git-repo Continue button no longer silently no-ops

### DIFF
--- a/turbollm/web/src/screens/engines/CustomBuildDialog.test.tsx
+++ b/turbollm/web/src/screens/engines/CustomBuildDialog.test.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import { CustomBuildDialog } from './CustomBuildDialog'
+
+vi.mock('../../lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/api')>()),
+  track: vi.fn(),
+  getBuildPrereqs: vi.fn().mockResolvedValue({
+    supported: true,
+    os: 'linux',
+    tools: [
+      { id: 'git', name: 'Git', found: true, installUrl: '' },
+      { id: 'cmake', name: 'CMake', found: true, installUrl: '' },
+    ],
+    packageManager: null,
+  }),
+  getStatus: vi.fn().mockResolvedValue({
+    engineBuild: { active: false, phase: 'preparing', engine: '', log: [], error: null },
+    engineProvision: { active: false },
+  }),
+  getSettings: vi.fn().mockResolvedValue({ build: { toolchainDirs: [] } }),
+}))
+
+function renderDialog() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <CustomBuildDialog />
+    </QueryClientProvider>,
+  )
+}
+
+describe('CustomBuildDialog', () => {
+  it('hands off to the build guide after Continue, in one click', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    await user.click(screen.getByRole('button', { name: /Add via git repo/ }))
+    await user.type(screen.getByPlaceholderText('My llama.cpp fork'), 'My Fork')
+    await user.type(screen.getByPlaceholderText('https://github.com/owner/repo'), 'https://github.com/owner/repo')
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    // BuildGuideDialog is a SEPARATE Radix Dialog root from the form dialog — closing one
+    // and opening the other synchronously in the same click handler lets the new dialog's
+    // outside-pointerdown detection see that very click (its portal wasn't mounted when the
+    // event fired) and close itself right back — a silent no-op, no error, nothing in the
+    // engine log. This must still show up on its own.
+    expect(await screen.findByText('Build My Fork from source')).toBeInTheDocument()
+    // And the form is really gone, not stacked underneath it.
+    expect(screen.queryByPlaceholderText('https://github.com/owner/repo')).not.toBeInTheDocument()
+  })
+
+  // jsdom's DismissableLayer doesn't reproduce the real browser race the fix guards against
+  // (its pointerdown-outside detection never actually fires on a same-tick dialog swap here),
+  // so the test above alone would pass even without the fix. This one asserts the code-level
+  // contract the fix relies on directly: opening the build guide must NOT happen synchronously
+  // inside the Continue click — it has to wait for a tick. If someone "simplifies" the handler
+  // back to a plain `setBuildOpen(true)`, this fails even though the test above wouldn't.
+  it('does not open the build guide synchronously inside the Continue click', () => {
+    vi.useFakeTimers()
+    try {
+      renderDialog()
+
+      fireEvent.click(screen.getByRole('button', { name: /Add via git repo/ }))
+      fireEvent.change(screen.getByPlaceholderText('My llama.cpp fork'), { target: { value: 'My Fork' } })
+      fireEvent.change(screen.getByPlaceholderText('https://github.com/owner/repo'), {
+        target: { value: 'https://github.com/owner/repo' },
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+      // Not yet — still inside the same tick as the click.
+      expect(screen.queryByText('Build My Fork from source')).not.toBeInTheDocument()
+
+      act(() => {
+        vi.runOnlyPendingTimers()
+      })
+
+      // Now it's up, once the deferred open has had its tick.
+      expect(screen.getByText('Build My Fork from source')).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/turbollm/web/src/screens/engines/CustomBuildDialog.tsx
+++ b/turbollm/web/src/screens/engines/CustomBuildDialog.tsx
@@ -72,7 +72,20 @@ export function CustomBuildDialog() {
 
           <DialogFooter>
             <Button variant="outline" onClick={() => { track('engines', 'cancel_custom_build_dialog'); setFormOpen(false) }}>Cancel</Button>
-            <Button onClick={() => { track('engines', 'continue_custom_build_dialog'); setFormOpen(false); setBuildOpen(true) }} disabled={!canContinue}>
+            <Button
+              onClick={() => {
+                track('engines', 'continue_custom_build_dialog')
+                setFormOpen(false)
+                // Defer to the next tick rather than opening BuildGuideDialog synchronously here.
+                // Both are separate Radix Dialog roots; closing one and mounting another inside the
+                // SAME click handler lets the new dialog's dismissable-layer see that very click as
+                // a "pointerdown outside" (its portal wasn't in the DOM yet when the event fired) and
+                // immediately close itself — a silent no-op with no error, no log line, nothing.
+                // Letting this dialog's close finish first avoids the race.
+                setTimeout(() => setBuildOpen(true), 0)
+              }}
+              disabled={!canContinue}
+            >
               Continue
             </Button>
           </DialogFooter>


### PR DESCRIPTION
## Summary
- The "Add via git repo" dialog's Continue button closed its own form dialog and opened `BuildGuideDialog` synchronously in the same click handler. Since both are separate Radix Dialog roots, swapping them within one event let the newly-mounted dialog's outside-pointerdown detection see that very click and immediately close itself again — a silent no-op with no error and nothing in the engine log.
- Deferring the second dialog's open by one tick (`setTimeout(..., 0)`) lets the first dialog's close settle before the second mounts, avoiding the race.
- Verified the build endpoint itself (`POST /api/v1/build/run`) was never at fault: a direct API call with the same repo/branch clones + compiles successfully every time. This was purely a UI handoff bug.

## Test plan
- [x] `npm run typecheck` (root) — clean
- [x] `npm test` (root) — 3606 passed, 0 failed
- [x] New `CustomBuildDialog.test.tsx`: verified it fails against the old synchronous handler and passes against the fix (confirms the regression guard actually discriminates)
- [x] Manually deployed the fix locally and drove the real "Add via git repo" flow end to end via the daemon API and browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)