### PR TITLE
feat(update): apply app updates in-app, with a button where the version is

### DIFF
--- a/turbollm/package.json
+++ b/turbollm/package.json
@@ -42,7 +42,7 @@
     "typecheck": "tsc --noEmit",
     "test": "tsx --test \"src/**/*.test.ts\" \"web/src/lib/argv.test.ts\" \"web/src/lib/engine-groups.test.ts\" \"web/src/lib/personas.test.ts\" \"web/src/lib/tool-explain.test.ts\" \"web/src/lib/vram.test.ts\"",
     "build:web": "cd web && npm ci && npm run build",
-    "build": "npm run typecheck && tsup && node -e \"const fs=require('fs'),p='dist/cli.js',c=fs.readFileSync(p,'utf8');fs.writeFileSync(p,c.replaceAll('from \\\"sqlite\\\"','from \\\"node:sqlite\\\"'))\" && node -e \"require('fs').cpSync('src/webdist','dist/webdist',{recursive:true,force:true})\" && node -e \"require('fs').cpSync('src/util/android-preload.cjs','dist/android-preload.cjs')\" && node -e \"require('fs').writeFileSync('dist/package.json','{\\\"type\\\":\\\"module\\\"}\\n')\"",
+    "build": "npm run typecheck && tsup && node -e \"const fs=require('fs'),p='dist/cli.js',c=fs.readFileSync(p,'utf8');fs.writeFileSync(p,c.replaceAll('from \\\"sqlite\\\"','from \\\"node:sqlite\\\"'))\" && node -e \"require('fs').cpSync('src/webdist','dist/webdist',{recursive:true,force:true})\" && node -e \"require('fs').cpSync('src/util/android-preload.cjs','dist/android-preload.cjs')\" && node -e \"require('fs').cpSync('src/update-helper.mjs','dist/update-helper.mjs')\" && node -e \"require('fs').writeFileSync('dist/package.json','{\\\"type\\\":\\\"module\\\"}\\n')\"",
     "prepublishOnly": "npm run build:web && npm run build",
     "prepare": "patch-package"
   },

--- a/turbollm/src/api/app-update-routes.test.ts
+++ b/turbollm/src/api/app-update-routes.test.ts
@@ -1,0 +1,173 @@
+// Route-level tests for the app self-update endpoints (spec 29 B.1/B.4), on a real Hono
+// app with a minimal Deps double — the same "real app, minimal Deps" discipline as
+// keys-network.test.ts, because what is under test here is the REFUSAL logic, and a refusal
+// only exists at the route.
+//
+// The happy path is deliberately absent: a successful POST spawns a detached process and
+// then exits the daemon. Asserting that would mean either killing the test runner or
+// mocking away the entire mechanism, and the machine running this suite may be running the
+// founder's own TurboLLM with live Code sessions in it. What IS asserted is everything that
+// must happen BEFORE the point of no return — because a wrongly-permitted update is the
+// failure that destroys work, and a wrongly-refused one merely annoys.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { Hono } from 'hono'
+import { registerApi } from './routes'
+import type { Deps } from '../deps'
+import { AppUpdateProgressState } from '../app-update-apply'
+
+interface Doubles {
+  /** Downloads the manager reports as live. */
+  downloads?: { status: string }[]
+  buildActive?: boolean
+  provisionActive?: boolean
+  codeActive?: boolean
+  managerState?: string
+  /** The app-update checker's cached answer; undefined = no checker wired. */
+  update?: { installed: string; latest: string | null; hasUpdate: boolean; checkedAt: string; comparable: boolean }
+  policy?: string
+  dismissedVersion?: string
+  /** Omit to assert the "not restartable" 501. */
+  restartable?: boolean
+}
+
+function fakeApp(o: Doubles = {}) {
+  const cfg = {
+    daemon: { lanBind: false, requireApiKey: false, port: 6996 },
+    apiKeys: [],
+    appUpdate: { policy: o.policy ?? 'notify', dismissedVersion: o.dismissedVersion ?? '' },
+  }
+  const restarts: { exitOnly?: boolean }[] = []
+  const app = new Hono()
+  const d = {
+    version: '1.12.7',
+    store: {
+      dir: () => '/tmp/turbollm-test',
+      snapshot: () => cfg,
+      update: (fn: (c: typeof cfg) => void) => fn(cfg),
+    },
+    manager: { status: () => ({ state: o.managerState ?? 'stopped', model: null }) },
+    downloads: { list: () => o.downloads ?? [] },
+    build: { isActive: () => o.buildActive ?? false },
+    provision: { get: () => ({ active: o.provisionActive ?? false }) },
+    codeRuns: { anyActive: () => o.codeActive ?? false },
+    appUpdates: o.update ? { get: () => o.update, isStale: () => false, check: async () => o.update } : undefined,
+    appUpdateProgress: new AppUpdateProgressState(),
+    ...(o.restartable === false ? {} : { requestRestart: (opts?: { exitOnly?: boolean }) => restarts.push(opts ?? {}) }),
+  } as unknown as Deps
+  registerApi(app, d)
+  return { app, cfg, restarts, d }
+}
+
+const AVAILABLE = { installed: '1.12.7', latest: '1.12.8', hasUpdate: true, checkedAt: '2026-09-09T00:00:00.000Z', comparable: true }
+
+// ─── GET /api/v1/app/update ───────────────────────────────────────────────────
+
+test('GET /api/v1/app/update: reports the install method and policy alongside the version check', async () => {
+  const { app } = fakeApp({ update: AVAILABLE })
+  const body = (await (await app.request('/api/v1/app/update')).json()) as Record<string, unknown>
+  assert.equal(body.latest, '1.12.8')
+  assert.equal(body.policy, 'notify')
+  assert.ok(typeof body.method === 'string', 'the UI needs the method to know what to offer')
+  assert.ok(typeof body.command === 'string' && (body.command as string).length > 0, 'never a dead end')
+})
+
+test("GET /api/v1/app/update: policy 'off' reports no update at all", async () => {
+  // Suppressed by reporting hasUpdate:false rather than by omitting a field, so the UI
+  // needs no second rule for the off case — the pill, the toast and the Settings block all
+  // already key off hasUpdate.
+  const { app } = fakeApp({ update: AVAILABLE, policy: 'off' })
+  const body = (await (await app.request('/api/v1/app/update')).json()) as Record<string, unknown>
+  assert.equal(body.hasUpdate, false)
+  assert.equal(body.policy, 'off')
+})
+
+test('GET /api/v1/app/update: an unrecognised stored policy reads as notify, never as a broken value', async () => {
+  const { app } = fakeApp({ update: AVAILABLE, policy: 'sometimes-maybe' })
+  const body = (await (await app.request('/api/v1/app/update')).json()) as Record<string, unknown>
+  assert.equal(body.policy, 'notify')
+})
+
+// ─── POST /api/v1/app/update (the refusals) ───────────────────────────────────
+
+test('POST /api/v1/app/update: 409 when there is no newer version to install', async () => {
+  const { app } = fakeApp({ update: { ...AVAILABLE, hasUpdate: false } })
+  const res = await app.request('/api/v1/app/update', { method: 'POST' })
+  assert.equal(res.status, 409)
+  const body = (await res.json()) as { error?: { code?: string } }
+  // The install-method refusal can legitimately win first in whatever environment the
+  // suite runs in; either way it must be a 409 with a reason, never a started update.
+  assert.ok(['no_update', 'update_not_supported'].includes(body.error?.code ?? ''))
+})
+
+test('POST /api/v1/app/update: 501 rather than a silent no-op when the daemon cannot restart', async () => {
+  const { app } = fakeApp({ update: AVAILABLE, restartable: false })
+  const res = await app.request('/api/v1/app/update', { method: 'POST' })
+  assert.equal(res.status, 501)
+})
+
+test('POST /api/v1/app/update: an in-flight download blocks, and nothing is restarted', async () => {
+  // The standing rule (ADR-240): a hard kill mid-write can CORRUPT a download rather than
+  // pause it. This is the route-level half of it.
+  const { app, restarts } = fakeApp({ update: AVAILABLE, downloads: [{ status: 'downloading' }] })
+  const res = await app.request('/api/v1/app/update', { method: 'POST' })
+  assert.equal(res.status, 409)
+  assert.equal(restarts.length, 0, 'a blocked update must never have touched the daemon')
+})
+
+test('POST /api/v1/app/update: a running Code session blocks', async () => {
+  const { app, restarts } = fakeApp({ update: AVAILABLE, codeActive: true })
+  const res = await app.request('/api/v1/app/update', { method: 'POST' })
+  assert.equal(res.status, 409)
+  assert.equal(restarts.length, 0)
+})
+
+test('POST /api/v1/app/update: an engine build blocks', async () => {
+  const { app, restarts } = fakeApp({ update: AVAILABLE, buildActive: true })
+  assert.equal((await app.request('/api/v1/app/update', { method: 'POST' })).status, 409)
+  assert.equal(restarts.length, 0)
+})
+
+test('POST /api/v1/app/update: a model mid-load blocks', async () => {
+  const { app, restarts } = fakeApp({ update: AVAILABLE, managerState: 'starting' })
+  assert.equal((await app.request('/api/v1/app/update', { method: 'POST' })).status, 409)
+  assert.equal(restarts.length, 0)
+})
+
+test('POST /api/v1/app/update: a second request while one is running is refused', async () => {
+  const { app, d } = fakeApp({ update: AVAILABLE })
+  d.appUpdateProgress!.set('installing', { target: '1.12.8' })
+  const res = await app.request('/api/v1/app/update', { method: 'POST' })
+  assert.equal(res.status, 409)
+})
+
+// ─── progress / policy / dismiss ──────────────────────────────────────────────
+
+test('GET /api/v1/app/update/progress: idle by default, and reflects a set state', async () => {
+  const { app, d } = fakeApp()
+  let body = (await (await app.request('/api/v1/app/update/progress')).json()) as { state: string }
+  assert.equal(body.state, 'idle')
+  d.appUpdateProgress!.set('restarting', { target: '1.12.8' })
+  body = (await (await app.request('/api/v1/app/update/progress')).json()) as { state: string }
+  assert.equal(body.state, 'restarting')
+})
+
+test('PUT /api/v1/app/update-policy: persists a valid policy and rejects anything else', async () => {
+  const { app, cfg } = fakeApp()
+  assert.equal((await app.request('/api/v1/app/update-policy', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ policy: 'auto' }) })).status, 200)
+  assert.equal(cfg.appUpdate.policy, 'auto')
+
+  const bad = await app.request('/api/v1/app/update-policy', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ policy: 'yes please' }) })
+  assert.equal(bad.status, 400)
+  assert.equal(cfg.appUpdate.policy, 'auto', 'a rejected patch must not have written anything')
+})
+
+test('POST /api/v1/app/update/dismiss: remembers the version so the toast never nags twice', async () => {
+  const { app, cfg } = fakeApp({ update: AVAILABLE })
+  const res = await app.request('/api/v1/app/update/dismiss', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ version: '1.12.8' }) })
+  assert.equal(res.status, 200)
+  assert.equal(cfg.appUpdate.dismissedVersion, '1.12.8')
+  const body = (await (await app.request('/api/v1/app/update')).json()) as { dismissedVersion?: string }
+  assert.equal(body.dismissedVersion, '1.12.8')
+})

--- a/turbollm/src/api/routes.ts
+++ b/turbollm/src/api/routes.ts
@@ -36,6 +36,9 @@ import {
   tagFromManagedBinPath,
   latestTagForInstalled,
 } from '../engines/update'
+import { checkApplyBlockers, currentRunState, detectInstall, spawnUpdateHelper } from '../app-update-apply'
+import { emit } from '../telemetry/runtime/typed-emit'
+import { appUpdateClicked } from '../telemetry/events/app-update'
 import type { BackendId } from '../engines/download'
 import { ensureMlxEnv } from '../engines/mlx'
 import { ensureRapidMlxEnv } from '../engines/rapid-mlx'
@@ -1241,14 +1244,134 @@ export function registerApi(app: Hono, d: Deps): void {
   // npm does the upgrade (`npm i -g turbollm`); we never auto-update the app. Offline-first:
   // serves the cached answer and NEVER fabricates a "latest" it didn't fetch. Non-blocking —
   // a stale (or `?refresh=1`) cache kicks a background re-check and returns the cache now.
-  app.get('/api/v1/app/update', (c) => {
+  //
+  // Since spec 29 B.1 this ALSO carries how the daemon is installed and therefore what the
+  // UI may offer: `canSelfUpdate` gates the "Update & restart" button, and `command` is the
+  // copyable fallback that keeps the dialog from being a dead end on Docker/source/desktop.
+  // Folded into the existing endpoint rather than added beside it deliberately — the pill,
+  // the dialog and the Settings section all render off ONE fetch, so they cannot disagree
+  // about whether an update exists or what to do about it (spec 29 B.3's "one
+  // implementation, two mounts", held on the server side too).
+  app.get('/api/v1/app/update', async (c) => {
+    const install = await detectInstall()
+    const cfg = d.store.snapshot().appUpdate
+    const extra = {
+      method: install.method,
+      canSelfUpdate: install.canSelfUpdate,
+      command: install.command,
+      note: install.note,
+      policy: normalizeUpdatePolicy(cfg.policy),
+      dismissedVersion: cfg.dismissedVersion,
+    }
     const fallback = { installed: d.version, latest: null, hasUpdate: false, checkedAt: new Date().toISOString(), comparable: false }
-    if (!d.appUpdates) return c.json(fallback)
+    if (!d.appUpdates) return c.json({ ...fallback, ...extra })
     const refresh = c.req.query('refresh') === '1'
     if (refresh || d.appUpdates.isStale()) {
       void d.appUpdates.check(AbortSignal.timeout(10_000)).catch(() => {})
     }
-    return c.json(d.appUpdates.get() ?? fallback)
+    // 'off' suppresses the whole surface (spec 29 B.4) — reported as "no update" rather
+    // than by hiding the field, so the UI needs no second rule for it.
+    const status = d.appUpdates.get() ?? fallback
+    const suppressed = extra.policy === 'off'
+    return c.json({ ...status, ...(suppressed ? { hasUpdate: false } : {}), ...extra })
+  })
+
+  // ---- app self-update: apply (spec 29 B.1) ----
+  // Everything before this endpoint was informational. This is the one that actually acts:
+  // it hands the update to a DETACHED helper and then exits without respawning, because a
+  // running daemon cannot have its own package files overwritten (Windows locks
+  // node_modules outright; every platform risks a half-written install). See
+  // app-update-apply.ts and update-helper.mjs for the mechanism.
+  //
+  // Refusals are loud and specific. Half-doing an update is the worst outcome available
+  // here, so anything in flight that a restart would destroy — a download mid-write, an
+  // engine build, a Code session, a model load — blocks with a sentence saying what and why
+  // rather than being silently killed.
+  app.post('/api/v1/app/update', async (c) => {
+    if (!d.appUpdateProgress) return err(c, 501, 'not_supported', 'Self-update is not available in this run mode.')
+    if (!d.requestRestart) return err(c, 501, 'not_supported', 'Self-update needs a restartable daemon, which this run mode is not.')
+
+    const install = await detectInstall()
+    if (!install.canSelfUpdate) {
+      return err(c, 409, 'update_not_supported', install.note || 'This TurboLLM install cannot update itself.')
+    }
+
+    const status = d.appUpdates?.get()
+    if (!status?.hasUpdate || !status.latest) {
+      return err(c, 409, 'no_update', 'There is no newer TurboLLM to install.')
+    }
+
+    if (d.appUpdateProgress.isRunning()) {
+      return err(c, 409, 'update_in_progress', 'An update is already running.')
+    }
+
+    const blocked = checkApplyBlockers({
+      // The standing rule (ADR-240): a hard kill mid-write can CORRUPT a download, not
+      // merely pause it, so this is checked before every restart — not just the first.
+      downloadActive: d.downloads.list().some((x) => x.status === 'downloading' || x.status === 'queued'),
+      engineBuildActive: d.build.isActive(),
+      engineProvisionActive: d.provision.get().active,
+      codeSessionActive: d.codeRuns?.anyActive() ?? false,
+      modelLoading: d.manager.status().state === 'starting',
+    })
+    if (blocked) return err(c, 409, 'update_blocked', blocked)
+
+    const run = currentRunState(d.version)
+    const spawned = spawnUpdateHelper({
+      dataDir: d.store.dir(),
+      method: install.method,
+      from: d.version,
+      to: status.latest,
+      run,
+    })
+    if (!spawned) {
+      d.appUpdateProgress.set('failed', { error: 'Could not start the update helper.', method: install.method })
+      return err(c, 500, 'update_failed', 'TurboLLM could not start its updater. Update from your terminal instead.')
+    }
+
+    d.appUpdateProgress.set('installing', { from: d.version, target: status.latest, method: install.method, error: null })
+    if (d.telemetry) emit(d.telemetry, appUpdateClicked, { method: install.method })
+
+    // Same shape as /daemon/restart: schedule past the response flush so this 202 reaches
+    // the browser before the listen socket goes away. `exitOnly` is the difference — the
+    // helper, not this process, brings the daemon back.
+    const restart = d.requestRestart
+    setTimeout(() => restart({ exitOnly: true }), 300).unref()
+    return c.json({ ok: true, updating: true, from: d.version, to: status.latest, method: install.method }, 202)
+  })
+
+  // Poll the apply. `done`/`failed` are reported by the RESTARTED daemon out of the result
+  // file the helper wrote — the process that ran the update is gone by then — so the UI's
+  // reconnect-and-confirm step reads a real outcome, not an inference from the version.
+  app.get('/api/v1/app/update/progress', (c) => {
+    if (!d.appUpdateProgress) return c.json({ state: 'idle', target: null, from: null, method: null, error: null, at: new Date().toISOString() })
+    return c.json(d.appUpdateProgress.get())
+  })
+
+  // App-level auto-update policy (spec 29 B.4) — the same off|notify|auto vocabulary as the
+  // per-engine control below, on purpose: one word must not mean two things in one product.
+  app.put('/api/v1/app/update-policy', async (c) => {
+    const b = await body<{ policy?: string }>(c)
+    if (b.policy !== 'off' && b.policy !== 'notify' && b.policy !== 'auto') {
+      return err(c, 400, 'invalid_config_value', 'policy must be off, notify, or auto.')
+    }
+    const policy = b.policy
+    d.store.update((cfg) => {
+      cfg.appUpdate.policy = policy
+    })
+    return c.json({ policy })
+  })
+
+  // "Don't show me this one again." Remembers the exact version whose toast was dismissed,
+  // daemon-side rather than per-browser — the same install is opened from several browsers
+  // and the desktop wrapper, and a per-browser memory would re-nag on every one of them.
+  app.post('/api/v1/app/update/dismiss', async (c) => {
+    const b = await body<{ version?: string }>(c)
+    const version = String(b.version ?? '').trim().slice(0, 64)
+    d.store.update((cfg) => {
+      cfg.appUpdate.dismissedVersion = version
+    })
+    return c.json({ dismissedVersion: version })
   })
 
   // Set an engine's per-engine auto-update policy (off | notify | auto). Default notify.

--- a/turbollm/src/app-update-apply.test.ts
+++ b/turbollm/src/app-update-apply.test.ts
@@ -1,0 +1,251 @@
+// Install-method detection, the apply pre-checks, and the cross-restart result handshake
+// (spec 29 B.1).
+//
+// These are unit tests over PURE functions on purpose, and that purpose is not stylistic:
+// there is no way to exercise six install methods by running the suite, because the suite
+// runs in exactly one of them. A misclassification is the most damaging bug this feature
+// can have — classifying a Docker container or a source checkout as a global npm install
+// would run `npm i -g turbollm@latest`, which "succeeds" while updating a completely
+// different copy of TurboLLM than the one the user is running — so every case gets an
+// explicit test rather than being covered by whichever environment CI happens to be.
+//
+// Deliberately NOT tested here: an end-to-end apply. That path kills and relaunches a real
+// daemon, and the machine this suite runs on may be running the user's own TurboLLM with
+// live Code sessions in it. The mechanism is verified by testing the decisions it is built
+// out of; the real end-to-end run is a manual step against a throwaway global install
+// (spec 29's test plan), with `~/.turbollm` backed up first.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  INSTALL_METHODS,
+  checkApplyBlockers,
+  classifyInstall,
+  classifyUpdateFailure,
+  progressFromResult,
+  AppUpdateProgressState,
+  type InstallSignals,
+} from './app-update-apply'
+import { APP_INSTALL_METHODS } from './telemetry/events/app-update'
+
+/** A plausible-but-unclassifiable baseline, so each test states ONLY the signal it is
+ *  about. Defaults are the "none of the special cases apply" answer. */
+function signals(over: Partial<InstallSignals> = {}): InstallSignals {
+  return {
+    platform: 'linux',
+    entry: '/opt/somewhere/turbollm/bin/turbollm.mjs',
+    desktopEnv: false,
+    inContainer: false,
+    npmGlobalRoot: null,
+    sourceCheckout: false,
+    ...over,
+  }
+}
+
+test('classifyInstall: a global npm install offers the self-update', () => {
+  const info = classifyInstall(
+    signals({
+      entry: '/usr/lib/node_modules/turbollm/bin/turbollm.mjs',
+      npmGlobalRoot: '/usr/lib/node_modules',
+    }),
+  )
+  assert.equal(info.method, 'npm_global')
+  assert.equal(info.canSelfUpdate, true)
+  assert.equal(info.command, 'npm i -g turbollm@latest')
+})
+
+test('classifyInstall: global detection is case-insensitive and separator-agnostic on Windows', () => {
+  const info = classifyInstall(
+    signals({
+      platform: 'win32',
+      entry: 'C:\\Users\\Owner\\AppData\\Roaming\\npm\\node_modules\\turbollm\\bin\\turbollm.mjs',
+      npmGlobalRoot: 'C:\\Users\\owner\\AppData\\Roaming\\npm\\node_modules',
+    }),
+  )
+  assert.equal(info.method, 'npm_global')
+})
+
+test('classifyInstall: a sibling directory that merely shares a prefix is NOT the global root', () => {
+  // The whole-segment check. Without it `/usr/lib/node_modules-old/...` reads as being
+  // under `/usr/lib/node_modules`, and a stale second copy gets "updated" instead.
+  const info = classifyInstall(
+    signals({
+      entry: '/usr/lib/node_modules-old/turbollm/bin/turbollm.mjs',
+      npmGlobalRoot: '/usr/lib/node_modules',
+    }),
+  )
+  assert.notEqual(info.method, 'npm_global')
+})
+
+test('classifyInstall: an npx cache run relaunches at @latest rather than installing', () => {
+  const info = classifyInstall(signals({ entry: '/home/u/.npm/_npx/8a3f/node_modules/turbollm/bin/turbollm.mjs' }))
+  assert.equal(info.method, 'npx')
+  assert.equal(info.canSelfUpdate, true)
+  assert.equal(info.command, 'npx turbollm@latest')
+})
+
+test('classifyInstall: the packaged desktop daemon is never treated as an npm install', () => {
+  // The dangerous case. The packaged daemon lives inside a node_modules-shaped tree of its
+  // own, so without the desktop check winning FIRST it can look like an npm install and
+  // `npm i -g` would update a different copy entirely, leaving the desktop app unchanged.
+  const info = classifyInstall(
+    signals({
+      entry: '/Applications/TurboLLM.app/Contents/Resources/daemon/bin/turbollm.mjs',
+      npmGlobalRoot: '/Applications',
+    }),
+  )
+  assert.equal(info.method, 'electron')
+  assert.equal(info.canSelfUpdate, false)
+})
+
+test('classifyInstall: the desktop env var alone is enough (wrapper-set, path-independent)', () => {
+  const info = classifyInstall(signals({ desktopEnv: true, entry: '/anything/at/all/cli.js' }))
+  assert.equal(info.method, 'electron')
+})
+
+test('classifyInstall: a container refuses and shows a rebuild command', () => {
+  const info = classifyInstall(signals({ inContainer: true }))
+  assert.equal(info.method, 'docker')
+  assert.equal(info.canSelfUpdate, false)
+  assert.ok(info.command.length > 0, 'must still offer a command — never a dead end')
+})
+
+test('classifyInstall: Android refuses and beats every other signal', () => {
+  // Even with signals that would otherwise read as a global npm install.
+  const info = classifyInstall(
+    signals({
+      platform: 'android',
+      inContainer: true,
+      entry: '/data/data/dev.turbollm/files/node_modules/turbollm/bin/turbollm.mjs',
+      npmGlobalRoot: '/data/data/dev.turbollm/files/node_modules',
+    }),
+  )
+  assert.equal(info.method, 'android')
+  assert.equal(info.canSelfUpdate, false)
+})
+
+test('classifyInstall: a source checkout refuses and says to pull', () => {
+  const info = classifyInstall(signals({ sourceCheckout: true, entry: '/home/u/code/TurboLLM/turbollm/src/cli.ts' }))
+  assert.equal(info.method, 'source')
+  assert.equal(info.canSelfUpdate, false)
+  assert.equal(info.command, 'git pull')
+})
+
+test('classifyInstall: an unrecognised install refuses honestly, but still offers a command', () => {
+  const info = classifyInstall(signals())
+  assert.equal(info.method, 'unknown')
+  assert.equal(info.canSelfUpdate, false)
+  assert.ok(info.command.length > 0)
+  assert.ok(info.note.length > 0)
+})
+
+test('every install method is covered by INSTALL_METHODS', () => {
+  // Guards the telemetry enum and the UI's method union against a method being added to
+  // the classifier and nowhere else.
+  const produced = new Set([
+    classifyInstall(signals({ entry: '/n/turbollm/x', npmGlobalRoot: '/n' })).method,
+    classifyInstall(signals({ entry: '/a/_npx/b/c' })).method,
+    classifyInstall(signals({ desktopEnv: true })).method,
+    classifyInstall(signals({ inContainer: true })).method,
+    classifyInstall(signals({ platform: 'android' })).method,
+    classifyInstall(signals({ sourceCheckout: true })).method,
+    classifyInstall(signals()).method,
+  ])
+  assert.deepEqual([...produced].sort(), [...INSTALL_METHODS].sort())
+})
+
+test('the telemetry install-method enum matches the classifier exactly', () => {
+  // events/app-update.ts writes this list out by hand rather than importing it, because
+  // importing app-update-apply.ts would drag node:child_process/node:fs into the
+  // telemetry Worker's bundle. This test is what closes the drift that copy creates.
+  assert.deepEqual([...APP_INSTALL_METHODS], [...INSTALL_METHODS])
+})
+
+// ─── pre-checks ───────────────────────────────────────────────────────────────
+
+const idle = {
+  modelLoading: false,
+  downloadActive: false,
+  codeSessionActive: false,
+  engineBuildActive: false,
+  engineProvisionActive: false,
+}
+
+test('checkApplyBlockers: an idle daemon may update', () => {
+  assert.equal(checkApplyBlockers(idle), null)
+})
+
+test('checkApplyBlockers: every in-flight activity blocks, with a reason naming it', () => {
+  for (const [key, word] of [
+    ['downloadActive', 'download'],
+    ['engineBuildActive', 'built'],
+    ['engineProvisionActive', 'installed'],
+    ['codeSessionActive', 'Code session'],
+    ['modelLoading', 'model'],
+  ] as const) {
+    const reason = checkApplyBlockers({ ...idle, [key]: true })
+    assert.ok(reason, `${key} must block`)
+    assert.match(reason, new RegExp(word, 'i'), `${key}'s reason must say what is blocking`)
+  }
+})
+
+test('checkApplyBlockers: a download outranks everything else', () => {
+  // The standing rule (ADR-240): a hard kill mid-write can corrupt a download rather than
+  // pause it, so when several things are in flight that is the one the user is told about.
+  const reason = checkApplyBlockers({ ...idle, downloadActive: true, codeSessionActive: true, modelLoading: true })
+  assert.match(String(reason), /download/i)
+})
+
+// ─── the cross-restart handshake ──────────────────────────────────────────────
+
+test('progressFromResult: a successful result becomes a done state', () => {
+  const p = progressFromResult(JSON.stringify({ ok: true, from: '1.12.7', to: '1.12.8', method: 'npm_global', at: '2026-09-09T00:00:00.000Z' }))
+  assert.equal(p?.state, 'done')
+  assert.equal(p?.target, '1.12.8')
+  assert.equal(p?.from, '1.12.7')
+  assert.equal(p?.method, 'npm_global')
+  assert.equal(p?.error, null)
+})
+
+test('progressFromResult: a failed result carries the reason through', () => {
+  const p = progressFromResult(JSON.stringify({ ok: false, from: '1.12.7', to: '1.12.8', method: 'npm_global', error: 'npm.cmd exited with code 1', at: 'x' }))
+  assert.equal(p?.state, 'failed')
+  assert.equal(p?.error, 'npm.cmd exited with code 1')
+})
+
+test('progressFromResult: garbage is null, never a fabricated outcome', () => {
+  // A truncated/corrupt file must read as "no update ran", not as a success — reporting a
+  // version bump that did not happen is worse than reporting nothing.
+  assert.equal(progressFromResult('not json'), null)
+  assert.equal(progressFromResult('{}'), null)
+  assert.equal(progressFromResult('{"ok":"yes"}'), null)
+})
+
+test('progressFromResult: an unrecognised method degrades to null rather than passing through', () => {
+  const p = progressFromResult(JSON.stringify({ ok: true, from: 'a', to: 'b', method: 'carrier-pigeon', at: 'x' }))
+  assert.equal(p?.state, 'done')
+  assert.equal(p?.method, null, 'telemetry enums are closed — an unknown value must not reach one')
+})
+
+test('classifyUpdateFailure: maps helper text into the closed telemetry vocabulary', () => {
+  assert.equal(classifyUpdateFailure('The running TurboLLM did not shut down in time, so the update was not applied.'), 'daemon_did_not_exit')
+  assert.equal(classifyUpdateFailure('npm.cmd exited with code 1'), 'install_failed')
+  assert.equal(classifyUpdateFailure('EPERM: operation not permitted'), 'install_failed')
+  assert.equal(classifyUpdateFailure('spawn npm ENOENT'), 'install_failed')
+  assert.equal(classifyUpdateFailure('something nobody predicted'), 'other')
+  assert.equal(classifyUpdateFailure(null), 'other')
+})
+
+test('AppUpdateProgressState: only the in-flight states count as running', () => {
+  const s = new AppUpdateProgressState()
+  assert.equal(s.get().state, 'idle')
+  assert.equal(s.isRunning(), false)
+  s.set('installing', { target: '1.12.8' })
+  assert.equal(s.isRunning(), true)
+  assert.equal(s.get().target, '1.12.8')
+  s.set('done')
+  assert.equal(s.isRunning(), false, 'a finished update must not block the next one')
+  // The target survives a transition that does not restate it — the dialog reads it after
+  // the restart to confirm which version it landed on.
+  assert.equal(s.get().target, '1.12.8')
+})

--- a/turbollm/src/app-update-apply.ts
+++ b/turbollm/src/app-update-apply.ts
@@ -1,0 +1,476 @@
+// Applying an app update, and knowing whether we're even allowed to try (spec 29 B.1).
+//
+// `app-update.ts` answers "is a newer TurboLLM published?". This module answers the two
+// questions that have to come next before a button can exist:
+//
+//   1. HOW is this daemon installed? A global npm install, an `npx` cache run, the
+//      packaged Electron desktop app, a Docker container, the Android app, or a source
+//      checkout. The correct action differs for every one of them, and a WRONG guess is
+//      worse than no button at all — `npm i -g turbollm@latest` inside a Docker container
+//      or against a source checkout does not update the thing the user is running, it
+//      installs a second copy somewhere else and leaves them convinced they upgraded.
+//   2. Is it SAFE to apply right now? An update restarts the daemon, so an in-flight
+//      model load, download, engine build or Code session must block it with a clear
+//      reason rather than being silently destroyed.
+//
+// Same shape as the rest of the update code: the DECISION is a pure, unit-tested function
+// over explicitly-passed signals (`classifyInstall`, `checkApplyBlockers`), and the I/O
+// that gathers those signals is a thin shell around it (`detectInstall`). That's what
+// makes install-method detection testable at all — none of the six cases can be
+// reproduced by running the test suite in the environment it happens to run in.
+
+import { execFile, spawn } from 'node:child_process'
+import { existsSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** How this daemon was installed. `unknown` is a real, expected answer (an embedding we
+ *  don't recognise) and is treated exactly like the refuse-to-self-update methods. */
+export type InstallMethod = 'npm_global' | 'npx' | 'electron' | 'docker' | 'android' | 'source' | 'unknown'
+
+/** Every install methods there is, in classification order. Exported so the telemetry
+ *  enum is derived from this list rather than being a second hand-maintained copy. */
+export const INSTALL_METHODS: readonly InstallMethod[] = [
+  'npm_global',
+  'npx',
+  'electron',
+  'docker',
+  'android',
+  'source',
+  'unknown',
+]
+
+/** The raw environment facts `classifyInstall` decides from. Passed in rather than read,
+ *  so a test can present any of the six installs without being one. */
+export interface InstallSignals {
+  /** `process.platform` — 'android' is its own install method (the Play Store app). */
+  platform: string
+  /** The entry script actually running (`process.argv[1]`), resolved. */
+  entry: string
+  /** The desktop wrapper sets `TURBOLLM_DESKTOP=1` when it spawns the daemon. The
+   *  primary desktop signal; `resources/daemon` in the path is the fallback for a
+   *  wrapper older than that env var. */
+  desktopEnv: boolean
+  /** True when a container marker was found (`/.dockerenv`, or 'docker'/'containerd'
+   *  in /proc/1/cgroup). */
+  inContainer: boolean
+  /** `npm root -g`, or null when it couldn't be resolved (no npm on PATH — itself a
+   *  strong hint this is not an npm install). */
+  npmGlobalRoot: string | null
+  /** A repo marker (`.git`, or the monorepo's own `turbollm/src`) sits above the entry
+   *  script — i.e. this is `tsx src/cli.ts` in a checkout, not an installed package. */
+  sourceCheckout: boolean
+}
+
+/** What the UI may offer for this install. `command` is ALWAYS a usable manual path, even
+ *  when `canSelfUpdate` is false — spec 29 B.3's "never a dead end" rule: a user on Docker
+ *  or a source checkout still gets told exactly what to run. */
+export interface InstallInfo {
+  method: InstallMethod
+  /** May the daemon apply this update itself (POST /api/v1/app/update)? */
+  canSelfUpdate: boolean
+  /** The command to run by hand, or '' when there is no command (desktop/Android, where
+   *  the update is a download or a store release rather than a shell line). */
+  command: string
+  /** One sentence for the dialog explaining what to do instead. '' when self-update is
+   *  offered and no explanation is needed. */
+  note: string
+}
+
+/** Pure: which install is this, and what may we offer for it?
+ *
+ *  Order matters and is most-specific-first. Android before container (the Android app is
+ *  not a Docker deployment even where a cgroup marker exists); desktop before npx/global
+ *  (the packaged daemon lives inside a `node_modules`-shaped tree of its own and would
+ *  otherwise be misread as an npm install — the single most damaging misclassification
+ *  here, since it would run `npm i -g` and update a completely different copy). */
+export function classifyInstall(s: InstallSignals): InstallInfo {
+  // Lower-cased and forward-slashed, so every path test below is one spelling rather
+  // than a Windows branch and a POSIX branch (and so a test can present either shape).
+  const entry = s.entry.toLowerCase().replace(/\\/g, '/')
+
+  if (s.platform === 'android') {
+    return {
+      method: 'android',
+      canSelfUpdate: false,
+      command: '',
+      note: 'TurboLLM for Android updates through the Play Store.',
+    }
+  }
+
+  if (s.desktopEnv || entry.includes('/resources/daemon/')) {
+    return {
+      method: 'electron',
+      canSelfUpdate: false,
+      command: '',
+      note: 'The TurboLLM desktop app downloads updates in the background and installs them when you quit.',
+    }
+  }
+
+  if (s.inContainer) {
+    return {
+      method: 'docker',
+      canSelfUpdate: false,
+      command: 'docker compose build --pull',
+      note: 'This TurboLLM runs in a container — rebuild the image to update it.',
+    }
+  }
+
+  // `npx turbollm` unpacks into npm's `_npx` cache. There is nothing persistent to
+  // upgrade: the fix is to re-run with `@latest`, which fetches a fresh copy.
+  if (entry.includes('/_npx/')) {
+    return { method: 'npx', canSelfUpdate: true, command: 'npx turbollm@latest', note: '' }
+  }
+
+  if (s.npmGlobalRoot && isUnder(s.entry, s.npmGlobalRoot, s.platform === 'win32')) {
+    return { method: 'npm_global', canSelfUpdate: true, command: 'npm i -g turbollm@latest', note: '' }
+  }
+
+  if (s.sourceCheckout) {
+    return {
+      method: 'source',
+      canSelfUpdate: false,
+      command: 'git pull',
+      note: 'This TurboLLM runs from a source checkout — pull and rebuild to update it.',
+    }
+  }
+
+  return {
+    method: 'unknown',
+    canSelfUpdate: false,
+    command: 'npm i -g turbollm@latest',
+    note: "TurboLLM couldn't tell how it was installed, so it won't update itself. Run the command above in the same place you installed it.",
+  }
+}
+
+/** Path containment, case-insensitively when asked (Windows). Compares whole segments (a
+ *  trailing separator is appended before the prefix test) so `/usr/lib/node_modules-old`
+ *  is not "under" `/usr/lib/node_modules`. Separators are normalised to `/` so a test can
+ *  present a Windows-shaped path on Linux and vice versa — the classifier is pure over its
+ *  signals, and "which OS is the test running on" is not one of them. */
+function isUnder(child: string, parent: string, ignoreCase: boolean): boolean {
+  const norm = (p: string) => {
+    const r = p.replace(/\\/g, '/').replace(/\/+$/, '') + '/'
+    return ignoreCase ? r.toLowerCase() : r
+  }
+  return norm(child).startsWith(norm(parent))
+}
+
+// ─── The I/O shell: gather the signals ────────────────────────────────────────
+
+/** Is this process inside a container? Best-effort and Linux-only by nature; any read
+ *  failure means "no marker found", never a throw. */
+function detectContainer(): boolean {
+  try {
+    if (existsSync('/.dockerenv')) return true
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const cgroup = readFileSync('/proc/1/cgroup', 'utf8')
+    if (/docker|containerd|kubepods|podman/.test(cgroup)) return true
+  } catch {
+    /* not Linux, or not readable — no marker */
+  }
+  return false
+}
+
+/** Does a repo marker sit at or above the entry script's directory? Walks up a bounded
+ *  number of levels (a checkout is always shallow relative to the entry file). */
+function detectSourceCheckout(entry: string): boolean {
+  let dir = dirname(entry)
+  for (let i = 0; i < 6; i++) {
+    try {
+      if (existsSync(join(dir, '.git'))) return true
+    } catch {
+      /* best-effort */
+    }
+    const up = dirname(dir)
+    if (up === dir) break
+    dir = up
+  }
+  return false
+}
+
+/** `npm root -g`, or null when npm isn't reachable. Cached for the process lifetime —
+ *  it cannot change without a restart, and spawning npm on every status poll would be
+ *  absurd. Never throws. */
+let npmRootCache: { value: string | null } | null = null
+export async function npmGlobalRoot(): Promise<string | null> {
+  if (npmRootCache) return npmRootCache.value
+  const value = await new Promise<string | null>((res) => {
+    const cmd = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    execFile(cmd, ['root', '-g'], { timeout: 10_000, windowsHide: true }, (e, stdout) => {
+      if (e) return res(null)
+      const out = String(stdout).trim()
+      res(out || null)
+    })
+  }).catch(() => null)
+  npmRootCache = { value }
+  return value
+}
+
+/** Reset the `npm root -g` memo. Tests only. */
+export function resetNpmRootCache(): void {
+  npmRootCache = null
+}
+
+/** Classify the running daemon. Async only because `npm root -g` is a subprocess; every
+ *  other signal is a cheap local read. Never throws. */
+export async function detectInstall(): Promise<InstallInfo> {
+  const entry = resolve(process.argv[1] ?? '')
+  return classifyInstall({
+    platform: process.platform,
+    entry,
+    desktopEnv: process.env.TURBOLLM_DESKTOP === '1',
+    inContainer: detectContainer(),
+    npmGlobalRoot: await npmGlobalRoot(),
+    sourceCheckout: detectSourceCheckout(entry),
+  })
+}
+
+// ─── Blocking an unsafe apply ─────────────────────────────────────────────────
+
+/** The live facts an apply must not run on top of. All booleans so the check itself
+ *  stays pure — the route gathers them from `Deps`. */
+export interface ApplyBlockers {
+  /** A model is loading right now (manager state 'starting'). */
+  modelLoading: boolean
+  /** At least one download is queued or in flight (the standing "check
+   *  GET /api/v1/downloads before a restart" rule — a hard kill mid-write can corrupt a
+   *  download, not merely pause it). */
+  downloadActive: boolean
+  /** A Code session has a live or queued turn. */
+  codeSessionActive: boolean
+  /** A compile-from-source engine build is running. */
+  engineBuildActive: boolean
+  /** An engine archive is being downloaded/extracted (ProvisionState). */
+  engineProvisionActive: boolean
+}
+
+/** Pure: the reason an update must not be applied right now, or null when it may.
+ *  One reason, not a list — the dialog shows a sentence, and the first blocker found is
+ *  as actionable as all of them. Ordered by how destructive interrupting it would be. */
+export function checkApplyBlockers(b: ApplyBlockers): string | null {
+  if (b.downloadActive) return 'A download is in progress. Wait for it to finish (or pause it) before updating.'
+  if (b.engineBuildActive) return 'An engine is being built from source. Wait for the build to finish before updating.'
+  if (b.engineProvisionActive) return 'An engine is being installed. Wait for it to finish before updating.'
+  if (b.codeSessionActive) return 'A Code session is running. Stop it before updating.'
+  if (b.modelLoading) return 'A model is loading. Wait for it to finish before updating.'
+  return null
+}
+
+// ─── Progress + the cross-restart result handshake ────────────────────────────
+
+/** Where an apply has got to. `downloading` is npm/electron fetching the package;
+ *  `installing` is it being written; `restarting` is the daemon coming back. `done` and
+ *  `failed` are terminal and are what the RESTARTED daemon reports, read from the result
+ *  file the helper wrote — the process that started the update is gone by then. */
+export type AppUpdateState = 'idle' | 'downloading' | 'installing' | 'restarting' | 'done' | 'failed'
+
+export interface AppUpdateProgress {
+  state: AppUpdateState
+  /** The version being installed, when known. */
+  target: string | null
+  /** The version the daemon was on when the apply started. */
+  from: string | null
+  method: InstallMethod | null
+  /** Human-readable failure text — set only in `failed`. */
+  error: string | null
+  /** ISO timestamp of the last transition. */
+  at: string
+}
+
+/** The file the detached helper writes when it finishes, in the data dir, and the
+ *  restarted daemon reads exactly once on boot (spec 29 B.1 step 5: "failure is loud").
+ *  A crashed helper leaves no file, which reads as "nothing happened" — the old version
+ *  is still running and untouched, which is the honest state. */
+export const UPDATE_RESULT_FILE = 'update-result.json'
+/** The daemon's own launch identity, written at boot so the helper relaunches it EXACTLY
+ *  as it was started rather than guessing (spec 29 B.1 step 3). */
+export const RUN_STATE_FILE = 'run-state.json'
+/** Where the detached helper's own stdout/stderr goes. */
+export const UPDATE_LOG_FILE = 'update.log'
+
+/** What the helper writes into {@link UPDATE_RESULT_FILE}. */
+export interface UpdateResult {
+  ok: boolean
+  from: string
+  to: string
+  method: InstallMethod
+  error?: string
+  at: string
+}
+
+/** Parse a result file's contents into a progress record, or null when it is missing or
+ *  unreadable. Pure over the text so the boot path is unit-testable. */
+export function progressFromResult(text: string): AppUpdateProgress | null {
+  let r: Partial<UpdateResult>
+  try {
+    r = JSON.parse(text) as Partial<UpdateResult>
+  } catch {
+    return null
+  }
+  if (typeof r !== 'object' || r === null || typeof r.ok !== 'boolean') return null
+  return {
+    state: r.ok ? 'done' : 'failed',
+    target: typeof r.to === 'string' && r.to ? r.to : null,
+    from: typeof r.from === 'string' && r.from ? r.from : null,
+    method: (INSTALL_METHODS as readonly string[]).includes(r.method as string) ? (r.method as InstallMethod) : null,
+    error: !r.ok && typeof r.error === 'string' ? r.error : null,
+    at: typeof r.at === 'string' && r.at ? r.at : new Date().toISOString(),
+  }
+}
+
+/** Map the helper's free-text failure into the closed telemetry vocabulary
+ *  (`APP_UPDATE_FAIL_REASONS`, telemetry/events/app-update.ts). Pure and unit-tested: the
+ *  telemetry rule is that a failure may never carry an arbitrary string, so the string has
+ *  to be classified somewhere, and doing it here keeps the mapping testable instead of
+ *  inline in a boot path. Anything unrecognised is honestly `other` — never guessed. */
+export function classifyUpdateFailure(error: string | null): 'daemon_did_not_exit' | 'install_failed' | 'helper_spawn_failed' | 'other' {
+  const e = (error ?? '').toLowerCase()
+  if (e.includes('did not shut down')) return 'daemon_did_not_exit'
+  if (e.includes('exited with code') || e.includes('enoent') || e.includes('eperm') || e.includes('ebusy')) return 'install_failed'
+  if (e.includes('spawn')) return 'helper_spawn_failed'
+  return 'other'
+}
+
+/** Process-lifetime progress of an in-flight (or just-completed) app update.
+ *
+ *  In-memory on purpose, with ONE exception: the terminal `done`/`failed` state is seeded
+ *  from the helper's result file at boot, because the process that ran the update is by
+ *  definition dead by the time there is anything to report. */
+export class AppUpdateProgressState {
+  private p: AppUpdateProgress = { state: 'idle', target: null, from: null, method: null, error: null, at: new Date().toISOString() }
+
+  get(): AppUpdateProgress {
+    return { ...this.p }
+  }
+
+  /** True while an apply is under way — a second POST must not start another one. */
+  isRunning(): boolean {
+    return this.p.state === 'downloading' || this.p.state === 'installing' || this.p.state === 'restarting'
+  }
+
+  set(state: AppUpdateState, patch: Partial<Omit<AppUpdateProgress, 'state' | 'at'>> = {}): void {
+    this.p = { ...this.p, ...patch, state, at: new Date().toISOString() }
+  }
+
+  /** Seed a terminal state from the helper's result file (boot path). */
+  adopt(p: AppUpdateProgress): void {
+    this.p = p
+  }
+}
+
+// ─── Launch identity + the detached helper ────────────────────────────────────
+
+/** What the daemon records at boot so the helper can bring it back EXACTLY as it was
+ *  started, rather than reconstructing a plausible command line (spec 29 B.1 step 3).
+ *  `argv` is `process.argv.slice(1)` — the script path plus its flags, i.e. what to pass
+ *  to `execPath` — matching what cli.ts's own `spawnReplacement` re-execs with. */
+export interface RunState {
+  pid: number
+  execPath: string
+  argv: string[]
+  cwd: string
+  version: string
+  startedAt: string
+}
+
+/** This daemon's launch identity, read straight off the live process. */
+export function currentRunState(version: string): RunState {
+  return {
+    pid: process.pid,
+    execPath: process.execPath,
+    argv: process.argv.slice(1),
+    cwd: process.cwd(),
+    version,
+    startedAt: new Date().toISOString(),
+  }
+}
+
+/** Record this daemon's launch identity into the data dir at boot.
+ *
+ *  The apply path itself does NOT read this file back — it is the live process, so it
+ *  builds the identity directly ({@link currentRunState}). The file exists for the case
+ *  the live process can't cover: diagnosing a relaunch that went wrong (the helper's log
+ *  says what it ran; this says what it was told to run), and any future out-of-process
+ *  recovery. Best-effort — a failure here costs a diagnostic, not the daemon's boot. */
+export function writeRunState(dataDir: string, version: string): void {
+  try {
+    writeFileSync(join(dataDir, RUN_STATE_FILE), JSON.stringify(currentRunState(version), null, 2))
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Read back the helper's result exactly once and delete the file, so the "update
+ *  applied" / "update failed" toast fires on the boot after the update and never again.
+ *  Returns null when there was no update (the overwhelmingly common boot). */
+export function consumeUpdateResult(dataDir: string): AppUpdateProgress | null {
+  const path = join(dataDir, UPDATE_RESULT_FILE)
+  let text: string
+  try {
+    text = readFileSync(path, 'utf8')
+  } catch {
+    return null // no update ran — the normal case
+  }
+  try {
+    unlinkSync(path)
+  } catch {
+    /* best-effort: a stale file would only re-show one toast */
+  }
+  return progressFromResult(text)
+}
+
+/** Where the helper script lives. Resolved as a sibling of THIS module in both worlds:
+ *  `src/update-helper.mjs` next to `src/app-update-apply.ts` under tsx, and
+ *  `dist/update-helper.mjs` next to the bundled `dist/cli.js` once built (package.json's
+ *  build step copies it there). Same arrangement, and the same reason, as
+ *  `tools/builtin.ts`'s WORKER_PATH. */
+export function helperPath(): string {
+  return fileURLToPath(new URL('./update-helper.mjs', import.meta.url))
+}
+
+/** Spawn the detached updater and return true when it was launched.
+ *
+ *  `detached: true` + `unref()` is what makes it outlive the daemon that spawned it — the
+ *  whole point. stdio goes to `~/.turbollm/update.log`, NEVER to the parent's streams:
+ *  the parent is about to exit, and inheriting handles from a dying (possibly itself
+ *  detached) process breaks the child's output immediately. */
+export function spawnUpdateHelper(opts: {
+  dataDir: string
+  method: InstallMethod
+  from: string
+  to: string
+  run: RunState
+}): boolean {
+  let out: number | 'ignore' = 'ignore'
+  try {
+    out = openSync(join(opts.dataDir, UPDATE_LOG_FILE), 'a')
+  } catch {
+    out = 'ignore'
+  }
+  const payload = JSON.stringify({
+    pid: opts.run.pid,
+    dataDir: opts.dataDir,
+    method: opts.method,
+    from: opts.from,
+    to: opts.to,
+    execPath: opts.run.execPath,
+    argv: opts.run.argv,
+    cwd: opts.run.cwd,
+  })
+  try {
+    const child = spawn(process.execPath, [helperPath(), payload], {
+      cwd: opts.dataDir,
+      detached: true,
+      stdio: ['ignore', out, out],
+      windowsHide: true,
+    })
+    child.unref()
+    return true
+  } catch {
+    return false
+  }
+}

--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -18,6 +18,13 @@ import { executeRoutine } from './routines/execute'
 import { sweepInteractiveCliRuns, type CliInteractiveSweepDeps } from './routines/cli-interactive-runner'
 import { getTerminalManager } from './terminal/terminal-routes'
 import { AppUpdateChecker } from './app-update'
+import {
+  AppUpdateProgressState,
+  classifyUpdateFailure,
+  consumeUpdateResult,
+  detectInstall,
+  writeRunState,
+} from './app-update-apply'
 import { applyEngineUpdate } from './engines/update-apply'
 import { seedDefaultEngines, ensureAndroidBundledEngine } from './engines/seed'
 import { engineAcceptsFormat } from './engines/compat'
@@ -57,6 +64,7 @@ import { flush } from './telemetry/uploader'
 import { emit } from './telemetry/runtime/typed-emit'
 import { modelLoad, modelDownloaded, buildModelLoadConfig } from './telemetry/events/model'
 import { engineInstalled } from './telemetry/events/engine'
+import { appUpdateAvailable, appUpdateApplied, appUpdateFailed } from './telemetry/events/app-update'
 import { checkDailyQueryRollups } from './telemetry/runtime/daily-query-rollups'
 import { markEverLoadedModel } from './api/onboarding-routes'
 
@@ -449,6 +457,22 @@ deps.agentTasks = new AgentTaskState()
 // request with no restart needed.
 deps.requestLog = new RequestLog(store.snapshot().requestLog.maxEntries)
 
+// App self-update apply state (spec 29 B.1). Two boot-time jobs:
+//  1. Record this daemon's launch identity (execPath/argv/cwd) so the detached update
+//     helper relaunches us exactly as we were started instead of guessing.
+//  2. Read — exactly once, then delete — the result file the helper wrote before it
+//     brought us back, so a completed or FAILED update is loud (a toast) rather than a
+//     version number that silently did or didn't change.
+deps.appUpdateProgress = new AppUpdateProgressState()
+writeRunState(store.dir(), version)
+const lastUpdateResult = consumeUpdateResult(store.dir())
+if (lastUpdateResult) deps.appUpdateProgress.adopt(lastUpdateResult)
+// Warm the install-method classification off the request path. Its one expensive signal is
+// `npm root -g`, a subprocess — memoized for the process lifetime, but the FIRST caller pays
+// for it, and that caller would otherwise be a routine `GET /api/v1/app/update` status poll
+// on whichever screen the user happened to open first.
+setTimeout(() => void detectInstall().catch(() => {}), 2_000).unref()
+
 // Journey telemetry (ADR-299). Constructing it is unconditional and harmless —
 // the Emitter itself enforces consent and the kill switch, so there is no state
 // here that could leak if those checks were somehow skipped upstream.
@@ -730,7 +754,33 @@ await registerCodeRoutesIfSupported(app, deps)
 // Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the
 // Settings chip is ready without the user clicking refresh. Offline-silent; unref'd so it
 // never holds the process open. The 24h re-check is on-demand when the cache goes stale.
-setTimeout(() => void appUpdates.check(AbortSignal.timeout(10_000)).catch(() => {}), 5_000).unref()
+setTimeout(() => {
+  void appUpdates
+    .check(AbortSignal.timeout(10_000))
+    .then(async (status) => {
+      // spec 29 B.5: the "an update exists on this machine" signal — the denominator
+      // complaint #3 ("existing users never update") was never measurable without.
+      // Once per daemon start, and only on a REAL answer (an offline check reports
+      // hasUpdate: false, which must not be counted as "no update was available").
+      if (!status.hasUpdate) return
+      const info = await detectInstall()
+      emit(telemetry, appUpdateAvailable, { method: info.method, canSelfUpdate: info.canSelfUpdate })
+    })
+    .catch(() => {})
+}, 5_000).unref()
+
+// The outcome of an update applied by the PREVIOUS run of this daemon. It can only be
+// reported from here: the process that ran the update exited so the installer could
+// overwrite its own package files, so "did it work?" is a fact this boot inherits from
+// the helper's result file (consumed above) rather than something the updating process
+// could ever have sent itself.
+if (lastUpdateResult) {
+  const method = lastUpdateResult.method ?? 'unknown'
+  if (lastUpdateResult.state === 'done') emit(telemetry, appUpdateApplied, { method })
+  else if (lastUpdateResult.state === 'failed') {
+    emit(telemetry, appUpdateFailed, { method, reason: classifyUpdateFailure(lastUpdateResult.error) })
+  }
+}
 
 // Background auto-update checker (ADR-085, Phase 6): runs shortly after boot + every
 // ~24h. Refreshes per-engine update status; for 'auto' engines with an available update
@@ -1010,9 +1060,18 @@ function spawnReplacement(): void {
   })
   child.unref()
 }
-deps.requestRestart = () => {
+// `exitOnly` is the app-self-update mode (spec 29 B.1 step 2): tear down exactly as a
+// restart does — engine stopped, sockets drained, DB closed, port released — but do NOT
+// spawn a replacement. Something else is going to: the detached update helper is already
+// waiting for this PID to die so it can overwrite the package files (which Windows will
+// not let it do while we hold them) and then relaunch us. Respawning here would race the
+// installer against a live daemon, which is the precise failure this whole mechanism
+// exists to avoid. Expressed as a flag on the existing path rather than a second copy of
+// it, so the (carefully ordered, watchdog-guarded) teardown can never drift between the two.
+deps.requestRestart = (opts?: { exitOnly?: boolean }) => {
   if (restarting) return
   restarting = true
+  const respawn = !opts?.exitOnly
   updateScheduler.stop() // don't let an update tick fire mid-teardown
   routineScheduler.stop() // don't let a routine tick fire mid-teardown
   clearInterval(cliInteractiveSweepTimer)
@@ -1021,10 +1080,12 @@ deps.requestRestart = () => {
   const finish = () => {
     if (spawned) return
     spawned = true
-    try {
-      spawnReplacement()
-    } catch (e) {
-      console.warn(`restart spawn failed: ${e}`)
+    if (respawn) {
+      try {
+        spawnReplacement()
+      } catch (e) {
+        console.warn(`restart spawn failed: ${e}`)
+      }
     }
     process.exit(0)
   }

--- a/turbollm/src/code/code-run-manager.ts
+++ b/turbollm/src/code/code-run-manager.ts
@@ -133,6 +133,18 @@ export class CodeRunManager {
     return !!s && (s.active !== null || s.queue.length > 0)
   }
 
+  /** Is ANY session mid-turn? The session-agnostic form of {@link isActive}, for callers that
+   *  must not disturb the daemon while a Code run is in flight — today the app self-update
+   *  pre-check (spec 29 B.1), which restarts the process and would take a running agent with
+   *  it. Deliberately not derived by iterating session ids at the call site: that would let a
+   *  caller miss a session it didn't know to ask about. */
+  anyActive(): boolean {
+    for (const s of this.sessions.values()) {
+      if (s.active !== null || s.queue.length > 0) return true
+    }
+    return false
+  }
+
   /** The turns currently WAITING behind the active turn (not the running one) — the server-side
    *  message queue, surfaced to the UI so its "Queued" chips survive a disconnect. `userMsgId`
    *  (not just index) identifies each entry so a per-chip action (sendNow) can target one

--- a/turbollm/src/config/config.ts
+++ b/turbollm/src/config/config.ts
@@ -358,6 +358,24 @@ export interface CodeConfig {
 export interface CloudDeployConfig {
   runpodTemplateId: string
 }
+
+/** App-level auto-update settings (spec 29 B.4). Deliberately reuses the per-engine
+ *  update vocabulary (`normalizeUpdatePolicy`, engines/update.ts: `off | notify | auto`,
+ *  default `notify`) rather than inventing a second one — a user who has learned what
+ *  "notify" means for an engine must not have to learn a different meaning for the app.
+ *
+ *  `dismissedVersion` is the "don't nag me twice for the same release" memory (spec 29
+ *  B.3): the exact `latest` string the user dismissed the toast for. Daemon-side rather
+ *  than browser-side deliberately — the same install is reached from several browsers
+ *  (and from the desktop wrapper), and a per-browser memory would re-nag on each one. */
+export interface AppUpdateConfig {
+  /** `off` = never check/surface, `notify` = show the pill + one toast (default),
+   *  `auto` = apply at the next idle moment (desktop: download in the background and
+   *  install on quit). */
+  policy: string
+  /** The `latest` version whose toast the user dismissed, or '' when none. */
+  dismissedVersion: string
+}
 /** A user-created chat Agent (Customize → Agents): a named system prompt with a
  *  scoped skill + tool allow-list, selected when starting a new conversation —
  *  distinct from {@link AgentType} below, which scopes the separate pi-driven
@@ -531,6 +549,8 @@ export interface Config {
   code: CodeConfig
   /** Cloud Launch deploy-link settings (ADR-153). */
   cloudDeploy: CloudDeployConfig
+  /** App-level auto-update policy + dismissed-toast memory (spec 29 B.4). */
+  appUpdate: AppUpdateConfig
   devModel?: DevModel
   /** Onboarding progress (spec 25 §3, ADR-338). Absent on pre-v1.11 configs;
    *  `normalizeOnboarding` supplies the default, so no migration step is needed. */
@@ -679,6 +699,7 @@ export function defaultConfig(): Config {
     build: { toolchainDirs: [] },
     code: { agentsMdProjectCandidates: ['AGENTS.md', 'agents.md', 'CLAUDE.md'], agentsMdGlobalCandidates: ['agents.md', 'AGENTS.md', 'CLAUDE.md'], defaultAgent: 'turbollm' },
     cloudDeploy: { runpodTemplateId: '' },
+    appUpdate: { policy: 'notify', dismissedVersion: '' },
   }
 }
 
@@ -1117,6 +1138,15 @@ function normalize(c: Config): void {
   // Cloud Launch deploy-link settings (ADR-153): absent in pre-ADR-153 configs → ''.
   const cd = (c.cloudDeploy ?? {}) as Partial<CloudDeployConfig>
   c.cloudDeploy = { runpodTemplateId: typeof cd.runpodTemplateId === 'string' ? cd.runpodTemplateId.trim() : '' }
+  // App auto-update settings (spec 29 B.4): absent in pre-this-feature configs → the
+  // 'notify' default. The policy string is NOT validated here — `normalizeUpdatePolicy`
+  // (engines/update.ts) already maps anything unrecognized to 'notify' at every read
+  // site, which is the same one-source-of-truth arrangement the per-engine policy uses.
+  const au = (c.appUpdate ?? {}) as Partial<AppUpdateConfig>
+  c.appUpdate = {
+    policy: typeof au.policy === 'string' ? au.policy : 'notify',
+    dismissedVersion: typeof au.dismissedVersion === 'string' ? au.dismissedVersion : '',
+  }
   // Experimental feature flags (2026-07-14): absent in pre-this-decision configs → default
   // false for cloudDeploy, same conservative posture as lanBind. `memory` is the one
   // exception: a config that ALREADY had autoMemoryEnabled=true (the user had genuinely opted

--- a/turbollm/src/deps.ts
+++ b/turbollm/src/deps.ts
@@ -6,6 +6,7 @@ import type { ProvisionState } from './engines/provision-state'
 import type { BuildState } from './engines/build-state'
 import type { UpdateChecker } from './engines/update'
 import type { AppUpdateChecker } from './app-update'
+import type { AppUpdateProgressState } from './app-update-apply'
 import type { Scanner } from './models/scanner'
 import type { HashStore } from './models/hashes'
 import type { ConversationStore } from './chat/db'
@@ -75,7 +76,10 @@ export interface Deps {
    *  Gracefully stops the engine, releases the listen socket, then spawns a detached
    *  replacement and exits. Optional: only wired in the real `serve()` entrypoint
    *  (cli.ts); absent under tests, where the restart route returns 501. */
-  requestRestart?: () => void
+  requestRestart?: (opts?: { exitOnly?: boolean }) => void
+  /** In-flight (or just-finished) app self-update state, spec 29 B.1. Optional — absent
+   *  under tests that don't exercise the apply routes, same convention as `appUpdates`. */
+  appUpdateProgress?: AppUpdateProgressState
   /** Re-point the HTTP listener at the host/port the config now wants, WITHOUT a full
    *  restart — keeps the engine + model loaded. Used for LAN/port changes. Wired only
    *  in the real `serve()` entrypoint (cli.ts); absent under tests. */

--- a/turbollm/src/telemetry/events/app-update.ts
+++ b/turbollm/src/telemetry/events/app-update.ts
@@ -1,0 +1,99 @@
+/** App auto-update funnel (spec 29 B.5). Complaint #3 — "existing users never update" —
+ *  was completely unmeasurable before these: the app knew about updates and had no event
+ *  saying whether anyone ever acted on one.
+ *
+ *  Four events, one per real step, so the funnel is derived from things that happened
+ *  rather than from one event's parameter space:
+ *    `app_update_available` — this daemon found a newer published version (once per boot,
+ *       from cli.ts's post-boot check).
+ *    `app_update_clicked`   — the user pressed "Update & restart" (POST /api/v1/app/update
+ *       was accepted; a request refused by a pre-check emits nothing, since the user did
+ *       not get to update).
+ *    `app_update_applied` / `app_update_failed` — the outcome, emitted by the RESTARTED
+ *       daemon from the helper's result file, because the process that ran the update is
+ *       dead by the time there is an outcome to report.
+ *
+ *  Every one carries the detected install method, because "did anyone update?" is a
+ *  different question per method — a Docker or source install literally cannot press the
+ *  button, and averaging them into one rate hides that.
+ *
+ *  `since: 4` — a new generation. The standing lesson applies with full force here: any
+ *  funnel over these MUST filter on `app.version` first. These events do not exist in any
+ *  already-installed build, so a population-wide rate computed across versions measures
+ *  "how many people are on a version that can emit this" and understates adoption by
+ *  whatever fraction of the installed base has not updated — which is the exact quantity
+ *  being measured. That circularity is why the version gate is not optional.
+ *
+ *  Payloads are closed enums only. They structurally cannot carry a path, a version
+ *  string, an error message, or a registry URL.
+ */
+
+import { defineEvent, f } from '../core/define'
+
+/** The install-method dimension. Mirrors `app-update-apply.ts`'s `InstallMethod` /
+ *  `INSTALL_METHODS`, and — unlike `events/link.ts`'s `LINK_PRESET_NAMES`, which imports
+ *  its domain source directly — is deliberately written out here instead of imported.
+ *
+ *  The reason is the Worker: `telemetry-worker/src/index.ts` inlines `schema.ts` at deploy
+ *  time, which transitively pulls in every file in `events/`. `app-update-apply.ts` imports
+ *  `node:child_process` and `node:fs`, so importing it from an event definition would drag
+ *  those into a Cloudflare Workers bundle that has neither. The drift this normally risks
+ *  is closed by `app-update.test.ts`, which asserts these two lists are identical — a test
+ *  can import both freely, since tests are never bundled.
+ *
+ *  APPEND-ONLY: the order is part of the event schema, so a new install method goes on the
+ *  end of both lists and never in the middle. */
+export const APP_INSTALL_METHODS = ['npm_global', 'npx', 'electron', 'docker', 'android', 'source', 'unknown'] as const
+
+/** Why an update did not complete. A closed vocabulary written by THIS codebase, never by
+ *  npm, a filesystem, or a user — `other` is the deliberate long-tail catch-all rather
+ *  than an excuse to send free text. */
+export const APP_UPDATE_FAIL_REASONS = ['daemon_did_not_exit', 'install_failed', 'helper_spawn_failed', 'other'] as const
+
+export const appUpdateAvailable = defineEvent({
+  name: 'app_update_available',
+  since: 4,
+  consent: 'anon',
+  lifecycle: 'per-action',
+  description: 'This daemon found a newer published TurboLLM than the one it is running.',
+  payload: {
+    method: f.enum(APP_INSTALL_METHODS),
+    /** Whether the button was actually offered — the denominator that separates "saw an
+     *  update" from "could do anything about it". */
+    canSelfUpdate: f.bool(),
+  },
+})
+
+export const appUpdateClicked = defineEvent({
+  name: 'app_update_clicked',
+  since: 4,
+  consent: 'anon',
+  lifecycle: 'per-action',
+  description: 'The user asked TurboLLM to update and restart itself.',
+  payload: {
+    method: f.enum(APP_INSTALL_METHODS),
+  },
+})
+
+export const appUpdateApplied = defineEvent({
+  name: 'app_update_applied',
+  since: 4,
+  consent: 'anon',
+  lifecycle: 'per-action',
+  description: 'An in-app update completed and the daemon came back on the new version.',
+  payload: {
+    method: f.enum(APP_INSTALL_METHODS),
+  },
+})
+
+export const appUpdateFailed = defineEvent({
+  name: 'app_update_failed',
+  since: 4,
+  consent: 'anon',
+  lifecycle: 'per-action',
+  description: 'An in-app update did not complete; the previous version is still installed.',
+  payload: {
+    method: f.enum(APP_INSTALL_METHODS),
+    reason: f.enum(APP_UPDATE_FAIL_REASONS),
+  },
+})

--- a/turbollm/src/telemetry/events/index.ts
+++ b/turbollm/src/telemetry/events/index.ts
@@ -22,6 +22,7 @@ import { codeDaily } from './code'
 import { uiAction, uiDaily } from './ui'
 import { onboardingProfile, onboardingRecovery } from './onboarding'
 import { linkMinted, linkAdded, linkStatusChanged, inferenceServed } from './link'
+import { appUpdateAvailable, appUpdateClicked, appUpdateApplied, appUpdateFailed } from './app-update'
 
 export const REGISTRY = {
   app_first_run: appFirstRun,
@@ -47,6 +48,10 @@ export const REGISTRY = {
   link_added: linkAdded,
   link_status_changed: linkStatusChanged,
   inference_served: inferenceServed,
+  app_update_available: appUpdateAvailable,
+  app_update_clicked: appUpdateClicked,
+  app_update_applied: appUpdateApplied,
+  app_update_failed: appUpdateFailed,
 } as const
 
 export type EventName = keyof typeof REGISTRY
@@ -77,4 +82,8 @@ export {
   linkAdded,
   linkStatusChanged,
   inferenceServed,
+  appUpdateAvailable,
+  appUpdateClicked,
+  appUpdateApplied,
+  appUpdateFailed,
 }

--- a/turbollm/src/update-helper.mjs
+++ b/turbollm/src/update-helper.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// The detached app-updater helper (spec 29 B.1, steps 1/3/5).
+//
+// This exists because of one hard constraint: on Windows you CANNOT rewrite the package
+// files of a running daemon. `node_modules` is locked by the live process and `npm i -g`
+// fails with EPERM/EBUSY. So the update cannot be performed by the process being updated
+// — something outside it has to wait for it to die, swap the files, and start it again.
+// That something is this file.
+//
+// Deliberately a plain, dependency-free `.mjs` rather than a TypeScript module bundled
+// into `dist/cli.js`:
+//   - it must survive the moment the daemon's own package is being overwritten, so it
+//     may not import anything out of that package;
+//   - it is spawned as a real file (`node update-helper.mjs <json>`), so it has to exist
+//     as a file on disk in both dev (src/) and the published package (dist/) — exactly
+//     the same reasoning as run-code-worker (tools/builtin.ts's WORKER_PATH). It sits
+//     beside app-update-apply.ts in src/ and beside cli.js in dist/, so the sibling-URL
+//     resolution is identical in both worlds.
+//
+// Contract with the daemon (all via argv[2], one JSON blob — no shared imports):
+//   { pid, dataDir, method, from, to, execPath, argv, cwd, npmCmd }
+// It writes `<dataDir>/update-result.json` on the way out, ALWAYS — success or failure —
+// which is what the restarted daemon reads once on boot and surfaces as a toast. A
+// failed install leaves the old version installed and simply relaunches it.
+
+import { spawn } from 'node:child_process'
+import { openSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/** How long to wait for the old daemon to actually exit before giving up. Must comfortably
+ *  exceed cli.ts's own 14s restart watchdog (a loaded model takes up to ~8s to force-kill
+ *  on Windows). Giving up here is not a failure of the update — it means the daemon is
+ *  still alive, and installing over a live process is precisely what this file exists to
+ *  avoid, so we abort instead. */
+const WAIT_FOR_EXIT_MS = 60_000
+const POLL_MS = 250
+
+const opts = JSON.parse(process.argv[2] ?? '{}')
+
+function log(line) {
+  process.stdout.write(`[${new Date().toISOString()}] ${line}\n`)
+}
+
+function writeResult(ok, error) {
+  try {
+    writeFileSync(
+      join(opts.dataDir, 'update-result.json'),
+      JSON.stringify({ ok, from: opts.from ?? '', to: opts.to ?? '', method: opts.method ?? 'unknown', ...(error ? { error } : {}), at: new Date().toISOString() }, null, 2),
+    )
+  } catch (e) {
+    log(`could not write result file: ${e}`)
+  }
+}
+
+/** Is the daemon PID still alive? `kill(pid, 0)` is the portable liveness probe: it sends
+ *  no signal and throws ESRCH once the process is gone. EPERM means it exists but belongs
+ *  to someone else — still alive, so keep waiting. */
+function alive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return e && e.code === 'EPERM'
+  }
+}
+
+async function waitForExit(pid) {
+  const deadline = Date.now() + WAIT_FOR_EXIT_MS
+  while (Date.now() < deadline) {
+    if (!alive(pid)) return true
+    await new Promise((r) => setTimeout(r, POLL_MS))
+  }
+  return false
+}
+
+function run(cmd, args) {
+  return new Promise((res) => {
+    log(`> ${cmd} ${args.join(' ')}`)
+    // `shell: false`. On Windows the executable is `npm.cmd`, which Node spawns directly;
+    // going through a shell would mean quoting user-influenced strings into a command
+    // line, and there is no reason to when every argument here is a fixed literal.
+    const child = spawn(cmd, args, { stdio: ['ignore', 'inherit', 'inherit'], windowsHide: true })
+    child.on('error', (e) => res({ ok: false, error: String(e && e.message ? e.message : e) }))
+    child.on('exit', (code) => res(code === 0 ? { ok: true } : { ok: false, error: `${cmd} exited with code ${code}` }))
+  })
+}
+
+/** Relaunch the daemon EXACTLY as it was launched, from the identity the daemon recorded
+ *  at boot (spec 29 B.1 step 3 — "so the helper never has to guess"). Detached with its
+ *  own log file: this helper is about to exit, so inheriting its streams would break the
+ *  new daemon's stdio the moment it does. */
+function relaunch() {
+  let out = 'ignore'
+  try {
+    out = openSync(join(opts.dataDir, 'update.log'), 'a')
+  } catch {
+    out = 'ignore'
+  }
+  const exe = opts.method === 'npx' ? (process.platform === 'win32' ? 'npx.cmd' : 'npx') : opts.execPath
+  const args = opts.method === 'npx' ? ['-y', 'turbollm@latest', ...(opts.argv ?? []).slice(1)] : opts.argv ?? []
+  log(`relaunching: ${exe} ${args.join(' ')}`)
+  const child = spawn(exe, args, { cwd: opts.cwd, detached: true, stdio: ['ignore', out, out], windowsHide: true })
+  child.unref()
+}
+
+async function main() {
+  log(`update helper starting (pid=${opts.pid}, method=${opts.method}, ${opts.from} → ${opts.to})`)
+
+  if (!(await waitForExit(opts.pid))) {
+    writeResult(false, 'The running TurboLLM did not shut down in time, so the update was not applied.')
+    log('daemon did not exit — aborting without touching anything')
+    return
+  }
+  log('daemon exited')
+
+  // npx has nothing installed to upgrade: the relaunch below re-resolves `turbollm@latest`
+  // from the registry, which IS the update. Only the global-install path runs npm.
+  if (opts.method === 'npm_global') {
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const r = await run(npm, ['install', '-g', 'turbollm@latest'])
+    if (!r.ok) {
+      // The install failed, so the OLD version is still what's on disk, intact. Relaunch it
+      // — leaving the user daemonless because an update failed would be far worse than the
+      // update simply not happening.
+      writeResult(false, r.error)
+      log(`install failed: ${r.error} — relaunching the previous version`)
+      relaunch()
+      return
+    }
+  }
+
+  writeResult(true)
+  relaunch()
+  log('done')
+}
+
+main().catch((e) => {
+  writeResult(false, String(e && e.message ? e.message : e))
+  log(`unexpected failure: ${e}`)
+  // Still try to bring the daemon back — see the install-failure branch above.
+  try {
+    relaunch()
+  } catch {
+    /* nothing more we can do */
+  }
+})

--- a/turbollm/web/src/components/AppUpdateControl.tsx
+++ b/turbollm/web/src/components/AppUpdateControl.tsx
@@ -1,0 +1,379 @@
+// The app-update surface (spec 29 B.3): ONE implementation, mounted twice.
+//
+// Before this, the only place an available update appeared was Settings → About, three
+// clicks deep, and the only thing it offered was a command to go type in a terminal. That
+// is the whole of complaint #3 ("existing users never update"). This component is the
+// clickable version of it, and it is deliberately a single component used by both the
+// NavRail (bottom-left, where the version already lives) and AboutSection — two mounts of
+// one implementation, so the two surfaces cannot drift into disagreeing about whether an
+// update exists or what pressing the button does.
+//
+// It is never a dead end. When the daemon reports an install method that cannot update
+// itself (Docker, a source checkout, the desktop app, or an install it honestly could not
+// classify), the dialog falls back to exactly what Settings showed before: the copyable
+// command, plus a sentence saying why the button isn't there.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ArrowUpCircle, Check, ExternalLink, Loader2, TriangleAlert } from 'lucide-react'
+import { applyAppUpdate, getAppUpdateProgress, track } from '../lib/api'
+import { useAppUpdate, useAppUpdatePolicyMutation, useDismissAppUpdateMutation, useStatus, useSysInfo } from '../lib/queries'
+import { isAndroidOs } from '../lib/platform'
+import type { AppUpdate, UpdatePolicy } from '../lib/types'
+import { Button } from './ui/button'
+import { CopyButton } from './ui/copy-button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from './ui/dialog'
+import { toast } from './ui/sonner'
+
+/** The manual command shown when the daemon is too old to report one (it predates spec 29
+ *  B.1's install-method detection). The global-npm install is by far the most common, and
+ *  this is exactly what Settings → About showed before this component existed. */
+const FALLBACK_COMMAND = 'npm i -g turbollm'
+
+const RELEASES_URL = 'https://github.com/mohitsoni48/TurboLLM/releases'
+
+/** Give up waiting for the daemon to come back. Generous on purpose: the restart drains a
+ *  loaded model first, which can take ~8s on its own, and the install in between is an npm
+ *  registry round-trip on whatever connection the user has. Hitting this is not "the update
+ *  failed" — it is "we stopped watching", and the dialog says so and offers the command. */
+const RECONNECT_TIMEOUT_MS = 5 * 60_000
+
+/** Versions we have already toasted about, for the life of this page. Module-level rather
+ *  than component state because BOTH mounts of this component run the same effect — a
+ *  per-component guard would fire the toast twice on every screen that shows both. */
+const toasted = new Set<string>()
+
+type Phase = 'idle' | 'starting' | 'restarting' | 'done' | 'failed'
+
+/** Everything both mounts need, resolved once. Exported so the NavRail can decide whether
+ *  to render anything at all without duplicating the visibility rules. */
+export function useAppUpdateState(): {
+  update: AppUpdate | undefined
+  installed: string
+  latest: string
+  /** Show the update affordance? False on Android, when the check hasn't landed, when the
+   *  policy is `off`, and when there is simply nothing newer. */
+  visible: boolean
+} {
+  const { data: update } = useAppUpdate()
+  const { data: status } = useStatus()
+  const sys = useSysInfo().data
+  const installed = update?.installed || status?.version || ''
+  const latest = update?.latest ?? ''
+  // Android's real update path is a Play Store release — there is no terminal to run a
+  // command in and no npm on the device. Suppressed here exactly as AboutSection has
+  // always suppressed it, rather than shown-and-disabled.
+  const visible = !!update?.hasUpdate && !!latest && !isAndroidOs(sys?.os ?? '')
+  return { update, installed, latest, visible }
+}
+
+/** The bottom-of-the-rail version slot (spec 29 B.3). With no update it renders exactly
+ *  the plain version line NavRail has always shown; with one it becomes a clickable,
+ *  accent-tinted pill. One component owning both states is what guarantees the rail can
+ *  never show a stale version beside an update pill claiming a different one. */
+export function AppUpdateRailSlot({ version }: { version: string }) {
+  const { installed, latest, visible } = useAppUpdateState()
+  const [open, setOpen] = useState(false)
+  useUpdateToast(() => setOpen(true))
+
+  if (!visible) return <span className="hidden text-[11px] text-faint xl:inline">{version}</span>
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          track('settings', 'open_app_update_from_nav')
+          setOpen(true)
+        }}
+        aria-label={`Update available: v${installed} to v${latest}`}
+        title={`TurboLLM v${latest} is available`}
+        className="inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[11px] font-medium transition-colors"
+        style={{
+          color: 'var(--accent)',
+          background: 'color-mix(in srgb, var(--accent) 12%, transparent)',
+        }}
+      >
+        <ArrowUpCircle size={12} />
+        {/* Below xl the rail is collapsed to icons and there is no room for two version
+            strings, so the accent-tinted arrow carries the signal on its own. A bare accent
+            DOT was the obvious alternative and is rejected: beside the engine state chip's
+            dot immediately above it, a second dot reads as another status light rather than
+            something to press. */}
+        <span className="hidden xl:inline">{`v${installed} → v${latest}`}</span>
+      </button>
+      <AppUpdateDialog open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+
+/** The Settings → About body: the version row's companion. Same dialog, same state. */
+export function AppUpdateSettingsBlock() {
+  const { update, installed, latest, visible } = useAppUpdateState()
+  const [open, setOpen] = useState(false)
+  const policy = useAppUpdatePolicyMutation()
+  const current: UpdatePolicy = update?.policy ?? 'notify'
+
+  return (
+    <>
+      {visible ? (
+        <div
+          className="mt-2 flex flex-col gap-2 rounded-md border p-3"
+          style={{
+            borderColor: 'color-mix(in srgb, var(--accent) 40%, var(--border))',
+            background: 'color-mix(in srgb, var(--accent) 6%, transparent)',
+          }}
+        >
+          <div className="flex items-center gap-2 text-[13px] font-medium" style={{ color: 'var(--accent)' }}>
+            <ArrowUpCircle size={15} />
+            TurboLLM v{latest} is available
+          </div>
+          <div className="text-[12px] text-muted">You're on v{installed}.</div>
+          <div>
+            <Button
+              size="sm"
+              onClick={() => {
+                track('settings', 'open_app_update_from_settings')
+                setOpen(true)
+              }}
+            >
+              View update
+            </Button>
+          </div>
+        </div>
+      ) : update?.latest && !update.hasUpdate ? (
+        // Checked successfully and current — a quiet confirmation, no call to action.
+        <div className="mt-1 inline-flex items-center gap-1.5 text-[12px] text-faint">
+          <Check size={13} style={{ color: 'var(--ok)' }} />
+          You're on the latest version
+        </div>
+      ) : null}
+
+      {/* Update policy (spec 29 B.4) — the same off | notify | auto vocabulary the
+          per-engine control uses, deliberately. */}
+      <div className="mt-3 flex items-center justify-between gap-3 border-t border-border pt-3">
+        <div>
+          <div className="text-[14px] font-medium text-ink">Updates</div>
+          <div className="text-[12px] text-muted">
+            {current === 'off'
+              ? "Don't check for new TurboLLM versions"
+              : current === 'auto'
+                ? 'Install new versions automatically when TurboLLM is idle'
+                : 'Tell me when a new version is available'}
+          </div>
+        </div>
+        <select
+          value={current}
+          onChange={(e) => {
+            const next = e.target.value as UpdatePolicy
+            track('settings', 'set_app_update_policy')
+            policy.mutate(next)
+          }}
+          className="rounded-md border border-border bg-bg px-2 py-1 text-[13px] text-ink outline-none"
+        >
+          <option value="off">Off</option>
+          <option value="notify">Notify me</option>
+          <option value="auto">Automatic</option>
+        </select>
+      </div>
+
+      <AppUpdateDialog open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+
+/** One dismissible toast per new version per page load (spec 29 B.3: "never nagging twice
+ *  for the same version"). The dismissed version is remembered DAEMON-side, not in this
+ *  browser, so opening TurboLLM in a second browser doesn't re-ask. */
+function useUpdateToast(onOpen: () => void) {
+  const { update, latest, visible } = useAppUpdateState()
+  const dismiss = useDismissAppUpdateMutation()
+  const dismissRef = useRef(dismiss)
+  dismissRef.current = dismiss
+
+  useEffect(() => {
+    if (!visible || !latest) return
+    if (update?.dismissedVersion === latest) return
+    if (toasted.has(latest)) return
+    toasted.add(latest)
+    toast(`TurboLLM v${latest} is available`, {
+      description: "You're running an older version.",
+      action: { label: 'Update', onClick: onOpen },
+      cancel: { label: 'Later', onClick: () => dismissRef.current.mutate(latest) },
+      duration: 12_000,
+    })
+    // `onOpen` is a fresh closure each render and would re-run this effect forever if
+    // depended on; the version is the real identity of "should we toast".
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, latest, update?.dismissedVersion])
+}
+
+/** Current → new, what will happen, and the one button that does it. */
+export function AppUpdateDialog({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
+  const { update, installed, latest } = useAppUpdateState()
+  const dismiss = useDismissAppUpdateMutation()
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const timers = useRef<{ poll?: ReturnType<typeof setInterval>; giveUp?: ReturnType<typeof setTimeout> }>({})
+
+  const canSelfUpdate = update?.canSelfUpdate ?? false
+  const command = update?.command || FALLBACK_COMMAND
+  const note = update?.note ?? ''
+
+  const clearTimers = useCallback(() => {
+    if (timers.current.poll) clearInterval(timers.current.poll)
+    if (timers.current.giveUp) clearTimeout(timers.current.giveUp)
+    timers.current = {}
+  }, [])
+  useEffect(() => clearTimers, [clearTimers])
+
+  /** Watch the daemon through its own restart. Every failed request here is EXPECTED — the
+   *  process is gone for a few seconds — so a rejection means "still restarting", never an
+   *  error. The terminal answer comes from the RESTARTED daemon, which reports the outcome
+   *  the updater helper recorded before relaunching it. */
+  const watchRestart = useCallback(() => {
+    clearTimers()
+    setPhase('restarting')
+    timers.current.poll = setInterval(() => {
+      void getAppUpdateProgress()
+        .then((p) => {
+          if (p.state === 'done') {
+            clearTimers()
+            setPhase('done')
+          } else if (p.state === 'failed') {
+            clearTimers()
+            setError(p.error || 'The update did not complete. TurboLLM is still on the previous version.')
+            setPhase('failed')
+          }
+        })
+        .catch(() => {
+          /* daemon is down mid-restart — that's the normal path through this */
+        })
+    }, 1500)
+    timers.current.giveUp = setTimeout(() => {
+      clearTimers()
+      setError("TurboLLM is taking longer than expected to come back. Check ~/.turbollm/update.log, or run the command below.")
+      setPhase('failed')
+    }, RECONNECT_TIMEOUT_MS)
+  }, [clearTimers])
+
+  const start = () => {
+    track('settings', 'apply_app_update')
+    setError(null)
+    setPhase('starting')
+    void applyAppUpdate()
+      .then(() => watchRestart())
+      .catch((e: unknown) => {
+        // A refusal (a download in flight, a Code session running, an install method that
+        // can't self-update) arrives here with the daemon's own sentence. Show it verbatim
+        // — it says exactly what to do — rather than a generic failure.
+        setError(e instanceof Error ? e.message : 'The update could not be started.')
+        setPhase('failed')
+      })
+  }
+
+  const busy = phase === 'starting' || phase === 'restarting'
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        // Never let the dialog be dismissed mid-restart: closing it would strand the user on
+        // a page whose daemon is deliberately down, with nothing saying why.
+        if (busy) return
+        onOpenChange(v)
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{phase === 'done' ? 'TurboLLM is up to date' : 'Update TurboLLM'}</DialogTitle>
+          <DialogDescription>
+            {phase === 'done' ? `Now running v${latest}.` : `v${installed} → v${latest}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {phase === 'done' ? (
+          <div className="flex items-center gap-2 text-[13px] text-ink">
+            <Check size={15} style={{ color: 'var(--ok)' }} />
+            The update was installed and TurboLLM restarted. Reload this page to pick up the new UI.
+          </div>
+        ) : busy ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-[13px] text-ink">
+              <Loader2 size={15} className="animate-spin" />
+              {phase === 'starting' ? 'Starting the update…' : 'Installing and restarting — TurboLLM will be back in a moment.'}
+            </div>
+            <div className="text-[12px] text-muted">
+              Don't close this window. If anything goes wrong the previous version is left untouched.
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {error ? (
+              <div className="flex items-start gap-2 text-[13px]" style={{ color: 'var(--err)' }}>
+                <TriangleAlert size={15} className="mt-0.5 shrink-0" />
+                <span>{error}</span>
+              </div>
+            ) : null}
+
+            {note ? <div className="text-[12px] text-muted">{note}</div> : null}
+
+            {canSelfUpdate && phase !== 'failed' ? (
+              <div className="text-[12px] text-muted">
+                TurboLLM will install the new version and restart itself. Any loaded model is unloaded
+                first, and chats are not affected.
+              </div>
+            ) : (
+              // The never-a-dead-end fallback: exactly what Settings → About showed before
+              // this component existed.
+              <div className="flex flex-col gap-1.5">
+                <div className="text-[12px] text-muted">Update it yourself:</div>
+                <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-bg px-2.5 py-1.5">
+                  <code className="select-all font-mono text-[12px] text-ink">{command}</code>
+                  <CopyButton text={command} screen="settings" />
+                </div>
+              </div>
+            )}
+
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-[12px] text-muted transition-colors hover:text-ink"
+            >
+              <ExternalLink size={12} />
+              What's new in v{latest}
+            </a>
+          </div>
+        )}
+
+        <DialogFooter>
+          {phase === 'done' ? (
+            <Button size="sm" onClick={() => window.location.reload()}>
+              Reload
+            </Button>
+          ) : busy ? null : (
+            <>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  // "Later" is also the dismissal: it records this version so neither the
+                  // toast nor a second prompt asks again for the same release.
+                  if (latest) dismiss.mutate(latest)
+                  onOpenChange(false)
+                }}
+              >
+                Later
+              </Button>
+              {canSelfUpdate ? (
+                <Button size="sm" onClick={start}>
+                  Update &amp; restart
+                </Button>
+              ) : null}
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/turbollm/web/src/components/Shell.tsx
+++ b/turbollm/web/src/components/Shell.tsx
@@ -13,6 +13,7 @@ import { BoltMark } from './Logo'
 import { HardwareBar } from './HardwareBar'
 import { EngineProvisionBanner } from './EngineProvisionBanner'
 import { EngineLoadErrorBanner } from './EngineLoadErrorBanner'
+import { AppUpdateRailSlot } from './AppUpdateControl'
 import {
   Tooltip,
   TooltipContent,
@@ -320,8 +321,13 @@ function NavRail({
             {(online ? 'Daemon connected' : 'Daemon offline') + ` · ${version}`}
           </TooltipContent>
         </Tooltip>
-        {/* Version string beneath the chip (xl+ only — no room when collapsed). */}
-        <span className="hidden text-[11px] text-faint xl:inline">{version}</span>
+        {/* Version string beneath the chip (xl+ only — no room when collapsed) — which
+            BECOMES the clickable update pill when npm has a newer TurboLLM (spec 29 B.3).
+            This spot rather than a banner because the version is already here: the thing a
+            user looks at to check what they're running becomes the thing that updates it.
+            AppUpdateRailSlot falls back to exactly this plain span when there's no update,
+            so the default appearance of the rail is unchanged. */}
+        <AppUpdateRailSlot version={version} />
       </div>
     </nav>
   )

--- a/turbollm/web/src/lib/api.ts
+++ b/turbollm/web/src/lib/api.ts
@@ -31,6 +31,7 @@ import type {
   ModelsList,
   Status,
   AppUpdate,
+  AppUpdateProgress,
   TokenUsageStats,
   TokenUsageRange,
 } from './types'
@@ -348,6 +349,31 @@ export function getEngineUpdates(refresh = false): Promise<EngineUpdates> {
  *  live re-check. Informational only; npm performs the upgrade. */
 export function getAppUpdate(refresh = false): Promise<AppUpdate> {
   return request<AppUpdate>(`/api/v1/app/update${refresh ? '?refresh=1' : ''}`)
+}
+
+/** Apply the update and restart (spec 29 B.1). 202 on accept; a 409 carries the reason it
+ *  was refused (a download in flight, a Code session running, an install method that can't
+ *  self-update). The daemon goes away moments after this resolves — the caller polls
+ *  {@link getAppUpdateProgress} / `/status` through the restart. */
+export function applyAppUpdate(): Promise<{ ok: boolean; updating: boolean; from: string; to: string; method: string }> {
+  return request('/api/v1/app/update', { method: 'POST', json: {} })
+}
+
+/** Poll an in-flight update. Also how the RESTARTED daemon reports the outcome of the
+ *  update that restarted it. */
+export function getAppUpdateProgress(): Promise<AppUpdateProgress> {
+  return request<AppUpdateProgress>('/api/v1/app/update/progress')
+}
+
+/** Set the app-level auto-update policy (off | notify | auto). */
+export function setAppUpdatePolicy(policy: UpdatePolicy): Promise<unknown> {
+  return request('/api/v1/app/update-policy', { method: 'PUT', json: { policy } })
+}
+
+/** Remember that the user dismissed the toast for this exact version, so it never asks
+ *  twice for the same release. */
+export function dismissAppUpdate(version: string): Promise<unknown> {
+  return request('/api/v1/app/update/dismiss', { method: 'POST', json: { version } })
 }
 
 /** Set an engine's auto-update policy (off | notify | auto). */

--- a/turbollm/web/src/lib/queries.ts
+++ b/turbollm/web/src/lib/queries.ts
@@ -47,6 +47,8 @@ import {
   updateLlamafile,
   getEngineUpdates,
   getAppUpdate,
+  setAppUpdatePolicy,
+  dismissAppUpdate,
   setEngineUpdatePolicy,
   getStatus,
   getTokenUsage,
@@ -455,6 +457,35 @@ export function useAppUpdate(): UseQueryResult<AppUpdate> {
     refetchIntervalInBackground: false,
     staleTime: 60_000,
     retry: false,
+  })
+}
+
+/** Set the app-level auto-update policy (off | notify | auto).
+ *
+ *  Note what is deliberately NOT here: applying the update and polling its progress. Those
+ *  two calls are made directly against `api.ts` from `AppUpdateControl`, because they run
+ *  THROUGH a daemon restart — every request in that window legitimately fails, and a query
+ *  hook's error/retry semantics would render that expected downtime as a failure. The
+ *  dialog needs "a rejection means still restarting", which is a plain poll loop, not a
+ *  query. */
+export function useAppUpdatePolicyMutation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (policy: UpdatePolicy) => setAppUpdatePolicy(policy),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.appUpdate })
+    },
+  })
+}
+
+/** Remember a dismissed version so the toast never fires twice for the same release. */
+export function useDismissAppUpdateMutation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (version: string) => dismissAppUpdate(version),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.appUpdate })
+    },
   })
 }
 

--- a/turbollm/web/src/lib/types.ts
+++ b/turbollm/web/src/lib/types.ts
@@ -239,6 +239,33 @@ export type AppUpdate = {
   checkedAt: string
   error?: 'offline' | 'rate_limited'
   comparable: boolean
+  /** How this daemon is installed (spec 29 B.1). Decides what the update dialog may
+   *  offer — a wrong guess is worse than no button, so the daemon classifies rather than
+   *  the browser. Optional: a daemon older than this feature simply omits it. */
+  method?: 'npm_global' | 'npx' | 'electron' | 'docker' | 'android' | 'source' | 'unknown'
+  /** May the daemon apply the update itself (POST /api/v1/app/update)? */
+  canSelfUpdate?: boolean
+  /** The copyable manual command. Always present when there is one — this is what keeps
+   *  the dialog from dead-ending on Docker / source / unknown installs. */
+  command?: string
+  /** One sentence explaining what to do instead, when self-update isn't offered. */
+  note?: string
+  /** App-level update policy (spec 29 B.4), same vocabulary as the per-engine one. */
+  policy?: UpdatePolicy
+  /** The version whose toast the user already dismissed, so it never nags twice. */
+  dismissedVersion?: string
+}
+
+/** Where an in-app update has got to (GET /api/v1/app/update/progress). `done`/`failed`
+ *  come from the RESTARTED daemon reading the updater helper's result file — the process
+ *  that ran the update is gone by the time there is an outcome. */
+export type AppUpdateProgress = {
+  state: 'idle' | 'downloading' | 'installing' | 'restarting' | 'done' | 'failed'
+  target: string | null
+  from: string | null
+  method: AppUpdate['method'] | null
+  error: string | null
+  at: string
 }
 
 /** Live ComfyUI coordination state (GET /api/v1/status). Drives the "paused while

--- a/turbollm/web/src/screens/SettingsScreen.tsx
+++ b/turbollm/web/src/screens/SettingsScreen.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, RefreshCw, Check, X, Loader2, AlertTriangle, ArrowUpCircle, SlidersHorizontal, Boxes, ShieldCheck, Wifi, Cpu, ChevronRight, FlaskConical } from 'lucide-react'
+import { Moon, Sun, Monitor, Save, ExternalLink, ShieldAlert, RefreshCw, Check, X, Loader2, AlertTriangle, SlidersHorizontal, Boxes, ShieldCheck, Wifi, Cpu, ChevronRight, FlaskConical } from 'lucide-react'
 import { getPersonalization, savePersonalization, type Personalization } from '../lib/personas'
 import { ScreenHeader } from '../components/common'
+import { AppUpdateSettingsBlock } from '../components/AppUpdateControl'
 import { Button } from '../components/ui/button'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible'
 import { cn } from '../lib/utils'
@@ -19,14 +20,12 @@ import {
   useTelemetryLog,
   useRegenerateMachineId,
   useAppUpdate,
-  useSysInfo,
 } from '../lib/queries'
-import { CopyButton } from '../components/ui/copy-button'
 import { ModelDirs } from './models/ModelDirs'
 import { ToolPermissionsSection } from './settings/ToolPermissionsSection'
 import { CodeContextSection } from './settings/CodeContextSection'
 import { CodeAgentSection } from './settings/CodeAgentSection'
-import { useCodeFeatureEnabled, isAndroidOs } from '../lib/platform'
+import { useCodeFeatureEnabled } from '../lib/platform'
 import { MemorySection } from './settings/MemorySection'
 import { ExperimentalSection } from './settings/ExperimentalSection'
 import { TurboLinkSection } from './settings/TurboLinkSection'
@@ -1631,13 +1630,14 @@ function PersonalizationSection() {
   )
 }
 
-// ── About + app self-update check (F-006, ADR-031) ────────────────────────────
-// Shows the running version and, when npm has a newer TurboLLM, an "update available"
-// chip with the install command to copy. Informational only — npm performs the upgrade;
-// the app never auto-updates itself. Offline-silent: when the npm check couldn't run we
-// just show the current version with no error (never a false "up to date").
-
-const APP_UPDATE_COMMAND = 'npm i -g turbollm'
+// ── About + app self-update (F-006, ADR-031; spec 29 B.3/B.4) ─────────────────
+// Shows the running version. Everything below it — the "update available" block, the
+// update dialog, and the off|notify|auto policy — is `AppUpdateSettingsBlock`, the SAME
+// component the NavRail's version pill mounts. Two mounts, one implementation: the whole
+// point (spec 29 B.3) is that these two surfaces cannot disagree about whether an update
+// exists or what pressing the button does, which two hand-kept copies would eventually do.
+//
+// This section used to own that markup itself, and could only offer a command to copy.
 
 function AboutSection() {
   // The running version always comes from /status (present immediately); the npm
@@ -1645,14 +1645,6 @@ function AboutSection() {
   const { data: status } = useStatus()
   const { data: update } = useAppUpdate()
   const installed = update?.installed || status?.version || ''
-  // The Android app's real update path is a new Play Store release, not `npm i -g turbollm` —
-  // there is no terminal to run it in and no npm on the device. `hasUpdate` therefore stays
-  // false on Android regardless of what the npm registry check says, hiding only the
-  // actionable banner below. The plain version row and the "you're on the latest version"
-  // confirmation (an npm-vs-bundled-daemon fact, not an instruction) stay on every platform —
-  // neither one implies an action a phone can't take.
-  const sys = useSysInfo().data
-  const hasUpdate = !!update?.hasUpdate && !!update?.latest && !isAndroidOs(sys?.os ?? '')
 
   return (
     <section className="rounded-lg border border-border bg-panel p-4">
@@ -1666,31 +1658,7 @@ function AboutSection() {
         <span className="font-mono text-[13px] text-ink">{installed ? `v${installed}` : '—'}</span>
       </div>
 
-      {hasUpdate ? (
-        <div
-          className="mt-2 flex flex-col gap-2 rounded-md border p-3"
-          style={{
-            borderColor: 'color-mix(in srgb, var(--accent) 40%, var(--border))',
-            background: 'color-mix(in srgb, var(--accent) 6%, transparent)',
-          }}
-        >
-          <div className="flex items-center gap-2 text-[13px] font-medium" style={{ color: 'var(--accent)' }}>
-            <ArrowUpCircle size={15} />
-            TurboLLM v{update!.latest} is available
-          </div>
-          <div className="text-[12px] text-muted">Update from your terminal:</div>
-          <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-bg px-2.5 py-1.5">
-            <code className="select-all font-mono text-[12px] text-ink">{APP_UPDATE_COMMAND}</code>
-            <CopyButton text={APP_UPDATE_COMMAND} screen="settings" />
-          </div>
-        </div>
-      ) : update?.latest && !update.hasUpdate ? (
-        // Checked successfully and current — a quiet confirmation, no call to action.
-        <div className="mt-1 inline-flex items-center gap-1.5 text-[12px] text-faint">
-          <Check size={13} style={{ color: 'var(--ok)' }} />
-          You're on the latest version
-        </div>
-      ) : null}
+      <AppUpdateSettingsBlock />
     </section>
   )
 }

--- a/wrapper/main.js
+++ b/wrapper/main.js
@@ -40,6 +40,67 @@ function getDaemonDir () {
 
 let daemonProcess = null
 
+// ── Auto-update (spec 29 B.2) ─────────────────────────────────────────────────
+// The desktop app updates itself through electron-updater against the `latest*.yml`
+// manifests electron-builder publishes onto each GitHub release. The npm/CLI install has
+// its own mechanism entirely (the daemon's POST /api/v1/app/update + the detached updater
+// helper) — this is the desktop half, and the two must never both run: the daemon's
+// install-method detection classifies the packaged daemon as `electron` precisely so it
+// refuses to shell out to npm inside an app bundle.
+//
+// TWO HARD PREREQUISITES, both owned by the version-lockstep PR (spec 29 Part C, PR 2),
+// which must land before this does anything at all:
+//   1. `wrapper/package.json`'s version must equal the published npm version. It has drifted
+//      three minors behind (1.9.7 vs 1.12.7). electron-updater compares the APP's own
+//      version against `latest.yml`, so with the drift in place the desktop app believes it
+//      is AHEAD of every release ever published and will never update — worse than no
+//      auto-update, because it looks like it works.
+//   2. `electron-builder.config.cjs` needs a `publish:` block, and the release workflow's
+//      upload globs need `latest*.yml` / `*.blockmap`. Without those manifests there is
+//      nothing for electron-updater to read.
+// Until then this whole block no-ops via the require guard below rather than crashing the
+// app on a missing dependency.
+//
+// Unsigned (spec 29 D6): updates install, but each one re-triggers SmartScreen on Windows.
+// That is a stated, accepted trade — not something to paper over here.
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000 // every 6h, plus once on launch
+
+function setupAutoUpdate () {
+  // Only meaningful in a packaged app: a dev run has no update manifest to compare against
+  // and electron-updater throws rather than no-oping.
+  if (!app.isPackaged) return
+
+  let autoUpdater
+  try {
+    ;({ autoUpdater } = require('electron-updater'))
+  } catch (err) {
+    // Dependency not installed yet (see prerequisite 2 above). Degrade to "no auto-update"
+    // — never to a failed launch.
+    console.warn('electron-updater not available; auto-update disabled:', err.message)
+    return
+  }
+
+  // Download in the background, install when the user quits anyway (spec 29 D5: desktop
+  // defaults to auto-download / notify-to-install). Deliberately NOT autoInstallOnAppQuit
+  // = false + a modal: interrupting someone mid-session to ask about an update is the
+  // behaviour that trains people to dismiss update prompts forever.
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  // Unsigned builds (D6): electron-updater on Windows otherwise refuses to apply an update
+  // whose signature it cannot verify against the installed app's.
+  autoUpdater.disableWebInstaller = true
+
+  autoUpdater.on('error', (err) => { console.error('Auto-update error:', err && err.message ? err.message : err) })
+  autoUpdater.on('update-available', (info) => { console.log(`Update available: ${info && info.version}`) })
+  autoUpdater.on('update-downloaded', (info) => { console.log(`Update downloaded: ${info && info.version} — installs on quit`) })
+
+  const check = () => { autoUpdater.checkForUpdates().catch(() => { /* offline: try again next tick */ }) }
+  check()
+  const timer = setInterval(check, UPDATE_CHECK_INTERVAL_MS)
+  // Don't let the interval hold the app open past a quit.
+  app.on('before-quit', () => clearInterval(timer))
+}
+
 // ── Health check ──────────────────────────────────────────────────────────────
 function waitForDaemon (retryMs = 500, timeoutMs = 45000) {
   return new Promise((resolve, reject) => {
@@ -78,6 +139,12 @@ function launchDaemon () {
     cwd: daemonDir,
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true, // hide the console window on Windows
+    // The daemon's install-method detection (spec 29 B.1) reads this. It can infer the
+    // desktop case from `resources/daemon` in its own path, but that is a heuristic over a
+    // packaging layout; this is the wrapper stating the fact outright. It matters because
+    // getting it wrong means the daemon offering `npm i -g` inside an app bundle, which
+    // would "succeed" against an entirely different copy of TurboLLM.
+    env: { ...process.env, TURBOLLM_DESKTOP: '1' },
   })
 
   daemonProcess.stdout.on('data', (data) => { process.stdout.write(data) })
@@ -101,6 +168,8 @@ app.whenReady().then(() => {
     app.quit()
     return
   }
+
+  setupAutoUpdate()
 
   waitForDaemon().then(() => {
     mainWindow = new BrowserWindow({


### PR DESCRIPTION
Spec 29 Part B — **B.1, B.3, B.4, B.5** (PR 3 of that spec's sequencing table).

The app already knew when a newer TurboLLM was published (`GET /api/v1/app/update`, refreshed on boot and every 24h). Its only consumer was Settings → About, three clicks deep, and the only thing it offered was `npm i -g turbollm` to copy into a terminal. Nothing was clickable and nothing updated anything. That is complaint #3 in full. This PR makes the update real.

## B.1 — applying it

New `turbollm/src/app-update-apply.ts` classifies **how this daemon is installed** — global npm, `npx` cache, packaged Electron, Docker, Android, source checkout — because the correct action differs per method and a wrong guess is worse than no button at all: `npm i -g turbollm@latest` inside a container or an app bundle *succeeds* while updating a completely different copy of TurboLLM than the one running.

`POST /api/v1/app/update` refuses loudly, with a sentence naming what is in the way, on:
- an in-flight download (the standing ADR-240 rule: a hard kill mid-write can **corrupt** a download, not merely pause it),
- an engine build or an engine install,
- a live Code session,
- a model mid-load.

When it does proceed, the mechanism is the part that is easy to get wrong. A running daemon cannot have its own package files overwritten — Windows locks `node_modules` outright and `npm i -g` fails `EPERM`/`EBUSY` — so:

1. the daemon spawns a **detached, dependency-free** `update-helper.mjs` (shipped as a real file in `dist/`, resolved as a sibling of the bundle exactly like `run-code-worker`),
2. returns `202` and calls the existing restart path in a new **`exitOnly`** mode — a flag on that carefully-ordered, watchdog-guarded teardown rather than a second copy of it,
3. the helper waits for the PID to actually die, installs, and relaunches the daemon **exactly as it was launched**, from an identity recorded at boot rather than reconstructed,
4. a failed install leaves the old version installed and untouched, and relaunches it — being left daemonless because an update failed would be far worse than the update not happening,
5. the outcome reaches the restarted daemon in a result file it reads **once**, then deletes.

`GET /api/v1/app/update/progress` polls `idle | downloading | installing | restarting | done | failed`.

## B.3 — the button, where the version already is

`AppUpdateControl.tsx` is **one component, two mounts**: the NavRail's bottom-left version line (which *becomes* an accent-tinted `v1.12.7 → v1.12.8` pill) and Settings → About. Two hand-kept copies would eventually disagree about whether an update exists; one implementation cannot.

The dialog shows current → new, a primary **Update & restart**, a secondary **Later**, polls through the restart (every failed request in that window means "still restarting", never an error — which is why this path deliberately does *not* go through a query hook), and confirms the new version. For every install method that cannot self-update it falls back to exactly today's copyable command, so it is **never a dead end**. Hidden on Android as `hasUpdate` already was. One dismissible toast per new version, with the dismissed version remembered **daemon-side** so opening TurboLLM in a second browser doesn't re-ask.

## B.4 — policy

`off | notify | auto` in Settings → About, reusing `normalizeUpdatePolicy`'s exact vocabulary rather than inventing a second one. Default `notify`. `off` is reported as `hasUpdate: false` so the UI needs no second rule for it.

## B.5 — measurability

`app_update_available` / `_clicked` / `_applied` / `_failed`, each carrying the detected install method — "did anyone update?" is a different question per method, and averaging a Docker install (which literally cannot press the button) into one rate hides that.

## ⚠️ Two things this PR depends on

- **The telemetry Worker must be redeployed before this ships.** These are new events, so `telemetry-worker`'s schema-hash gate fails on this branch by design — that gate exists precisely to stop a schema change shipping without a deploy. Run `cd telemetry-worker && npm run deploy` (which also writes `deployed.schema.sha256`) and commit the hash **before this merges**, or every one of these events is silently rejected at the edge. Not done here on purpose.
- **PR 2 (wrapper version lockstep + `publish:` block + `electron-updater` dependency) must land first.** `wrapper/main.js`'s electron-updater wiring is written and correct but sits behind a `require` guard, so it no-ops until that dependency exists. More importantly, `wrapper/package.json` is three minors behind npm (1.9.7 vs 1.12.7) — electron-updater compares the app's own version against `latest.yml`, so with that drift in place the desktop app believes it is *ahead* of every release ever published. Auto-update that looks like it works and never fires is worse than none.

`wrapper/main.js` also now passes `TURBOLLM_DESKTOP=1` to the daemon, so the packaged install can never be mistaken for an npm one.

## Verification

- `npm run typecheck` (turbollm) — clean
- `cd web && npx tsc --noEmit` — clean
- `npm test` (turbollm) — **3712 passed, 0 failed**, 4 skipped (34 new)
- `cd web && npx vitest run` — 795 passed, 71 files
- `npm run build` (turbollm) — succeeds; `dist/update-helper.mjs` ships and the bundle's sibling-URL resolution is correct
- Web production build — succeeds

New tests cover all six install-method classifications (including the two that matter most: the packaged desktop daemon must never read as an npm install, and a sibling directory sharing a path prefix is not the global root), the full pre-check matrix, the result-file handshake including corrupt input, and the route-level refusals. **No end-to-end apply was run** — that path kills and relaunches a real daemon, and per CLAUDE.md hard rule 5 nothing here touched a live daemon on :6996. The real end-to-end run against a throwaway global install (with `~/.turbollm` backed up first) remains a manual step from spec 29's test plan.
