### PR TITLE
fix(desktop): version lockstep with turbollm + emit update manifests

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -55,13 +55,62 @@ jobs:
         run: npm ci
         working-directory: wrapper
 
+      # The Electron app's own version is what electron-updater compares against
+      # latest.yml. If wrapper/ drifts behind turbollm/ (it sat three minors
+      # behind for months) the desktop app believes it is ahead of every
+      # published release and never updates. Fail the build instead.
+      - name: Assert wrapper/turbollm version lockstep
+        shell: bash
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const read = p => JSON.parse(fs.readFileSync(p, 'utf8')).version;
+            const daemon = read('turbollm/package.json');
+            const wrapper = read('wrapper/package.json');
+            if (daemon !== wrapper) {
+              console.error('Version mismatch: turbollm/package.json is ' + daemon + ' but wrapper/package.json is ' + wrapper + '. They must be identical — the desktop app version is what electron-updater compares against latest.yml.');
+              process.exit(1);
+            }
+            console.log('Version lockstep OK: ' + daemon);
+          "
+
       - name: Package installer
         run: npm run package
         working-directory: wrapper
+
+      # electron-builder only emits update manifests when a publish provider is
+      # configured. If that config is ever dropped the installers still build
+      # fine and auto-update silently dies — so assert the manifests exist.
+      - name: Assert update manifests were generated
+        shell: bash
+        working-directory: wrapper
+        run: |
+          shopt -s nullglob
+          manifests=(dist/latest*.yml)
+          if [ ${#manifests[@]} -eq 0 ]; then
+            echo "No dist/latest*.yml produced — electron-updater cannot work without it. Check the publish: block in electron-builder.config.cjs." >&2
+            ls -la dist || true
+            exit 1
+          fi
+          printf 'update manifest: %s\n' "${manifests[@]}"
 
       - name: Upload installer to the release
         shell: bash
         working-directory: wrapper
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" ${{ matrix.artifact_glob }} --clobber
+        run: |
+          shopt -s nullglob
+          # Fixed installer names (TurboLLM-Setup-x64.exe / TurboLLM-arm64.dmg /
+          # TurboLLM-x86_64.AppImage) must keep uploading exactly as before —
+          # /download links releases/latest/download/<fixed-name>.
+          installers=(${{ matrix.artifact_glob }})
+          if [ ${#installers[@]} -eq 0 ]; then
+            echo "No installer matched ${{ matrix.artifact_glob }}" >&2
+            exit 1
+          fi
+          # Update manifests + differential-download blockmaps for
+          # electron-updater. Blockmaps do not exist for every target (AppImage
+          # has none), hence nullglob rather than a hard requirement.
+          manifests=(dist/latest*.yml dist/*.blockmap)
+          gh release upload "${{ github.event.release.tag_name }}" "${installers[@]}" "${manifests[@]}" --clobber

--- a/wrapper/electron-builder.config.cjs
+++ b/wrapper/electron-builder.config.cjs
@@ -22,11 +22,22 @@ module.exports = {
     output: 'dist',
     buildResources: 'build',
   },
-  // Allowlist, not default include-everything: wrapper/dist (build output),
-  // wrapper/build (icon source, build-time only) and wrapper/node_modules
-  // (empty of runtime deps — main.js uses only Electron/Node builtins) must
-  // NOT end up inside the packaged app.
-  files: ['main.js', 'package.json'],
+  // Allowlist, not default include-everything: wrapper/dist (build output) and
+  // wrapper/build (icon source, build-time only) must NOT end up inside the
+  // packaged app.
+  //
+  // node_modules IS shipped now: `electron-updater` is a real runtime
+  // dependency of main.js (auto-update), so it has to exist inside the asar.
+  // electron-builder resolves the *production* dependency tree itself, so the
+  // devDependencies (electron, electron-builder) are still excluded — only the
+  // ~16 packages under `electron-updater` come along.
+  files: ['main.js', 'package.json', 'node_modules/**/*'],
+  // Emit latest.yml / latest-linux.yml / latest-mac.yml + .blockmap files
+  // alongside the installers. Without a publish provider electron-builder
+  // generates no update manifests at all, and electron-updater cannot work.
+  // Nothing is auto-published from here — desktop-release.yml uploads the
+  // artifacts onto the already-created GitHub release with `gh release upload`.
+  publish: [{ provider: 'github', owner: 'mohitsoni48', repo: 'TurboLLM' }],
   extraResources: [
     { from: join(TURBOLLM_ROOT, 'dist'), to: 'daemon/dist' },
     { from: join(TURBOLLM_ROOT, 'bin'), to: 'daemon/bin' },

--- a/wrapper/package-lock.json
+++ b/wrapper/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "turbollm-desktop",
-  "version": "1.9.7",
+  "version": "1.12.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turbollm-desktop",
-      "version": "1.9.7",
+      "version": "1.12.7",
       "license": "FSL-1.1-ALv2",
+      "dependencies": {
+        "electron-updater": "^6.6.2"
+      },
       "devDependencies": {
         "electron": "43.2.0",
         "electron-builder": "^26.0.12"
@@ -879,7 +882,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -1035,7 +1037,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1271,7 +1272,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1580,6 +1580,34 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-winstaller": {
@@ -1984,7 +2012,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2157,7 +2184,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2383,7 +2409,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
       "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2441,7 +2466,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2464,7 +2488,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -2472,6 +2495,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -2620,7 +2656,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -3172,7 +3207,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -3424,6 +3458,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3514,7 +3554,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/wrapper/package.json
+++ b/wrapper/package.json
@@ -1,13 +1,16 @@
 {
   "name": "turbollm-desktop",
-  "version": "1.9.7",
+  "version": "1.12.7",
   "description": "TurboLLM Desktop — native window wrapper for the TurboLLM daemon",
   "main": "main.js",
   "license": "FSL-1.1-ALv2",
   "scripts": {
     "start": "electron .",
     "prepare-daemon": "node prepare-daemon.js",
-    "package": "npm run prepare-daemon && electron-builder --config electron-builder.config.cjs"
+    "package": "npm run prepare-daemon && electron-builder --config electron-builder.config.cjs --publish never"
+  },
+  "dependencies": {
+    "electron-updater": "^6.6.2"
   },
   "devDependencies": {
     "electron": "43.2.0",


### PR DESCRIPTION
PR 2 of the release-automation / auto-update sequence (`docs/specs/29`, Part B.2 items 1-3). Infrastructure only — **no updater calls are wired into `main.js` here**; that is PR 3.

## Why

`wrapper/package.json` was at **1.9.7** while npm/`turbollm/package.json` is at **1.12.7** — three minors of drift. That version string is exactly what electron-updater compares against `latest.yml`, so the desktop app would have believed it was *ahead* of every published release and never updated. On top of that, no `latest*.yml` or `.blockmap` was ever generated or uploaded, so electron-updater had nothing to read even in principle.

## What changed

| File | Change |
|---|---|
| `wrapper/package.json` | version `1.9.7` -> `1.12.7`; `electron-updater` added as a **runtime** dependency; `--publish never` on the package script |
| `wrapper/package-lock.json` | regenerated (`npm install --package-lock-only`) — 16 new production packages under `electron-updater` |
| `wrapper/electron-builder.config.cjs` | `publish: [{ provider: 'github', owner: 'mohitsoni48', repo: 'TurboLLM' }]`; `node_modules/**/*` added to the `files` allowlist |
| `.github/workflows/desktop-release.yml` | version-lockstep assertion before packaging; manifest-exists assertion after packaging; upload glob widened |

### On shipping `node_modules`

`electron-updater` is required at runtime from inside the packaged app, so it has to exist in the asar. The `files` allowlist previously excluded `node_modules` entirely (its comment said the wrapper had no runtime deps — true until now). Adding `node_modules/**/*` is the simplest correct option: electron-builder resolves the **production** dependency tree itself, so `electron` and `electron-builder` are still filtered out and only those 16 small packages come along. No bundler needed.

### On `--publish never`

The `publish:` block exists purely so electron-builder *generates* the update manifests. Nothing is auto-published: CI still uploads with `gh release upload`, and `--publish never` guarantees electron-builder does not try to push to GitHub itself (the packaging step has no `GH_TOKEN`). The new manifest assertion turns a silently-missing `latest.yml` into a red build rather than auto-update quietly dying months later.

### Fixed installer names are untouched

`/download` links `releases/latest/download/<fixed-name>`, so `TurboLLM-Setup-x64.exe`, `TurboLLM-arm64.dmg` and `TurboLLM-x86_64.AppImage` still upload exactly as before. The manifests and blockmaps are added alongside them, under `nullglob` so a target with no blockmap (AppImage) does not break the upload.

## Verification

- Lockstep assertion passes on this branch (`Version lockstep OK: 1.12.7`) and exits 1 on a simulated mismatch.
- `electron-builder.config.cjs` loads and evaluates; `files` and `publish` resolve as intended.
- Workflow YAML parses; step order is `... -> Assert lockstep -> Package installer -> Assert manifests -> Upload`.
- Upload shell logic exercised against a fake `dist/` (installer + manifest + blockmap present; and the empty-manifest case correctly fails).
- `wrapper/package-lock.json` is in sync with `package.json` (root deps match, lock version bumped to 1.12.7).
- No `turbollm/` source changed, so daemon typecheck is unaffected.

The end-to-end proof (a real `latest.yml` appearing on a release) can only come from an actual release run — which is why the manifest assertion is a hard failure rather than a warning.