### PR TITLE
fix(code): every /api/v1/code/* route 404'd since v1.12.5 (route-order regression)

### DIFF
--- a/turbollm/src/cli.ts
+++ b/turbollm/src/cli.ts
@@ -47,7 +47,7 @@ import { RequestLog } from './observability/request-log'
 import { launchCli, syncHarnessModelConfig, CONFIG_FILE_HARNESSES } from './cli-launch'
 import { writePidfile, removePidfile, stopDaemon, resolveDaemonPort } from './daemon-pid'
 import { runMcpServer } from './mcp-server'
-import { createApp, registerCodeRoutesIfSupported } from './server'
+import { createApp, registerCodeRoutesIfSupported, registerSpaFallback } from './server'
 import { registerTerminalWs } from './terminal/terminal-routes'
 import { reapStaleTerminals, killTrackedTerminalsSync } from './terminal/terminal-manager'
 import { provisionBootstrapApiKey, provisionTunnelApiKey } from './auth'
@@ -750,6 +750,9 @@ cliInteractiveSweepTimer.unref()
 
 const app = createApp(deps)
 await registerCodeRoutesIfSupported(app, deps)
+// Must be registered last — it's a catch-all `GET /*`, and Hono shadows any route added
+// after an overlapping catch-all (see registerSpaFallback's doc comment in server.ts).
+registerSpaFallback(app)
 
 // Warm the app-update cache shortly after boot (ADR-031: "once per daemon start") so the
 // Settings chip is ready without the user clicking refresh. Offline-silent; unref'd so it

--- a/turbollm/src/server.route-order.test.ts
+++ b/turbollm/src/server.route-order.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { createApp, registerCodeRoutesIfSupported, registerSpaFallback } from './server'
+import type { Deps } from './deps'
+
+const RAW_KEY = 'tllm-route-order-test-key'
+
+/** Regression test for the bug that made every `/api/v1/code/*` route 404 with "Unknown
+ *  endpoint." from a7a85c2 onward (v1.12.5 through v1.13.0, reported by many users): that
+ *  commit moved Code/Agents route registration out of `createApp()` to run lazily afterward
+ *  (`registerCodeRoutesIfSupported`), by which point `createApp()` had already registered the
+ *  SPA's catch-all `GET /*`. Hono matches an overlapping catch-all in registration order, so
+ *  the specific Code routes added later were silently unreachable — the request fell through
+ *  to the catch-all's 404 first. This drives the REAL boot sequence (`createApp` +
+ *  `registerCodeRoutesIfSupported` + `registerSpaFallback`, in that order, exactly like
+ *  cli.ts), not a hand-composed mini-app, because the defect was the ordering between those
+ *  calls — a test that re-declares the order would pass against the broken build. */
+
+function mkDeps(): Deps {
+  // Same minimal-double approach as server.link-telemetry.test.ts: `createApp` wires every
+  // route module, several of which touch the DB at registration time (e.g.
+  // CodeRunManager.reconcileOnStartup). A Proxy answering every call with `[]` is sufficient
+  // since this test is about routing order, not those modules' business logic.
+  const db = new Proxy({}, { get: () => () => [] })
+  const cfg: Record<string, unknown> = {
+    // No `grant` field — a key that carries one is a Turbo Link facade-only credential and
+    // is refused by verifyKeyValue/isFacadeOnlyKey (ADR-376) for every other auth surface,
+    // codeAuth included.
+    apiKeys: [{
+      id: 'k1', name: 'test', hash: createHash('sha256').update(RAW_KEY).digest('hex'),
+      prefix: RAW_KEY.slice(0, 12), createdAt: 'c', lastUsedAt: null,
+    }],
+    links: [],
+    // isLocalRequest (auth.ts) can't see a real loopback socket through Hono's fake
+    // `.request()` dispatch, so codeAuth would 401 every call without a key on file too —
+    // this mirrors server.link-telemetry.test.ts's own workaround for the same gap.
+    daemon: { lanBind: true, requireApiKey: false, machineId: 'machine-test', port: 6996 },
+  }
+  return {
+    version: 'test',
+    store: { snapshot: () => cfg, update: (fn: (c: never) => void) => fn(cfg as never), dir: () => '.' },
+    db,
+    telemetry: { firstUse: () => {}, useFeature: () => {} },
+  } as unknown as Deps
+}
+
+test('Code routes are reachable after the real createApp + registerCodeRoutesIfSupported + registerSpaFallback boot sequence', async () => {
+  const d = mkDeps()
+  const app = createApp(d)
+  await registerCodeRoutesIfSupported(app, d)
+  registerSpaFallback(app)
+
+  const res = await app.request('/api/v1/code/sessions', { headers: { 'X-TurboLLM-Auth': RAW_KEY } })
+  const body = await res.json()
+  assert.equal(res.status, 200, `expected the real Code route to answer, got ${JSON.stringify(body)}`)
+  assert.deepEqual(body, { sessions: [] })
+})
+
+test('the SPA catch-all still 404s unknown /api paths that no route module claimed', async () => {
+  const d = mkDeps()
+  const app = createApp(d)
+  await registerCodeRoutesIfSupported(app, d)
+  registerSpaFallback(app)
+
+  const res = await app.request('/api/v1/this-route-does-not-exist')
+  assert.equal(res.status, 404)
+  assert.deepEqual(await res.json(), { error: { code: 'not_found', message: 'Unknown endpoint.' } })
+})

--- a/turbollm/src/server.ts
+++ b/turbollm/src/server.ts
@@ -179,7 +179,18 @@ export function createApp(d: Deps): Hono {
   }, 30_000)
   extRunsReaper.unref()
 
-  // Embedded SPA with client-side-routing fallback (spec 08 §1).
+  return app
+}
+
+/** Embedded SPA with client-side-routing fallback (spec 08 §1) — a catch-all `GET /*`, so it
+ *  MUST be the last route registered on `app`. Kept out of `createApp()` and called separately,
+ *  after `registerCodeRoutesIfSupported()`, because Hono routes are matched in REGISTRATION
+ *  order for an overlapping catch-all: a specific route added after `/*` is already registered
+ *  never gets reached, it falls through to this handler's 404 first (confirmed live — this is
+ *  what silently 404'd every `/api/v1/code/*` route from a7a85c2 onward, since that commit moved
+ *  Code/Agents route registration to run lazily, after `createApp()` returned with `/*` already
+ *  in place; the old inline comment claiming registration order didn't matter was wrong). */
+export function registerSpaFallback(app: Hono): void {
   app.get('/*', (c) => {
     const path = decodeURIComponent(new URL(c.req.url).pathname).replace(/^\/+/, '')
     if (path.startsWith('api/') || path.startsWith('v1/')) {
@@ -192,8 +203,6 @@ export function createApp(d: Deps): Hono {
     if (!existsSync(file)) return c.text('web ui not built — run `npm run build:web`', 500)
     return new Response(readFileSync(file), { status: 200, headers: { 'Content-Type': contentType(file) } })
   })
-
-  return app
 }
 
 /** Registers the Code/Agents feature's routes, lazily — call once, right after
@@ -210,9 +219,11 @@ export function createApp(d: Deps): Hono {
  *  unavailable there) regardless — skipping registration entirely on Android costs nothing
  *  real. Every other platform's behavior/route surface is unchanged (import resolves
  *  immediately, same handlers as before, still registered in the same relative order
- *  before terminal/routine/gateway/ext — Hono matches by path pattern, not registration
- *  order, so moving this call out of `createApp()`'s synchronous body doesn't change
- *  routing behavior). */
+ *  before terminal/routine/gateway/ext) — PROVIDED the caller registers the SPA catch-all
+ *  (`registerSpaFallback`, below) only AFTER awaiting this, never before: Hono matches routes
+ *  in registration order for an overlapping catch-all, so a `/*` added first silently shadows
+ *  every Code/Agents route added afterward (this is exactly what a7a85c2 broke — see
+ *  `registerSpaFallback`'s doc comment). */
 export async function registerCodeRoutesIfSupported(app: Hono, d: Deps): Promise<void> {
   if (process.platform === 'android') return
   // code-routes.ts ships as its OWN tsup entry, in its OWN separate build pass (see


### PR DESCRIPTION
## Summary
- `a7a85c2` moved Code/Agents route registration out of `createApp()` into an async `registerCodeRoutesIfSupported()`, called after `createApp()` already registered the SPA's catch-all `GET /*`. Hono shadows any route registered after an overlapping catch-all, so every `/api/v1/code/*` route has 404'd with `{"error":{"code":"not_found","message":"Unknown endpoint."}}` since v1.12.5 — widely reported by users. No data was lost; sessions stayed intact in `turbollm.db`, just unreachable via the API.
- Extracts the SPA fallback into `registerSpaFallback(app)` and moves its call site in `cli.ts` to run after `registerCodeRoutesIfSupported()`, so the catch-all is always registered last.
- Full root-cause writeup: `docs/decisions/decision-log.md` ADR-421 (docs repo, not in this diff).

## Test plan
- [x] New regression test `turbollm/src/server.route-order.test.ts` drives the real `createApp()` → `registerCodeRoutesIfSupported()` → `registerSpaFallback()` sequence; confirmed it fails against the pre-fix ordering and passes after
- [x] Full suite: 3714/3718 pass (4 pre-existing unrelated skips), typecheck clean
- [x] Verified live against a real running daemon + UI: all 32/33 real Code sessions and stats restored, an existing session's full transcript reopens correctly
- [x] Needs a `v1.13.1` patch release once merged — v1.12.5 through v1.13.0 are all affected